### PR TITLE
feat: add debugger data surface foundation

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -139,9 +139,16 @@ const (
 
 // Defines values for TraceStatus.
 const (
-	COMPLETED TraceStatus = "COMPLETED"
-	FAILED    TraceStatus = "FAILED"
-	RUNNING   TraceStatus = "RUNNING"
+	TraceStatusCOMPLETED TraceStatus = "COMPLETED"
+	TraceStatusFAILED    TraceStatus = "FAILED"
+	TraceStatusRUNNING   TraceStatus = "RUNNING"
+)
+
+// Defines values for TraceDetailStatus.
+const (
+	TraceDetailStatusCOMPLETED TraceDetailStatus = "COMPLETED"
+	TraceDetailStatusFAILED    TraceDetailStatus = "FAILED"
+	TraceDetailStatusRUNNING   TraceDetailStatus = "RUNNING"
 )
 
 // Defines values for ListTracesParamsStatus.
@@ -345,17 +352,25 @@ type Span struct {
 	Id           openapi_types.UUID `json:"id"`
 
 	// Input Span input payload (any valid JSON)
-	Input     interface{}             `json:"input,omitempty"`
-	Kind      SpanKind                `json:"kind"`
-	LatencyMs *int                    `json:"latency_ms,omitempty"`
-	Metadata  *map[string]interface{} `json:"metadata,omitempty"`
-	Name      string                  `json:"name"`
+	Input                  interface{}             `json:"input,omitempty"`
+	InputOriginalSizeBytes *int64                  `json:"input_original_size_bytes,omitempty"`
+	InputTruncated         *bool                   `json:"input_truncated,omitempty"`
+	InputTruncationReason  *string                 `json:"input_truncation_reason,omitempty"`
+	Kind                   SpanKind                `json:"kind"`
+	LatencyMs              *int                    `json:"latency_ms,omitempty"`
+	Metadata               *map[string]interface{} `json:"metadata,omitempty"`
+	Model                  *string                 `json:"model,omitempty"`
+	Name                   string                  `json:"name"`
 
 	// Output Span output payload (any valid JSON)
-	Output interface{} `json:"output,omitempty"`
+	Output                  interface{} `json:"output,omitempty"`
+	OutputOriginalSizeBytes *int64      `json:"output_original_size_bytes,omitempty"`
+	OutputTruncated         *bool       `json:"output_truncated,omitempty"`
+	OutputTruncationReason  *string     `json:"output_truncation_reason,omitempty"`
 
 	// ParentSpanId External parent span identifier
 	ParentSpanId *string `json:"parent_span_id,omitempty"`
+	Provider     *string `json:"provider,omitempty"`
 
 	// SpanId External span identifier (used for parent-child relationships)
 	SpanId    string             `json:"span_id"`
@@ -444,6 +459,37 @@ type Trace struct {
 
 // TraceStatus defines model for Trace.Status.
 type TraceStatus string
+
+// TraceDetail defines model for TraceDetail.
+type TraceDetail struct {
+	EndedAt     *time.Time `json:"ended_at,omitempty"`
+	Environment *string    `json:"environment,omitempty"`
+
+	// ErrorCount Count of failed spans in this trace
+	ErrorCount *int               `json:"error_count,omitempty"`
+	Id         openapi_types.UUID `json:"id"`
+
+	// Input Trace input payload (any valid JSON)
+	Input    interface{}             `json:"input,omitempty"`
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Name     string                  `json:"name"`
+
+	// Output Trace output payload (any valid JSON)
+	Output         interface{}         `json:"output,omitempty"`
+	Release        *string             `json:"release,omitempty"`
+	SessionId      *openapi_types.UUID `json:"session_id,omitempty"`
+	StartedAt      time.Time           `json:"started_at"`
+	Status         TraceDetailStatus   `json:"status"`
+	Tags           *[]string           `json:"tags,omitempty"`
+	TotalCostUsd   *float32            `json:"total_cost_usd,omitempty"`
+	TotalTokensIn  *int                `json:"total_tokens_in,omitempty"`
+	TotalTokensOut *int                `json:"total_tokens_out,omitempty"`
+	TraceId        *string             `json:"trace_id,omitempty"`
+	UserId         *string             `json:"user_id,omitempty"`
+}
+
+// TraceDetailStatus defines model for TraceDetail.Status.
+type TraceDetailStatus string
 
 // TraceList defines model for TraceList.
 type TraceList struct {

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -181,6 +181,17 @@ export interface components {
             error_count?: number;
             metadata?: Record<string, never>;
         };
+        TraceDetail: components["schemas"]["Trace"] & {
+            trace_id?: string;
+            user_id?: string;
+            tags?: string[];
+            environment?: string;
+            release?: string;
+            /** @description Trace input payload (any valid JSON) */
+            input?: unknown;
+            /** @description Trace output payload (any valid JSON) */
+            output?: unknown;
+        };
         TraceList: {
             traces: components["schemas"]["Trace"][];
             total: number;
@@ -208,10 +219,20 @@ export interface components {
             cost_usd?: number;
             latency_ms?: number;
             error_message?: string;
+            model?: string;
+            provider?: string;
             /** @description Span input payload (any valid JSON) */
             input?: unknown;
+            input_truncated?: boolean;
+            /** Format: int64 */
+            input_original_size_bytes?: number;
+            input_truncation_reason?: string;
             /** @description Span output payload (any valid JSON) */
             output?: unknown;
+            output_truncated?: boolean;
+            /** Format: int64 */
+            output_original_size_bytes?: number;
+            output_truncation_reason?: string;
             metadata?: Record<string, never>;
         };
         SpanList: {
@@ -614,7 +635,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Trace"];
+                    "application/json": components["schemas"]["TraceDetail"];
                 };
             };
             /** @description Unauthorized - missing or invalid API key */

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -203,7 +203,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Trace'
+                $ref: '#/components/schemas/TraceDetail'
         '401':
           description: Unauthorized - missing or invalid API key
           content:
@@ -427,6 +427,27 @@ components:
           description: Count of failed spans in this trace
         metadata:
           type: object
+    TraceDetail:
+      allOf:
+        - $ref: '#/components/schemas/Trace'
+        - type: object
+          properties:
+            trace_id:
+              type: string
+            user_id:
+              type: string
+            tags:
+              type: array
+              items:
+                type: string
+            environment:
+              type: string
+            release:
+              type: string
+            input:
+              description: Trace input payload (any valid JSON)
+            output:
+              description: Trace output payload (any valid JSON)
     TraceList:
       type: object
       required:
@@ -495,10 +516,28 @@ components:
           type: integer
         error_message:
           type: string
+        model:
+          type: string
+        provider:
+          type: string
         input:
           description: Span input payload (any valid JSON)
+        input_truncated:
+          type: boolean
+        input_original_size_bytes:
+          type: integer
+          format: int64
+        input_truncation_reason:
+          type: string
         output:
           description: Span output payload (any valid JSON)
+        output_truncated:
+          type: boolean
+        output_original_size_bytes:
+          type: integer
+          format: int64
+        output_truncation_reason:
+          type: string
         metadata:
           type: object
     SpanList:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -205,7 +205,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Trace'
+                $ref: '#/components/schemas/TraceDetail'
         '401':
           description: Unauthorized - missing or invalid API key
           content:
@@ -424,6 +424,28 @@ components:
         metadata:
           type: object
 
+    TraceDetail:
+      allOf:
+        - $ref: '#/components/schemas/Trace'
+        - type: object
+          properties:
+            trace_id:
+              type: string
+            user_id:
+              type: string
+            tags:
+              type: array
+              items:
+                type: string
+            environment:
+              type: string
+            release:
+              type: string
+            input:
+              description: Trace input payload (any valid JSON)
+            output:
+              description: Trace output payload (any valid JSON)
+
     TraceList:
       type: object
       required: [traces, total]
@@ -475,10 +497,28 @@ components:
           type: integer
         error_message:
           type: string
+        model:
+          type: string
+        provider:
+          type: string
         input:
           description: Span input payload (any valid JSON)
+        input_truncated:
+          type: boolean
+        input_original_size_bytes:
+          type: integer
+          format: int64
+        input_truncation_reason:
+          type: string
         output:
           description: Span output payload (any valid JSON)
+        output_truncated:
+          type: boolean
+        output_original_size_bytes:
+          type: integer
+          format: int64
+        output_truncation_reason:
+          type: string
         metadata:
           type: object
 

--- a/internal/api/mapper.go
+++ b/internal/api/mapper.go
@@ -67,6 +67,52 @@ func traceToAPI(t *platform.Trace) Trace {
 	return trace
 }
 
+// traceDetailToAPI converts a database trace to the detail API schema by
+// composing the summary mapper output with debugger-specific fields.
+// NOTE: oapi-codegen currently flattens TraceDetail's allOf shape, so any new
+// summary fields added to traceToAPI must also be copied into TraceDetail here.
+func traceDetailToAPI(t *platform.Trace) TraceDetail {
+	summary := traceToAPI(t)
+	trace := TraceDetail{
+		Id:             summary.Id,
+		Name:           summary.Name,
+		Status:         TraceDetailStatus(summary.Status),
+		StartedAt:      summary.StartedAt,
+		EndedAt:        summary.EndedAt,
+		SessionId:      summary.SessionId,
+		TotalTokensIn:  summary.TotalTokensIn,
+		TotalTokensOut: summary.TotalTokensOut,
+		TotalCostUsd:   summary.TotalCostUsd,
+		ErrorCount:     summary.ErrorCount,
+		Metadata:       summary.Metadata,
+	}
+
+	if t.TraceID != "" {
+		trace.TraceId = &t.TraceID
+	}
+	if t.UserID != nil {
+		trace.UserId = t.UserID
+	}
+	if len(t.Tags) > 0 {
+		tags := append([]string(nil), t.Tags...)
+		trace.Tags = &tags
+	}
+	if t.Environment != nil {
+		trace.Environment = t.Environment
+	}
+	if t.Release != nil {
+		trace.Release = t.Release
+	}
+	if input, ok := parseJSONValue(t.Input); ok {
+		trace.Input = input
+	}
+	if output, ok := parseJSONValue(t.Output); ok {
+		trace.Output = output
+	}
+
+	return trace
+}
+
 // spanToAPI converts a database span to an API span.
 func spanToAPI(sp *platform.Span) Span {
 	span := Span{
@@ -126,19 +172,38 @@ func spanToAPI(sp *platform.Span) Span {
 	}
 
 	// Input payload (JSON from DB bytes - can be any valid JSON)
-	if len(sp.Input) > 0 {
-		var input interface{}
-		if err := parseJSON(sp.Input, &input); err == nil {
-			span.Input = &input
-		}
+	if input, ok := parseJSONValue(sp.Input); ok {
+		span.Input = input
 	}
 
 	// Output payload (JSON from DB bytes - can be any valid JSON)
-	if len(sp.Output) > 0 {
-		var output interface{}
-		if err := parseJSON(sp.Output, &output); err == nil {
-			span.Output = &output
-		}
+	if output, ok := parseJSONValue(sp.Output); ok {
+		span.Output = output
+	}
+
+	if sp.Model != nil {
+		span.Model = sp.Model
+	}
+	if sp.Provider != nil {
+		span.Provider = sp.Provider
+	}
+	if sp.InputTruncated != nil {
+		span.InputTruncated = sp.InputTruncated
+	}
+	if sp.InputOriginalSizeBytes != nil {
+		span.InputOriginalSizeBytes = sp.InputOriginalSizeBytes
+	}
+	if sp.InputTruncationReason != nil {
+		span.InputTruncationReason = sp.InputTruncationReason
+	}
+	if sp.OutputTruncated != nil {
+		span.OutputTruncated = sp.OutputTruncated
+	}
+	if sp.OutputOriginalSizeBytes != nil {
+		span.OutputOriginalSizeBytes = sp.OutputOriginalSizeBytes
+	}
+	if sp.OutputTruncationReason != nil {
+		span.OutputTruncationReason = sp.OutputTruncationReason
 	}
 
 	return span
@@ -345,6 +410,28 @@ func parseJSON(data []byte, v interface{}) error {
 		return nil
 	}
 	return json.Unmarshal(data, v)
+}
+
+func parseJSONValue(data []byte) (interface{}, bool) {
+	if len(data) == 0 {
+		return nil, false
+	}
+
+	var value interface{}
+	if err := parseJSON(data, &value); err != nil {
+		return nil, false
+	}
+	if value == nil {
+		return jsonNull{}, true
+	}
+
+	return value, true
+}
+
+type jsonNull struct{}
+
+func (jsonNull) MarshalJSON() ([]byte, error) {
+	return []byte("null"), nil
 }
 
 // numericToFloat32 converts a pgtype.Numeric to float32.

--- a/internal/api/mapper_trace_test.go
+++ b/internal/api/mapper_trace_test.go
@@ -51,7 +51,7 @@ func TestTraceDetailToAPI_MapsSummaryAndDetailFields(t *testing.T) {
 	require.NotNil(t, detail.EndedAt)
 	assert.Equal(t, end, *detail.EndedAt)
 	require.NotNil(t, detail.SessionId)
-	assert.Equal(t, sessionID, uuid.UUID(*detail.SessionId))
+	assert.Equal(t, sessionID, *detail.SessionId)
 	require.NotNil(t, detail.TotalTokensIn)
 	assert.Equal(t, 12, *detail.TotalTokensIn)
 	require.NotNil(t, detail.TotalTokensOut)

--- a/internal/api/mapper_trace_test.go
+++ b/internal/api/mapper_trace_test.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestTraceDetailToAPI_MapsSummaryAndDetailFields(t *testing.T) {
+	start := time.Date(2026, 3, 12, 9, 30, 0, 0, time.UTC)
+	end := start.Add(45 * time.Second)
+	sessionID := uuid.New()
+	name := "Debugger Trace"
+	userID := "user@example.com"
+	environment := "production"
+	release := "v1.2.3"
+	errorCount := int32(2)
+
+	trace := platform.Trace{
+		ID:               uuid.New(),
+		SessionID:        pgtype.UUID{Bytes: sessionID, Valid: true},
+		TraceID:          "trace-ext-123",
+		Name:             &name,
+		UserID:           &userID,
+		Environment:      &environment,
+		Release:          &release,
+		Metadata:         []byte(`{"source":"sdk"}`),
+		Status:           "completed",
+		StartTime:        testutil.PgtypeTimestamptz(start),
+		EndTime:          testutil.PgtypeTimestamptz(end),
+		ErrorCount:       &errorCount,
+		TotalTokensIn:    12,
+		TotalTokensOut:   34,
+		ServerReceivedAt: start.Add(-time.Second),
+	}
+
+	detail := traceDetailToAPI(&trace)
+
+	assert.Equal(t, trace.ID, detail.Id)
+	assert.Equal(t, name, detail.Name)
+	assert.Equal(t, TraceDetailStatusCOMPLETED, detail.Status)
+	assert.Equal(t, start, detail.StartedAt)
+	require.NotNil(t, detail.EndedAt)
+	assert.Equal(t, end, *detail.EndedAt)
+	require.NotNil(t, detail.SessionId)
+	assert.Equal(t, sessionID, uuid.UUID(*detail.SessionId))
+	require.NotNil(t, detail.TotalTokensIn)
+	assert.Equal(t, 12, *detail.TotalTokensIn)
+	require.NotNil(t, detail.TotalTokensOut)
+	assert.Equal(t, 34, *detail.TotalTokensOut)
+	require.NotNil(t, detail.ErrorCount)
+	assert.Equal(t, 2, *detail.ErrorCount)
+	require.NotNil(t, detail.Metadata)
+	assert.Equal(t, "sdk", (*detail.Metadata)["source"])
+	require.NotNil(t, detail.TraceId)
+	assert.Equal(t, "trace-ext-123", *detail.TraceId)
+	require.NotNil(t, detail.UserId)
+	assert.Equal(t, userID, *detail.UserId)
+	require.NotNil(t, detail.Environment)
+	assert.Equal(t, environment, *detail.Environment)
+	require.NotNil(t, detail.Release)
+	assert.Equal(t, release, *detail.Release)
+}
+
+func TestTraceDetailToAPI_TagsMapping(t *testing.T) {
+	t.Run("omits empty tags", func(t *testing.T) {
+		trace := platform.Trace{
+			ID:        uuid.New(),
+			TraceID:   "trace-ext-empty-tags",
+			Name:      testutil.StrPtr("Trace"),
+			Status:    "running",
+			StartTime: testutil.PgtypeTimestamptz(time.Now().UTC()),
+			Tags:      []string{},
+		}
+
+		detail := traceDetailToAPI(&trace)
+		assert.Nil(t, detail.Tags)
+	})
+
+	t.Run("maps non-empty tags", func(t *testing.T) {
+		trace := platform.Trace{
+			ID:        uuid.New(),
+			TraceID:   "trace-ext-tags",
+			Name:      testutil.StrPtr("Trace"),
+			Status:    "running",
+			StartTime: testutil.PgtypeTimestamptz(time.Now().UTC()),
+			Tags:      []string{"prod", "v2"},
+		}
+
+		detail := traceDetailToAPI(&trace)
+		require.NotNil(t, detail.Tags)
+		assert.Equal(t, []string{"prod", "v2"}, *detail.Tags)
+	})
+}
+
+func TestTraceDetailToAPI_PreservesArbitraryJSON(t *testing.T) {
+	testCases := []struct {
+		name string
+		json string
+	}{
+		{name: "false", json: `false`},
+		{name: "zero", json: `0`},
+		{name: "empty string", json: `""`},
+		{name: "null", json: `null`},
+		{name: "array", json: `[]`},
+		{name: "object", json: `{}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			trace := platform.Trace{
+				ID:        uuid.New(),
+				TraceID:   "trace-ext-json",
+				Name:      testutil.StrPtr("Trace"),
+				Status:    "completed",
+				StartTime: testutil.PgtypeTimestamptz(time.Now().UTC()),
+				Input:     []byte(tc.json),
+				Output:    []byte(tc.json),
+			}
+
+			detail := traceDetailToAPI(&trace)
+
+			payload, err := json.Marshal(detail)
+			require.NoError(t, err)
+
+			var body map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(payload, &body))
+
+			rawInput, ok := body["input"]
+			require.True(t, ok, "input should be present for %s", tc.name)
+			rawOutput, ok := body["output"]
+			require.True(t, ok, "output should be present for %s", tc.name)
+
+			assertJSONValue(t, rawInput, tc.json)
+			assertJSONValue(t, rawOutput, tc.json)
+		})
+	}
+}
+
+func TestSpanToAPI_MapsLLMContextAndTruncationFields(t *testing.T) {
+	t.Run("maps truncated payload metadata", func(t *testing.T) {
+		inputReason := "size_limit"
+		outputReason := "size_limit"
+		model := "gpt-4o"
+		provider := "openai"
+		inputTruncated := true
+		outputTruncated := true
+		inputSize := int64(524288)
+		outputSize := int64(1048576)
+
+		span := platform.Span{
+			ID:                      uuid.New(),
+			TraceID:                 uuid.New(),
+			SpanID:                  "span-1",
+			Name:                    "LLM Span",
+			Type:                    "llm",
+			Status:                  "completed",
+			StartTime:               time.Now().UTC(),
+			Model:                   &model,
+			Provider:                &provider,
+			InputTruncated:          &inputTruncated,
+			InputOriginalSizeBytes:  &inputSize,
+			InputTruncationReason:   &inputReason,
+			OutputTruncated:         &outputTruncated,
+			OutputOriginalSizeBytes: &outputSize,
+			OutputTruncationReason:  &outputReason,
+		}
+
+		apiSpan := spanToAPI(&span)
+
+		require.NotNil(t, apiSpan.Model)
+		assert.Equal(t, model, *apiSpan.Model)
+		require.NotNil(t, apiSpan.Provider)
+		assert.Equal(t, provider, *apiSpan.Provider)
+		require.NotNil(t, apiSpan.InputTruncated)
+		assert.True(t, *apiSpan.InputTruncated)
+		require.NotNil(t, apiSpan.InputOriginalSizeBytes)
+		assert.Equal(t, inputSize, *apiSpan.InputOriginalSizeBytes)
+		require.NotNil(t, apiSpan.InputTruncationReason)
+		assert.Equal(t, inputReason, *apiSpan.InputTruncationReason)
+		require.NotNil(t, apiSpan.OutputTruncated)
+		assert.True(t, *apiSpan.OutputTruncated)
+		require.NotNil(t, apiSpan.OutputOriginalSizeBytes)
+		assert.Equal(t, outputSize, *apiSpan.OutputOriginalSizeBytes)
+		require.NotNil(t, apiSpan.OutputTruncationReason)
+		assert.Equal(t, outputReason, *apiSpan.OutputTruncationReason)
+	})
+
+	t.Run("preserves false truncation booleans", func(t *testing.T) {
+		inputTruncated := false
+		outputTruncated := false
+
+		span := platform.Span{
+			ID:              uuid.New(),
+			TraceID:         uuid.New(),
+			SpanID:          "span-2",
+			Name:            "LLM Span",
+			Type:            "llm",
+			Status:          "completed",
+			StartTime:       time.Now().UTC(),
+			InputTruncated:  &inputTruncated,
+			OutputTruncated: &outputTruncated,
+		}
+
+		apiSpan := spanToAPI(&span)
+
+		require.NotNil(t, apiSpan.InputTruncated)
+		assert.False(t, *apiSpan.InputTruncated)
+		require.NotNil(t, apiSpan.OutputTruncated)
+		assert.False(t, *apiSpan.OutputTruncated)
+		assert.Nil(t, apiSpan.InputOriginalSizeBytes)
+		assert.Nil(t, apiSpan.InputTruncationReason)
+		assert.Nil(t, apiSpan.OutputOriginalSizeBytes)
+		assert.Nil(t, apiSpan.OutputTruncationReason)
+	})
+}
+
+func assertJSONValue(t *testing.T, actual interface{}, expectedJSON string) {
+	t.Helper()
+
+	actualBytes, err := json.Marshal(actual)
+	require.NoError(t, err)
+
+	var actualValue interface{}
+	require.NoError(t, json.Unmarshal(actualBytes, &actualValue))
+
+	var expectedValue interface{}
+	require.NoError(t, json.Unmarshal([]byte(expectedJSON), &expectedValue))
+
+	assert.Equal(t, expectedValue, actualValue)
+}

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -139,9 +139,16 @@ const (
 
 // Defines values for TraceStatus.
 const (
-	COMPLETED TraceStatus = "COMPLETED"
-	FAILED    TraceStatus = "FAILED"
-	RUNNING   TraceStatus = "RUNNING"
+	TraceStatusCOMPLETED TraceStatus = "COMPLETED"
+	TraceStatusFAILED    TraceStatus = "FAILED"
+	TraceStatusRUNNING   TraceStatus = "RUNNING"
+)
+
+// Defines values for TraceDetailStatus.
+const (
+	TraceDetailStatusCOMPLETED TraceDetailStatus = "COMPLETED"
+	TraceDetailStatusFAILED    TraceDetailStatus = "FAILED"
+	TraceDetailStatusRUNNING   TraceDetailStatus = "RUNNING"
 )
 
 // Defines values for ListTracesParamsStatus.
@@ -345,17 +352,25 @@ type Span struct {
 	Id           openapi_types.UUID `json:"id"`
 
 	// Input Span input payload (any valid JSON)
-	Input     interface{}             `json:"input,omitempty"`
-	Kind      SpanKind                `json:"kind"`
-	LatencyMs *int                    `json:"latency_ms,omitempty"`
-	Metadata  *map[string]interface{} `json:"metadata,omitempty"`
-	Name      string                  `json:"name"`
+	Input                  interface{}             `json:"input,omitempty"`
+	InputOriginalSizeBytes *int64                  `json:"input_original_size_bytes,omitempty"`
+	InputTruncated         *bool                   `json:"input_truncated,omitempty"`
+	InputTruncationReason  *string                 `json:"input_truncation_reason,omitempty"`
+	Kind                   SpanKind                `json:"kind"`
+	LatencyMs              *int                    `json:"latency_ms,omitempty"`
+	Metadata               *map[string]interface{} `json:"metadata,omitempty"`
+	Model                  *string                 `json:"model,omitempty"`
+	Name                   string                  `json:"name"`
 
 	// Output Span output payload (any valid JSON)
-	Output interface{} `json:"output,omitempty"`
+	Output                  interface{} `json:"output,omitempty"`
+	OutputOriginalSizeBytes *int64      `json:"output_original_size_bytes,omitempty"`
+	OutputTruncated         *bool       `json:"output_truncated,omitempty"`
+	OutputTruncationReason  *string     `json:"output_truncation_reason,omitempty"`
 
 	// ParentSpanId External parent span identifier
 	ParentSpanId *string `json:"parent_span_id,omitempty"`
+	Provider     *string `json:"provider,omitempty"`
 
 	// SpanId External span identifier (used for parent-child relationships)
 	SpanId    string             `json:"span_id"`
@@ -444,6 +459,37 @@ type Trace struct {
 
 // TraceStatus defines model for Trace.Status.
 type TraceStatus string
+
+// TraceDetail defines model for TraceDetail.
+type TraceDetail struct {
+	EndedAt     *time.Time `json:"ended_at,omitempty"`
+	Environment *string    `json:"environment,omitempty"`
+
+	// ErrorCount Count of failed spans in this trace
+	ErrorCount *int               `json:"error_count,omitempty"`
+	Id         openapi_types.UUID `json:"id"`
+
+	// Input Trace input payload (any valid JSON)
+	Input    interface{}             `json:"input,omitempty"`
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Name     string                  `json:"name"`
+
+	// Output Trace output payload (any valid JSON)
+	Output         interface{}         `json:"output,omitempty"`
+	Release        *string             `json:"release,omitempty"`
+	SessionId      *openapi_types.UUID `json:"session_id,omitempty"`
+	StartedAt      time.Time           `json:"started_at"`
+	Status         TraceDetailStatus   `json:"status"`
+	Tags           *[]string           `json:"tags,omitempty"`
+	TotalCostUsd   *float32            `json:"total_cost_usd,omitempty"`
+	TotalTokensIn  *int                `json:"total_tokens_in,omitempty"`
+	TotalTokensOut *int                `json:"total_tokens_out,omitempty"`
+	TraceId        *string             `json:"trace_id,omitempty"`
+	UserId         *string             `json:"user_id,omitempty"`
+}
+
+// TraceDetailStatus defines model for TraceDetail.Status.
+type TraceDetailStatus string
 
 // TraceList defines model for TraceList.
 type TraceList struct {

--- a/internal/api/traces_handlers.go
+++ b/internal/api/traces_handlers.go
@@ -69,7 +69,7 @@ func (s *Server) GetTrace(w http.ResponseWriter, r *http.Request, id openapi_typ
 		return
 	}
 
-	resp := traceToAPI(&trace)
+	resp := traceDetailToAPI(&trace)
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/internal/api/traces_handlers_test.go
+++ b/internal/api/traces_handlers_test.go
@@ -266,6 +266,240 @@ func TestGetTraceEvents_ProjectScopingReturns404(t *testing.T) {
 	assert.Equal(t, "not_found", resp.Code)
 }
 
+func TestGetTrace_ReturnsTraceDetailFields(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	userID := "user@example.com"
+	environment := "production"
+	release := "v1.2.3"
+	start := time.Date(2026, 3, 7, 14, 0, 0, 0, time.UTC)
+	end := start.Add(90 * time.Second)
+
+	trace := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID:   projectID,
+		TraceID:     "external-trace-123",
+		Name:        testutil.StrPtr("Debugger Detail Trace"),
+		UserID:      &userID,
+		Tags:        []string{"prod", "v2"},
+		Environment: &environment,
+		Release:     &release,
+		Input:       []byte(`{"prompt":"hello"}`),
+		Output:      []byte(`["done",false]`),
+		Status:      "completed",
+		StartTime:   testutil.PgtypeTimestamptz(start),
+		EndTime:     testutil.PgtypeTimestamptz(end),
+	})
+
+	rec := invokeGetTrace(t, server, projectID, trace.ID)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[TraceDetail](t, rec)
+	require.NotNil(t, resp.TraceId)
+	assert.Equal(t, "external-trace-123", *resp.TraceId)
+	require.NotNil(t, resp.UserId)
+	assert.Equal(t, userID, *resp.UserId)
+	require.NotNil(t, resp.Tags)
+	assert.Equal(t, []string{"prod", "v2"}, *resp.Tags)
+	require.NotNil(t, resp.Environment)
+	assert.Equal(t, environment, *resp.Environment)
+	require.NotNil(t, resp.Release)
+	assert.Equal(t, release, *resp.Release)
+	assertJSONValue(t, resp.Input, `{"prompt":"hello"}`)
+	assertJSONValue(t, resp.Output, `["done",false]`)
+}
+
+func TestGetTrace_JSONIsFlat(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	trace := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "flat-trace-123",
+		Name:      testutil.StrPtr("Flat Trace"),
+		Status:    "running",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 7, 15, 0, 0, 0, time.UTC)),
+	})
+
+	rec := invokeGetTrace(t, server, projectID, trace.ID)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	assert.Contains(t, body, "id")
+	assert.Contains(t, body, "trace_id")
+	assert.NotContains(t, body, "trace")
+}
+
+func TestListSpansByTrace_ReturnsLLMContextAndTruncationFields(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	trace := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "span-trace-123",
+		Name:      testutil.StrPtr("Span Trace"),
+		Status:    "running",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 7, 16, 0, 0, 0, time.UTC)),
+	})
+
+	model := "gpt-4o"
+	provider := "openai"
+	inputTruncated := true
+	outputTruncated := true
+	inputSize := int64(524288)
+	outputSize := int64(1048576)
+	reason := "size_limit"
+
+	upsertSpanRecord(ctx, t, q, platform.UpsertSpanParams{
+		ProjectID:               projectID,
+		TraceID:                 trace.ID,
+		SpanID:                  "llm-span-1",
+		Name:                    "LLM Span",
+		Type:                    "llm",
+		Status:                  "completed",
+		Level:                   "default",
+		StartTime:               time.Date(2026, 3, 7, 16, 0, 1, 0, time.UTC),
+		EndTime:                 testutil.PgtypeTimestamptz(time.Date(2026, 3, 7, 16, 0, 2, 0, time.UTC)),
+		Model:                   &model,
+		Provider:                &provider,
+		InputTruncated:          &inputTruncated,
+		InputOriginalSizeBytes:  &inputSize,
+		InputTruncationReason:   &reason,
+		OutputTruncated:         &outputTruncated,
+		OutputOriginalSizeBytes: &outputSize,
+		OutputTruncationReason:  &reason,
+		TotalCost:               testutil.PgtypeNumericFromFloat64(0),
+	})
+
+	rec := invokeListSpansByTrace(t, server, projectID, trace.ID)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[SpanList](t, rec)
+	require.Len(t, resp.Spans, 1)
+
+	span := resp.Spans[0]
+	require.NotNil(t, span.Model)
+	assert.Equal(t, model, *span.Model)
+	require.NotNil(t, span.Provider)
+	assert.Equal(t, provider, *span.Provider)
+	require.NotNil(t, span.InputTruncated)
+	assert.True(t, *span.InputTruncated)
+	require.NotNil(t, span.InputOriginalSizeBytes)
+	assert.Equal(t, inputSize, *span.InputOriginalSizeBytes)
+	require.NotNil(t, span.InputTruncationReason)
+	assert.Equal(t, reason, *span.InputTruncationReason)
+	require.NotNil(t, span.OutputTruncated)
+	assert.True(t, *span.OutputTruncated)
+	require.NotNil(t, span.OutputOriginalSizeBytes)
+	assert.Equal(t, outputSize, *span.OutputOriginalSizeBytes)
+	require.NotNil(t, span.OutputTruncationReason)
+	assert.Equal(t, reason, *span.OutputTruncationReason)
+}
+
+func TestListTraces_OmitsDetailFields(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	userID := "user@example.com"
+	environment := "production"
+	release := "v1.2.3"
+
+	upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID:   projectID,
+		TraceID:     "summary-trace-123",
+		Name:        testutil.StrPtr("Summary Trace"),
+		UserID:      &userID,
+		Tags:        []string{"prod"},
+		Environment: &environment,
+		Release:     &release,
+		Input:       []byte(`{"prompt":"hello"}`),
+		Output:      []byte(`{"result":"ok"}`),
+		Status:      "completed",
+		StartTime:   testutil.PgtypeTimestamptz(time.Date(2026, 3, 7, 17, 0, 0, 0, time.UTC)),
+	})
+
+	rec := invokeListTraces(t, server, projectID, ListTracesParams{})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Traces []map[string]json.RawMessage `json:"traces"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Traces, 1)
+
+	for _, key := range []string{"trace_id", "user_id", "tags", "environment", "release", "input", "output"} {
+		assert.NotContains(t, body.Traces[0], key)
+	}
+}
+
+func TestGetTrace_ProjectScopingReturns404(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectAID := testutil.CreateTestProject(t, ctx, q)
+	projectBID := testutil.CreateTestProject(t, ctx, q)
+
+	trace := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectBID,
+		TraceID:   "scoped-trace-123",
+		Name:      testutil.StrPtr("Scoped Trace"),
+		Status:    "running",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 7, 18, 0, 0, 0, time.UTC)),
+	})
+
+	rec := invokeGetTrace(t, server, projectAID, trace.ID)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	resp := decodeJSONBody[Error](t, rec)
+	assert.Equal(t, "not_found", resp.Code)
+}
+
+func TestListSpansByTrace_ProjectScopingReturns404(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectAID := testutil.CreateTestProject(t, ctx, q)
+	projectBID := testutil.CreateTestProject(t, ctx, q)
+
+	trace := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectBID,
+		TraceID:   "scoped-span-trace-123",
+		Name:      testutil.StrPtr("Scoped Span Trace"),
+		Status:    "running",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 7, 19, 0, 0, 0, time.UTC)),
+	})
+
+	rec := invokeListSpansByTrace(t, server, projectAID, trace.ID)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	resp := decodeJSONBody[Error](t, rec)
+	assert.Equal(t, "not_found", resp.Code)
+}
+
 func invokeGetTraceEvents(t *testing.T, server *Server, projectID, traceID uuid.UUID, params GetTraceEventsParams) *httptest.ResponseRecorder {
 	t.Helper()
 
@@ -274,6 +508,42 @@ func invokeGetTraceEvents(t *testing.T, server *Server, projectID, traceID uuid.
 	rec := httptest.NewRecorder()
 
 	server.GetTraceEvents(rec, req.WithContext(ctx), traceID, params)
+
+	return rec
+}
+
+func invokeGetTrace(t *testing.T, server *Server, projectID, traceID uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/traces/"+traceID.String(), nil)
+	ctx := context.WithValue(req.Context(), middleware.ProjectIDKey, projectID)
+	rec := httptest.NewRecorder()
+
+	server.GetTrace(rec, req.WithContext(ctx), traceID)
+
+	return rec
+}
+
+func invokeListSpansByTrace(t *testing.T, server *Server, projectID, traceID uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/traces/"+traceID.String()+"/spans", nil)
+	ctx := context.WithValue(req.Context(), middleware.ProjectIDKey, projectID)
+	rec := httptest.NewRecorder()
+
+	server.ListSpansByTrace(rec, req.WithContext(ctx), traceID)
+
+	return rec
+}
+
+func invokeListTraces(t *testing.T, server *Server, projectID uuid.UUID, params ListTracesParams) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/traces", nil)
+	ctx := context.WithValue(req.Context(), middleware.ProjectIDKey, projectID)
+	rec := httptest.NewRecorder()
+
+	server.ListTraces(rec, req.WithContext(ctx), params)
 
 	return rec
 }
@@ -297,6 +567,20 @@ func createTimelineTrace(
 		StartTime: testutil.PgtypeTimestamptz(start),
 		EndTime:   testutil.PgtypeTimestamptzPtr(end),
 	})
+	require.NoError(t, err)
+
+	return trace
+}
+
+func upsertTraceRecord(
+	ctx context.Context,
+	t *testing.T,
+	q *platform.Queries,
+	params platform.UpsertTraceParams,
+) platform.Trace {
+	t.Helper()
+
+	trace, err := q.UpsertTrace(ctx, params)
 	require.NoError(t, err)
 
 	return trace
@@ -328,6 +612,20 @@ func createTimelineSpan(
 		EndTime:   testutil.PgtypeTimestamptzPtr(end),
 		TotalCost: testutil.PgtypeNumericFromFloat64(0),
 	})
+	require.NoError(t, err)
+
+	return span
+}
+
+func upsertSpanRecord(
+	ctx context.Context,
+	t *testing.T,
+	q *platform.Queries,
+	params platform.UpsertSpanParams,
+) platform.Span {
+	t.Helper()
+
+	span, err := q.UpsertSpan(ctx, params)
 	require.NoError(t, err)
 
 	return span

--- a/openspec/changes/add-debugger-data-surface/design.md
+++ b/openspec/changes/add-debugger-data-surface/design.md
@@ -1,0 +1,88 @@
+## Context
+
+Phase 5 extends the debugger data surface — the fields returned by trace and span API endpoints — without changing ingestion, migrations, or SQL queries. The goal is to expose data already stored in the database so the web UI can render richer trace context and LLM-specific span information.
+
+### Current State
+
+- `GET /api/traces/{id}` returns `Trace` (summary): id, session_id, name, status, started_at, ended_at, total_tokens_in/out, total_cost_usd, error_count, metadata
+- `GET /api/traces/{id}/spans` returns `Span`: id, trace_id, span_id, parent_span_id, name, kind, status, started_at, ended_at, tokens_in/out, cost_usd, latency_ms, error_message, input, output, metadata
+- Database `traces` table has: trace_id, user_id, tags, environment, release, input, output — all unmapped
+- Database `spans` table has: model, provider, input_truncated, input_original_size_bytes, input_truncation_reason, output_truncated, output_original_size_bytes, output_truncation_reason — all unmapped
+- Web UI has no Trace Context section and no LLM Context block
+
+### Constraints
+
+- Contract-first: OpenAPI changes before implementation
+- No new SQL queries, migrations, or store methods
+- Generated code via `make generate`
+- `Trace` summary schema must not grow (used by list endpoints)
+- Web client types are handwritten (not generated) for this phase
+
+## Goals / Non-Goals
+
+**Goals**
+- Expose trace identity/context fields via a `TraceDetail` schema on `GET /api/traces/{id}`
+- Expose span LLM metadata (model, provider) and truncation fields on `GET /api/traces/{id}/spans`
+- Add Trace Context section to the trace detail page
+- Add LLM Context block to span detail panel
+- Introduce `JsonValue` type for arbitrary JSON in frontend
+
+**Non-Goals**
+- Trace search or filter UI changes
+- Truncation badges or indicators in the UI
+- `duration_ms` or `total_spans` on traces (deferred)
+- Session external_id resolution or display
+- `thinking` field exposure
+- Replay or export fields
+
+## Decisions
+
+### Decision 1: allOf Composition for TraceDetail
+
+**What:** Define `TraceDetail` using OpenAPI `allOf` referencing `Trace` as base, plus an inline object with the additional properties.
+
+**Why:** oapi-codegen generates an embedded `Trace` struct inside `TraceDetail`, producing flat JSON serialization. This avoids duplicating summary fields and keeps the `Trace` schema as the single source of truth for summary data.
+
+**Alternative considered:** Separate `TraceDetail` schema duplicating all `Trace` fields. Rejected because it creates drift risk and violates DRY.
+
+### Decision 2: Untyped Input/Output
+
+**What:** Trace and span `input`/`output` fields have no `type` constraint in OpenAPI 3.1. Go maps to `interface{}`, TypeScript to a `JsonValue` union.
+
+**Why:** These fields can be any valid JSON — arrays, scalars, objects, `null`, `false`, `0`, empty strings. Adding `type: object` would reject valid payloads.
+
+**Go mapping:** `json.Unmarshal(bytes, &interface{})` preserves the original JSON structure. Presence is determined by `len(bytes) > 0`, not truthiness of the unmarshalled value.
+
+**TypeScript mapping:** `JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue }`. Presence checks use `!== undefined`, not `!!value`.
+
+### Decision 3: Tags Empty-Slice Guard
+
+**What:** Only assign `tags` to `TraceDetail` when `len(t.Tags) > 0`.
+
+**Why:** PostgreSQL returns empty text arrays as `[]string{}` (non-nil empty slice), not `nil`. Without the guard, the API would serialize `"tags": []` for traces with no tags. The API contract says tags is optional — omission is cleaner than an empty array.
+
+### Decision 4: Trace Detail Mapper Composition
+
+**What:** `traceDetailToAPI()` calls `traceToAPI()` for summary fields, then constructs the generated `TraceDetail` type embedding the summary and setting detail fields.
+
+**Why:** Reuses existing mapper logic. If `traceToAPI()` gains new summary fields, `traceDetailToAPI()` inherits them automatically.
+
+### Decision 5: Span Truncation — API-Only, No UI
+
+**What:** Six truncation fields are added to the `Span` schema and mapped in Go, but not rendered in the web UI.
+
+**Truncation boolean contract:** `input_truncated` and `output_truncated` are always present in the API response (including `false`) because the ingest processor always writes explicit boolean values to the database (`processor.go:322-323`). This lets clients distinguish "payload confirmed complete" (`false`) from "field unavailable / legacy row" (`absent`). Only `*_original_size_bytes` and `*_truncation_reason` remain optional (nil when not truncated).
+
+**Why:** Truncation badges and indicators are a separate UX concern. Making the data available now unblocks future UI work without coupling it to this phase.
+
+## Risks / Trade-offs
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| oapi-codegen allOf produces unexpected struct shape | Mapper won't compile or JSON nests incorrectly | Test asserting flat JSON structure |
+| `interface{}` unmarshal loses type fidelity for large numbers | Extremely large integers may become float64 | Acceptable for observability payloads; not a precision-critical path |
+| Tags empty-array leak | `"tags": []` in response for no-tag traces | `len(t.Tags) > 0` guard |
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-debugger-data-surface/proposal.md
+++ b/openspec/changes/add-debugger-data-surface/proposal.md
@@ -1,0 +1,78 @@
+# Change: Add Debugger Data Surface Foundation
+
+## Why
+
+The API exposes only summary trace data (name, status, tokens, cost). Seven fields already stored in the database — `trace_id`, `user_id`, `tags`, `environment`, `release`, `input`, `output` — are invisible to debugger users. Similarly, span responses omit `model`, `provider`, and all truncation metadata. Surfacing these fields is a prerequisite for trace context, LLM-specific debugging, and the future replay engine.
+
+## What Changes
+
+### Capabilities
+
+| Capability | Type | Description |
+|------------|------|-------------|
+| **trace-detail-api** | NEW | `TraceDetail` schema via `allOf` composition on `Trace`, returned by `GET /api/traces/{id}` only. Adds `trace_id`, `user_id`, `tags`, `environment`, `release`, `input`, `output`. |
+| **span-llm-context** | NEW | Extend `Span` schema with optional `model`, `provider`, and six truncation fields. Map from existing DB columns. |
+| **web-debugger-ui** | NEW | Trace Context section on detail page, LLM Context block in span detail, `TraceDetail` client type, `JsonValue` type for arbitrary JSON. |
+
+### Key Design Decisions
+
+1. **Summary/Detail split**: `Trace` stays lightweight for list endpoints. `TraceDetail` extends it via `allOf` for `GET /api/traces/{id}` only.
+2. **allOf composition**: `TraceDetail` uses OpenAPI `allOf` referencing `Trace` so oapi-codegen embeds the base struct — flat JSON, not nested.
+3. **Untyped input/output**: Trace and span `input`/`output` remain schema-less in OpenAPI 3.1 (any valid JSON). Go maps to `interface{}`, TypeScript to `JsonValue`.
+4. **Tags empty-slice safety**: Map `tags` only when `len(t.Tags) > 0` because Postgres returns `[]string{}` for empty arrays, not `nil`.
+5. **No new SQL**: All needed columns are already selected by existing queries.
+6. **Truncation data available, not displayed**: Truncation fields are in API responses and client types but not rendered in UI yet.
+7. **Truncation booleans always present**: `input_truncated` and `output_truncated` are always serialized (including `false`) because the ingest processor always writes explicit values. Only size and reason are optional.
+
+### Breaking Changes
+
+None. All changes are additive:
+- `GET /api/traces/{id}` returns a superset of the current `Trace`.
+- `Span` gains optional fields that were previously omitted.
+
+## Impact
+
+### Affected Specs
+
+- `trace-detail-api` (new)
+- `span-llm-context` (new)
+- `web-debugger-ui` (new)
+
+### Affected Code
+
+| Path | Change |
+|------|--------|
+| `contracts/openapi/openapi.yaml` | ADD: `TraceDetail` schema with `allOf`, extend `Span` with 8 optional fields, update `GET /api/traces/{id}` response ref |
+| `internal/api/mapper.go` | ADD: `traceDetailToAPI()` mapper; MODIFY: `spanToAPI()` to include model/provider/truncation |
+| `internal/api/traces_handlers.go` | MODIFY: `GetTrace` handler to use detail mapper and return `TraceDetail` |
+| `web/src/api/client.ts` | ADD: `TraceDetail`, `JsonValue` types; MODIFY: `fetchTrace` return type |
+| `web/src/pages/TraceDetailPage.tsx` | ADD: Trace Context section |
+| `web/src/components/SpanDetail.tsx` | ADD: LLM Context block |
+
+### Database Changes
+
+None. No migrations, no new queries.
+
+### OpenAPI Changes
+
+- ADD: `TraceDetail` schema (`allOf` on `Trace` + detail fields)
+- MODIFY: `GET /api/traces/{id}` response → `TraceDetail`
+- MODIFY: `Span` schema → add `model`, `provider`, 6 truncation fields
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| oapi-codegen `allOf` produces nested struct instead of flat | Add test asserting JSON response has no nested `trace` key |
+| Falsy JSON values (`false`, `0`, `""`, `null`) dropped by mapper | Use `interface{}` unmarshal + explicit presence checks in Go and TypeScript |
+| Tags serialized as `[]` instead of omitted | Guard with `len(t.Tags) > 0` before assignment |
+
+## Dependencies
+
+None. No new Go or JS dependencies.
+
+## Related Documents
+
+- Design: [design.md](./design.md)
+- Tasks: [tasks.md](./tasks.md)
+- Spec Deltas: [specs/](./specs/)

--- a/openspec/changes/add-debugger-data-surface/specs/span-llm-context/spec.md
+++ b/openspec/changes/add-debugger-data-surface/specs/span-llm-context/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Span LLM Metadata Fields
+
+The `Span` API schema SHALL include optional `model` and `provider` fields for LLM spans.
+
+#### Scenario: Model mapped from database
+- **WHEN** a span has `Model = "gpt-4o"` in the database
+- **THEN** `model` in the API response is `"gpt-4o"`
+
+#### Scenario: Provider mapped from database
+- **WHEN** a span has `Provider = "openai"` in the database
+- **THEN** `provider` in the API response is `"openai"`
+
+#### Scenario: Model and provider absent for non-LLM spans
+- **WHEN** a span has nil `Model` and nil `Provider` in the database
+- **THEN** `model` and `provider` are absent from the API response
+
+### Requirement: Span Truncation Metadata Fields
+
+The `Span` API schema SHALL include truncation fields to indicate payload truncation status. The boolean flags (`input_truncated`, `output_truncated`) SHALL always be present when the ingest processor has written them, including `false`. Size and reason fields are optional and present only when truncation occurred.
+
+#### Scenario: Input truncation fields mapped when truncated
+- **WHEN** a span has `InputTruncated = true`, `InputOriginalSizeBytes = 524288`, `InputTruncationReason = "size_limit"` in the database
+- **THEN** the API response includes `input_truncated: true`, `input_original_size_bytes: 524288`, `input_truncation_reason: "size_limit"`
+
+#### Scenario: Output truncation fields mapped when truncated
+- **WHEN** a span has `OutputTruncated = true`, `OutputOriginalSizeBytes = 1048576`, `OutputTruncationReason = "size_limit"` in the database
+- **THEN** the API response includes `output_truncated: true`, `output_original_size_bytes: 1048576`, `output_truncation_reason: "size_limit"`
+
+#### Scenario: Truncation booleans present when not truncated
+- **WHEN** a span has `InputTruncated = false` and `OutputTruncated = false` in the database
+- **THEN** `input_truncated: false` and `output_truncated: false` are present in the API response
+- **AND** `input_original_size_bytes`, `input_truncation_reason`, `output_original_size_bytes`, `output_truncation_reason` are absent
+
+#### Scenario: Truncation fields absent for legacy rows
+- **WHEN** a span has nil `InputTruncated` and nil `OutputTruncated` in the database (legacy row)
+- **THEN** all six truncation fields are absent from the API response
+
+#### Scenario: Truncation fields in spans-by-trace response
+- **WHEN** `GET /api/traces/{id}/spans` is called
+- **THEN** each span includes truncation fields according to the rules above

--- a/openspec/changes/add-debugger-data-surface/specs/trace-detail-api/spec.md
+++ b/openspec/changes/add-debugger-data-surface/specs/trace-detail-api/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: TraceDetail Schema
+
+The API SHALL define a `TraceDetail` schema using `allOf` composition on `Trace` that exposes additional trace context fields on `GET /api/traces/{id}`.
+
+#### Scenario: TraceDetail extends Trace via allOf
+- **WHEN** `TraceDetail` is defined in OpenAPI
+- **THEN** it uses `allOf` referencing `Trace` as the base schema
+- **AND** adds `trace_id`, `user_id`, `tags`, `environment`, `release`, `input`, `output` as optional properties
+
+#### Scenario: GetTrace returns TraceDetail
+- **WHEN** `GET /api/traces/{id}` is called
+- **THEN** the response body conforms to `TraceDetail`
+- **AND** includes all `Trace` summary fields plus detail fields
+
+#### Scenario: TraceDetail JSON is flat
+- **WHEN** `GET /api/traces/{id}` returns JSON
+- **THEN** summary fields and detail fields appear at the same level
+- **AND** there is no nested `trace` object introduced by allOf serialization
+
+#### Scenario: ListTraces still returns Trace summary
+- **WHEN** `GET /api/traces` is called
+- **THEN** each item in the response uses the `Trace` summary schema
+- **AND** detail-only fields (`trace_id`, `user_id`, `tags`, `environment`, `release`, `input`, `output`) are absent
+
+### Requirement: TraceDetail Field Mapping
+
+The `traceDetailToAPI()` mapper SHALL populate all detail fields from the existing database row.
+
+#### Scenario: External trace_id mapped
+- **WHEN** a trace has `TraceID = "abc-123"` in the database
+- **THEN** `trace_id` in the API response is `"abc-123"`
+
+#### Scenario: User ID mapped
+- **WHEN** a trace has `UserID = "user@example.com"` in the database
+- **THEN** `user_id` in the API response is `"user@example.com"`
+
+#### Scenario: Tags mapped when non-empty
+- **WHEN** a trace has `Tags = ["prod", "v2"]` in the database
+- **THEN** `tags` in the API response is `["prod", "v2"]`
+
+#### Scenario: Tags omitted when empty
+- **WHEN** a trace has `Tags = []` (Postgres empty array) in the database
+- **THEN** `tags` is absent from the API response (not serialized as `[]`)
+
+#### Scenario: Environment and release mapped
+- **WHEN** a trace has `Environment = "production"` and `Release = "v1.2.0"`
+- **THEN** `environment` is `"production"` and `release` is `"v1.2.0"` in the API response
+
+#### Scenario: Trace input preserves arbitrary JSON
+- **WHEN** a trace has `Input` containing `[1, "hello", false, null]` as JSON bytes
+- **THEN** `input` in the API response is `[1, "hello", false, null]`
+
+#### Scenario: Trace output preserves falsy values
+- **WHEN** a trace has `Output` containing `0` as JSON bytes
+- **THEN** `output` in the API response is `0` (not omitted)
+
+#### Scenario: Trace input/output absent when empty
+- **WHEN** a trace has empty `Input` and `Output` bytes in the database
+- **THEN** `input` and `output` are absent from the API response
+
+### Requirement: TraceDetail Mapper Composition
+
+The `traceDetailToAPI()` mapper SHALL compose the existing `traceToAPI()` output.
+
+#### Scenario: Summary fields inherited
+- **WHEN** `traceDetailToAPI()` is called
+- **THEN** all fields produced by `traceToAPI()` are present in the result
+- **AND** no summary field mapping logic is duplicated

--- a/openspec/changes/add-debugger-data-surface/specs/web-debugger-ui/spec.md
+++ b/openspec/changes/add-debugger-data-surface/specs/web-debugger-ui/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: Trace Context Section
+
+The trace detail page SHALL display a Trace Context section with identity and environment fields.
+
+#### Scenario: Context section rendered above spans
+- **WHEN** a trace detail page is loaded
+- **THEN** a full-width Trace Context section appears above the spans/detail split
+
+#### Scenario: Internal and external IDs displayed
+- **WHEN** a trace has both internal UUID and external `trace_id`
+- **THEN** both are displayed, with the external ID labeled "External Trace ID"
+
+#### Scenario: Session ID links to session page
+- **WHEN** a trace has a `session_id`
+- **THEN** it is rendered as a clickable link to `/sessions/{id}`
+
+#### Scenario: Tags rendered as chips
+- **WHEN** a trace has `tags: ["prod", "v2"]`
+- **THEN** tags are rendered as chip/badge elements
+
+#### Scenario: Tags show dash when absent
+- **WHEN** a trace has no tags
+- **THEN** a `-` placeholder is displayed
+
+#### Scenario: Environment and release displayed
+- **WHEN** a trace has `environment` and/or `release`
+- **THEN** they are displayed as labeled rows in the context section
+
+#### Scenario: User ID displayed
+- **WHEN** a trace has `user_id`
+- **THEN** it is displayed as a labeled row in the context section
+
+#### Scenario: Missing context values show dash
+- **WHEN** any context field (`user_id`, `environment`, `release`, `trace_id`) is absent
+- **THEN** the row is still rendered with `-` as the value (rows are never hidden)
+
+### Requirement: Trace Input/Output Display
+
+The trace detail page SHALL render trace-level input and output payloads.
+
+#### Scenario: Input rendered when present
+- **WHEN** a trace has `input !== undefined`
+- **THEN** it is rendered in a `JsonViewer` panel labeled "Input"
+
+#### Scenario: Output rendered when present
+- **WHEN** a trace has `output !== undefined`
+- **THEN** it is rendered in a `JsonViewer` panel labeled "Output"
+
+#### Scenario: Falsy values not suppressed
+- **WHEN** a trace has `input = 0` or `input = false` or `input = null`
+- **THEN** the input panel is still rendered (presence check, not truthiness)
+
+### Requirement: LLM Context Block in Span Detail
+
+The span detail panel SHALL show model and provider for LLM spans.
+
+#### Scenario: LLM Context shown for LLM spans
+- **WHEN** the selected span has `kind === 'LLM'` and at least one of `model` or `provider` is present
+- **THEN** an "LLM Context" block is rendered above the Input section
+
+#### Scenario: Model and provider displayed
+- **WHEN** an LLM span has `model = "gpt-4o"` and `provider = "openai"`
+- **THEN** both are displayed as labeled rows
+
+#### Scenario: Missing model or provider shows dash
+- **WHEN** an LLM span has `model` but not `provider` (or vice versa)
+- **THEN** the present field is displayed and the missing field shows `-`
+
+#### Scenario: LLM Context hidden for non-LLM spans
+- **WHEN** the selected span has `kind !== 'LLM'`
+- **THEN** no LLM Context block is rendered
+
+#### Scenario: LLM Context hidden when no model or provider
+- **WHEN** the selected span has `kind === 'LLM'` but both `model` and `provider` are undefined
+- **THEN** no LLM Context block is rendered
+
+### Requirement: TraceDetail Client Type
+
+The web client SHALL define a `TraceDetail` type extending `Trace` for detail page use.
+
+#### Scenario: TraceDetail extends Trace
+- **WHEN** `TraceDetail` is defined in `client.ts`
+- **THEN** it extends the `Trace` interface with `trace_id`, `user_id`, `tags`, `environment`, `release`, `input`, `output`
+
+#### Scenario: fetchTrace returns TraceDetail
+- **WHEN** `fetchTrace(id)` is called
+- **THEN** it returns `TraceDetail`
+
+#### Scenario: List functions return Trace
+- **WHEN** `fetchTraces` or `fetchTracesBySession` is called
+- **THEN** they return `Trace` (not `TraceDetail`)
+
+### Requirement: JsonValue Type
+
+The web client SHALL define a `JsonValue` type for arbitrary JSON values.
+
+#### Scenario: JsonValue covers all JSON types
+- **WHEN** `JsonValue` is defined
+- **THEN** it is a union of `string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue }`
+
+#### Scenario: JsonValue used for input/output
+- **WHEN** `Span.input`, `Span.output`, `TraceDetail.input`, `TraceDetail.output` are typed
+- **THEN** they use `JsonValue` (or `JsonValue | undefined` for optional)

--- a/openspec/changes/add-debugger-data-surface/tasks.md
+++ b/openspec/changes/add-debugger-data-surface/tasks.md
@@ -1,0 +1,70 @@
+## 1. Contract Changes
+
+- [x] 1.1 Add `TraceDetail` schema to `contracts/openapi/openapi.yaml` using `allOf` on `Trace` with additional properties: `trace_id` (string), `user_id` (string), `tags` (array of string), `environment` (string), `release` (string), `input` (any JSON), `output` (any JSON)
+- [x] 1.2 Update `GET /api/traces/{id}` response to reference `TraceDetail` instead of `Trace`
+- [x] 1.3 Extend `Span` schema with optional `model` (string), `provider` (string), `input_truncated` (boolean — always present when known), `input_original_size_bytes` (integer), `input_truncation_reason` (string), `output_truncated` (boolean — always present when known), `output_original_size_bytes` (integer), `output_truncation_reason` (string)
+- [ ] 1.4 Run `make generate` and verify generated Go types compile; confirm `TraceDetail` embeds `Trace`
+
+Note: `make generate` and `go build ./...` succeeded, but the current `oapi-codegen` output flattened `TraceDetail` instead of embedding `Trace`. Flat JSON is still preserved and covered by handler tests.
+
+**Validation:** `make generate` succeeds, `go build ./...` passes
+
+## 2. Backend Mapper Updates
+
+- [x] 2.1 Add `traceDetailToAPI()` in `internal/api/mapper.go`: compose `traceToAPI()` output into generated `TraceDetail`, then set `trace_id` (from `t.TraceID`), `user_id`, `tags` (only when `len > 0`), `environment`, `release`, `input`, `output`
+- [x] 2.2 Map trace `input` and `output` via `json.Unmarshal` into `interface{}`, guarded by `len(bytes) > 0`
+- [x] 2.3 Extend `spanToAPI()` to map `model`, `provider`, and all six truncation fields from `platform.Span`. Map `input_truncated` and `output_truncated` unconditionally (always present, including `false`). Map size and reason only when non-nil.
+- [x] 2.4 Update `GetTrace` handler in `internal/api/traces_handlers.go` to call `traceDetailToAPI()` and return the `TraceDetail` response
+
+**Validation:** `go build ./...` passes, `go vet ./...` clean
+
+## 3. Backend Tests
+
+- [x] 3.1 Add mapper test for `traceDetailToAPI()`: verify `trace_id`, `user_id`, `environment`, `release` mapping
+- [x] 3.2 Add mapper test: tags omitted when DB returns empty slice; tags present when DB returns non-empty slice
+- [x] 3.3 Add mapper test: trace `input`/`output` with arbitrary JSON including falsy values (`false`, `0`, `""`, `null`, `[]`, `{}`)
+- [x] 3.4 Add mapper test for span: `model`, `provider`, and all truncation fields mapped correctly; assert `input_truncated: false` is present (not absent) when payload is not truncated
+- [x] 3.5 Add handler test for `GET /api/traces/{id}`: insert trace with detail fields, assert response includes them
+- [x] 3.6 Add handler test: assert `GET /api/traces/{id}` JSON is flat (no nested `trace` object from allOf)
+- [x] 3.7 Add handler test for `GET /api/traces/{id}/spans`: insert LLM span with model/provider/truncation, assert fields returned
+- [x] 3.8 Add handler test for `GET /api/traces`: assert detail-only fields (`trace_id`, `user_id`, `tags`, `environment`, `release`, `input`, `output`) are absent from list response
+- [x] 3.9 Add project-scoping 404 tests for `GetTrace` and `ListSpansByTrace` (these do not exist yet in `traces_handlers_test.go`)
+
+**Validation:** `go test ./internal/api/...` passes
+
+## 4. Web Client Types
+
+- [x] 4.1 Add `JsonValue` type to `web/src/api/client.ts`: `string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue }`
+- [x] 4.2 Add `TraceDetail` interface extending `Trace` with `trace_id`, `user_id`, `tags`, `environment`, `release`, `input` (`JsonValue`), `output` (`JsonValue`)
+- [x] 4.3 Update `Span` interface to include optional `model`, `provider`, `input_truncated`, `input_original_size_bytes`, `input_truncation_reason`, `output_truncated`, `output_original_size_bytes`, `output_truncation_reason`
+- [x] 4.4 Update `fetchTrace` return type from `Trace` to `TraceDetail`; leave `fetchTraces` and `fetchTracesBySession` on `Trace`
+- [x] 4.5 Update `Span.input` and `Span.output` typing to `JsonValue` (from current implicit any)
+
+**Validation:** `make type-check` passes
+
+## 5. Trace Detail Page — Trace Context Section
+
+- [x] 5.1 Add full-width Trace Context section to `TraceDetailPage.tsx` above the spans/detail split
+- [x] 5.2 Render rows: internal trace UUID (labeled "ID"), external `trace_id` (labeled "External Trace ID"), session UUID (link to `/sessions/{id}` when present), user ID, environment, release. Show `-` for any missing value (do not hide the row).
+- [x] 5.3 Render tags as chips when present, `-` when absent
+- [x] 5.4 Render trace `input` and `output` in separate `JsonViewer` panels using presence checks (`!== undefined`), not truthiness
+
+**Validation:** `make type-check` passes; visual review in browser
+
+## 6. Span Detail — LLM Context Block
+
+- [x] 6.1 Add LLM Context block to `SpanDetail.tsx` above the Input section
+- [x] 6.2 Render only when `span.kind === 'LLM'` and at least one of `model` or `provider` is present
+- [x] 6.3 Display model and provider as labeled rows; show `-` for whichever is missing
+
+**Validation:** `make type-check` passes; visual review in browser
+
+## 7. Final Validation
+
+- [x] 7.1 `make generate` — no drift
+- [x] 7.2 `go test ./internal/api/...` — mapper and handler tests pass
+- [x] 7.3 `make type-check` — no TypeScript errors
+- [ ] 7.4 `make lint` — no new warnings
+- [x] 7.5 `make test` — full test suite (if local Postgres available)
+
+Note: `make lint` is blocked in this environment because `golangci-lint` is not installed (`make: golangci-lint: No such file or directory`).

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -78,6 +78,14 @@ export async function fetchAPI<T>(
 /**
  * Trace types from the API.
  */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 export interface Trace {
   id: string;
   session_id?: string;
@@ -90,6 +98,16 @@ export interface Trace {
   total_cost_usd?: number;
   error_count?: number;
   metadata?: Record<string, unknown>;
+}
+
+export interface TraceDetail extends Trace {
+  trace_id?: string;
+  user_id?: string;
+  tags?: string[];
+  environment?: string;
+  release?: string;
+  input?: JsonValue;
+  output?: JsonValue;
 }
 
 export interface TraceList {
@@ -112,8 +130,16 @@ export interface Span {
   cost_usd?: number;
   latency_ms?: number;
   error_message?: string;
-  input?: Record<string, unknown>;
-  output?: Record<string, unknown>;
+  model?: string;
+  provider?: string;
+  input?: JsonValue;
+  input_truncated?: boolean;
+  input_original_size_bytes?: number;
+  input_truncation_reason?: string;
+  output?: JsonValue;
+  output_truncated?: boolean;
+  output_original_size_bytes?: number;
+  output_truncation_reason?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -179,8 +205,8 @@ export async function fetchTraces(limit = 20, offset = 0): Promise<TraceList> {
 /**
  * Fetch a single trace by ID.
  */
-export async function fetchTrace(id: string): Promise<Trace> {
-  return fetchAPI<Trace>(`/api/traces/${id}`);
+export async function fetchTrace(id: string): Promise<TraceDetail> {
+  return fetchAPI<TraceDetail>(`/api/traces/${id}`);
 }
 
 /**

--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import { Span } from '../api/client';
 import { StatusBadge } from './StatusBadge';
 import { JsonViewer } from './JsonViewer';
@@ -20,6 +21,9 @@ export function SpanDetail({ span }: SpanDetailProps) {
   }
 
   const totalTokens = (span.tokens_in ?? 0) + (span.tokens_out ?? 0);
+  const showLLMContext =
+    span.kind === 'LLM' &&
+    (span.model !== undefined || span.provider !== undefined);
 
   return (
     <div className="h-full overflow-y-auto p-4">
@@ -66,8 +70,19 @@ export function SpanDetail({ span }: SpanDetailProps) {
         </div>
       )}
 
+      {/* LLM context */}
+      {showLLMContext && (
+        <div className="mb-6">
+          <h3 className="mb-2 text-sm font-medium text-gray-700">LLM Context</h3>
+          <div className="rounded bg-gray-50 p-3 text-sm">
+            <DetailRow label="Model" value={span.model} />
+            <DetailRow label="Provider" value={span.provider} className="mt-1" />
+          </div>
+        </div>
+      )}
+
       {/* Input */}
-      {span.input && (
+      {span.input !== undefined && (
         <div className="mb-6">
           <h3 className="text-sm font-medium text-gray-700 mb-2">Input</h3>
           <JsonViewer data={span.input} />
@@ -75,7 +90,7 @@ export function SpanDetail({ span }: SpanDetailProps) {
       )}
 
       {/* Output */}
-      {span.output && (
+      {span.output !== undefined && (
         <div className="mb-6">
           <h3 className="text-sm font-medium text-gray-700 mb-2">Output</h3>
           <JsonViewer data={span.output} />
@@ -94,19 +109,15 @@ export function SpanDetail({ span }: SpanDetailProps) {
       <div className="mb-6">
         <h3 className="text-sm font-medium text-gray-700 mb-2">Identifiers</h3>
         <div className="bg-gray-50 rounded p-3 text-sm">
-          <div className="flex justify-between mb-1">
-            <span className="text-gray-600">Span ID:</span>
-            <span className="font-mono text-xs">{span.id}</span>
-          </div>
-          <div className="flex justify-between mb-1">
-            <span className="text-gray-600">Trace ID:</span>
-            <span className="font-mono text-xs">{span.trace_id}</span>
-          </div>
+          <DetailRow label="Span ID" value={span.id} mono />
+          <DetailRow label="Trace ID" value={span.trace_id} mono className="mt-1" />
           {span.parent_span_id && (
-            <div className="flex justify-between">
-              <span className="text-gray-600">Parent Span ID:</span>
-              <span className="font-mono text-xs">{span.parent_span_id}</span>
-            </div>
+            <DetailRow
+              label="Parent Span ID"
+              value={span.parent_span_id}
+              mono
+              className="mt-1"
+            />
           )}
         </div>
       </div>
@@ -115,19 +126,18 @@ export function SpanDetail({ span }: SpanDetailProps) {
       <div>
         <h3 className="text-sm font-medium text-gray-700 mb-2">Timestamps</h3>
         <div className="bg-gray-50 rounded p-3 text-sm">
-          <div className="flex justify-between mb-1">
-            <span className="text-gray-600">Started:</span>
-            <span className="font-mono text-xs">
-              {new Date(span.started_at).toISOString()}
-            </span>
-          </div>
+          <DetailRow
+            label="Started"
+            value={new Date(span.started_at).toISOString()}
+            mono
+          />
           {span.ended_at && (
-            <div className="flex justify-between">
-              <span className="text-gray-600">Ended:</span>
-              <span className="font-mono text-xs">
-                {new Date(span.ended_at).toISOString()}
-              </span>
-            </div>
+            <DetailRow
+              label="Ended"
+              value={new Date(span.ended_at).toISOString()}
+              mono
+              className="mt-1"
+            />
           )}
         </div>
       </div>
@@ -145,6 +155,30 @@ function MetricCard({ label, value }: MetricCardProps) {
     <div className="bg-gray-50 rounded p-3 text-center">
       <div className="text-xl font-semibold text-gray-900">{value}</div>
       <div className="text-xs text-gray-500 mt-1">{label}</div>
+    </div>
+  );
+}
+
+interface DetailRowProps {
+  label: string;
+  value?: ReactNode;
+  mono?: boolean;
+  className?: string;
+}
+
+function DetailRow({ label, value, mono = false, className = '' }: DetailRowProps) {
+  const hasValue = value !== undefined && value !== null && value !== '';
+
+  return (
+    <div className={`flex justify-between gap-4 ${className}`.trim()}>
+      <span className="text-gray-600">{label}:</span>
+      {hasValue ? (
+        <span className={mono ? 'font-mono text-xs text-right' : 'text-right'}>
+          {value}
+        </span>
+      ) : (
+        <span className="text-gray-400">-</span>
+      )}
     </div>
   );
 }

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
@@ -6,6 +6,7 @@ import {
   fetchTrace,
   Span,
 } from '../api/client';
+import { JsonViewer } from '../components/JsonViewer';
 import { SpanDetail } from '../components/SpanDetail';
 import { SpanTree } from '../components/SpanTree';
 import { StatusBadge } from '../components/StatusBadge';
@@ -148,6 +149,80 @@ function TraceDetailContent({
 
       <div className="flex-1 overflow-y-auto p-4">
         <div className="mx-auto flex max-w-7xl flex-col gap-4">
+          <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+            <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-gray-600">
+                Trace Context
+              </h2>
+            </div>
+            <div className="space-y-6 p-4">
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <TraceContextField
+                  label="ID"
+                  value={renderContextText(trace.id, true)}
+                />
+                <TraceContextField
+                  label="External Trace ID"
+                  value={renderContextText(trace.trace_id, true)}
+                />
+                <TraceContextField
+                  label="Session UUID"
+                  value={trace.session_id ? (
+                    <Link
+                      to={`/sessions/${trace.session_id}`}
+                      className="font-mono text-xs text-blue-600 hover:text-blue-800"
+                    >
+                      {trace.session_id}
+                    </Link>
+                  ) : (
+                    renderContextText(undefined)
+                  )}
+                />
+                <TraceContextField
+                  label="User ID"
+                  value={renderContextText(trace.user_id)}
+                />
+                <TraceContextField
+                  label="Environment"
+                  value={renderContextText(trace.environment)}
+                />
+                <TraceContextField
+                  label="Release"
+                  value={renderContextText(trace.release)}
+                />
+                <TraceContextField
+                  label="Tags"
+                  className="md:col-span-2 xl:col-span-3"
+                  value={trace.tags && trace.tags.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {trace.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-full border border-gray-200 bg-white px-3 py-1 font-mono text-xs text-gray-700"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    renderContextText(undefined)
+                  )}
+                />
+              </div>
+
+              {(trace.input !== undefined || trace.output !== undefined) && (
+                <div className="grid gap-4 xl:grid-cols-2">
+                  {trace.input !== undefined && (
+                    <TracePayloadPanel title="Input" data={trace.input} />
+                  )}
+                  {trace.output !== undefined && (
+                    <TracePayloadPanel title="Output" data={trace.output} />
+                  )}
+                </div>
+              )}
+            </div>
+          </section>
+
           <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
             <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
               <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
@@ -193,5 +268,43 @@ function TraceDetailContent({
         </div>
       </div>
     </div>
+  );
+}
+
+interface TraceContextFieldProps {
+  label: string;
+  value: ReactNode;
+  className?: string;
+}
+
+function TraceContextField({ label, value, className = '' }: TraceContextFieldProps) {
+  return (
+    <div className={`rounded-lg border border-gray-200 bg-gray-50 p-4 ${className}`.trim()}>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-500">
+        {label}
+      </div>
+      <div className="mt-2 text-sm text-gray-900">{value}</div>
+    </div>
+  );
+}
+
+function TracePayloadPanel({ title, data }: { title: string; data: unknown }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+      <h3 className="mb-2 text-sm font-medium text-gray-700">{title}</h3>
+      <JsonViewer data={data} className="max-h-80 overflow-y-auto bg-white" />
+    </div>
+  );
+}
+
+function renderContextText(value: string | undefined, monospace = false) {
+  if (value === undefined) {
+    return <span className="text-sm text-gray-400">-</span>;
+  }
+
+  return (
+    <span className={monospace ? 'font-mono text-xs text-gray-900' : 'text-sm text-gray-900'}>
+      {value}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary
- add TraceDetail to the trace detail API and keep trace list responses summary-only
- expose span LLM context and truncation metadata in the API and handwritten web client
- add Phase 5 OpenSpec change docs, mapper coverage, and trace detail / span detail UI updates

## Verification
- openspec validate add-debugger-data-surface --strict
- make generate
- go test ./internal/api/...
- make type-check
- make test

## Notes
- make lint is still blocked locally because golangci-lint is not installed in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace detail API now returns expanded TraceDetail with trace_id, user_id, tags, environment, release, and preserved input/output JSON.
  * Spans include LLM metadata (model, provider) plus truncation flags, original-size and truncation-reason fields.
  * UI: Trace Context section, JSON Input/Output panels, and LLM Context block in Span details.

* **Documentation**
  * Added design, specs, and proposal documents describing TraceDetail, span LLM/truncation metadata, and UI behavior.

* **Tests**
  * New backend tests validating mapping, JSON preservation, and truncation/LLM fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->