### PR TITLE
feat: add trace discovery and triage

### DIFF
--- a/openspec/changes/add-trace-discovery-triage/design.md
+++ b/openspec/changes/add-trace-discovery-triage/design.md
@@ -1,0 +1,99 @@
+## Context
+
+Phase 6 is frontend-only. The backend (`listTraces` handler) already accepts all filter query parameters defined in the OpenAPI contract. This change surfaces those filters in the web UI without touching Go, SQL, or OpenAPI.
+
+Key stakeholders: frontend consumers of the traces list, users debugging AI agents.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Expose all existing backend filter capabilities in the web UI
+  - Make filtered views bookmarkable and shareable via URL
+  - Improve trace list triage with visual emphasis and error highlighting
+  - Establish web test infrastructure (vitest + testing-library)
+
+- Non-Goals:
+  - Backend changes (no OpenAPI, handler, or SQL modifications)
+  - Client-side sorting or ranking
+  - Payload/content search
+  - Collapsible filter drawer or mobile-specific layout beyond responsive stacking
+  - Expanding the list schema with `user_id`, `tags`, `environment`, or `release` fields
+
+## Decisions
+
+### URL as single source of truth for filter state
+
+- Decision: All filter state lives in URL search params. React state is only for local draft values (pre-commit debounce).
+- Why: Enables bookmarking, sharing, and back/forward navigation. Avoids state synchronization bugs.
+- Alternatives considered: React state with URL sync — rejected because it creates two sources of truth.
+
+### Pure utilities + thin hook split
+
+- Decision: `tracesSearchParams.ts` contains pure parse/normalize/serialize functions; `useTracesSearchParams.ts` is a thin React wrapper.
+- Why: Pure utilities are trivially testable without React. Hook stays minimal and focused.
+
+### Canonical query string as TanStack Query key
+
+- Decision: Build one canonical query-string from normalized params, use it both for the fetch URL and as `['traces', canonicalQueryString]`.
+- Why: Guarantees cache identity matches request identity. No stale cache on param reorder.
+
+### Normalization rules for all URL params
+
+- Decision: The parser normalizes every param on read. Specific rules:
+  - `q`: trim whitespace; if result is empty, treat as unset (no chip, no param in URL). Prevents ghost chips when the backend ignores whitespace-only queries.
+  - `status`: canonical URL form is **lowercase** (`running`, `completed`, `failed`). Accept case-insensitive input and normalize to lowercase. Canonicalize known backend aliases: `error` → `failed`. Truly unknown values (e.g., `pending`, `cancelled`) are dropped to unset.
+  - `session_id`: validate as UUID format (`/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i`). Invalid values are dropped to unset rather than forwarded as a doomed request.
+  - `min_duration_ms`: parse with `Number()`; drop if NaN, negative, 0, or non-integer (`!Number.isInteger()`). Non-integer values like `1.9` are treated as invalid/unset rather than silently truncated.
+  - `offset`: parse as integer; drop if NaN or negative; reset to 0.
+  - `has_errors`: only activates when the param is exactly `"true"` (case-sensitive).
+  - `start_time_from`, `start_time_to`: must be valid ISO date-time strings; invalid values dropped.
+- Why: Defensive normalization prevents malformed shared URLs from producing fetch errors or phantom UI state.
+
+### `session_id` as URL-only supported filter
+
+- Decision: `session_id` has no visible filter control in the filter bar. It is accepted from the URL (e.g., deep links from session pages), applied to the query, surfaced as an active chip, and clearable via chip dismiss or "Clear all."
+- Why: Adding a session picker control adds complexity without clear user value in Phase 6. Deep links from the session detail page cover the primary use case.
+
+### `min_duration_ms` input semantics
+
+- Decision: Render as `<input type="number" min="1" step="1">`. Accept positive integers only. 0 is treated as unset (equivalent to no filter). Non-integer values (e.g., `1.9`) are treated as invalid/unset rather than silently truncated.
+- Why: The backend parameter is `int64`. Allowing decimals or negative values creates a mismatch.
+
+### Debounce text inputs, commit selects immediately
+
+- Decision: `q`, `user_id`, `min_duration_ms` use 300ms debounce + Enter to commit. `status`, `has_errors`, dates commit on change.
+- Why: Text inputs fire on every keystroke; debouncing avoids excessive requests. Selects and dates produce final values on change.
+- Not committing on blur: prevents accidental partial-value commits when tabbing through controls.
+
+### Native `<input type="date">` for date range
+
+- Decision: Use native date inputs instead of a date picker library.
+- Why: Reduces bundle size, avoids new dependencies, provides consistent mobile UX. Convert local dates to ISO boundary timestamps (start-of-day / end-of-day).
+- Timezone note: Committed ISO timestamps are derived from the user's local timezone. A shared URL may render as a different calendar day in another timezone. This is acceptable for Phase 6; the alternative (UTC-only date pickers) hurts local usability more than cross-timezone sharing helps.
+
+### History push for user actions, replace for normalization
+
+- Decision: Filter/pagination changes push history entries. Canonicalization and stale-offset repair use `replace`.
+- Why: Push preserves user's navigation trail. Replace avoids cluttering history with auto-corrections.
+
+### `keepPreviousData` during refetch
+
+- Decision: Use `placeholderData: keepPreviousData` in TanStack Query.
+- Why: Prevents content flash when changing filters. Previous rows stay visible with an updating indicator.
+
+### Chips rendered only when active
+
+- Decision: Active-chip row is conditional on having at least one non-default filter param.
+- Why: Chips are an explicit Phase 6 deliverable but should not consume space when unused.
+
+## Risks / Trade-offs
+
+- Native date inputs have inconsistent styling across browsers -> Acceptable for Phase 6; a date picker library can replace later.
+- No blur-commit means a user could type a filter and navigate away without it applying -> Acceptable; avoiding accidental commits while tabbing away is the higher-priority behavior for Phase 6.
+- `session_id` is accepted from URL but has no dedicated filter control -> Keeps the filter bar simple while supporting deep links from session pages.
+- Shared date-filter URLs may show a different calendar day in other timezones -> Acceptable; local-date UX is preferred over UTC-only pickers.
+- Return navigation depends on router state which is lost on refresh/new-tab -> Falls back to `/traces`; full durability would require encoding the return URL in the route itself, which is out of scope.
+
+## Open Questions
+
+None — all ambiguities resolved in the plan review.

--- a/openspec/changes/add-trace-discovery-triage/proposal.md
+++ b/openspec/changes/add-trace-discovery-triage/proposal.md
@@ -1,0 +1,33 @@
+# Change: Add Trace Discovery & Triage (Phase 6)
+
+## Why
+
+The backend already supports rich filtering (`q`, `status`, `start_time_from`, `start_time_to`, `user_id`, `session_id`, `has_errors`, `min_duration_ms`) but the web UI exposes none of it. Users must scan an unfiltered, unpaginated-by-URL list to find traces, with no way to bookmark or share a filtered view.
+
+## What Changes
+
+- **Web client API**: Replace `fetchTraces(limit, offset)` with `fetchTraces(params?: FetchTracesParams)` that forwards all supported filter parameters. Remove `fetchTracesBySession`; `SessionDetailPage` calls `fetchTraces({ session_id })` instead.
+- **URL/state architecture**: New `tracesSearchParams.ts` utilities and `useTracesSearchParams` hook drive all filter state from URL search params. Back/forward navigation restores prior filter states.
+- **Filter bar UI**: Responsive filter bar on `TracesPage` with six visible controls: search (`q`), status select, date range (`<input type="date">`), user ID, has-errors toggle, and min-duration input (`<input type="number" min="1" step="1">`, positive integers only, 0 and non-integers treated as unset). Text inputs debounce 300ms; selects/dates commit immediately. `session_id` is a URL-only supported filter with no dedicated control — it is accepted from the URL, applied to the query, surfaced as a chip, and clearable.
+- **Active filter chips**: Rendered only when at least one filter is active. Each chip has a clear action; "Clear all" resets everything including `session_id` and `offset`.
+- **Search hint**: Single concise line beneath the search box.
+- **Empty & error states**: Differentiated onboarding vs. filtered-no-matches empty states. Error banner with retry; controls stay interactive on error.
+- **Row triage improvements**: Stronger name emphasis, linked session line, clearer error emphasis via `error_count`. No schema expansion.
+- **Responsive table**: Horizontal scroll on narrow screens.
+- **Return navigation**: Trace list links pass current filtered URL in router state; detail page uses it for back-link when present, falling back to `/traces` on refresh or direct entry.
+- **Test tooling**: Add vitest, jsdom, @testing-library/{react,jest-dom,user-event} to `web/`; extend `vite.config.ts` with test block.
+
+## Impact
+
+- Affected specs: `trace-discovery` (new capability)
+- Affected code:
+  - `web/src/api/client.ts` (modified)
+  - `web/src/utils/tracesSearchParams.ts` (new)
+  - `web/src/hooks/useTracesSearchParams.ts` (new)
+  - `web/src/pages/TracesPage.tsx` (modified)
+  - `web/src/pages/TraceDetailPage.tsx` (modified)
+  - `web/src/pages/SessionDetailPage.tsx` (modified)
+  - `web/vite.config.ts` (modified)
+  - `web/package.json` (modified)
+  - `web/src/test/setup.ts` (new)
+- No backend, OpenAPI, Go handler, SQL, or migration changes.

--- a/openspec/changes/add-trace-discovery-triage/specs/trace-discovery/spec.md
+++ b/openspec/changes/add-trace-discovery-triage/specs/trace-discovery/spec.md
@@ -1,0 +1,197 @@
+## ADDED Requirements
+
+### Requirement: Trace List Filtering
+
+The traces page SHALL expose six visible filter controls: text search (`q`), status, date range (`start_time_from`, `start_time_to`), user ID, has-errors toggle, and minimum duration (`min_duration_ms`, rendered as `<input type="number" min="1" step="1">`, positive integers only, 0 and non-integers treated as unset). `session_id` is a URL-only supported filter with no visible control — it is accepted from the URL, applied to the query, surfaced as a chip, and clearable. Filter state SHALL be driven entirely by URL search params so that filtered views are bookmarkable and shareable. The canonical URL form for `status` SHALL be lowercase (`running`, `completed`, `failed`); the parser SHALL accept case-insensitive input and normalize to lowercase.
+
+#### Scenario: User applies a text search filter
+- **WHEN** the user types a search query into the search input and the 300ms debounce expires or the user presses Enter
+- **THEN** the `q` parameter is added to the URL, the traces list is re-fetched with the `q` filter, offset resets to 0, and a search chip appears in the active-chip row
+
+#### Scenario: User applies a status filter
+- **WHEN** the user selects a status value from the status dropdown
+- **THEN** the `status` parameter is added to the URL immediately, the traces list is re-fetched, offset resets to 0, and a status chip appears
+
+#### Scenario: User applies a date range filter
+- **WHEN** the user sets a start date and/or end date using native date inputs
+- **THEN** the dates are converted to ISO boundary timestamps (start-of-day for `from`, end-of-day 23:59:59.999 for `to`), added to the URL, and the traces list is re-fetched
+
+#### Scenario: Invalid date range
+- **WHEN** the committed `start_time_from` is later than `start_time_to`
+- **THEN** an inline validation error is shown and the traces query is suppressed until corrected
+
+#### Scenario: User applies has-errors filter
+- **WHEN** the user activates the has-errors toggle
+- **THEN** the `has_errors=true` parameter is added to the URL and the traces list is re-fetched showing only traces with errors
+
+#### Scenario: User applies min-duration filter
+- **WHEN** the user enters a positive integer minimum duration value and the 300ms debounce expires or Enter is pressed
+- **THEN** the `min_duration_ms` parameter is added to the URL and the traces list is re-fetched
+
+#### Scenario: Min-duration value of 0 is treated as unset
+- **WHEN** the user enters 0 as the minimum duration value
+- **THEN** the `min_duration_ms` parameter is removed from the URL and no duration filter is applied
+
+#### Scenario: Non-integer min-duration is treated as unset
+- **WHEN** the URL contains a non-integer `min_duration_ms` value (e.g., `1.9`, `abc`)
+- **THEN** the `min_duration_ms` parameter is removed from the URL and no duration filter is applied
+
+#### Scenario: Session ID filter from URL (URL-only supported filter)
+- **WHEN** the URL contains a `session_id` parameter with a valid UUID value (e.g., from a deep link or session page navigation)
+- **THEN** the filter is applied, a session chip is shown, and the chip can be cleared
+
+#### Scenario: Invalid session_id in URL is normalized away
+- **WHEN** the URL contains a `session_id` parameter with an invalid (non-UUID) value
+- **THEN** the `session_id` parameter is silently removed from the URL via replace and no session filter is applied
+
+#### Scenario: Whitespace-only search query is normalized away
+- **WHEN** the URL contains a `q` parameter that is empty or whitespace-only after trimming
+- **THEN** the `q` parameter is removed from the URL, no search chip is shown, and no search filter is applied
+
+#### Scenario: Status case normalization
+- **WHEN** the URL contains a `status` parameter with a valid value in any case (e.g., `RUNNING`, `Running`, `running`)
+- **THEN** the value is normalized to lowercase in the URL and the status filter is applied
+
+#### Scenario: Status alias normalization
+- **WHEN** the URL contains `status=error` (a backend-accepted alias for `failed`)
+- **THEN** the value is canonicalized to `status=failed` in the URL and the failed status filter is applied
+
+#### Scenario: Text inputs do not commit on blur
+- **WHEN** a user types into `q`, `user_id`, or `min_duration_ms` and then tabs or clicks away without pressing Enter and before the debounce expires
+- **THEN** the filter value is NOT committed to the URL
+
+### Requirement: Active Filter Chips
+
+The traces page SHALL display active filter chips only when at least one filter parameter is set. Each chip SHALL have an individual clear action. A "Clear all" action SHALL remove every filter parameter including `session_id` and reset `offset` to 0.
+
+#### Scenario: Chips appear when filters are active
+- **WHEN** one or more filter parameters are set in the URL
+- **THEN** a chip row appears below the filter bar showing one chip per active filter, each with a clear button
+
+#### Scenario: Clear individual chip
+- **WHEN** the user clicks the clear button on a single chip
+- **THEN** only that filter parameter is removed from the URL, the traces list re-fetches, and offset resets to 0
+
+#### Scenario: Clear all filters
+- **WHEN** the user clicks "Clear all"
+- **THEN** all filter parameters including `session_id` and `offset` are removed from the URL and the traces list shows unfiltered results
+
+### Requirement: Search Hint
+
+The traces page SHALL display a concise search hint near the search input describing the search scope.
+
+#### Scenario: Hint visibility
+- **WHEN** the traces page is rendered
+- **THEN** a short hint is displayed: "Search names, user IDs, and matching span names."
+
+### Requirement: URL-Driven Pagination and History
+
+The traces page SHALL drive pagination from the `offset` URL parameter. User-initiated filter and pagination changes SHALL push browser history entries. Internal normalization (e.g., invalid param cleanup, stale-offset repair) SHALL use `replace` to avoid junk history entries.
+
+#### Scenario: Browser back/forward restores filtered state
+- **WHEN** the user navigates back or forward in browser history
+- **THEN** the filter controls, chip row, and fetched results reflect the URL state at that history entry
+
+#### Scenario: Stale offset repair
+- **WHEN** the current offset is out of range and a fetch returns 0 rows with `total > 0`
+- **THEN** the offset is replaced (not pushed) to the last valid page and the list re-fetches
+
+#### Scenario: Default state
+- **WHEN** the user navigates to `/traces` with no query parameters
+- **THEN** the page shows all traces, first page, limit 20, with no active chips
+
+### Requirement: Differentiated Empty States
+
+The traces page SHALL distinguish between having no traces at all and having no matches for active filters.
+
+#### Scenario: No traces exist
+- **WHEN** the fetch returns 0 total traces and no filters are active
+- **THEN** an onboarding-style empty state is shown
+
+#### Scenario: No filter matches
+- **WHEN** the fetch returns 0 traces but filters are active
+- **THEN** a filtered empty state is shown with a "Clear all" action
+
+### Requirement: Error Handling with Interactive Controls
+
+The traces page SHALL show an error banner above the table on fetch failure with an error message and retry action. Filter controls SHALL remain interactive during error state.
+
+#### Scenario: Fetch failure
+- **WHEN** the traces fetch fails
+- **THEN** an error banner is displayed above the table area, a retry button is available, and all filter controls remain interactive
+
+### Requirement: Trace Row Triage Improvements
+
+The traces list rows SHALL provide improved visual triage using existing list fields only: stronger name emphasis, session shown as a secondary linked line when present, and clearer failed/error emphasis via `error_count`.
+
+#### Scenario: Row with errors
+- **WHEN** a trace has `error_count > 0`
+- **THEN** the error count is visually emphasized in the row
+
+#### Scenario: Row with session
+- **WHEN** a trace has a `session_id`
+- **THEN** the session is shown as a secondary linked line beneath the trace name
+
+### Requirement: Responsive Table Layout
+
+The traces list table container SHALL be horizontally scrollable on narrow screens instead of relying on fixed-width columns.
+
+#### Scenario: Narrow viewport
+- **WHEN** the viewport is narrower than the table's minimum width
+- **THEN** the table container scrolls horizontally
+
+### Requirement: Filtered-List Return Navigation
+
+Links from the traces list to trace detail SHALL pass the current `/traces?...` location in router state. The trace detail page SHALL use that state for its back link when present, falling back to `/traces` when router state is unavailable (e.g., after page refresh or direct URL entry).
+
+#### Scenario: Return to filtered list via router state
+- **WHEN** the user clicks the back link on a trace detail page after arriving from a filtered traces list in the same session
+- **THEN** the browser navigates to the filtered URL that was active when the user left the list
+
+#### Scenario: Return to traces list without router state
+- **WHEN** the user loads a trace detail page directly (via bookmark, refresh, or new tab) and clicks the back link
+- **THEN** the browser navigates to `/traces` with no filters
+
+### Requirement: Data Freshness During Refetch
+
+The traces page SHALL keep previous rows visible while a new filter or page request is in flight, using TanStack Query's `keepPreviousData` behavior.
+
+#### Scenario: Filter change during loading
+- **WHEN** the user changes a filter and a new request is in flight
+- **THEN** the previous rows remain visible until the new data arrives
+
+### Requirement: Filter Control Accessibility
+
+All filter controls, chip dismiss buttons, and the "Clear all" button SHALL be keyboard-reachable via Tab. Each control SHALL have an associated `<label>` element or `aria-label` attribute. Interactive elements SHALL have visible focus indicators.
+
+#### Scenario: Keyboard navigation through filters
+- **WHEN** the user navigates the filter bar using the Tab key
+- **THEN** every filter control, chip dismiss button, and "Clear all" button receives focus in a logical order with a visible focus indicator
+
+### Requirement: Draft State Rehydration on URL Change
+
+When URL search params change due to back/forward navigation, chip clear, or "Clear all," the draft input values for debounced controls (`q`, `user_id`, `min_duration_ms`) SHALL be rehydrated from the new URL state so that displayed input values match the active query.
+
+#### Scenario: Back navigation updates draft inputs
+- **WHEN** the user navigates back in browser history to a URL with different filter values
+- **THEN** the text input controls display the values from the restored URL, not stale draft values
+
+### Requirement: Server-Ordered Results
+
+The traces page SHALL render traces in the exact order returned by the API and SHALL NOT apply client-side re-sorting. This preserves backend relevance ranking when `q` is present and default time ordering otherwise.
+
+#### Scenario: Search results preserve relevance ordering
+- **WHEN** the user applies a text search filter (`q`) and the backend returns results in relevance-ranked order
+- **THEN** the traces list renders rows in the same order as the API response without re-sorting
+
+#### Scenario: Unfiltered results preserve API ordering
+- **WHEN** no `q` parameter is set and the backend returns results in default time order
+- **THEN** the traces list renders rows in the same order as the API response without re-sorting
+
+### Requirement: Unified Trace Fetch API
+
+The web client SHALL provide a single `fetchTraces(params?: FetchTracesParams)` function that accepts all filter parameters. The `fetchTracesBySession` function SHALL be removed; callers SHALL use `fetchTraces({ session_id })` instead.
+
+#### Scenario: Session detail page fetches traces
+- **WHEN** `SessionDetailPage` needs traces for a specific session
+- **THEN** it calls `fetchTraces({ session_id, limit, offset })` instead of the removed `fetchTracesBySession`

--- a/openspec/changes/add-trace-discovery-triage/tasks.md
+++ b/openspec/changes/add-trace-discovery-triage/tasks.md
@@ -1,0 +1,73 @@
+## 1. Test Infrastructure Setup
+- [x] 1.1 Add vitest, jsdom, @testing-library/react, @testing-library/jest-dom, @testing-library/user-event as devDependencies in `web/package.json`
+- [x] 1.2 Extend `web/vite.config.ts` with a `test` block (environment: jsdom, setup files, globals)
+- [x] 1.3 Create `web/src/test/setup.ts` with @testing-library/jest-dom import
+- [x] 1.4 Add `"test": "vitest run"` script to `web/package.json`
+- [x] 1.5 Verify `pnpm --filter web test` runs and exits cleanly (no tests yet)
+
+## 2. Pure URL Utilities
+- [x] 2.1 Create `web/src/utils/tracesSearchParams.ts` with types: `TracesFilterState`, `FetchTracesParams`
+- [x] 2.2 Implement `parseTracesParams(searchParams: URLSearchParams): TracesFilterState` with normalization: invalid offset->0; `q` trimmed, whitespace-only->unset; `status` lowercased, alias `error`->`failed`, unknown values->unset (only `running`/`completed`/`failed` accepted after aliasing); `session_id` validated as UUID format, invalid->unset; invalid dates->unset; `has_errors` only on exactly `"true"`; `min_duration_ms` parsed with `Number()`, non-integer/NaN/negative/0->unset
+- [x] 2.3 Implement `serializeTracesParams(state: TracesFilterState): URLSearchParams` omitting empty/default values
+- [x] 2.4 Implement `buildCanonicalQueryString(state: TracesFilterState): string` for query key + fetch URL
+- [x] 2.5 Implement `localDateToISOStart(date: string): string` and `localDateToISOEnd(date: string): string` for date boundary conversion
+- [x] 2.6 Implement `deriveActiveChips(state: TracesFilterState): Chip[]` and `clearChip(state: TracesFilterState, chipKey: string): TracesFilterState`
+- [x] 2.7 Write unit tests for all pure utilities: parse/serialize round-trip, normalization (whitespace-only q, case-insensitive status, status alias `error`->`failed`, invalid session_id UUID, 0/negative/non-integer min_duration_ms all->unset), date conversion, chip derivation, session_id preservation, and canonicalization equality (equivalent param sets in different input order produce identical canonical strings)
+
+## 3. API Client Update
+- [x] 3.1 Define `FetchTracesParams` interface in `web/src/api/client.ts`
+- [x] 3.2 Replace `fetchTraces(limit, offset)` with `fetchTraces(params?: FetchTracesParams)` building query string from params
+- [x] 3.3 Remove `fetchTracesBySession` function
+
+## 4. URL Hook
+- [x] 4.1 Create `web/src/hooks/useTracesSearchParams.ts` wrapping `useSearchParams()` with parse/serialize from utilities
+- [x] 4.2 Expose: `filters: TracesFilterState`, `setFilters(updates, mode: 'push' | 'replace')`, `clearAll()`, `clearChip(key)`
+
+## 5. TracesPage Rewrite
+- [x] 5.1 Replace `useState(offset)` with `useTracesSearchParams` hook
+- [x] 5.2 Update TanStack Query to use `['traces', canonicalQueryString]` as key and `fetchTraces(params)` as queryFn with `placeholderData: keepPreviousData`
+- [x] 5.3 Add responsive filter bar: search input (`q`), status select, date range inputs, user ID input, has-errors checkbox, min-duration input (`<input type="number" min="1" step="1">`). All controls MUST have associated `<label>` elements or `aria-label` attributes
+- [x] 5.4 Implement 300ms debounce for `q`, `user_id`, `min_duration_ms` with Enter commit; immediate commit for status, has_errors, dates
+- [x] 5.4a Rehydrate draft input values (`q`, `user_id`, `min_duration_ms`) from URL when search params change externally (back/forward navigation, chip clear, clearAll)
+- [x] 5.5 Add date validation: inline error when `start_time_from > start_time_to`, suppress query until corrected
+- [x] 5.6 Add search hint line below search box
+- [x] 5.7 Add conditional active-chip row with individual clear and "Clear all" actions
+- [x] 5.8 Add error banner above table with error message and retry button; keep controls interactive on error
+- [x] 5.9 Differentiate empty states: onboarding (no traces at all) vs. filtered-no-matches (with "Clear all")
+- [x] 5.10 Improve row triage: stronger name emphasis, linked session line, error emphasis via `error_count`
+- [x] 5.11 Make table container horizontally scrollable on narrow screens
+- [x] 5.12 Reset offset to 0 on every committed filter change
+- [x] 5.13 Handle stale offset: if fetch returns 0 rows with total > 0, replace offset to last valid page
+
+## 6. Return Navigation
+- [x] 6.1 Pass current `/traces?...` location in router state when linking from trace list to detail
+- [x] 6.2 Update `TraceDetailPage.tsx` back link to use router state for filtered-list URL when present, falling back to `/traces` on refresh or direct entry
+
+## 7. SessionDetailPage Update
+- [x] 7.1 Replace `fetchTracesBySession` import with `fetchTraces`
+- [x] 7.2 Update query to call `fetchTraces({ session_id, limit: PAGE_SIZE, offset })`
+
+## 8. Integration Tests
+- [x] 8.1 TracesPage integration tests with MemoryRouter + mocked fetch:
+  - Initial load from `/traces` with no filters
+  - Deep link pre-populates controls and issues exact filtered request
+  - Debounced search commits after idle and on Enter
+  - Text filters do not commit on blur
+  - Filter composition and pagination reset
+  - Invalid date range validation
+  - Chip clear and "Clear all" behavior
+  - `session_id` URL param honored and clearable
+  - Error banner and retry
+  - Filtered vs unfiltered empty states
+  - Rendered row order matches API response order (mock intentionally non-time-sorted search results)
+  - Back link from detail restores filtered list URL when router state present; falls back to `/traces` on refresh
+  - Keyboard accessibility: all controls and chip dismiss buttons reachable via Tab, visible focus indicators
+  - Draft inputs rehydrate correctly on back/forward navigation
+  - Malformed session_id in URL is normalized away (no fetch error)
+  - Whitespace-only q in URL is normalized away (no ghost chip)
+
+## 9. Verification
+- [x] 9.1 `pnpm --filter web type-check` passes
+- [x] 9.2 `pnpm --filter web test` passes
+- [x] 9.3 `go test ./internal/store -run 'TestSearch_(FindTraceBySpanName|CombinedSearchAndFilter|Pagination|FilterByTimeRange|FilterByHasErrors|FilterByMinDuration)'` passes unchanged
+- [ ] 9.4 Manual smoke test: filter bar, chips, pagination, back/forward, responsive layout

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: link:../../contracts
       openai:
         specifier: '>=4.0.0'
-        version: 6.15.0
+        version: 6.15.0(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: 22.9.0
@@ -72,7 +72,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: 2.1.4
-        version: 2.1.4(@types/node@22.9.0)
+        version: 2.1.4(@types/node@22.9.0)(jsdom@25.0.1)
 
   web:
     dependencies:
@@ -104,6 +104,15 @@ importers:
         specifier: 2.5.4
         version: 2.5.4
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: 6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 16.0.1
+        version: 16.0.1(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: 14.5.2
+        version: 14.5.2(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12
@@ -131,6 +140,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: 0.4.14
         version: 0.4.14(eslint@8.57.1)
+      jsdom:
+        specifier: 25.0.1
+        version: 25.0.1
       postcss:
         specifier: 8.4.47
         version: 8.4.47
@@ -143,8 +155,14 @@ importers:
       vite:
         specifier: 5.4.10
         version: 5.4.10(@types/node@22.15.21)
+      vitest:
+        specifier: 2.1.4
+        version: 2.1.4(@types/node@22.15.21)(jsdom@25.0.1)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -158,6 +176,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -252,6 +273,34 @@ packages:
       enzyme: ^3.11.0
       react: '>=18'
       react-dom: '>=18'
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emotion/is-prop-valid@1.2.2':
     resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
@@ -900,6 +949,38 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.0.1':
+    resolution: {integrity: sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0
+      '@types/react-dom': ^18.0.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.5.2':
+    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1070,6 +1151,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -1082,6 +1167,13 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -1193,6 +1285,10 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1288,16 +1384,27 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1319,6 +1426,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decko@1.2.0:
     resolution: {integrity: sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==}
@@ -1342,6 +1452,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -1354,6 +1468,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -1696,8 +1816,16 @@ packages:
   html-element-map@1.3.1:
     resolution: {integrity: sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   http2-client@1.3.5:
     resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==}
@@ -1721,6 +1849,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
@@ -1813,6 +1945,9 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1876,6 +2011,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1948,12 +2092,18 @@ packages:
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1965,6 +2115,10 @@ packages:
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1996,6 +2150,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2093,6 +2251,9 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
   oas-kit-common@1.0.8:
     resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==}
@@ -2328,6 +2489,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -2362,6 +2527,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -2411,6 +2579,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   redoc@2.2.0:
     resolution: {integrity: sha512-52rz/xJtpUBc3Y/GAkaX03czKhQXTxoU7WnkXNzRLuGwiGb/iEO4OgwcgQqtwHWrYNaZXTyqZ4MAVXpi/e1gAg==}
@@ -2475,6 +2647,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   rst-selector-parser@2.2.3:
     resolution: {integrity: sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==}
 
@@ -2498,6 +2676,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2627,6 +2809,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -2664,6 +2850,9 @@ packages:
   swagger2openapi@7.0.8:
     resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
     hasBin: true
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@2.5.4:
     resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
@@ -2705,15 +2894,30 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -2891,11 +3095,19 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -2904,6 +3116,10 @@ packages:
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
@@ -2964,6 +3180,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3009,11 +3244,21 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@anthropic-ai/sdk@0.71.2':
     dependencies:
       json-schema-to-ts: 3.1.1
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -3139,6 +3384,26 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.3.1
       react-shallow-renderer: 16.15.0(react@18.3.1)
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emotion/is-prop-valid@1.2.2':
     dependencies:
@@ -3578,6 +3843,43 @@ snapshots:
       '@tanstack/query-core': 5.59.20
       react: 18.3.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.23
+      redent: 3.0.0
+
+  '@testing-library/react@16.0.1(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.5
@@ -3728,6 +4030,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
+  '@vitest/mocker@2.1.4(vite@5.4.10(@types/node@22.15.21))':
+    dependencies:
+      '@vitest/spy': 2.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.10(@types/node@22.15.21)
+
   '@vitest/mocker@2.1.4(vite@5.4.10(@types/node@22.9.0))':
     dependencies:
       '@vitest/spy': 2.1.4
@@ -3792,6 +4102,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -3802,6 +4114,12 @@ snapshots:
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -3925,6 +4243,11 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4037,11 +4360,23 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.1.3: {}
 
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -4067,6 +4402,8 @@ snapshots:
     optionalDependencies:
       supports-color: 9.4.0
 
+  decimal.js@10.6.0: {}
+
   decko@1.2.0: {}
 
   deep-eql@5.0.2: {}
@@ -4087,6 +4424,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   didyoumean@1.2.2: {}
 
   discontinuous-range@1.0.0: {}
@@ -4096,6 +4435,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -4614,12 +4957,23 @@ snapshots:
       array.prototype.filter: 1.0.4
       call-bind: 1.0.8
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   htmlparser2@10.0.0:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 6.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
 
   http2-client@1.3.5: {}
 
@@ -4642,6 +4996,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   index-to-position@1.2.0: {}
 
@@ -4735,6 +5091,8 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -4792,6 +5150,34 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.19.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -4844,11 +5230,15 @@ snapshots:
 
   lodash.sortby@4.7.0: {}
 
+  lodash@4.17.23: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
 
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -4859,6 +5249,8 @@ snapshots:
       react: 18.3.1
 
   lunr@2.3.9: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4882,6 +5274,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -4960,6 +5354,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nwsapi@2.2.23: {}
+
   oas-kit-common@1.0.8:
     dependencies:
       fast-safe-stringify: 2.1.1
@@ -5031,7 +5427,9 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@6.15.0: {}
+  openai@6.15.0(ws@8.19.0):
+    optionalDependencies:
+      ws: 8.19.0
 
   openapi-sampler@1.6.2:
     dependencies:
@@ -5185,6 +5583,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prismjs@1.30.0: {}
 
   prop-types@15.8.1:
@@ -5219,6 +5623,8 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -5267,6 +5673,11 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redoc@2.2.0(core-js@3.47.0)(enzyme@3.11.0)(mobx@6.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
@@ -5377,6 +5788,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.54.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   rst-selector-parser@2.2.3:
     dependencies:
       lodash.flattendeep: 4.4.0
@@ -5408,6 +5823,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -5573,6 +5992,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   strnum@1.1.2: {}
@@ -5626,6 +6049,8 @@ snapshots:
       yargs: 17.0.1
     transitivePeerDependencies:
       - encoding
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@2.5.4: {}
 
@@ -5681,13 +6106,27 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
 
   tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
 
@@ -5814,6 +6253,23 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vite-node@2.1.4(@types/node@22.15.21):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@9.4.0)
+      pathe: 1.1.2
+      vite: 5.4.10(@types/node@22.15.21)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@2.1.4(@types/node@22.9.0):
     dependencies:
       cac: 6.7.14
@@ -5849,7 +6305,43 @@ snapshots:
       '@types/node': 22.9.0
       fsevents: 2.3.3
 
-  vitest@2.1.4(@types/node@22.9.0):
+  vitest@2.1.4(@types/node@22.15.21)(jsdom@25.0.1):
+    dependencies:
+      '@vitest/expect': 2.1.4
+      '@vitest/mocker': 2.1.4(vite@5.4.10(@types/node@22.15.21))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.4
+      '@vitest/snapshot': 2.1.4
+      '@vitest/spy': 2.1.4
+      '@vitest/utils': 2.1.4
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@9.4.0)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.10(@types/node@22.15.21)
+      vite-node: 2.1.4(@types/node@22.15.21)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.21
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.4(@types/node@22.9.0)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.4
       '@vitest/mocker': 2.1.4(vite@5.4.10(@types/node@22.9.0))
@@ -5873,6 +6365,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.9.0
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5884,15 +6377,26 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@4.0.2: {}
+
+  webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -5968,6 +6472,12 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@7.5.10: {}
+
+  ws@8.19.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "type-check": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -24,6 +25,9 @@
     "tailwind-merge": "2.5.4"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.0.1",
+    "@testing-library/user-event": "14.5.2",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@typescript-eslint/eslint-plugin": "8.13.0",
@@ -33,9 +37,11 @@
     "eslint": "8.57.1",
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-react-refresh": "0.4.14",
+    "jsdom": "25.0.1",
     "postcss": "8.4.47",
     "tailwindcss": "3.4.14",
     "typescript": "5.6.3",
-    "vite": "5.4.10"
+    "vite": "5.4.10",
+    "vitest": "2.1.4"
   }
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,7 +3,14 @@
  * Uses fetch with API key header from localStorage.
  */
 
+import {
+  buildCanonicalQueryString,
+  type FetchTracesParams,
+} from '../utils/tracesSearchParams';
+
 const API_KEY_STORAGE_KEY = 'continua_api_key';
+
+export type { FetchTracesParams } from '../utils/tracesSearchParams';
 
 /**
  * Get the stored API key.
@@ -196,10 +203,12 @@ export interface SessionList {
 }
 
 /**
- * Fetch traces with pagination.
+ * Fetch traces with filters and pagination.
  */
-export async function fetchTraces(limit = 20, offset = 0): Promise<TraceList> {
-  return fetchAPI<TraceList>(`/api/traces?limit=${limit}&offset=${offset}`);
+export async function fetchTraces(params: FetchTracesParams = {}): Promise<TraceList> {
+  const query = buildCanonicalQueryString(params);
+  const path = query ? `/api/traces?${query}` : '/api/traces';
+  return fetchAPI<TraceList>(path);
 }
 
 /**
@@ -253,17 +262,4 @@ export async function fetchSessions(limit = 20, offset = 0): Promise<SessionList
  */
 export async function fetchSession(id: string): Promise<Session> {
   return fetchAPI<Session>(`/api/sessions/${id}`);
-}
-
-/**
- * Fetch traces filtered by session ID.
- */
-export async function fetchTracesBySession(
-  sessionId: string,
-  limit = 20,
-  offset = 0
-): Promise<TraceList> {
-  return fetchAPI<TraceList>(
-    `/api/traces?session_id=${sessionId}&limit=${limit}&offset=${offset}`
-  );
 }

--- a/web/src/components/PaginationControls.tsx
+++ b/web/src/components/PaginationControls.tsx
@@ -19,11 +19,13 @@ export function PaginationControls({
   return (
     <div className="mt-4 flex items-center justify-between">
       <button
+        type="button"
+        aria-label="Previous page"
         onClick={() => onOffsetChange(Math.max(0, offset - pageSize))}
         disabled={!hasPrevPage}
         className={`px-4 py-2 rounded-lg ${
           hasPrevPage
-            ? 'bg-blue-600 text-white hover:bg-blue-700'
+            ? 'bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200'
             : 'bg-gray-200 text-gray-400 cursor-not-allowed'
         }`}
       >
@@ -33,11 +35,13 @@ export function PaginationControls({
         Showing {showingFrom} - {showingTo} of {total}
       </span>
       <button
+        type="button"
+        aria-label="Next page"
         onClick={() => onOffsetChange(offset + pageSize)}
         disabled={!hasNextPage}
         className={`px-4 py-2 rounded-lg ${
           hasNextPage
-            ? 'bg-blue-600 text-white hover:bg-blue-700'
+            ? 'bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200'
             : 'bg-gray-200 text-gray-400 cursor-not-allowed'
         }`}
       >

--- a/web/src/hooks/useTracesSearchParams.ts
+++ b/web/src/hooks/useTracesSearchParams.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  clearChip as clearTracesChip,
+  parseTracesParams,
+  serializeTracesParams,
+  type ChipKey,
+  type TracesFilterState,
+} from '../utils/tracesSearchParams';
+
+type HistoryMode = 'push' | 'replace';
+
+function shouldResetOffset(
+  filters: TracesFilterState,
+  updates: Partial<TracesFilterState>
+): boolean {
+  return Object.entries(updates).some(
+    ([key, value]) =>
+      key !== 'offset' &&
+      filters[key as keyof TracesFilterState] !== value
+  );
+}
+
+export function useTracesSearchParams() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = parseTracesParams(searchParams);
+  const canonicalSearch = serializeTracesParams(filters).toString();
+
+  useEffect(() => {
+    if (searchParams.toString() === canonicalSearch) {
+      return;
+    }
+
+    setSearchParams(new URLSearchParams(canonicalSearch), { replace: true });
+  }, [canonicalSearch, searchParams, setSearchParams]);
+
+  const setFilters = useCallback(
+    (updates: Partial<TracesFilterState>, mode: HistoryMode = 'push') => {
+      const next = {
+        ...filters,
+        ...updates,
+      };
+
+      const normalizedNext = shouldResetOffset(filters, updates)
+        ? { ...next, offset: 0 }
+        : next;
+
+      setSearchParams(serializeTracesParams(normalizedNext), {
+        replace: mode === 'replace',
+      });
+    },
+    [filters, setSearchParams]
+  );
+
+  const clearAll = useCallback(() => {
+    setSearchParams(new URLSearchParams(), { replace: false });
+  }, [setSearchParams]);
+
+  const clearChip = useCallback(
+    (key: ChipKey, mode: HistoryMode = 'push') => {
+      setSearchParams(serializeTracesParams(clearTracesChip(filters, key)), {
+        replace: mode === 'replace',
+      });
+    },
+    [filters, setSearchParams]
+  );
+
+  return {
+    filters,
+    setFilters,
+    clearAll,
+    clearChip,
+  };
+}

--- a/web/src/pages/SessionDetailPage.tsx
+++ b/web/src/pages/SessionDetailPage.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link, useParams } from 'react-router-dom';
 import {
   fetchSession,
-  fetchTracesBySession,
+  fetchTraces,
   Trace,
 } from '../api/client';
 import { PaginationControls } from '../components/PaginationControls';
@@ -70,7 +70,12 @@ function SessionDetailContent({
     error: tracesError,
   } = useQuery({
     queryKey: ['session-traces', sessionId, offset],
-    queryFn: () => fetchTracesBySession(sessionId, PAGE_SIZE, offset),
+    queryFn: () =>
+      fetchTraces({
+        session_id: sessionId,
+        limit: PAGE_SIZE,
+        offset,
+      }),
   });
 
   if (isSessionLoading) {

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
   fetchSpans,
@@ -55,11 +55,28 @@ interface TraceDetailContentProps {
   onSelectSpan: (span: Span | null) => void;
 }
 
+function getReturnToDestination(state: unknown): string {
+  if (
+    typeof state !== 'object' ||
+    state === null ||
+    !('returnTo' in state) ||
+    typeof state.returnTo !== 'string'
+  ) {
+    return '/traces';
+  }
+
+  const { returnTo } = state;
+  return returnTo === '/traces' || returnTo.startsWith('/traces?')
+    ? returnTo
+    : '/traces';
+}
+
 function TraceDetailContent({
   traceId,
   selectedSpan,
   onSelectSpan,
 }: TraceDetailContentProps) {
+  const location = useLocation();
   const traceQuery = useQuery({
     queryKey: ['trace', traceId],
     queryFn: () => fetchTrace(traceId),
@@ -120,12 +137,13 @@ function TraceDetailContent({
   const duration = calculateDuration(trace.started_at, trace.ended_at);
   const totalTokens =
     (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
+  const returnTo = getReturnToDestination(location.state);
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-50">
       <header className="border-b bg-white px-6 py-4">
         <div className="flex items-center gap-4">
-          <Link to="/traces" className="text-gray-500 hover:text-gray-700">
+          <Link to={returnTo} className="text-gray-500 hover:text-gray-700">
             ← Traces
           </Link>
           <div className="min-w-0 flex-1">

--- a/web/src/pages/TracesPage.test.tsx
+++ b/web/src/pages/TracesPage.test.tsx
@@ -1,0 +1,698 @@
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearApiKey, setApiKey, type Trace, type TraceDetail } from '../api/client';
+import { localDateToISOEnd, localDateToISOStart } from '../utils/tracesSearchParams';
+import { TraceDetailPage } from './TraceDetailPage';
+import { TracesPage } from './TracesPage';
+
+const SESSION_ID = '123e4567-e89b-12d3-a456-426614174000';
+const OTHER_SESSION_ID = '123e4567-e89b-12d3-a456-426614174001';
+
+const TRACE_ONE: Trace = {
+  id: 'trace-checkout',
+  session_id: SESSION_ID,
+  name: 'Checkout Trace',
+  status: 'FAILED',
+  started_at: '2026-03-14T10:00:00.000Z',
+  ended_at: '2026-03-14T10:00:02.000Z',
+  total_tokens_in: 120,
+  total_tokens_out: 80,
+  total_cost_usd: 0.12,
+  error_count: 2,
+};
+
+const TRACE_TWO: Trace = {
+  id: 'trace-latency',
+  session_id: OTHER_SESSION_ID,
+  name: 'Latency Trace',
+  status: 'RUNNING',
+  started_at: '2026-03-14T11:00:00.000Z',
+  total_tokens_in: 50,
+  total_tokens_out: 25,
+  total_cost_usd: 0.03,
+  error_count: 0,
+};
+
+const TRACE_THREE: Trace = {
+  id: 'trace-alpha',
+  session_id: SESSION_ID,
+  name: 'Alpha Trace',
+  status: 'COMPLETED',
+  started_at: '2026-03-14T09:00:00.000Z',
+  ended_at: '2026-03-14T09:00:03.000Z',
+  total_tokens_in: 20,
+  total_tokens_out: 10,
+  total_cost_usd: 0.01,
+  error_count: 0,
+};
+
+const TRACE_ZETA: Trace = {
+  ...TRACE_ONE,
+  id: 'trace-zeta',
+  name: 'Zeta Trace',
+  session_id: OTHER_SESSION_ID,
+  error_count: 1,
+};
+
+const TRACE_DETAIL: TraceDetail = {
+  ...TRACE_ONE,
+  trace_id: 'external-trace-checkout',
+  user_id: 'user-123',
+  tags: ['checkout'],
+  environment: 'prod',
+  release: '2026.03.14',
+  input: { prompt: 'hello' },
+  output: { answer: 'world' },
+};
+
+type RequestInput = string | URL | Request;
+
+type JsonHandler = (url: URL) => Promise<Response> | Response;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+function buildFetchHandler({
+  list,
+  detail,
+  spans,
+  timeline,
+}: {
+  list?: JsonHandler;
+  detail?: JsonHandler;
+  spans?: JsonHandler;
+  timeline?: JsonHandler;
+} = {}) {
+  return async (input: RequestInput) => {
+    const url = new URL(readRequestUrl(input), 'http://localhost');
+
+    if (url.pathname === '/api/traces') {
+      return (
+        list?.(url) ??
+        jsonResponse({
+          traces: [TRACE_ONE, TRACE_TWO],
+          total: 2,
+        })
+      );
+    }
+
+    if (/^\/api\/traces\/[^/]+\/spans$/.test(url.pathname)) {
+      return spans?.(url) ?? jsonResponse({ spans: [] });
+    }
+
+    if (/^\/api\/traces\/[^/]+\/events$/.test(url.pathname)) {
+      return (
+        timeline?.(url) ??
+        jsonResponse({
+          events: [],
+          trace_status: 'COMPLETED',
+          has_more: false,
+        })
+      );
+    }
+
+    if (/^\/api\/traces\/[^/]+$/.test(url.pathname)) {
+      return detail?.(url) ?? jsonResponse(TRACE_DETAIL);
+    }
+
+    throw new Error(`Unhandled request: ${url.pathname}${url.search}`);
+  };
+}
+
+function readRequestUrl(input: RequestInput): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}
+
+function getTraceListRequests(): URL[] {
+  return fetchMock.mock.calls
+    .map(([input]) => new URL(readRequestUrl(input as RequestInput), 'http://localhost'))
+    .filter((url) => url.pathname === '/api/traces');
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+function renderTraceRoutes(initialEntries: Array<string | { pathname: string; state?: unknown }>) {
+  const queryClient = createQueryClient();
+  const router = createMemoryRouter(
+    [
+      { path: '/traces', element: <TracesPage /> },
+      { path: '/traces/:id', element: <TraceDetailPage /> },
+    ],
+    { initialEntries }
+  );
+
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+
+  return { ...view, queryClient, router };
+}
+
+async function waitForListFetch(search: string) {
+  await waitFor(() => {
+    const requests = getTraceListRequests();
+    expect(requests.at(-1)?.search).toBe(search);
+  });
+}
+
+async function waitForDebounce() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 350));
+  });
+}
+
+function createDeferredResponse() {
+  let resolveResponse: (response: Response) => void = () => {};
+  const promise = new Promise<Response>((resolve) => {
+    resolveResponse = resolve;
+  });
+
+  return {
+    promise,
+    resolve: resolveResponse,
+  };
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  localStorage.clear();
+  setApiKey('test-key');
+});
+
+afterEach(() => {
+  clearApiKey();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('TracesPage', () => {
+  it('loads the default trace list from /traces', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes(['/traces']);
+
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    expect(
+      screen.getByText('Search names, user IDs, and matching span names.')
+    ).toBeInTheDocument();
+    await waitForListFetch('?limit=20');
+    expect(screen.queryByRole('button', { name: 'Clear all' })).not.toBeInTheDocument();
+  });
+
+  it('pre-populates controls from a deep link and issues the filtered request', async () => {
+    const start = localDateToISOStart('2026-03-10');
+    const end = localDateToISOEnd('2026-03-12');
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes([
+      `/traces?session_id=${SESSION_ID}&q=checkout&status=failed&start_time_from=${encodeURIComponent(
+        start
+      )}&start_time_to=${encodeURIComponent(end)}&user_id=user-123&has_errors=true&min_duration_ms=1200`,
+    ]);
+
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    await waitForListFetch(
+      `?limit=20&session_id=${SESSION_ID}&q=checkout&status=failed&start_time_from=${encodeURIComponent(
+        start
+      )}&start_time_to=${encodeURIComponent(
+        end
+      )}&user_id=user-123&has_errors=true&min_duration_ms=1200`
+    );
+
+    expect(screen.getByLabelText('Search')).toHaveValue('checkout');
+    expect(screen.getByLabelText('Status')).toHaveValue('failed');
+    expect(screen.getByLabelText('Start Date')).toHaveValue('2026-03-10');
+    expect(screen.getByLabelText('End Date')).toHaveValue('2026-03-12');
+    expect(screen.getByLabelText('User ID')).toHaveValue('user-123');
+    expect(screen.getByLabelText('Min Duration (ms)')).toHaveValue(1200);
+    expect(screen.getByLabelText('Only show traces with errors')).toBeChecked();
+  });
+
+  it('commits text filters after debounce and immediately on Enter', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    fetchMock.mockClear();
+    const searchInput = screen.getByLabelText('Search');
+
+    await user.type(searchInput, ' latency');
+    expect(getTraceListRequests()).toHaveLength(0);
+
+    await waitForDebounce();
+    await waitForListFetch('?limit=20&q=latency');
+
+    fetchMock.mockClear();
+    await user.clear(searchInput);
+    await user.type(searchInput, 'errors');
+    await user.keyboard('{Enter}');
+    await waitForListFetch('?limit=20&q=errors');
+  });
+
+  it('does not commit text filters on blur before debounce elapses', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const { router } = renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    fetchMock.mockClear();
+    const userIdInput = screen.getByLabelText('User ID');
+
+    await user.type(userIdInput, 'owner-42');
+    fireEvent.blur(userIdInput);
+    await waitForDebounce();
+
+    expect(getTraceListRequests()).toHaveLength(0);
+    expect(router.state.location.search).toBe('');
+  });
+
+  it('commits min duration after debounce and on Enter', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    fetchMock.mockClear();
+    const minDurationInput = screen.getByLabelText('Min Duration (ms)');
+
+    await user.type(minDurationInput, '1500');
+    await waitForDebounce();
+    await waitForListFetch('?limit=20&min_duration_ms=1500');
+
+    fetchMock.mockClear();
+    await user.clear(minDurationInput);
+    await user.type(minDurationInput, '2400');
+    await user.keyboard('{Enter}');
+    await waitForListFetch('?limit=20&min_duration_ms=2400');
+  });
+
+  it('does not commit min duration on blur before debounce elapses', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const { router } = renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    fetchMock.mockClear();
+    const minDurationInput = screen.getByLabelText('Min Duration (ms)');
+
+    await user.type(minDurationInput, '1500');
+    fireEvent.blur(minDurationInput);
+    await waitForDebounce();
+
+    expect(getTraceListRequests()).toHaveLength(0);
+    expect(router.state.location.search).toBe('');
+  });
+
+  it('composes filters and resets pagination when a filter changes', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: (url) =>
+          jsonResponse({
+            traces: url.searchParams.get('offset') === '20' ? [TRACE_TWO] : [TRACE_ONE],
+            total: 42,
+          }),
+      })
+    );
+
+    const { router } = renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    await waitForListFetch('?limit=20&offset=20');
+
+    await user.selectOptions(screen.getByLabelText('Status'), 'running');
+    await waitForListFetch('?limit=20&status=running');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?status=running');
+    });
+  });
+
+  it('repairs stale offsets with replace and refetches the last valid page', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: (url) => {
+          const offset = url.searchParams.get('offset');
+
+          if (offset === '40') {
+            return jsonResponse({ traces: [], total: 21 });
+          }
+          if (offset === '20') {
+            return jsonResponse({ traces: [TRACE_TWO], total: 21 });
+          }
+
+          return jsonResponse({ traces: [TRACE_ONE], total: 21 });
+        },
+      })
+    );
+
+    const { router } = renderTraceRoutes(['/traces?offset=40']);
+    expect(await screen.findByText('Latency Trace')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(getTraceListRequests().map((request) => request.search)).toEqual([
+        '?limit=20&offset=40',
+        '?limit=20&offset=20',
+      ]);
+    });
+    expect(router.state.location.search).toBe('?offset=20');
+  });
+
+  it('validates inverted date ranges and suppresses the fetch until corrected', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    fetchMock.mockClear();
+
+    fireEvent.change(screen.getByLabelText('End Date'), {
+      target: { value: '2026-03-14' },
+    });
+    await waitForListFetch(
+      `?limit=20&start_time_to=${encodeURIComponent(localDateToISOEnd('2026-03-14'))}`
+    );
+
+    fetchMock.mockClear();
+
+    fireEvent.change(screen.getByLabelText('Start Date'), {
+      target: { value: '2026-03-15' },
+    });
+
+    expect(
+      await screen.findByText('Start date must be on or before the end date.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Fix the date range to load traces.')).toBeInTheDocument();
+    expect(getTraceListRequests()).toHaveLength(0);
+  });
+
+  it('honors session_id filters, clears chips individually, and clears all filters', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const { router } = renderTraceRoutes([
+      `/traces?offset=20&session_id=${SESSION_ID}&q=checkout&has_errors=true`,
+    ]);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    await waitForListFetch(
+      `?limit=20&offset=20&session_id=${SESSION_ID}&q=checkout&has_errors=true`
+    );
+
+    expect(screen.getByText(SESSION_ID)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear Search filter' }));
+    await waitForListFetch(`?limit=20&session_id=${SESSION_ID}&has_errors=true`);
+
+    await user.click(screen.getByRole('button', { name: 'Clear Session filter' }));
+    await waitForListFetch('?limit=20&has_errors=true');
+
+    await user.click(screen.getByRole('button', { name: 'Clear all' }));
+    await waitForListFetch('?limit=20');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('');
+    });
+  });
+
+  it('shows an error banner and retries without disabling the controls', async () => {
+    const user = userEvent.setup();
+    let shouldFail = true;
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: () =>
+          shouldFail
+            ? jsonResponse({ code: 'error', message: 'backend exploded' }, 500)
+            : jsonResponse({ traces: [TRACE_ONE], total: 1 }),
+      })
+    );
+
+    renderTraceRoutes(['/traces']);
+
+    expect(await screen.findByText('Could not load traces')).toBeInTheDocument();
+    expect(screen.getByLabelText('Search')).toBeEnabled();
+
+    shouldFail = false;
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getTraceListRequests()).toHaveLength(2);
+    });
+  });
+
+  it('keeps previous rows visible and shows updating while a refetch is pending', async () => {
+    const user = userEvent.setup();
+    const deferred = createDeferredResponse();
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: (url) =>
+          url.searchParams.get('status') === 'running'
+            ? deferred.promise
+            : jsonResponse({ traces: [TRACE_ONE], total: 1 }),
+      })
+    );
+
+    renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText('Status'), 'running');
+
+    expect(screen.getByText('Checkout Trace')).toBeInTheDocument();
+    expect(screen.getByText('Updating...')).toBeInTheDocument();
+
+    deferred.resolve(jsonResponse({ traces: [TRACE_TWO], total: 1 }));
+
+    expect(await screen.findByText('Latency Trace')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('Updating...')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders distinct empty states for onboarding and filtered no-match results', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: () => jsonResponse({ traces: [], total: 0 }),
+      })
+    );
+
+    const firstView = renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('No traces yet')).toBeInTheDocument();
+    firstView.unmount();
+
+    renderTraceRoutes(['/traces?q=missing']);
+    expect(await screen.findByText('No matching traces')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear all' })).toBeInTheDocument();
+  });
+
+  it('preserves API response ordering when rendering rows', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: () =>
+          jsonResponse({
+            traces: [TRACE_ZETA, TRACE_THREE],
+            total: 2,
+          }),
+      })
+    );
+
+    renderTraceRoutes(['/traces?q=trace']);
+    expect(await screen.findByText('Zeta Trace')).toBeInTheDocument();
+
+    const links = within(screen.getByRole('table')).getAllByRole('link', {
+      name: /(Zeta|Alpha) Trace/,
+    });
+    expect(links.map((link) => link.textContent)).toEqual([
+      'Zeta Trace',
+      'Alpha Trace',
+    ]);
+  });
+
+  it('uses the filtered return URL in detail and falls back to /traces otherwise', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const withState = renderTraceRoutes([
+      {
+        pathname: `/traces/${TRACE_ONE.id}`,
+        state: { returnTo: '/traces?q=checkout&status=failed' },
+      },
+    ]);
+
+    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Traces' })).toHaveAttribute(
+      'href',
+      '/traces?q=checkout&status=failed'
+    );
+    withState.unmount();
+
+    const unrelatedState = renderTraceRoutes([
+      {
+        pathname: `/traces/${TRACE_ONE.id}`,
+        state: { returnTo: '/sessions' },
+      },
+    ]);
+    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Traces' })).toHaveAttribute(
+      'href',
+      '/traces'
+    );
+    unrelatedState.unmount();
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Traces' })).toHaveAttribute(
+      'href',
+      '/traces'
+    );
+  });
+
+  it('keeps controls and chip dismiss buttons keyboard reachable with visible focus classes', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes([
+      `/traces?q=checkout&has_errors=true&session_id=${SESSION_ID}`,
+    ]);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    const searchInput = screen.getByLabelText('Search');
+    const statusSelect = screen.getByLabelText('Status');
+    const startDate = screen.getByLabelText('Start Date');
+    const endDate = screen.getByLabelText('End Date');
+    const userIdInput = screen.getByLabelText('User ID');
+    const minDurationInput = screen.getByLabelText('Min Duration (ms)');
+    const hasErrorsCheckbox = screen.getByLabelText('Only show traces with errors');
+    const clearSearch = screen.getByRole('button', { name: 'Clear Search filter' });
+    const clearErrors = screen.getByRole('button', { name: 'Clear Errors filter' });
+    const clearSession = screen.getByRole('button', { name: 'Clear Session filter' });
+    const clearAll = screen.getByRole('button', { name: 'Clear all' });
+
+    await user.tab();
+    expect(searchInput).toHaveFocus();
+    await user.tab();
+    expect(statusSelect).toHaveFocus();
+    await user.tab();
+    expect(startDate).toHaveFocus();
+    await user.tab();
+    expect(endDate).toHaveFocus();
+    await user.tab();
+    expect(userIdInput).toHaveFocus();
+    await user.tab();
+    expect(minDurationInput).toHaveFocus();
+    await user.tab();
+    expect(hasErrorsCheckbox).toHaveFocus();
+    await user.tab();
+    expect(clearSearch).toHaveFocus();
+    await user.tab();
+    expect(clearErrors).toHaveFocus();
+    await user.tab();
+    expect(clearSession).toHaveFocus();
+    await user.tab();
+    expect(clearAll).toHaveFocus();
+
+    expect(searchInput.className).toContain('focus:ring-2');
+    expect(clearSearch.className).toContain('focus:ring-2');
+    expect(clearAll.className).toContain('focus:ring-2');
+  });
+
+  it('rehydrates draft text inputs on back and forward navigation', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const { router } = renderTraceRoutes(['/traces?q=alpha']);
+    const searchInput = (await screen.findByLabelText('Search')) as HTMLInputElement;
+    expect(searchInput.value).toBe('alpha');
+
+    await user.clear(searchInput);
+    await user.type(searchInput, 'beta');
+    await waitForDebounce();
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?q=beta');
+    });
+
+    await act(async () => {
+      await router.navigate(-1);
+    });
+    await waitFor(() => {
+      expect(searchInput.value).toBe('alpha');
+    });
+
+    await act(async () => {
+      await router.navigate(1);
+    });
+    await waitFor(() => {
+      expect(searchInput.value).toBe('beta');
+    });
+  });
+
+  it('normalizes malformed session_id params away before fetching', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const { router } = renderTraceRoutes(['/traces?session_id=not-a-uuid']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    await waitForListFetch('?limit=20');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('');
+    });
+    expect(screen.queryByText('Session:')).not.toBeInTheDocument();
+  });
+
+  it('normalizes whitespace-only q params away without rendering a ghost chip', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const { router } = renderTraceRoutes(['/traces?q=%20%20%20']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    await waitForListFetch('?limit=20');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('');
+    });
+    expect(screen.getByLabelText('Search')).toHaveValue('');
+    expect(
+      screen.queryByRole('button', { name: 'Clear Search filter' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/TracesPage.tsx
+++ b/web/src/pages/TracesPage.tsx
@@ -1,117 +1,547 @@
-import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
-import { fetchTraces, Trace } from '../api/client';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { fetchTraces, type Trace } from '../api/client';
 import { PaginationControls } from '../components/PaginationControls';
 import { StatusBadge } from '../components/StatusBadge';
 import { useRequireApiKey } from '../hooks/useRequireApiKey';
+import { useTracesSearchParams } from '../hooks/useTracesSearchParams';
 import {
-  formatDuration,
-  formatTokens,
-  formatCost,
-  formatRelativeTime,
+  buildCanonicalQueryString,
+  deriveActiveChips,
+  isoToLocalDateInputValue,
+  localDateToISOEnd,
+  localDateToISOStart,
+} from '../utils/tracesSearchParams';
+import {
   calculateDuration,
+  formatCost,
+  formatDuration,
+  formatRelativeTime,
+  formatTokens,
 } from '../utils/format';
 
 const PAGE_SIZE = 20;
+const DEBOUNCE_MS = 300;
+
+function normalizeTrimmedDraft(value: string): string {
+  return value.trim();
+}
+
+function normalizeDurationDraft(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isInteger(parsed) && parsed > 0 ? String(parsed) : '';
+}
+
+function getDateRangeError(startDate: string, endDate: string): string | null {
+  if (!startDate || !endDate) {
+    return null;
+  }
+
+  return startDate > endDate
+    ? 'Start date must be on or before the end date.'
+    : null;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
+function handleEnterCommit(
+  event: KeyboardEvent<HTMLInputElement>,
+  onCommit: (value: string) => void,
+  value: string
+) {
+  if (event.key !== 'Enter') {
+    return;
+  }
+
+  event.preventDefault();
+  onCommit(value);
+}
+
+function useDebouncedDraftCommit({
+  draftValue,
+  committedValue,
+  onCommit,
+  isActive,
+  normalizeForComparison,
+}: {
+  draftValue: string;
+  committedValue: string;
+  onCommit: (value: string) => void;
+  isActive: boolean;
+  normalizeForComparison: (value: string) => string;
+}) {
+  useEffect(() => {
+    if (!isActive || normalizeForComparison(draftValue) === committedValue) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      onCommit(draftValue);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [committedValue, draftValue, isActive, normalizeForComparison, onCommit]);
+}
+
+function useDraftFocus() {
+  const [isFocused, setIsFocused] = useState(false);
+
+  return {
+    isFocused,
+    onFocus: useCallback(() => setIsFocused(true), []),
+    onBlur: useCallback(() => setIsFocused(false), []),
+  };
+}
 
 /**
- * Traces list page with pagination.
+ * Traces list page with URL-driven filters and pagination.
  */
 export function TracesPage() {
   const { hasApiKey, prompt } = useRequireApiKey();
-  const [offset, setOffset] = useState(0);
 
-  // Show API key prompt if not configured
   if (!hasApiKey) {
     return prompt;
   }
 
-  return <TracesContent offset={offset} setOffset={setOffset} />;
+  return <TracesContent />;
 }
 
-interface TracesContentProps {
-  offset: number;
-  setOffset: (offset: number) => void;
-}
+function TracesContent() {
+  const location = useLocation();
+  const { filters, setFilters, clearAll, clearChip } = useTracesSearchParams();
+  const [searchDraft, setSearchDraft] = useState(filters.q ?? '');
+  const [userIdDraft, setUserIdDraft] = useState(filters.user_id ?? '');
+  const [minDurationDraft, setMinDurationDraft] = useState(
+    filters.min_duration_ms?.toString() ?? ''
+  );
+  const searchFocus = useDraftFocus();
+  const userIdFocus = useDraftFocus();
+  const minDurationFocus = useDraftFocus();
 
-function TracesContent({ offset, setOffset }: TracesContentProps) {
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['traces', offset],
-    queryFn: () => fetchTraces(PAGE_SIZE, offset),
+  useEffect(() => {
+    setSearchDraft(filters.q ?? '');
+  }, [filters.q]);
+
+  useEffect(() => {
+    setUserIdDraft(filters.user_id ?? '');
+  }, [filters.user_id]);
+
+  useEffect(() => {
+    setMinDurationDraft(filters.min_duration_ms?.toString() ?? '');
+  }, [filters.min_duration_ms]);
+
+  const commitSearch = useCallback(
+    (value: string) => {
+      const normalizedValue = normalizeTrimmedDraft(value);
+      setSearchDraft(normalizedValue);
+      setFilters({ q: normalizedValue || undefined }, 'push');
+    },
+    [setFilters]
+  );
+
+  const commitUserId = useCallback(
+    (value: string) => {
+      const normalizedValue = normalizeTrimmedDraft(value);
+      setUserIdDraft(normalizedValue);
+      setFilters({ user_id: normalizedValue || undefined }, 'push');
+    },
+    [setFilters]
+  );
+
+  const commitMinDuration = useCallback(
+    (value: string) => {
+      const normalizedValue = normalizeDurationDraft(value);
+      setMinDurationDraft(normalizedValue);
+      setFilters(
+        {
+          min_duration_ms: normalizedValue ? Number(normalizedValue) : undefined,
+        },
+        'push'
+      );
+    },
+    [setFilters]
+  );
+
+  useDebouncedDraftCommit({
+    draftValue: searchDraft,
+    committedValue: filters.q ?? '',
+    onCommit: commitSearch,
+    isActive: searchFocus.isFocused,
+    normalizeForComparison: normalizeTrimmedDraft,
   });
 
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-gray-500">Loading traces...</div>
-      </div>
-    );
-  }
+  useDebouncedDraftCommit({
+    draftValue: userIdDraft,
+    committedValue: filters.user_id ?? '',
+    onCommit: commitUserId,
+    isActive: userIdFocus.isFocused,
+    normalizeForComparison: normalizeTrimmedDraft,
+  });
 
-  if (error) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-red-600">
-          Error loading traces: {error instanceof Error ? error.message : 'Unknown error'}
-        </div>
-      </div>
-    );
-  }
+  useDebouncedDraftCommit({
+    draftValue: minDurationDraft,
+    committedValue: filters.min_duration_ms?.toString() ?? '',
+    onCommit: commitMinDuration,
+    isActive: minDurationFocus.isFocused,
+    normalizeForComparison: normalizeDurationDraft,
+  });
 
-  const traces = data?.traces ?? [];
-  const total = data?.total ?? 0;
+  const startDate = isoToLocalDateInputValue(filters.start_time_from);
+  const endDate = isoToLocalDateInputValue(filters.start_time_to);
+  const dateRangeError = getDateRangeError(startDate, endDate);
+  const activeChips = deriveActiveChips(filters);
+  const hasActiveFilters = activeChips.length > 0;
+  const queryParams = {
+    ...filters,
+    limit: PAGE_SIZE,
+  };
+  const canonicalQueryString = buildCanonicalQueryString(queryParams);
+  const tracesQuery = useQuery({
+    queryKey: ['traces', canonicalQueryString],
+    queryFn: () => fetchTraces(queryParams),
+    enabled: !dateRangeError,
+    placeholderData: keepPreviousData,
+  });
+
+  const traces = tracesQuery.data?.traces ?? [];
+  const total = tracesQuery.data?.total ?? 0;
+  const currentListUrl = `${location.pathname}${location.search}`;
+
+  useEffect(() => {
+    if (traces.length !== 0 || total === 0 || filters.offset === 0) {
+      return;
+    }
+
+    const lastValidOffset = Math.floor((total - 1) / PAGE_SIZE) * PAGE_SIZE;
+    if (lastValidOffset !== filters.offset) {
+      setFilters({ offset: lastValidOffset }, 'replace');
+    }
+  }, [filters.offset, setFilters, total, traces.length]);
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold text-gray-900">Traces</h1>
-          <span className="text-sm text-gray-500">{total} total</span>
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Traces</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Find traces by name, owner, time window, or error signals.
+            </p>
+          </div>
+          <div className="text-sm text-gray-500">
+            <span>{total} total</span>
+            {tracesQuery.isFetching && !tracesQuery.isPending && (
+              <span className="ml-2 text-blue-600">Updating...</span>
+            )}
+          </div>
         </div>
 
-        {traces.length === 0 ? (
-          <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
-            No traces found. Start sending traces from your application.
+        <section className="mb-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
+            <div className="xl:col-span-2">
+              <label
+                htmlFor="trace-search"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                Search
+              </label>
+              <input
+                id="trace-search"
+                type="text"
+                value={searchDraft}
+                onChange={(event) => setSearchDraft(event.target.value)}
+                onFocus={searchFocus.onFocus}
+                onBlur={searchFocus.onBlur}
+                onKeyDown={(event) =>
+                  handleEnterCommit(event, commitSearch, searchDraft)
+                }
+                aria-describedby="trace-search-hint"
+                placeholder="Search traces"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+              <p id="trace-search-hint" className="mt-1 text-xs text-gray-500">
+                Search names, user IDs, and matching span names.
+              </p>
+            </div>
+
+            <div>
+              <label
+                htmlFor="trace-status"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                Status
+              </label>
+              <select
+                id="trace-status"
+                value={filters.status ?? ''}
+                onChange={(event) =>
+                  setFilters(
+                    {
+                      status: event.target.value
+                        ? (event.target.value as 'running' | 'completed' | 'failed')
+                        : undefined,
+                    },
+                    'push'
+                  )
+                }
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              >
+                <option value="">All statuses</option>
+                <option value="running">Running</option>
+                <option value="completed">Completed</option>
+                <option value="failed">Failed</option>
+              </select>
+            </div>
+
+            <div>
+              <label
+                htmlFor="trace-start-date"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                Start Date
+              </label>
+              <input
+                id="trace-start-date"
+                type="date"
+                value={startDate}
+                onChange={(event) =>
+                  setFilters(
+                    {
+                      start_time_from: event.target.value
+                        ? localDateToISOStart(event.target.value)
+                        : undefined,
+                    },
+                    'push'
+                  )
+                }
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="trace-end-date"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                End Date
+              </label>
+              <input
+                id="trace-end-date"
+                type="date"
+                value={endDate}
+                onChange={(event) =>
+                  setFilters(
+                    {
+                      start_time_to: event.target.value
+                        ? localDateToISOEnd(event.target.value)
+                        : undefined,
+                    },
+                    'push'
+                  )
+                }
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="trace-user-id"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                User ID
+              </label>
+              <input
+                id="trace-user-id"
+                type="text"
+                value={userIdDraft}
+                onChange={(event) => setUserIdDraft(event.target.value)}
+                onFocus={userIdFocus.onFocus}
+                onBlur={userIdFocus.onBlur}
+                onKeyDown={(event) =>
+                  handleEnterCommit(event, commitUserId, userIdDraft)
+                }
+                placeholder="Filter by user"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] xl:grid-cols-1 xl:gap-2">
+              <div>
+                <label
+                  htmlFor="trace-min-duration"
+                  className="mb-1 block text-sm font-medium text-gray-700"
+                >
+                  Min Duration (ms)
+                </label>
+                <input
+                  id="trace-min-duration"
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={minDurationDraft}
+                  onChange={(event) => setMinDurationDraft(event.target.value)}
+                  onFocus={minDurationFocus.onFocus}
+                  onBlur={minDurationFocus.onBlur}
+                  onKeyDown={(event) =>
+                    handleEnterCommit(event, commitMinDuration, minDurationDraft)
+                  }
+                  placeholder="e.g. 1500"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                />
+              </div>
+
+              <label className="flex items-end gap-2 text-sm font-medium text-gray-700 xl:pt-0">
+                <input
+                  type="checkbox"
+                  checked={Boolean(filters.has_errors)}
+                  onChange={(event) =>
+                    setFilters(
+                      {
+                        has_errors: event.target.checked ? true : undefined,
+                      },
+                      'push'
+                    )
+                  }
+                  aria-label="Only show traces with errors"
+                  className="mt-0 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
+                />
+                <span>Has errors</span>
+              </label>
+            </div>
           </div>
+
+          {dateRangeError && (
+            <p className="mt-3 text-sm font-medium text-red-600">{dateRangeError}</p>
+          )}
+        </section>
+
+        {hasActiveFilters && (
+          <div className="mb-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+            <div className="flex flex-wrap items-center gap-2">
+              {activeChips.map((chip) => (
+                <span
+                  key={chip.key}
+                  className="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-sm text-gray-700"
+                >
+                  <span className="font-medium">{chip.label}:</span>
+                  <span>{chip.value}</span>
+                  <button
+                    type="button"
+                    onClick={() => clearChip(chip.key)}
+                    aria-label={`Clear ${chip.label} filter`}
+                    className="rounded-full p-0.5 text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+              <button
+                type="button"
+                onClick={clearAll}
+                className="ml-auto rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:border-gray-400 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              >
+                Clear all
+              </button>
+            </div>
+          </div>
+        )}
+
+        {tracesQuery.error && (
+          <div className="mb-4 flex flex-col gap-3 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-semibold">Could not load traces</p>
+              <p className="text-sm">{getErrorMessage(tracesQuery.error)}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void tracesQuery.refetch()}
+              className="rounded-lg bg-red-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-200"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {dateRangeError ? (
+          <div className="rounded-xl border border-dashed border-red-200 bg-white p-8 text-center text-sm text-gray-600 shadow-sm">
+            Fix the date range to load traces.
+          </div>
+        ) : tracesQuery.isPending && !tracesQuery.data ? (
+          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-gray-500 shadow-sm">
+            Loading traces...
+          </div>
+        ) : tracesQuery.error && !tracesQuery.data ? (
+          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-gray-600 shadow-sm">
+            Retry the request or adjust your filters to continue.
+          </div>
+        ) : traces.length === 0 ? (
+          hasActiveFilters ? (
+            <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900">No matching traces</h2>
+              <p className="mt-2 text-sm text-gray-500">
+                Try broadening the filters or clearing them entirely.
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900">No traces yet</h2>
+              <p className="mt-2 text-sm text-gray-500">
+                Start sending traces from your application to see them here.
+              </p>
+            </div>
+          )
         ) : (
           <>
-            <div className="bg-white shadow overflow-hidden rounded-lg">
+            <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Name
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Status
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Duration
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Tokens
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Cost
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Started
                     </th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
+                <tbody className="divide-y divide-gray-200 bg-white">
                   {traces.map((trace) => (
-                    <TraceRow key={trace.id} trace={trace} />
+                    <TraceRow
+                      key={trace.id}
+                      trace={trace}
+                      returnTo={currentListUrl}
+                    />
                   ))}
                 </tbody>
               </table>
             </div>
             <PaginationControls
-              offset={offset}
+              offset={filters.offset}
               pageSize={PAGE_SIZE}
               total={total}
-              onOffsetChange={setOffset}
+              onOffsetChange={(offset) => setFilters({ offset }, 'push')}
             />
           </>
         )}
@@ -122,41 +552,54 @@ function TracesContent({ offset, setOffset }: TracesContentProps) {
 
 interface TraceRowProps {
   trace: Trace;
+  returnTo: string;
 }
 
-function TraceRow({ trace }: TraceRowProps) {
+function TraceRow({ trace, returnTo }: TraceRowProps) {
   const duration = calculateDuration(trace.started_at, trace.ended_at);
-  const totalTokens =
-    (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
+  const totalTokens = (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
 
   return (
-    <tr className="hover:bg-gray-50">
-      <td className="px-6 py-4 whitespace-nowrap">
-        <Link
-          to={`/traces/${trace.id}`}
-          className="text-blue-600 hover:text-blue-800 font-medium"
-        >
-          {trace.name}
-        </Link>
-        {trace.session_id && (
-          <p className="text-xs text-gray-400 mt-1">
-            Session: {trace.session_id.slice(0, 8)}...
-          </p>
-        )}
+    <tr className="transition hover:bg-gray-50">
+      <td className="px-6 py-4 align-top">
+        <div className="min-w-[16rem]">
+          <div className="flex flex-wrap items-center gap-2">
+            <Link
+              to={`/traces/${trace.id}`}
+              state={{ returnTo }}
+              className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            >
+              {trace.name}
+            </Link>
+            {trace.error_count && trace.error_count > 0 && (
+              <span className="inline-flex rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">
+                {trace.error_count} error{trace.error_count === 1 ? '' : 's'}
+              </span>
+            )}
+          </div>
+          {trace.session_id && (
+            <Link
+              to={`/sessions/${trace.session_id}`}
+              className="mt-1 inline-flex text-xs text-gray-500 transition hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            >
+              Session {trace.session_id.slice(0, 8)}...
+            </Link>
+          )}
+        </div>
       </td>
-      <td className="px-6 py-4 whitespace-nowrap">
+      <td className="px-6 py-4 whitespace-nowrap align-top">
         <StatusBadge status={trace.status} />
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
         {formatDuration(duration)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
         {formatTokens(totalTokens)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
         {formatCost(trace.total_cost_usd)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 align-top">
         {formatRelativeTime(trace.started_at)}
       </td>
     </tr>

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/web/src/utils/tracesSearchParams.test.ts
+++ b/web/src/utils/tracesSearchParams.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCanonicalQueryString,
+  clearChip,
+  deriveActiveChips,
+  isoToLocalDateInputValue,
+  localDateToISOEnd,
+  localDateToISOStart,
+  parseTracesParams,
+  serializeTracesParams,
+} from './tracesSearchParams';
+
+describe('tracesSearchParams', () => {
+  it('normalizes parsed params and round-trips through serialization', () => {
+    const params = new URLSearchParams({
+      offset: '20',
+      q: '  checkout flow  ',
+      status: 'ERROR',
+      start_time_from: '2026-03-14T00:00:00+05:30',
+      start_time_to: '2026-03-14T23:59:59+05:30',
+      user_id: '  user-123  ',
+      has_errors: 'true',
+      min_duration_ms: '2500',
+      session_id: 'ABCDEF12-3456-7890-ABCD-EF1234567890',
+    });
+
+    const parsed = parseTracesParams(params);
+
+    expect(parsed).toEqual({
+      offset: 20,
+      q: 'checkout flow',
+      status: 'failed',
+      start_time_from: '2026-03-13T18:30:00.000Z',
+      start_time_to: '2026-03-14T18:29:59.000Z',
+      user_id: 'user-123',
+      has_errors: true,
+      min_duration_ms: 2500,
+      session_id: 'abcdef12-3456-7890-abcd-ef1234567890',
+    });
+
+    expect(serializeTracesParams(parsed).toString()).toBe(
+      [
+        'offset=20',
+        'session_id=abcdef12-3456-7890-abcd-ef1234567890',
+        'q=checkout+flow',
+        'status=failed',
+        'start_time_from=2026-03-13T18%3A30%3A00.000Z',
+        'start_time_to=2026-03-14T18%3A29%3A59.000Z',
+        'user_id=user-123',
+        'has_errors=true',
+        'min_duration_ms=2500',
+      ].join('&')
+    );
+  });
+
+  it('drops malformed values during parsing', () => {
+    const parsed = parseTracesParams(
+      new URLSearchParams({
+        offset: '-5',
+        q: '   ',
+        status: 'pending',
+        session_id: 'not-a-uuid',
+        start_time_from: '2026-03-14',
+        start_time_to: 'still-not-a-date',
+        has_errors: 'TRUE',
+        min_duration_ms: '1.9',
+      })
+    );
+
+    expect(parsed).toEqual({ offset: 0 });
+    expect(deriveActiveChips(parsed)).toEqual([]);
+  });
+
+  it('treats zero, negative, and non-integer min duration values as unset', () => {
+    expect(
+      parseTracesParams(new URLSearchParams({ min_duration_ms: '0' })).min_duration_ms
+    ).toBeUndefined();
+    expect(
+      parseTracesParams(new URLSearchParams({ min_duration_ms: '-10' })).min_duration_ms
+    ).toBeUndefined();
+    expect(
+      parseTracesParams(new URLSearchParams({ min_duration_ms: '1.9' })).min_duration_ms
+    ).toBeUndefined();
+  });
+
+  it('converts local date boundaries to ISO timestamps', () => {
+    const start = new Date(localDateToISOStart('2026-03-14'));
+    const end = new Date(localDateToISOEnd('2026-03-14'));
+
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(2);
+    expect(start.getDate()).toBe(14);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
+    expect(start.getMilliseconds()).toBe(0);
+
+    expect(end.getFullYear()).toBe(2026);
+    expect(end.getMonth()).toBe(2);
+    expect(end.getDate()).toBe(14);
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+    expect(end.getSeconds()).toBe(59);
+    expect(end.getMilliseconds()).toBe(999);
+  });
+
+  it('derives active chips and clears individual filters while resetting pagination', () => {
+    const state = parseTracesParams(
+      new URLSearchParams({
+        offset: '40',
+        q: 'trace search',
+        has_errors: 'true',
+        session_id: '123e4567-e89b-12d3-a456-426614174000',
+      })
+    );
+
+    expect(deriveActiveChips(state)).toEqual([
+      { key: 'q', label: 'Search', value: 'trace search' },
+      { key: 'has_errors', label: 'Errors', value: 'Only traces with errors' },
+      {
+        key: 'session_id',
+        label: 'Session',
+        value: '123e4567-e89b-12d3-a456-426614174000',
+      },
+    ]);
+
+    expect(clearChip(state, 'q')).toEqual({
+      offset: 0,
+      has_errors: true,
+      session_id: '123e4567-e89b-12d3-a456-426614174000',
+    });
+  });
+
+  it('builds identical canonical strings for equivalent params', () => {
+    const first = buildCanonicalQueryString(
+      parseTracesParams(
+        new URLSearchParams({
+          q: '  flow  ',
+          status: 'FAILED',
+          has_errors: 'true',
+          offset: '20',
+          session_id: '123E4567-E89B-12D3-A456-426614174000',
+        })
+      )
+    );
+
+    const second = buildCanonicalQueryString(
+      parseTracesParams(
+        new URLSearchParams({
+          session_id: '123e4567-e89b-12d3-a456-426614174000',
+          offset: '20',
+          has_errors: 'true',
+          status: 'error',
+          q: 'flow',
+        })
+      )
+    );
+
+    expect(first).toBe(
+      'offset=20&session_id=123e4567-e89b-12d3-a456-426614174000&q=flow&status=failed&has_errors=true'
+    );
+    expect(second).toBe(first);
+  });
+
+  it('preserves valid session ids and formats ISO dates for date inputs', () => {
+    const parsed = parseTracesParams(
+      new URLSearchParams({
+        session_id: '123e4567-e89b-12d3-a456-426614174000',
+        start_time_from: '2026-03-14T00:00:00.000Z',
+      })
+    );
+
+    expect(parsed.session_id).toBe('123e4567-e89b-12d3-a456-426614174000');
+    expect(isoToLocalDateInputValue(parsed.start_time_from)).toBe('2026-03-14');
+  });
+});

--- a/web/src/utils/tracesSearchParams.ts
+++ b/web/src/utils/tracesSearchParams.ts
@@ -1,0 +1,373 @@
+export type TraceStatusFilter = 'running' | 'completed' | 'failed';
+
+export interface FetchTracesParams {
+  limit?: number;
+  offset?: number;
+  session_id?: string;
+  q?: string;
+  status?: TraceStatusFilter;
+  start_time_from?: string;
+  start_time_to?: string;
+  user_id?: string;
+  has_errors?: boolean;
+  min_duration_ms?: number;
+}
+
+export interface TracesFilterState {
+  offset: number;
+  session_id?: string;
+  q?: string;
+  status?: TraceStatusFilter;
+  start_time_from?: string;
+  start_time_to?: string;
+  user_id?: string;
+  has_errors?: boolean;
+  min_duration_ms?: number;
+}
+
+export type ChipKey = Exclude<keyof TracesFilterState, 'offset'>;
+
+export interface Chip {
+  key: ChipKey;
+  label: string;
+  value?: string;
+}
+
+interface NormalizedTracesParams extends FetchTracesParams {
+  offset: number;
+}
+
+type NormalizableTracesParams = {
+  [Key in keyof FetchTracesParams]?: FetchTracesParams[Key] | string;
+} & {
+  offset?: number | string;
+};
+
+const VALID_STATUSES = new Set<TraceStatusFilter>(['running', 'completed', 'failed']);
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DATE_INPUT_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_DATE_TIME_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const CANONICAL_PARAM_ORDER: Array<keyof FetchTracesParams> = [
+  'limit',
+  'offset',
+  'session_id',
+  'q',
+  'status',
+  'start_time_from',
+  'start_time_to',
+  'user_id',
+  'has_errors',
+  'min_duration_ms',
+];
+
+function normalizeOptionalText(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeStatus(value: string | null | undefined): TraceStatusFilter | undefined {
+  const candidate = value?.trim().toLowerCase();
+  if (!candidate) {
+    return undefined;
+  }
+
+  const normalized = candidate === 'error' ? 'failed' : candidate;
+  return VALID_STATUSES.has(normalized as TraceStatusFilter)
+    ? (normalized as TraceStatusFilter)
+    : undefined;
+}
+
+function normalizeUUID(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !UUID_PATTERN.test(trimmed)) {
+    return undefined;
+  }
+
+  return trimmed.toLowerCase();
+}
+
+function normalizeBooleanTrue(value: boolean | string | undefined): boolean | undefined {
+  return value === true || value === 'true' ? true : undefined;
+}
+
+function normalizeNonNegativeInteger(value: number | string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function normalizePositiveInteger(value: number | string | undefined): number | undefined {
+  const parsed = normalizeNonNegativeInteger(value);
+  if (parsed === undefined || parsed === 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function normalizeISODateTime(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !ISO_DATE_TIME_PATTERN.test(trimmed)) {
+    return undefined;
+  }
+
+  const timestamp = new Date(trimmed);
+  if (Number.isNaN(timestamp.getTime())) {
+    return undefined;
+  }
+
+  return timestamp.toISOString();
+}
+
+function normalizeTracesParams(
+  params: NormalizableTracesParams
+): NormalizedTracesParams {
+  return {
+    limit: normalizePositiveInteger(params.limit),
+    offset: normalizeNonNegativeInteger(params.offset) ?? 0,
+    session_id: normalizeUUID(params.session_id),
+    q: normalizeOptionalText(params.q),
+    status: normalizeStatus(params.status),
+    start_time_from: normalizeISODateTime(params.start_time_from),
+    start_time_to: normalizeISODateTime(params.start_time_to),
+    user_id: normalizeOptionalText(params.user_id),
+    has_errors: normalizeBooleanTrue(params.has_errors),
+    min_duration_ms: normalizePositiveInteger(params.min_duration_ms),
+  };
+}
+
+function toQueryEntries(
+  params: NormalizedTracesParams
+): Array<[keyof FetchTracesParams, string]> {
+  const entries: Array<[keyof FetchTracesParams, string]> = [];
+
+  if (params.limit !== undefined) {
+    entries.push(['limit', String(params.limit)]);
+  }
+  if (params.offset > 0) {
+    entries.push(['offset', String(params.offset)]);
+  }
+  if (params.session_id) {
+    entries.push(['session_id', params.session_id]);
+  }
+  if (params.q) {
+    entries.push(['q', params.q]);
+  }
+  if (params.status) {
+    entries.push(['status', params.status]);
+  }
+  if (params.start_time_from) {
+    entries.push(['start_time_from', params.start_time_from]);
+  }
+  if (params.start_time_to) {
+    entries.push(['start_time_to', params.start_time_to]);
+  }
+  if (params.user_id) {
+    entries.push(['user_id', params.user_id]);
+  }
+  if (params.has_errors) {
+    entries.push(['has_errors', 'true']);
+  }
+  if (params.min_duration_ms !== undefined) {
+    entries.push(['min_duration_ms', String(params.min_duration_ms)]);
+  }
+
+  return entries.sort(
+    ([left], [right]) =>
+      CANONICAL_PARAM_ORDER.indexOf(left) - CANONICAL_PARAM_ORDER.indexOf(right)
+  );
+}
+
+function resetOffset(state: TracesFilterState): TracesFilterState {
+  return { ...state, offset: 0 };
+}
+
+function parseLocalDate(date: string): Date | null {
+  if (!DATE_INPUT_PATTERN.test(date)) {
+    return null;
+  }
+
+  const [yearString, monthString, dayString] = date.split('-');
+  const year = Number(yearString);
+  const month = Number(monthString);
+  const day = Number(dayString);
+  const parsed = new Date(year, month - 1, day);
+
+  if (
+    parsed.getFullYear() !== year ||
+    parsed.getMonth() !== month - 1 ||
+    parsed.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function parseTracesParams(searchParams: URLSearchParams): TracesFilterState {
+  const normalized = normalizeTracesParams({
+    offset: searchParams.get('offset') ?? undefined,
+    session_id: searchParams.get('session_id') ?? undefined,
+    q: searchParams.get('q') ?? undefined,
+    status: searchParams.get('status') ?? undefined,
+    start_time_from: searchParams.get('start_time_from') ?? undefined,
+    start_time_to: searchParams.get('start_time_to') ?? undefined,
+    user_id: searchParams.get('user_id') ?? undefined,
+    has_errors: searchParams.get('has_errors') ?? undefined,
+    min_duration_ms: searchParams.get('min_duration_ms') ?? undefined,
+  });
+
+  return {
+    offset: normalized.offset,
+    session_id: normalized.session_id,
+    q: normalized.q,
+    status: normalized.status,
+    start_time_from: normalized.start_time_from,
+    start_time_to: normalized.start_time_to,
+    user_id: normalized.user_id,
+    has_errors: normalized.has_errors,
+    min_duration_ms: normalized.min_duration_ms,
+  };
+}
+
+export function serializeTracesParams(state: TracesFilterState): URLSearchParams {
+  const normalized = normalizeTracesParams(state);
+  const params = new URLSearchParams();
+
+  toQueryEntries(normalized).forEach(([key, value]) => {
+    params.set(key, value);
+  });
+
+  return params;
+}
+
+export function buildCanonicalQueryString(
+  params: FetchTracesParams | TracesFilterState
+): string {
+  const normalized = normalizeTracesParams(params);
+  const query = new URLSearchParams();
+
+  toQueryEntries(normalized).forEach(([key, value]) => {
+    query.set(key, value);
+  });
+
+  return query.toString();
+}
+
+export function localDateToISOStart(date: string): string {
+  const parsed = parseLocalDate(date);
+  if (!parsed) {
+    throw new Error(`Invalid local date: ${date}`);
+  }
+
+  parsed.setHours(0, 0, 0, 0);
+  return parsed.toISOString();
+}
+
+export function localDateToISOEnd(date: string): string {
+  const parsed = parseLocalDate(date);
+  if (!parsed) {
+    throw new Error(`Invalid local date: ${date}`);
+  }
+
+  parsed.setHours(23, 59, 59, 999);
+  return parsed.toISOString();
+}
+
+export function isoToLocalDateInputValue(value?: string): string {
+  if (!value) {
+    return '';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+
+  const year = parsed.getFullYear();
+  const month = String(parsed.getMonth() + 1).padStart(2, '0');
+  const day = String(parsed.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function deriveActiveChips(state: TracesFilterState): Chip[] {
+  const normalized = normalizeTracesParams(state);
+  const chips: Chip[] = [];
+
+  if (normalized.q) {
+    chips.push({ key: 'q', label: 'Search', value: normalized.q });
+  }
+  if (normalized.status) {
+    chips.push({ key: 'status', label: 'Status', value: normalized.status });
+  }
+  if (normalized.start_time_from) {
+    chips.push({
+      key: 'start_time_from',
+      label: 'From',
+      value: isoToLocalDateInputValue(normalized.start_time_from),
+    });
+  }
+  if (normalized.start_time_to) {
+    chips.push({
+      key: 'start_time_to',
+      label: 'To',
+      value: isoToLocalDateInputValue(normalized.start_time_to),
+    });
+  }
+  if (normalized.user_id) {
+    chips.push({ key: 'user_id', label: 'User', value: normalized.user_id });
+  }
+  if (normalized.has_errors) {
+    chips.push({ key: 'has_errors', label: 'Errors', value: 'Only traces with errors' });
+  }
+  if (normalized.min_duration_ms !== undefined) {
+    chips.push({
+      key: 'min_duration_ms',
+      label: 'Min duration',
+      value: `${normalized.min_duration_ms} ms`,
+    });
+  }
+  if (normalized.session_id) {
+    chips.push({ key: 'session_id', label: 'Session', value: normalized.session_id });
+  }
+
+  return chips;
+}
+
+export function clearChip(
+  state: TracesFilterState,
+  chipKey: ChipKey
+): TracesFilterState {
+  const normalized = parseTracesParams(serializeTracesParams(state));
+
+  switch (chipKey) {
+    case 'q':
+      return resetOffset({ ...normalized, q: undefined });
+    case 'status':
+      return resetOffset({ ...normalized, status: undefined });
+    case 'start_time_from':
+      return resetOffset({ ...normalized, start_time_from: undefined });
+    case 'start_time_to':
+      return resetOffset({ ...normalized, start_time_to: undefined });
+    case 'user_id':
+      return resetOffset({ ...normalized, user_id: undefined });
+    case 'has_errors':
+      return resetOffset({ ...normalized, has_errors: undefined });
+    case 'min_duration_ms':
+      return resetOffset({ ...normalized, min_duration_ms: undefined });
+    case 'session_id':
+      return resetOffset({ ...normalized, session_id: undefined });
+    default:
+      return normalized;
+  }
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,4 +20,10 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: true,
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    passWithNoTests: true,
+    setupFiles: ['./src/test/setup.ts'],
+  },
 });


### PR DESCRIPTION
## Summary
- add URL-driven trace discovery filters, chips, pagination recovery, and filtered return navigation
- unify trace fetching behind `fetchTraces(params?)` and update session/detail consumers
- add Vitest + Testing Library coverage for URL normalization, debounce semantics, stale offsets, and refetch UX

## Verification
- local GitHub Actions equivalent passed (generate, lint, type-check, Go tests, JS tests, builds, and Python SDK E2E)
- `openspec validate add-trace-discovery-triage --strict`
- `pnpm --filter web test`
- `go test ./internal/store -run 'TestSearch_(FindTraceBySpanName|CombinedSearchAndFilter|Pagination|FilterByTimeRange|FilterByHasErrors|FilterByMinDuration)'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive trace filtering with six controls: text search, status, date range, user ID, error filtering, and duration thresholds.
  * Filters now driven by URL parameters, enabling shareable filtered views and browser history navigation.
  * Display active filters as dismissible chips with a "Clear all" option.
  * Improved trace list rendering with better visual emphasis and session linking.
  * Enhanced empty states distinguishing between no results and no matching filters.
  * Added error banner with retry functionality.

* **Tests**
  * Added testing framework and comprehensive test coverage for trace discovery features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->