### PR TITLE
feat(web): implement failure-first trace detail

### DIFF
--- a/openspec/changes/add-failure-first-trace-detail/design.md
+++ b/openspec/changes/add-failure-first-trace-detail/design.md
@@ -1,0 +1,71 @@
+## Context
+
+Phase 7 adds failure-first UX to the trace detail page. This is a coordination/state-management phase that builds on the existing span tree, timeline, and detail panel without changing the data model or API contracts.
+
+The primary challenge is managing selection state correctly across polling, auto-selection, and user interaction while keeping derived failure computations efficient and cycle-safe.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Deterministic primary failed span selection with stable tie-breaking
+  - Sticky user selection that survives polling and recomputation
+  - Linear, memoized failure analysis computed once per data change
+  - Cycle-safe parent chain traversal for breadcrumbs and highlighting
+  - Accessible keyboard-operable controls for all new interactions
+- Non-Goals:
+  - Changing the data model or API contracts
+  - Adding error boundaries (app has no existing pattern)
+  - Lifting full tree expansion state to the page level
+  - Server-side failure analysis or ranking
+
+## Decisions
+
+### Selection state model
+
+- **Decision**: Use `selectedSpanExternalId: string | null` as the canonical page-level key, with a `userHasSelected: boolean` flag to distinguish auto-selection from user selection.
+- **Why**: External `span_id` is the key used across tree ancestry, timeline span references, and failure-path logic. The `userHasSelected` flag prevents polling from overriding manual choices.
+- **Alternatives**: Using internal `id` was considered but rejected because parent-child relationships and timeline events reference external `span_id`.
+
+### Failure analysis as a pure helper
+
+- **Decision**: One pure TypeScript module (`failureAnalysis.ts`) with no React dependencies. Consumers call it with spans/events and get derived state back.
+- **Why**: Keeps logic testable without rendering, allows memoization at the call site via `useMemo`, and avoids coupling analysis logic to component lifecycle.
+- **Alternatives**: Custom hook was considered but a pure module is simpler and more portable.
+
+### Primary failed span determinism
+
+- **Decision**: Sort failed spans by `ended_at` ascending (earliest failure first), then `started_at`, then original array order. Take the first.
+- **Why**: The earliest failure is most likely the root cause. Deterministic tie-breaking prevents selection flickering during polling.
+
+### Tree highlighting without lifting expansion state
+
+- **Decision**: Pass a `revealPath: Set<string>` (set of external span IDs) from the page. Each `SpanTreeNode` checks if it's on the path and auto-expands if collapsed. Expansion state remains local to nodes.
+- **Why**: Avoids the complexity of controlled expansion for the entire tree. The reveal-path is a one-way signal that nodes can consume independently.
+
+### Error-only filter placement
+
+- **Decision**: Keep the toggle inside `Timeline.tsx`, driven by local state. The filter uses the existing `isTimelineErrorEvent` predicate.
+- **Why**: The filter is self-contained within the timeline and doesn't affect other components. No need to lift state.
+
+### Terminal refresh of trace and spans
+
+- **Decision**: When the timeline hook detects a terminal transition (`RUNNING` → `COMPLETED`/`FAILED`), invalidate the `traceQuery` and `spansQuery` via TanStack Query's `queryClient.invalidateQueries`. This triggers a refetch so failure analysis, header metrics, and the summary operate on current data.
+- **Why**: Currently `traceQuery` and `spansQuery` are one-shot fetches. Without invalidation after terminal transition, the failure-first UI would be driven by stale data (e.g., missing failed spans that arrived after initial load).
+- **Alternatives**: Adding independent polling for trace/spans was considered but rejected — the timeline hook already detects terminal state, so piggyback on that signal.
+
+### Cross-trace state reset
+
+- **Decision**: Use a `key={traceId}` prop on `TraceDetailContent` (or equivalent reset via `useEffect` on `traceId`) to reset all Phase 7 local state when the route parameter changes.
+- **Why**: The `/traces/:id` route reuses the same component, so React won't unmount/remount by default. Without explicit reset, `selectedSpanExternalId`, `userHasSelected`, error filter state, and reveal-path state would leak between traces.
+- **Alternatives**: Manual `useEffect` reset was considered but `key`-based remounting is simpler and guarantees all state (including state in child components like the timeline filter) resets.
+
+## Risks / Trade-offs
+
+- **Polling + auto-selection race**: If spans data and timeline data update at different times, the primary failed span could briefly differ. Mitigated by triggering trace/spans refetch on terminal transition, and by making user selection sticky.
+- **Cycle-safe traversal overhead**: The visited-set check adds minimal overhead per traversal. For traces with thousands of spans this is negligible compared to rendering.
+- **Stale trace signal false positives**: The 15-minute/5-minute thresholds are conservative defaults. Marked as experimental with local constants for easy tuning.
+- **Terminal refetch brief loading state**: After invalidation, TanStack Query may briefly show stale data while refetching. This is acceptable — the stale-while-revalidate pattern means the UI stays interactive.
+
+## Open Questions
+
+- None blocking implementation. Threshold tuning for the trust signal can be adjusted post-launch based on real usage data.

--- a/openspec/changes/add-failure-first-trace-detail/proposal.md
+++ b/openspec/changes/add-failure-first-trace-detail/proposal.md
@@ -1,0 +1,34 @@
+# Change: Add Failure-First Trace Detail Experience
+
+## Why
+
+When debugging failed AI agent traces, users currently must manually scan the span tree and timeline to locate failures. There is no automated guidance toward the root cause. This makes triage slow and error-prone, especially for deep span trees with many nodes.
+
+Phase 7 delivers a failure-first experience: the page automatically surfaces the primary failed span, highlights the failure path, and provides contextual navigation so users can understand what went wrong without hunting through the tree.
+
+## What Changes
+
+- **Failure analysis helper** — Pure TypeScript module that computes primary failed span, failure summary, inline error previews, breadcrumb paths, and a stale-trace trust signal. All logic is memoized and cycle-safe.
+- **Failure summary UI** — New `FailureSummary` component rendered above Trace Context for failed traces. Shows failure details and a jump-to action.
+- **Auto-selection** — Page auto-selects the primary failed span on initial load or when a running trace transitions to failed, but respects sticky user selection. Terminal transition triggers a refetch of trace and spans data so failure analysis operates on current state.
+- **Cross-trace state reset** — All Phase 7 local state (selection, user-has-selected flag, error filter, reveal path) resets when navigating between traces to prevent stale state leakage.
+- **Span tree highlighting** — Failed span rows are visually marked; the ancestor branch of the primary failed span is highlighted distinctly.
+- **Span breadcrumb** — New `SpanBreadcrumb` component at the top of the detail panel showing root-to-selected path with clickable ancestors.
+- **Error-only timeline filter** — Toggle button in the timeline header to filter to error events only.
+- **Stale trace signal** — Subtle informational text for long-running traces with sparse recent activity.
+
+All changes are frontend-only. No OpenAPI, Go, SQL, migration, or codegen changes.
+
+## Impact
+
+- Affected specs: (new) `failure-analysis`, `failure-summary-ui`, `span-breadcrumb`, `error-timeline-filter`, `stale-trace-signal`
+- Affected code:
+  - `web/src/pages/TraceDetailPage.tsx` — selection state, layout, new components
+  - `web/src/components/SpanTree.tsx` — failure highlighting, reveal-path signal
+  - `web/src/components/SpanDetail.tsx` — breadcrumb integration
+  - `web/src/components/Timeline.tsx` — error-only filter toggle
+  - New: `web/src/utils/failureAnalysis.ts` — pure helper module
+  - New: `web/src/components/FailureSummary.tsx`
+  - New: `web/src/components/SpanBreadcrumb.tsx`
+- Dependencies: Phase 6 (trace discovery/triage) must be merged or rebased first
+- Breaking changes: None

--- a/openspec/changes/add-failure-first-trace-detail/specs/error-timeline-filter/spec.md
+++ b/openspec/changes/add-failure-first-trace-detail/specs/error-timeline-filter/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Error-Only Timeline Filter
+
+The timeline header SHALL include an `Errors only` toggle button rendered as a keyboard-accessible toggle with `aria-pressed` attribute reflecting its state.
+
+When active, the timeline SHALL display only events matching the error predicate: `event_type` of `error`, `exception`, or `span_failed`, or `level === 'error'`.
+
+When active and no events match the predicate, the timeline SHALL display a filtered empty state message such as "No error events for this trace."
+
+#### Scenario: Toggle activated with error events present
+
+- **WHEN** the user activates the `Errors only` toggle and the trace has error events
+- **THEN** only error events are displayed in the timeline
+
+#### Scenario: Toggle activated with no error events
+
+- **WHEN** the user activates the `Errors only` toggle and the trace has no error events
+- **THEN** the timeline shows the filtered empty state message
+
+#### Scenario: Toggle deactivated
+
+- **WHEN** the user deactivates the `Errors only` toggle
+- **THEN** all timeline events are displayed again
+
+### Requirement: Error Filter Accessibility
+
+The `Errors only` toggle SHALL be keyboard focusable and activatable with Enter or Space. It SHALL use `aria-pressed` to communicate its state to assistive technologies.
+
+#### Scenario: Keyboard activation of filter toggle
+
+- **WHEN** a user focuses the toggle and presses Enter or Space
+- **THEN** the filter state toggles and `aria-pressed` updates accordingly

--- a/openspec/changes/add-failure-first-trace-detail/specs/failure-analysis/spec.md
+++ b/openspec/changes/add-failure-first-trace-detail/specs/failure-analysis/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Primary Failed Span Selection
+
+The system SHALL deterministically identify a primary failed span from the trace's span set using the following algorithm:
+
+1. Candidate set: all spans where `status === 'FAILED'`
+2. Sort candidates by `ended_at` ascending (spans without `ended_at` sort after those with it)
+3. Break ties by `started_at` ascending
+4. Break remaining ties by original spans array order
+5. The first candidate after sorting is the primary failed span
+
+If the candidate set is empty, the system SHALL report that no primary failed span exists.
+
+#### Scenario: Single failed span
+
+- **WHEN** a trace has exactly one span with `status === 'FAILED'`
+- **THEN** that span is identified as the primary failed span
+
+#### Scenario: Multiple failed spans with different end times
+
+- **WHEN** a trace has multiple failed spans with distinct `ended_at` values
+- **THEN** the span with the earliest `ended_at` is the primary failed span
+
+#### Scenario: Failed spans with missing ended_at
+
+- **WHEN** some failed spans have `ended_at` and others do not
+- **THEN** spans with `ended_at` sort before those without
+
+#### Scenario: Failed trace with no failed spans
+
+- **WHEN** a trace has `status === 'FAILED'` but no spans have `status === 'FAILED'`
+- **THEN** the system reports no primary failed span exists
+
+### Requirement: Cycle-Safe Parent Chain Traversal
+
+The system SHALL traverse span parent chains using a visited-set guard to prevent infinite loops. If a cycle or broken parent reference is encountered, traversal SHALL stop and return the longest valid path found. The system SHALL NOT throw exceptions during traversal.
+
+#### Scenario: Normal parent chain
+
+- **WHEN** a span has a valid parent chain to the root
+- **THEN** the full path from root to span is returned
+
+#### Scenario: Cyclic parent reference
+
+- **WHEN** a span's parent chain contains a cycle
+- **THEN** traversal stops at the cycle boundary and returns the path up to that point
+
+#### Scenario: Broken parent reference
+
+- **WHEN** a span references a `parent_span_id` that does not exist in the span set
+- **THEN** the path starts from that span (treated as a root) without throwing
+
+### Requirement: Inline Error Preview Extraction
+
+The system SHALL extract an inline error preview for failed spans using the following priority:
+
+1. `span.error_message` if present and non-empty
+2. The `message` field of the first timeline event matching `event_type` of `error` or `exception` for that span
+3. No preview (null)
+
+Preview formatting: trim whitespace, take the first non-empty line, truncate to 120 characters with ellipsis if needed.
+
+Note: The preview predicate is intentionally narrower than the error-only timeline filter. It targets only `error` and `exception` event types (not `span_failed` or `level === 'error'`) because `span_failed` synthetic events produce redundant messages like "X failed" (already conveyed by the status badge), and generic `level === 'error'` log events are not span-specific error messages suitable for inline preview.
+
+#### Scenario: Span with error_message
+
+- **WHEN** a failed span has a non-empty `error_message`
+- **THEN** the preview is derived from `error_message`
+
+#### Scenario: Span with error timeline event but no error_message
+
+- **WHEN** a failed span has no `error_message` but has an `error` type timeline event with a message
+- **THEN** the preview is derived from that event's message
+
+#### Scenario: Span with no error information
+
+- **WHEN** a failed span has no `error_message` and no matching timeline events
+- **THEN** no preview is shown
+
+#### Scenario: Long error message truncation
+
+- **WHEN** the extracted preview text exceeds 120 characters after taking the first line
+- **THEN** the text is truncated to 120 characters with an ellipsis appended
+
+### Requirement: Breadcrumb Path Generation
+
+The system SHALL generate a breadcrumb path from the root span to a given span using the span index and parent chain traversal. Each segment SHALL contain the span's `name` and `span_id`. The path SHALL be ordered root-first, target-last.
+
+#### Scenario: Nested span breadcrumb
+
+- **WHEN** a span is three levels deep in the tree
+- **THEN** the breadcrumb contains three segments: grandparent, parent, span
+
+#### Scenario: Root span breadcrumb
+
+- **WHEN** a span has no parent
+- **THEN** the breadcrumb contains only that span
+
+### Requirement: Failure Summary Computation
+
+The system SHALL compute a failure summary object containing: primary failed span (if any), failed span count, error event count, error preview (if any), failure timestamp (primary failed span's `ended_at`), and breadcrumb path to primary failed span (if any).
+
+Error event count SHALL use the same predicate as the error-only timeline filter (`isTimelineErrorEvent`): events with `event_type` of `error`, `exception`, or `span_failed`, or with `level === 'error'`.
+
+#### Scenario: Failed trace with primary failed span
+
+- **WHEN** a trace is failed and a primary failed span exists
+- **THEN** the summary includes all fields populated from the primary failed span
+
+#### Scenario: Failed trace with no failed spans
+
+- **WHEN** a trace is failed but no spans are failed
+- **THEN** the summary has null primary failed span, zero failed span count, and no breadcrumb path
+
+#### Scenario: Error event count matches timeline filter predicate
+
+- **WHEN** a trace has events of types `error`, `exception`, `span_failed`, and `level === 'error'`
+- **THEN** the error event count includes all of them, consistent with the error-only timeline filter

--- a/openspec/changes/add-failure-first-trace-detail/specs/failure-summary-ui/spec.md
+++ b/openspec/changes/add-failure-first-trace-detail/specs/failure-summary-ui/spec.md
@@ -1,0 +1,175 @@
+## ADDED Requirements
+
+### Requirement: Failure Summary Display
+
+The system SHALL render a failure summary section above Trace Context when the effective trace status is `FAILED` (where effective status is `timeline.traceStatus ?? trace.status`, consistent with the existing page pattern). The summary SHALL display:
+
+- Primary failed span name and kind, when a primary failed span exists
+- Short error preview, when available
+- Failure timestamp, when available
+- Failed span count
+- Error event count
+- Breadcrumb path to the primary failed span, when available
+- A jump action button that selects the primary failed span
+
+When no primary failed span exists, the summary SHALL display a generic message indicating the trace failed but no failed span was identified, and SHALL omit the jump action.
+
+The summary SHALL NOT render when the effective trace status is not `FAILED`.
+
+#### Scenario: Failed trace with primary failed span
+
+- **WHEN** the effective trace status is `FAILED` and a primary failed span exists
+- **THEN** the failure summary renders above Trace Context with all available failure details and a jump action
+
+#### Scenario: Failed trace with no failed spans
+
+- **WHEN** the effective trace status is `FAILED` but no spans have `status === 'FAILED'`
+- **THEN** the failure summary renders a generic failure message without a jump action
+
+#### Scenario: Non-failed trace
+
+- **WHEN** the effective trace status is `RUNNING` or `COMPLETED`
+- **THEN** no failure summary is rendered
+
+### Requirement: Failure Summary Jump Action
+
+The jump action SHALL select the primary failed span in the page-level selection state when activated. It SHALL be operable via keyboard (focusable, activatable with Enter/Space) and SHALL have an explicit accessible name.
+
+#### Scenario: User activates jump action
+
+- **WHEN** the user clicks or keyboard-activates the jump action
+- **THEN** the primary failed span becomes the selected span in the tree, detail panel, and timeline
+
+### Requirement: Auto-Selection of Primary Failed Span
+
+The page SHALL auto-select the primary failed span when:
+
+1. The trace first loads with an effective status of `FAILED` and no user selection exists
+2. The effective trace status transitions from `RUNNING` to `FAILED` during polling and the user has not manually selected a span
+
+Auto-selection depends on refreshed spans data. When the effective trace status transitions to `FAILED`, the page SHALL refetch trace and spans data so that failure analysis operates on current state (see Terminal Refresh of Trace and Spans Data requirement).
+
+User selection SHALL be sticky: once the user manually selects any span, auto-selection SHALL NOT override their choice until the page is reloaded or the user navigates to a different trace.
+
+If the selected span disappears from refreshed data, the system SHALL fall back to the primary failed span if one exists, otherwise clear the selection.
+
+#### Scenario: Initial load of failed trace
+
+- **WHEN** a failed trace loads for the first time
+- **THEN** the primary failed span is auto-selected
+
+#### Scenario: Running trace transitions to failed
+
+- **WHEN** a running trace transitions to failed during polling and the user has not selected a span
+- **THEN** the primary failed span is auto-selected
+
+#### Scenario: User has manually selected a span
+
+- **WHEN** the user has clicked a span and the trace transitions to failed
+- **THEN** the user's selection is preserved; auto-selection does not fire
+
+#### Scenario: Selected span removed during refresh
+
+- **WHEN** the currently selected span disappears from the spans array after a data refresh
+- **THEN** selection falls back to the primary failed span, or clears if none exists
+
+### Requirement: Span Tree Failure Highlighting
+
+All failed span rows in the span tree SHALL be visually marked as failed using indicators that do not rely on color alone (text labels, badges, or structural cues).
+
+The ancestor branch leading to the primary failed span SHALL be highlighted distinctly from other failed rows.
+
+A `revealPath` signal SHALL cause nodes on the selected span's ancestor path to auto-expand if they are collapsed. Tree expansion state SHALL remain local to individual nodes.
+
+#### Scenario: Failed span row appearance
+
+- **WHEN** a span has `status === 'FAILED'`
+- **THEN** its row in the span tree shows a failure indicator visible without relying on color alone
+
+#### Scenario: Primary ancestor branch highlighting
+
+- **WHEN** a primary failed span exists
+- **THEN** all ancestor nodes from root to the primary failed span are highlighted distinctly
+
+#### Scenario: Reveal path auto-expansion on auto-selection
+
+- **WHEN** the primary failed span is auto-selected and an ancestor node is collapsed
+- **THEN** that ancestor node auto-expands to reveal the path
+
+#### Scenario: Reveal path auto-expansion on manual navigation
+
+- **WHEN** a span is selected via the failure summary jump action, a breadcrumb click, or a timeline span click, and an ancestor node of that span is collapsed
+- **THEN** that ancestor node auto-expands to reveal the path to the newly selected span
+
+### Requirement: Span Tree Row Style Precedence
+
+When a span tree row has multiple visual states (selected, failed, on primary ancestor path), the following precedence SHALL apply:
+
+1. Selected state takes highest visual precedence
+2. Primary ancestor path highlighting takes second precedence
+3. Failed row highlighting takes third precedence
+
+The combined styling SHALL ensure that the active state is always visually distinguishable regardless of overlapping states.
+
+#### Scenario: Selected failed span on ancestor path
+
+- **WHEN** the primary failed span itself is selected
+- **THEN** the row shows selected styling, and the failed/ancestor states do not visually conflict
+
+#### Scenario: Unselected failed ancestor
+
+- **WHEN** a span is both failed and on the primary ancestor path but is not selected
+- **THEN** the row shows ancestor path highlighting combined with the failed indicator
+
+### Requirement: Inline Error Previews in Span Tree
+
+Failed span rows SHALL display an inline error preview beneath or beside the span name. The preview SHALL use the error preview extraction logic from the failure analysis module.
+
+#### Scenario: Failed span with error preview
+
+- **WHEN** a failed span has an extractable error preview
+- **THEN** the preview text appears on the span tree row
+
+#### Scenario: Failed span without error preview
+
+- **WHEN** a failed span has no extractable error information
+- **THEN** no inline preview text is shown on that row
+
+### Requirement: Terminal Refresh of Trace and Spans Data
+
+When the effective trace status transitions from `RUNNING` to a terminal state (`COMPLETED` or `FAILED`), the page SHALL refetch the trace and spans queries so that failure analysis, failure summary, span tree highlighting, and header metrics all operate on current data rather than the initial one-shot fetch.
+
+This refetch SHALL be triggered by observing the terminal transition from the timeline polling hook, which already detects non-`RUNNING` status.
+
+#### Scenario: Running trace transitions to failed
+
+- **WHEN** the timeline hook detects that `trace_status` has changed from `RUNNING` to `FAILED`
+- **THEN** the `traceQuery` and `spansQuery` are invalidated and refetched
+- **AND** the failure summary, auto-selection, and header metrics reflect the refreshed data
+
+#### Scenario: Running trace completes normally
+
+- **WHEN** the timeline hook detects that `trace_status` has changed from `RUNNING` to `COMPLETED`
+- **THEN** the `traceQuery` and `spansQuery` are invalidated and refetched so header duration and metrics are current
+
+### Requirement: Cross-Trace State Reset
+
+When the user navigates from one trace to another (the `traceId` route parameter changes), all Phase 7 local state SHALL reset to initial values:
+
+- `selectedSpanExternalId` resets to `null`
+- `userHasSelected` resets to `false`
+- The `Errors only` timeline filter resets to inactive
+- Any reveal-path signal clears
+
+This ensures no stale selection, filter, or highlight state leaks from a previously viewed trace into a newly navigated trace.
+
+#### Scenario: Navigate from trace A to trace B
+
+- **WHEN** the user navigates from `/traces/A` to `/traces/B`
+- **THEN** selection state, user-has-selected flag, error filter, and reveal path are all reset
+- **AND** auto-selection logic runs fresh against trace B's data
+
+#### Scenario: Navigate back to same trace
+
+- **WHEN** the user navigates away from trace A and later returns to it
+- **THEN** state resets as if loading trace A for the first time

--- a/openspec/changes/add-failure-first-trace-detail/specs/span-breadcrumb/spec.md
+++ b/openspec/changes/add-failure-first-trace-detail/specs/span-breadcrumb/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Span Breadcrumb Navigation
+
+The system SHALL render a breadcrumb path at the top of the selected span's detail panel. The breadcrumb SHALL show span names from root to the selected span, ordered root-first.
+
+Ancestor segments SHALL be clickable and SHALL trigger span selection via the shared page-level selection callback.
+
+The breadcrumb SHALL be synchronized with the shared selection state: when selection changes, the breadcrumb updates to reflect the new span's path.
+
+#### Scenario: Selected span with ancestors
+
+- **WHEN** a span three levels deep is selected
+- **THEN** the breadcrumb shows: grandparent > parent > span, with grandparent and parent clickable
+
+#### Scenario: Root span selected
+
+- **WHEN** a root span is selected
+- **THEN** the breadcrumb shows only the root span name, with no clickable ancestors
+
+#### Scenario: Clicking a breadcrumb ancestor
+
+- **WHEN** the user clicks an ancestor segment in the breadcrumb
+- **THEN** that ancestor becomes the selected span across the tree, detail panel, and timeline (full synchronization via the shared page-level selection state)
+
+### Requirement: Breadcrumb Keyboard Accessibility
+
+All breadcrumb segments that are interactive (ancestor segments) SHALL be keyboard focusable and activatable with Enter or Space. Each interactive segment SHALL have an explicit accessible name.
+
+#### Scenario: Keyboard navigation through breadcrumb
+
+- **WHEN** a user tabs through the breadcrumb
+- **THEN** each clickable ancestor segment receives focus in order
+
+#### Scenario: Keyboard activation of breadcrumb segment
+
+- **WHEN** a user presses Enter or Space on a focused breadcrumb segment
+- **THEN** that ancestor becomes the selected span

--- a/openspec/changes/add-failure-first-trace-detail/specs/stale-trace-signal/spec.md
+++ b/openspec/changes/add-failure-first-trace-detail/specs/stale-trace-signal/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Stale Trace Signal
+
+The system SHALL display a subtle, informational trust signal on the trace detail page when all of the following conditions are met:
+
+1. The effective trace status is `RUNNING`
+2. Total runtime (now minus `started_at`) is at least 15 minutes
+3. Latest observed activity is at least 5 minutes old
+
+Latest activity SHALL be derived from the following sources in priority order:
+
+1. Maximum timeline event timestamp
+2. Latest span `ended_at`
+3. Latest span `started_at`
+4. Trace `started_at`
+
+The signal copy SHALL be subtle and non-authoritative, for example: "Still marked running. Recent activity is sparse, so this trace may be stale or incomplete."
+
+The thresholds (15 minutes runtime, 5 minutes stale) SHALL be implemented as local constants for easy tuning.
+
+This feature is explicitly marked as experimental and heuristic.
+
+#### Scenario: Running trace exceeds both thresholds
+
+- **WHEN** a trace has been running for 20 minutes and the last activity was 7 minutes ago
+- **THEN** the stale trace signal is displayed
+
+#### Scenario: Running trace below runtime threshold
+
+- **WHEN** a trace has been running for 10 minutes (below 15-minute threshold)
+- **THEN** no stale trace signal is displayed
+
+#### Scenario: Running trace with recent activity
+
+- **WHEN** a trace has been running for 20 minutes but the last activity was 2 minutes ago (below 5-minute threshold)
+- **THEN** no stale trace signal is displayed
+
+#### Scenario: Completed or failed trace
+
+- **WHEN** a trace has status `COMPLETED` or `FAILED`
+- **THEN** no stale trace signal is displayed regardless of runtime
+
+### Requirement: Stale Signal Non-Intrusiveness
+
+The stale trace signal SHALL be rendered as static informational text, not an alert or live region. It SHALL NOT interrupt the page or announce repeatedly during polling refreshes.
+
+#### Scenario: Signal stability during polling
+
+- **WHEN** polling refreshes the trace data and the signal conditions remain met
+- **THEN** the signal text remains visible without re-announcing or flashing

--- a/openspec/changes/add-failure-first-trace-detail/tasks.md
+++ b/openspec/changes/add-failure-first-trace-detail/tasks.md
@@ -1,0 +1,90 @@
+## 1. Failure Analysis Helper
+
+- [x] 1.1 Create `web/src/utils/failureAnalysis.ts` with pure functions: `buildSpanIndex`, `findPrimaryFailedSpan`, `buildBreadcrumbPath`, `getInlineErrorPreview`, `buildFailureSummary`, `evaluateStaleTraceSignal`
+- [x] 1.2 Implement cycle-safe parent chain traversal with visited-set guard
+- [x] 1.3 Implement primary failed span selection with deterministic tie-breaking (ended_at asc → started_at asc → array order)
+- [x] 1.4 Implement inline error preview extraction (span.error_message → first error/exception event message → null; trim + first line + 120 char truncation). Note: intentionally narrower than the error-only filter predicate — excludes `span_failed` and `level === 'error'` events
+- [x] 1.5 Implement error event count using the shared `isTimelineErrorEvent` predicate (consistent with the error-only timeline filter)
+- [x] 1.6 Implement stale trace signal heuristic (RUNNING + 15min runtime + 5min since last activity)
+- [x] 1.7 Add unit tests for all helper functions in `web/src/utils/failureAnalysis.test.ts`
+
+**Validation**: `pnpm --filter web test -- failureAnalysis`
+
+## 2. Selection State, Auto-Selection, and Data Refresh
+
+- [x] 2.1 Refactor `TraceDetailPage.tsx` selection state to use `selectedSpanExternalId: string | null` + `userHasSelected: boolean`
+- [x] 2.2 Build memoized `spanByExternalId` map from spans array
+- [x] 2.3 Implement auto-selection logic: select primary failed span on initial failed load or running→failed transition, only when `!userHasSelected`
+- [x] 2.4 Implement sticky selection: set `userHasSelected = true` on manual span selection
+- [x] 2.5 Implement fallback: if selected span disappears from refreshed data, fall back to primary failed span or clear
+- [x] 2.6 Add terminal refresh: when timeline hook detects terminal transition (RUNNING → COMPLETED/FAILED), invalidate `traceQuery` and `spansQuery` via `queryClient.invalidateQueries` so failure analysis, header metrics, and summary operate on current data
+- [x] 2.7 Add cross-trace state reset: use `key={traceId}` on `TraceDetailContent` (or equivalent) to reset all Phase 7 local state when navigating between traces
+- [x] 2.8 Add integration tests for:
+  - Auto-selection on initial failed load
+  - Sticky selection across polling/re-render
+  - Running trace transitions to failed → refetched spans drive auto-selection
+  - Navigate from trace A to trace B → selection/filter state is clean
+
+**Validation**: `pnpm --filter web test -- TraceDetailPage`
+
+## 3. Failure Summary Component
+
+- [x] 3.1 Create `web/src/components/FailureSummary.tsx` rendering above Trace Context when effective trace status is `FAILED`
+- [x] 3.2 Display: primary failed span name/kind, error preview, failure timestamp, failed-span count, error-event count, breadcrumb path, jump action
+- [x] 3.3 Handle edge case: failed trace with no failed spans shows generic message, omits jump action
+- [x] 3.4 Ensure jump action and all interactive elements are keyboard accessible with explicit accessible names
+- [x] 3.5 Add integration tests for failure summary rendering and jump action
+
+**Validation**: `pnpm --filter web test`
+
+## 4. Span Tree Highlighting
+
+- [x] 4.1 Add `failedSpanIds: Set<string>` and `primaryAncestorPath: Set<string>` props to SpanTree/SpanTreeNode
+- [x] 4.2 Highlight all failed rows with visual indicator (not color-only: include text label or badge)
+- [x] 4.3 Highlight primary ancestor branch distinctly
+- [x] 4.4 Implement style precedence: selected > ancestor path > failed row
+- [x] 4.5 Add `revealPath: Set<string>` prop; nodes on the path auto-expand if collapsed (applies to auto-selection, jump action, breadcrumb clicks, and timeline clicks)
+- [x] 4.6 Add inline error previews on failed rows using failure analysis helper
+- [x] 4.7 Add integration tests for highlighting, reveal behavior, and style precedence
+
+**Validation**: `pnpm --filter web test`
+
+## 5. Span Breadcrumb Component
+
+- [x] 5.1 Create `web/src/components/SpanBreadcrumb.tsx` showing root-to-selected span path
+- [x] 5.2 Make ancestor segments clickable (triggers span selection via shared callback — full tree/detail/timeline synchronization)
+- [x] 5.3 Ensure keyboard accessibility for all breadcrumb segments
+- [x] 5.4 Integrate into SpanDetail panel header
+- [x] 5.5 Add integration tests for breadcrumb rendering, click behavior, and full synchronization
+
+**Validation**: `pnpm --filter web test`
+
+## 6. Error-Only Timeline Filter
+
+- [x] 6.1 Add `Errors only` toggle button in Timeline header with `aria-pressed`
+- [x] 6.2 Filter events client-side using `isTimelineErrorEvent` predicate
+- [x] 6.3 Show filtered empty state when active and no matching events
+- [x] 6.4 Ensure toggle is keyboard accessible
+- [x] 6.5 Ensure filter state resets on cross-trace navigation (handled by key-based remounting)
+- [x] 6.6 Add integration tests for filter toggle behavior
+
+**Validation**: `pnpm --filter web test`
+
+## 7. Stale Trace Signal
+
+- [x] 7.1 Add stale trace signal rendering in TraceDetailPage for qualifying traces
+- [x] 7.2 Use local constants for thresholds (15min runtime, 5min stale)
+- [x] 7.3 Derive latest activity from: max event timestamp → latest span ended_at → latest span started_at → trace started_at
+- [x] 7.4 Keep copy subtle and non-authoritative; mark as experimental
+- [x] 7.5 Ensure signal does not re-announce on polling (informational text, not alert — no `role="alert"` or `aria-live`)
+- [x] 7.6 Add unit test coverage for threshold logic
+- [x] 7.7 Add rendered integration test asserting signal appears as static text (not alert/live region) in the DOM
+
+**Validation**: `pnpm --filter web test`
+
+## 8. Final Verification
+
+- [x] 8.1 Run full test suite: `pnpm --filter web test`
+- [x] 8.2 Run type checking: `pnpm --filter web type-check`
+- [x] 8.3 Verify Phase 6 filtered back-link behavior is preserved
+- [ ] 8.4 Manual accessibility check: keyboard navigation through all new controls

--- a/web/src/components/FailureSummary.tsx
+++ b/web/src/components/FailureSummary.tsx
@@ -1,0 +1,117 @@
+import type { FailureSummary as FailureSummaryData } from '../utils/failureAnalysis';
+import { formatTimestamp } from '../utils/format';
+import { SpanBreadcrumb } from './SpanBreadcrumb';
+
+interface FailureSummaryProps {
+  summary: FailureSummaryData;
+  onJumpToPrimaryFailedSpan: (spanId: string) => void;
+}
+
+export function FailureSummary({
+  summary,
+  onJumpToPrimaryFailedSpan,
+}: FailureSummaryProps) {
+  const primaryFailedSpan = summary.primaryFailedSpan;
+
+  return (
+    <section className="overflow-hidden rounded-xl border border-red-200 bg-white shadow-sm">
+      <div className="border-b border-red-200 bg-red-50 px-4 py-3">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-red-700">
+          Failure Summary
+        </h2>
+        <p className="mt-1 text-sm text-red-700/80">
+          Failure-first guidance for this trace.
+        </p>
+      </div>
+
+      <div className="space-y-4 p-4">
+        {primaryFailedSpan ? (
+          <>
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-base font-semibold text-gray-900">
+                    {primaryFailedSpan.name}
+                  </h3>
+                  <span className="rounded-full bg-gray-900 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white">
+                    {primaryFailedSpan.kind}
+                  </span>
+                </div>
+
+                {summary.errorPreview ? (
+                  <p className="mt-2 text-sm text-gray-700">{summary.errorPreview}</p>
+                ) : (
+                  <p className="mt-2 text-sm text-gray-500">
+                    No inline error preview was available for the primary failed span.
+                  </p>
+                )}
+              </div>
+
+              <button
+                type="button"
+                className="inline-flex shrink-0 items-center justify-center rounded-full bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-200"
+                aria-label={`Jump to failed span ${primaryFailedSpan.name}`}
+                onClick={() => onJumpToPrimaryFailedSpan(primaryFailedSpan.span_id)}
+              >
+                Jump to failed span
+              </button>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-3">
+              <SummaryStat
+                label="Failed spans"
+                value={String(summary.failedSpanCount)}
+              />
+              <SummaryStat
+                label="Error events"
+                value={String(summary.errorEventCount)}
+              />
+              <SummaryStat
+                label="Failure timestamp"
+                value={formatTimestamp(summary.failureTimestamp)}
+              />
+            </div>
+
+            <div>
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-500">
+                Failure path
+              </div>
+              <SpanBreadcrumb
+                path={summary.breadcrumbPath}
+                ariaLabel="Failure path"
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-gray-700">
+              This trace is marked as failed, but no failed span could be identified
+              from the current span data.
+            </p>
+            <div className="grid gap-3 md:grid-cols-2">
+              <SummaryStat
+                label="Failed spans"
+                value={String(summary.failedSpanCount)}
+              />
+              <SummaryStat
+                label="Error events"
+                value={String(summary.errorEventCount)}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SummaryStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-500">
+        {label}
+      </div>
+      <div className="mt-2 text-sm font-medium text-gray-900">{value}</div>
+    </div>
+  );
+}

--- a/web/src/components/SpanBreadcrumb.tsx
+++ b/web/src/components/SpanBreadcrumb.tsx
@@ -1,0 +1,63 @@
+import type { BreadcrumbSegment } from '../utils/failureAnalysis';
+
+interface SpanBreadcrumbProps {
+  path: BreadcrumbSegment[];
+  onSelectSpan?: (spanId: string) => void;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function SpanBreadcrumb({
+  path,
+  onSelectSpan,
+  ariaLabel = 'Span breadcrumb',
+  className = '',
+}: SpanBreadcrumbProps) {
+  if (path.length === 0) {
+    return null;
+  }
+
+  const lastIndex = path.length - 1;
+
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className={`overflow-x-auto ${className}`.trim()}
+    >
+      <ol className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-gray-500">
+        {path.map((segment, index) => {
+          const isCurrent = index === lastIndex;
+          const isInteractive = !isCurrent && Boolean(onSelectSpan);
+
+          return (
+            <li key={segment.spanId} className="flex min-w-0 items-center gap-2">
+              {isInteractive ? (
+                <button
+                  type="button"
+                  className="truncate rounded-full border border-gray-200 bg-white px-2.5 py-1 font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  aria-label={`Select ancestor span ${segment.name}`}
+                  onClick={() => onSelectSpan?.(segment.spanId)}
+                >
+                  {segment.name}
+                </button>
+              ) : (
+                <span
+                  className={`truncate rounded-full px-2.5 py-1 ${
+                    isCurrent
+                      ? 'bg-gray-900 text-white'
+                      : 'bg-gray-100 font-medium text-gray-700'
+                  }`}
+                  aria-current={isCurrent ? 'page' : undefined}
+                >
+                  {segment.name}
+                </span>
+              )}
+
+              {!isCurrent && <span aria-hidden="true">{'>'}</span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -2,16 +2,29 @@ import { type ReactNode } from 'react';
 import { Span } from '../api/client';
 import { StatusBadge } from './StatusBadge';
 import { JsonViewer } from './JsonViewer';
-import { formatDuration, formatTokens, formatCost } from '../utils/format';
+import {
+  formatCost,
+  formatDuration,
+  formatTimestamp,
+  formatTokens,
+} from '../utils/format';
+import type { BreadcrumbSegment } from '../utils/failureAnalysis';
+import { SpanBreadcrumb } from './SpanBreadcrumb';
 
 interface SpanDetailProps {
   span: Span | null;
+  breadcrumbPath: BreadcrumbSegment[];
+  onSelectSpan: (spanId: string) => void;
 }
 
 /**
  * Panel showing detailed information about a selected span.
  */
-export function SpanDetail({ span }: SpanDetailProps) {
+export function SpanDetail({
+  span,
+  breadcrumbPath,
+  onSelectSpan,
+}: SpanDetailProps) {
   if (!span) {
     return (
       <div className="h-full flex items-center justify-center text-gray-500">
@@ -29,6 +42,11 @@ export function SpanDetail({ span }: SpanDetailProps) {
     <div className="h-full overflow-y-auto p-4">
       {/* Header */}
       <div className="mb-4">
+        <SpanBreadcrumb
+          path={breadcrumbPath}
+          onSelectSpan={onSelectSpan}
+          className="mb-3"
+        />
         <h2 className="text-lg font-semibold text-gray-900">{span.name}</h2>
         <div className="flex items-center gap-2 mt-1">
           <span className="text-sm text-gray-500">{span.kind}</span>
@@ -128,13 +146,13 @@ export function SpanDetail({ span }: SpanDetailProps) {
         <div className="bg-gray-50 rounded p-3 text-sm">
           <DetailRow
             label="Started"
-            value={new Date(span.started_at).toISOString()}
+            value={formatTimestamp(span.started_at)}
             mono
           />
           {span.ended_at && (
             <DetailRow
               label="Ended"
-              value={new Date(span.ended_at).toISOString()}
+              value={formatTimestamp(span.ended_at)}
               mono
               className="mt-1"
             />

--- a/web/src/components/SpanTree.tsx
+++ b/web/src/components/SpanTree.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Span } from '../api/client';
 import { StatusBadge } from './StatusBadge';
 import { formatDuration } from '../utils/format';
@@ -6,7 +6,12 @@ import { formatDuration } from '../utils/format';
 interface SpanTreeProps {
   spans: Span[];
   selectedSpanId: string | null;
-  onSelectSpan: (span: Span) => void;
+  onSelectSpan: (spanId: string) => void;
+  failedSpanIds: Set<string>;
+  primaryAncestorPath: Set<string>;
+  revealPath: Set<string>;
+  revealKey: number;
+  inlineErrorPreviews: Map<string, string>;
 }
 
 interface SpanNode {
@@ -21,11 +26,14 @@ interface SpanNode {
  */
 function buildSpanTree(spans: Span[]): SpanNode[] {
   const spanMap = new Map<string, SpanNode>();
+  const spanIndex = new Map<string, Span>();
   const roots: SpanNode[] = [];
+  const rootIds = new Set<string>();
 
   // Create nodes for all spans, keyed by external span_id
   for (const span of spans) {
     spanMap.set(span.span_id, { span, children: [] });
+    spanIndex.set(span.span_id, span);
   }
 
   // Build tree structure using external IDs
@@ -33,24 +41,30 @@ function buildSpanTree(spans: Span[]): SpanNode[] {
     const node = spanMap.get(span.span_id)!;
     if (span.parent_span_id) {
       const parent = spanMap.get(span.parent_span_id);
-      if (parent) {
+      if (
+        parent &&
+        !wouldCreateTreeCycle(span.span_id, span.parent_span_id, spanIndex)
+      ) {
         parent.children.push(node);
       } else {
-        // Parent not found, treat as root
-        roots.push(node);
+        addRoot(node, roots, rootIds);
       }
     } else {
-      roots.push(node);
+      addRoot(node, roots, rootIds);
     }
   }
 
   // Sort children by started_at
-  const sortChildren = (nodes: SpanNode[]) => {
+  const sortChildren = (nodes: SpanNode[], visited = new Set<string>()) => {
     nodes.sort((a, b) =>
       new Date(a.span.started_at).getTime() - new Date(b.span.started_at).getTime()
     );
     for (const node of nodes) {
-      sortChildren(node.children);
+      if (visited.has(node.span.span_id)) {
+        continue;
+      }
+      visited.add(node.span.span_id);
+      sortChildren(node.children, visited);
     }
   };
   sortChildren(roots);
@@ -58,10 +72,52 @@ function buildSpanTree(spans: Span[]): SpanNode[] {
   return roots;
 }
 
+function addRoot(node: SpanNode, roots: SpanNode[], rootIds: Set<string>) {
+  if (rootIds.has(node.span.span_id)) {
+    return;
+  }
+
+  roots.push(node);
+  rootIds.add(node.span.span_id);
+}
+
+function wouldCreateTreeCycle(
+  childSpanId: string,
+  parentSpanId: string,
+  spanIndex: Map<string, Span>
+): boolean {
+  const visited = new Set<string>([childSpanId]);
+  let currentParent = spanIndex.get(parentSpanId);
+
+  while (currentParent) {
+    if (visited.has(currentParent.span_id)) {
+      return true;
+    }
+
+    visited.add(currentParent.span_id);
+    if (!currentParent.parent_span_id) {
+      return false;
+    }
+
+    currentParent = spanIndex.get(currentParent.parent_span_id);
+  }
+
+  return false;
+}
+
 /**
  * Recursive span tree component.
  */
-export function SpanTree({ spans, selectedSpanId, onSelectSpan }: SpanTreeProps) {
+export function SpanTree({
+  spans,
+  selectedSpanId,
+  onSelectSpan,
+  failedSpanIds,
+  primaryAncestorPath,
+  revealPath,
+  revealKey,
+  inlineErrorPreviews,
+}: SpanTreeProps) {
   const tree = useMemo(() => buildSpanTree(spans), [spans]);
 
   if (tree.length === 0) {
@@ -81,6 +137,11 @@ export function SpanTree({ spans, selectedSpanId, onSelectSpan }: SpanTreeProps)
           depth={0}
           selectedSpanId={selectedSpanId}
           onSelectSpan={onSelectSpan}
+          failedSpanIds={failedSpanIds}
+          primaryAncestorPath={primaryAncestorPath}
+          revealPath={revealPath}
+          revealKey={revealKey}
+          inlineErrorPreviews={inlineErrorPreviews}
         />
       ))}
     </div>
@@ -91,7 +152,12 @@ interface SpanTreeNodeProps {
   node: SpanNode;
   depth: number;
   selectedSpanId: string | null;
-  onSelectSpan: (span: Span) => void;
+  onSelectSpan: (spanId: string) => void;
+  failedSpanIds: Set<string>;
+  primaryAncestorPath: Set<string>;
+  revealPath: Set<string>;
+  revealKey: number;
+  inlineErrorPreviews: Map<string, string>;
 }
 
 const kindColors: Record<string, string> = {
@@ -102,52 +168,116 @@ const kindColors: Record<string, string> = {
   CUSTOM: 'bg-gray-100 text-gray-800',
 };
 
-function SpanTreeNode({ node, depth, selectedSpanId, onSelectSpan }: SpanTreeNodeProps) {
+function SpanTreeNode({
+  node,
+  depth,
+  selectedSpanId,
+  onSelectSpan,
+  failedSpanIds,
+  primaryAncestorPath,
+  revealPath,
+  revealKey,
+  inlineErrorPreviews,
+}: SpanTreeNodeProps) {
   const [isExpanded, setIsExpanded] = useState(true);
   const hasChildren = node.children.length > 0;
-  const isSelected = node.span.id === selectedSpanId;
+  const isSelected = node.span.span_id === selectedSpanId;
+  const isFailed = failedSpanIds.has(node.span.span_id);
+  const isOnPrimaryPath = primaryAncestorPath.has(node.span.span_id);
+  const errorPreview = inlineErrorPreviews.get(node.span.span_id);
+  const rowStateId = `span-row-state-${node.span.id}`;
+
+  useEffect(() => {
+    if (hasChildren && revealPath.has(node.span.span_id)) {
+      setIsExpanded(true);
+    }
+  }, [hasChildren, node.span.span_id, revealKey, revealPath]);
+
+  const rowClasses = isSelected
+    ? 'border-blue-200 bg-blue-50 shadow-sm ring-1 ring-blue-200'
+    : isOnPrimaryPath
+      ? 'border-amber-300 bg-amber-50'
+      : isFailed
+        ? 'border-red-200 bg-red-50/80'
+        : 'border-transparent bg-white hover:bg-gray-50';
 
   return (
     <div>
       <div
-        className={`flex items-center px-2 py-1 cursor-pointer hover:bg-gray-100 ${
-          isSelected ? 'bg-blue-50 border-l-2 border-blue-500' : ''
-        }`}
+        className="flex items-start gap-1 px-2 py-1"
         style={{ paddingLeft: `${depth * 20 + 8}px` }}
-        onClick={() => onSelectSpan(node.span)}
       >
-        {/* Expand/collapse toggle */}
+        {hasChildren ? (
+          <button
+            type="button"
+            className="mt-3 flex h-6 w-6 shrink-0 items-center justify-center rounded text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            aria-label={`${isExpanded ? 'Collapse' : 'Expand'} span ${node.span.name}`}
+            onClick={() => setIsExpanded((expanded) => !expanded)}
+          >
+            {isExpanded ? '▼' : '▶'}
+          </button>
+        ) : (
+          <span
+            className="mt-3 flex h-6 w-6 shrink-0 items-center justify-center text-gray-300"
+            aria-hidden="true"
+          >
+            ·
+          </span>
+        )}
+
         <button
-          className="w-5 h-5 flex items-center justify-center text-gray-400 mr-1"
-          onClick={(e) => {
-            e.stopPropagation();
-            setIsExpanded(!isExpanded);
-          }}
+          type="button"
+          className={`flex min-w-0 flex-1 items-start justify-between rounded-xl border px-3 py-2 text-left transition ${rowClasses}`}
+          aria-label={`Select span ${node.span.name}`}
+          aria-describedby={rowStateId}
+          aria-pressed={isSelected}
+          onClick={() => onSelectSpan(node.span.span_id)}
         >
-          {hasChildren ? (isExpanded ? '▼' : '▶') : '·'}
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className={`rounded px-1.5 py-0.5 text-xs font-medium ${
+                  kindColors[node.span.kind] || kindColors.CUSTOM
+                }`}
+              >
+                {node.span.kind}
+              </span>
+              <span className="truncate text-sm font-medium text-gray-900">
+                {node.span.name}
+              </span>
+              {isSelected && (
+                <span className="rounded-full border border-blue-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-blue-700">
+                  Selected
+                </span>
+              )}
+              {isOnPrimaryPath && (
+                <span className="rounded-full border border-amber-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700">
+                  Failure path
+                </span>
+              )}
+              {isFailed && (
+                <span className="rounded-full border border-red-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-red-700">
+                  Failed
+                </span>
+              )}
+            </div>
+
+            <span id={rowStateId} className="sr-only">
+              {describeRowState(isSelected, isOnPrimaryPath, isFailed)}
+            </span>
+
+            {errorPreview && (
+              <p className="mt-1 truncate text-xs text-red-700">{errorPreview}</p>
+            )}
+          </div>
+
+          <div className="ml-3 flex shrink-0 items-center gap-2">
+            <span className="text-xs text-gray-500">
+              {formatDuration(node.span.latency_ms)}
+            </span>
+            <StatusBadge status={node.span.status} />
+          </div>
         </button>
-
-        {/* Kind badge */}
-        <span
-          className={`px-1.5 py-0.5 text-xs font-medium rounded mr-2 ${
-            kindColors[node.span.kind] || kindColors.CUSTOM
-          }`}
-        >
-          {node.span.kind}
-        </span>
-
-        {/* Span name */}
-        <span className="flex-1 truncate text-sm font-medium text-gray-900">
-          {node.span.name}
-        </span>
-
-        {/* Duration */}
-        <span className="text-xs text-gray-500 mx-2">
-          {formatDuration(node.span.latency_ms)}
-        </span>
-
-        {/* Status */}
-        <StatusBadge status={node.span.status} />
       </div>
 
       {/* Children */}
@@ -160,10 +290,35 @@ function SpanTreeNode({ node, depth, selectedSpanId, onSelectSpan }: SpanTreeNod
               depth={depth + 1}
               selectedSpanId={selectedSpanId}
               onSelectSpan={onSelectSpan}
+              failedSpanIds={failedSpanIds}
+              primaryAncestorPath={primaryAncestorPath}
+              revealPath={revealPath}
+              revealKey={revealKey}
+              inlineErrorPreviews={inlineErrorPreviews}
             />
           ))}
         </div>
       )}
     </div>
   );
+}
+
+function describeRowState(
+  isSelected: boolean,
+  isOnPrimaryPath: boolean,
+  isFailed: boolean
+): string {
+  const states = ['Selectable span row'];
+
+  if (isSelected) {
+    states.push('Currently selected');
+  }
+  if (isOnPrimaryPath) {
+    states.push('On the primary failure path');
+  }
+  if (isFailed) {
+    states.push('Failed span');
+  }
+
+  return states.join('. ');
 }

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -28,6 +28,11 @@ export function Timeline({
   selectedSpanId = null,
   onSelectSpan,
 }: TimelineProps) {
+  const [showErrorsOnly, setShowErrorsOnly] = useState(false);
+  const visibleEvents = showErrorsOnly
+    ? events.filter((event) => isTimelineErrorEvent(event))
+    : events;
+
   return (
     <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3">
@@ -39,13 +44,32 @@ export function Timeline({
             Chronological trace events with lifecycle markers and payload inspection.
           </p>
         </div>
-        <div className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600">
-          <span
-            className={`h-2.5 w-2.5 rounded-full ${
-              isLive ? 'animate-pulse bg-emerald-500' : traceStatus === 'FAILED' ? 'bg-red-500' : 'bg-gray-400'
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
+              showErrorsOnly
+                ? 'border-red-200 bg-red-50 text-red-700'
+                : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-100'
             }`}
-          />
-          <span>{timelineStatusLabel(traceStatus, isLive)}</span>
+            aria-label="Show error events only"
+            aria-pressed={showErrorsOnly}
+            onClick={() => setShowErrorsOnly((active) => !active)}
+          >
+            Errors only
+          </button>
+          <div className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600">
+            <span
+              className={`h-2.5 w-2.5 rounded-full ${
+                isLive
+                  ? 'animate-pulse bg-emerald-500'
+                  : traceStatus === 'FAILED'
+                    ? 'bg-red-500'
+                    : 'bg-gray-400'
+              }`}
+            />
+            <span>{timelineStatusLabel(traceStatus, isLive)}</span>
+          </div>
         </div>
       </div>
 
@@ -55,13 +79,15 @@ export function Timeline({
         </div>
       ) : error && events.length === 0 ? (
         <div className="px-4 py-12 text-center text-sm text-red-600">{error}</div>
-      ) : events.length === 0 ? (
+      ) : visibleEvents.length === 0 ? (
         <div className="px-4 py-12 text-center text-sm text-gray-500">
-          No timeline events recorded for this trace yet.
+          {showErrorsOnly
+            ? 'No error events for this trace.'
+            : 'No timeline events recorded for this trace yet.'}
         </div>
       ) : (
         <div className="divide-y divide-gray-100">
-          {events.map((event) => (
+          {visibleEvents.map((event) => (
             <TimelineRow
               key={event.id}
               event={event}

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -1,11 +1,8 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import {
-  fetchSpans,
-  fetchTrace,
-  Span,
-} from '../api/client';
+import { fetchSpans, fetchTrace, type Span } from '../api/client';
+import { FailureSummary } from '../components/FailureSummary';
 import { JsonViewer } from '../components/JsonViewer';
 import { SpanDetail } from '../components/SpanDetail';
 import { SpanTree } from '../components/SpanTree';
@@ -17,16 +14,32 @@ import {
   calculateDuration,
   formatCost,
   formatDuration,
+  formatRelativeTime,
   formatTokens,
+  formatTimestamp,
 } from '../utils/format';
+import {
+  buildBreadcrumbPath,
+  buildFailureAnalysis,
+  buildSpanIndex,
+  evaluateStaleTraceSignal,
+  type StaleTraceSignal,
+} from '../utils/failureAnalysis';
 
 /**
  * Trace detail page with span tree, detail panel, and merged event timeline.
  */
+const EMPTY_SPANS: Span[] = [];
+const EMPTY_STALE_TRACE_SIGNAL: StaleTraceSignal = {
+  shouldDisplay: false,
+  latestActivityAt: null,
+  runtimeMs: null,
+  inactivityMs: null,
+};
+
 export function TraceDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { hasApiKey, prompt } = useRequireApiKey();
-  const [selectedSpan, setSelectedSpan] = useState<Span | null>(null);
 
   if (!hasApiKey) {
     return prompt;
@@ -42,17 +55,14 @@ export function TraceDetailPage() {
 
   return (
     <TraceDetailContent
+      key={id}
       traceId={id}
-      selectedSpan={selectedSpan}
-      onSelectSpan={setSelectedSpan}
     />
   );
 }
 
 interface TraceDetailContentProps {
   traceId: string;
-  selectedSpan: Span | null;
-  onSelectSpan: (span: Span | null) => void;
 }
 
 function getReturnToDestination(state: unknown): string {
@@ -73,10 +83,13 @@ function getReturnToDestination(state: unknown): string {
 
 function TraceDetailContent({
   traceId,
-  selectedSpan,
-  onSelectSpan,
 }: TraceDetailContentProps) {
   const location = useLocation();
+  const [selectedSpanExternalId, setSelectedSpanExternalId] = useState<string | null>(
+    null
+  );
+  const [revealPathVersion, setRevealPathVersion] = useState(0);
+  const [userHasSelected, setUserHasSelected] = useState(false);
   const traceQuery = useQuery({
     queryKey: ['trace', traceId],
     queryFn: () => fetchTrace(traceId),
@@ -87,6 +100,98 @@ function TraceDetailContent({
     queryFn: () => fetchSpans(traceId),
   });
   const timeline = useTraceTimeline(traceId);
+  const trace = traceQuery.data ?? null;
+  const spans = spansQuery.data?.spans ?? EMPTY_SPANS;
+  const timelineStatus = trace ? timeline.traceStatus ?? trace.status : timeline.traceStatus;
+  const duration = trace ? calculateDuration(trace.started_at, trace.ended_at) : null;
+  const totalTokens = trace
+    ? (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0)
+    : 0;
+  const returnTo = getReturnToDestination(location.state);
+  const spanIndex = useMemo(() => buildSpanIndex(spans), [spans]);
+  const failureAnalysis = useMemo(
+    () => buildFailureAnalysis(spans, timeline.events, spanIndex),
+    [spanIndex, spans, timeline.events]
+  );
+  const selectedSpan = selectedSpanExternalId
+    ? spanIndex.get(selectedSpanExternalId) ?? null
+    : null;
+  const selectedBreadcrumbPath = useMemo(
+    () => buildBreadcrumbPath(selectedSpan, spanIndex),
+    [selectedSpan, spanIndex]
+  );
+  const revealPath = useMemo(
+    () => new Set(selectedBreadcrumbPath.map((segment) => segment.spanId)),
+    [selectedBreadcrumbPath]
+  );
+  const staleTraceSignal = useMemo(
+    () =>
+      timeline.hasSnapshot
+        ? evaluateStaleTraceSignal({
+            traceStatus: timelineStatus,
+            traceStartedAt: trace?.started_at,
+            spans,
+            events: timeline.events,
+          })
+        : EMPTY_STALE_TRACE_SIGNAL,
+    [spans, timeline.events, timeline.hasSnapshot, timelineStatus, trace?.started_at]
+  );
+
+  const selectSpan = (spanId: string | null, manualSelection: boolean) => {
+    setSelectedSpanExternalId(spanId);
+    if (spanId) {
+      setRevealPathVersion((version) => version + 1);
+    }
+    if (manualSelection) {
+      setUserHasSelected(true);
+    }
+  };
+
+  useEffect(() => {
+    if (!selectedSpanExternalId) {
+      return;
+    }
+
+    if (spanIndex.has(selectedSpanExternalId)) {
+      return;
+    }
+
+    const nextSelectedSpanId =
+      failureAnalysis.summary.primaryFailedSpan?.span_id ?? null;
+
+    setSelectedSpanExternalId(nextSelectedSpanId);
+    if (nextSelectedSpanId) {
+      setRevealPathVersion((version) => version + 1);
+    }
+    setUserHasSelected(false);
+  }, [
+    failureAnalysis.summary.primaryFailedSpan,
+    selectedSpanExternalId,
+    spanIndex,
+  ]);
+
+  useEffect(() => {
+    if (timelineStatus !== 'FAILED' || userHasSelected) {
+      return;
+    }
+
+    const nextSelectedSpanId =
+      failureAnalysis.summary.primaryFailedSpan?.span_id ?? null;
+
+    if (selectedSpanExternalId === nextSelectedSpanId) {
+      return;
+    }
+
+    setSelectedSpanExternalId(nextSelectedSpanId);
+    if (nextSelectedSpanId) {
+      setRevealPathVersion((version) => version + 1);
+    }
+  }, [
+    failureAnalysis.summary.primaryFailedSpan,
+    selectedSpanExternalId,
+    timelineStatus,
+    userHasSelected,
+  ]);
 
   if (traceQuery.isLoading || spansQuery.isLoading) {
     return (
@@ -122,9 +227,6 @@ function TraceDetailContent({
     );
   }
 
-  const trace = traceQuery.data;
-  const spans = spansQuery.data?.spans ?? [];
-
   if (!trace) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50">
@@ -132,12 +234,6 @@ function TraceDetailContent({
       </div>
     );
   }
-
-  const timelineStatus = timeline.traceStatus ?? trace.status;
-  const duration = calculateDuration(trace.started_at, trace.ended_at);
-  const totalTokens =
-    (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
-  const returnTo = getReturnToDestination(location.state);
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-50">
@@ -151,7 +247,7 @@ function TraceDetailContent({
               <h1 className="truncate text-xl font-semibold text-gray-900">
                 {trace.name}
               </h1>
-              <StatusBadge status={timelineStatus} />
+              <StatusBadge status={timelineStatus!} />
             </div>
             <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-gray-500">
               <span>{formatDuration(duration)}</span>
@@ -167,6 +263,31 @@ function TraceDetailContent({
 
       <div className="flex-1 overflow-y-auto p-4">
         <div className="mx-auto flex max-w-7xl flex-col gap-4">
+          {timelineStatus === 'FAILED' && (
+            <FailureSummary
+              summary={failureAnalysis.summary}
+              onJumpToPrimaryFailedSpan={(spanId) => selectSpan(spanId, true)}
+            />
+          )}
+
+          {staleTraceSignal.shouldDisplay && (
+            <section className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-sm">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-800">
+                Experimental stale trace signal
+              </div>
+              <p className="mt-2">
+                Still marked running. Recent activity is sparse, so this trace may
+                be stale or incomplete.
+              </p>
+              {staleTraceSignal.latestActivityAt && (
+                <p className="mt-2 text-xs text-amber-800">
+                  Latest activity: {formatTimestamp(staleTraceSignal.latestActivityAt)} (
+                  {formatRelativeTime(staleTraceSignal.latestActivityAt)})
+                </p>
+              )}
+            </section>
+          )}
+
           <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
             <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
               <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-gray-600">
@@ -251,8 +372,13 @@ function TraceDetailContent({
               <div className="h-[32rem] overflow-y-auto">
                 <SpanTree
                   spans={spans}
-                  selectedSpanId={selectedSpan?.id ?? null}
-                  onSelectSpan={onSelectSpan}
+                  selectedSpanId={selectedSpanExternalId}
+                  onSelectSpan={(spanId) => selectSpan(spanId, true)}
+                  failedSpanIds={failureAnalysis.failedSpanIds}
+                  primaryAncestorPath={failureAnalysis.primaryAncestorPath}
+                  revealPath={revealPath}
+                  revealKey={revealPathVersion}
+                  inlineErrorPreviews={failureAnalysis.inlineErrorPreviews}
                 />
               </div>
             </section>
@@ -264,7 +390,11 @@ function TraceDetailContent({
                 </h2>
               </div>
               <div className="h-[32rem]">
-                <SpanDetail span={selectedSpan} />
+                <SpanDetail
+                  span={selectedSpan}
+                  breadcrumbPath={selectedBreadcrumbPath}
+                  onSelectSpan={(spanId) => selectSpan(spanId, true)}
+                />
               </div>
             </section>
           </div>
@@ -275,13 +405,8 @@ function TraceDetailContent({
             isLive={timeline.isLive}
             isLoading={timeline.isLoading}
             error={timeline.error}
-            selectedSpanId={selectedSpan?.span_id ?? null}
-            onSelectSpan={(spanId) => {
-              const span = spans.find((candidate) => candidate.span_id === spanId) ?? null;
-              if (span) {
-                onSelectSpan(span);
-              }
-            }}
+            selectedSpanId={selectedSpanExternalId}
+            onSelectSpan={(spanId) => selectSpan(spanId, true)}
           />
         </div>
       </div>

--- a/web/src/pages/TracesPage.test.tsx
+++ b/web/src/pages/TracesPage.test.tsx
@@ -10,7 +10,14 @@ import {
 import userEvent from '@testing-library/user-event';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearApiKey, setApiKey, type Trace, type TraceDetail } from '../api/client';
+import {
+  clearApiKey,
+  setApiKey,
+  type Span,
+  type TimelineEvent,
+  type Trace,
+  type TraceDetail,
+} from '../api/client';
 import { localDateToISOEnd, localDateToISOStart } from '../utils/tracesSearchParams';
 import { TraceDetailPage } from './TraceDetailPage';
 import { TracesPage } from './TracesPage';
@@ -75,6 +82,8 @@ const TRACE_DETAIL: TraceDetail = {
   output: { answer: 'world' },
 };
 
+let testEntityCounter = 0;
+
 type RequestInput = string | URL | Request;
 
 type JsonHandler = (url: URL) => Promise<Response> | Response;
@@ -134,6 +143,57 @@ function buildFetchHandler({
     }
 
     throw new Error(`Unhandled request: ${url.pathname}${url.search}`);
+  };
+}
+
+function createSpan(overrides: Partial<Span> = {}): Span {
+  testEntityCounter += 1;
+  const spanId = overrides.span_id ?? `span-${testEntityCounter}`;
+
+  return {
+    id: overrides.id ?? `uuid-${spanId}`,
+    trace_id: overrides.trace_id ?? TRACE_ONE.id,
+    span_id: spanId,
+    parent_span_id: overrides.parent_span_id,
+    name: overrides.name ?? `Span ${testEntityCounter}`,
+    kind: overrides.kind ?? 'CHAIN',
+    status: overrides.status ?? 'COMPLETED',
+    started_at: overrides.started_at ?? '2026-03-14T10:00:00.000Z',
+    ended_at: overrides.ended_at,
+    tokens_in: overrides.tokens_in,
+    tokens_out: overrides.tokens_out,
+    cost_usd: overrides.cost_usd,
+    latency_ms: overrides.latency_ms ?? 1000,
+    error_message: overrides.error_message,
+    model: overrides.model,
+    provider: overrides.provider,
+    input: overrides.input,
+    input_truncated: overrides.input_truncated,
+    input_original_size_bytes: overrides.input_original_size_bytes,
+    input_truncation_reason: overrides.input_truncation_reason,
+    output: overrides.output,
+    output_truncated: overrides.output_truncated,
+    output_original_size_bytes: overrides.output_original_size_bytes,
+    output_truncation_reason: overrides.output_truncation_reason,
+    metadata: overrides.metadata,
+  };
+}
+
+function createTimelineEvent(overrides: Partial<TimelineEvent> = {}): TimelineEvent {
+  testEntityCounter += 1;
+
+  return {
+    id: overrides.id ?? `event-${testEntityCounter}`,
+    trace_id: overrides.trace_id ?? TRACE_ONE.id,
+    span_id: overrides.span_id,
+    span_name: overrides.span_name,
+    event_type: overrides.event_type ?? 'message',
+    timestamp: overrides.timestamp ?? '2026-03-14T10:00:00.000Z',
+    source: overrides.source ?? 'explicit',
+    level: overrides.level,
+    sequence: overrides.sequence,
+    message: overrides.message,
+    payload: overrides.payload,
   };
 }
 
@@ -210,6 +270,7 @@ function createDeferredResponse() {
 }
 
 beforeEach(() => {
+  testEntityCounter = 0;
   fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
   localStorage.clear();
@@ -219,6 +280,7 @@ beforeEach(() => {
 afterEach(() => {
   clearApiKey();
   localStorage.clear();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -694,5 +756,856 @@ describe('TracesPage', () => {
     expect(
       screen.queryByRole('button', { name: 'Clear Search filter' })
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('TraceDetailPage', () => {
+  it('auto-selects the primary failed span, highlights the failure path, and reveals it from the summary jump action', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({
+      span_id: 'root-agent',
+      name: 'Root agent',
+      status: 'COMPLETED',
+      ended_at: '2026-03-14T10:00:05.000Z',
+    });
+    const primaryFailedSpan = createSpan({
+      span_id: 'failed-tool',
+      name: 'Failed tool',
+      kind: 'TOOL',
+      parent_span_id: 'root-agent',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:05.000Z',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Primary failure preview',
+    });
+    const siblingFailedSpan = createSpan({
+      span_id: 'sibling-failure',
+      name: 'Sibling failure',
+      parent_span_id: 'root-agent',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:12.000Z',
+      ended_at: '2026-03-14T10:00:15.000Z',
+      error_message: 'Secondary failure preview',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () =>
+          jsonResponse({
+            spans: [rootSpan, primaryFailedSpan, siblingFailedSpan],
+          }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                span_id: 'failed-tool',
+                span_name: 'Failed tool',
+                event_type: 'error',
+                timestamp: '2026-03-14T10:00:10.000Z',
+                message: 'Primary failure preview',
+              }),
+              createTimelineEvent({
+                span_id: 'sibling-failure',
+                span_name: 'Sibling failure',
+                event_type: 'span_failed',
+                timestamp: '2026-03-14T10:00:15.000Z',
+                message: 'Sibling failure synthetic event',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Failure Summary' })
+    ).toBeInTheDocument();
+
+    const detailBreadcrumb = screen.getByLabelText('Span breadcrumb');
+    expect(within(detailBreadcrumb).getByText('Failed tool')).toBeInTheDocument();
+    expect(
+      within(detailBreadcrumb).getByRole('button', {
+        name: 'Select ancestor span Root agent',
+      })
+    ).toBeInTheDocument();
+
+    const rootRow = screen.getByRole('button', {
+      name: 'Select span Root agent',
+    });
+    const primaryRow = screen.getByRole('button', {
+      name: 'Select span Failed tool',
+    });
+    const siblingRow = screen.getByRole('button', {
+      name: 'Select span Sibling failure',
+    });
+
+    expect(rootRow).toHaveClass('bg-amber-50');
+    expect(rootRow).toHaveAttribute('aria-pressed', 'false');
+    expect(within(rootRow).getByText('Failure path')).toBeInTheDocument();
+    expect(primaryRow).toHaveClass('bg-blue-50');
+    expect(primaryRow).toHaveAttribute('aria-pressed', 'true');
+    expect(within(primaryRow).getByText('Selected')).toBeInTheDocument();
+    expect(within(primaryRow).getByText('Failure path')).toBeInTheDocument();
+    expect(siblingRow).toHaveClass('bg-red-50/80');
+    expect(
+      within(siblingRow).queryByText('Failure path')
+    ).not.toBeInTheDocument();
+
+    await user.click(rootRow);
+    await user.click(
+      screen.getByRole('button', { name: 'Collapse span Root agent' })
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Select span Failed tool' })
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Jump to failed span Failed tool',
+      })
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Select span Failed tool' })
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Failed tool')
+    ).toBeInTheDocument();
+  });
+
+  it(
+    'preserves a manual selection across running-trace polling updates',
+    async () => {
+      const user = userEvent.setup();
+    const runningTraceDetail: TraceDetail = {
+      ...TRACE_DETAIL,
+      status: 'RUNNING',
+      ended_at: undefined,
+      error_count: 0,
+    };
+    const rootSpan = createSpan({
+      span_id: 'running-root',
+      name: 'Running root',
+      status: 'STARTED',
+    });
+    const childSpan = createSpan({
+      span_id: 'running-child',
+      name: 'Running child',
+      parent_span_id: 'running-root',
+      status: 'STARTED',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(runningTraceDetail),
+        spans: () => jsonResponse({ spans: [rootSpan, childSpan] }),
+        timeline: (url) => {
+          if (url.searchParams.get('after') === 'cursor-running') {
+            return jsonResponse({
+              events: [
+                createTimelineEvent({
+                  id: 'poll-running-event',
+                  span_id: 'running-child',
+                  span_name: 'Running child',
+                  event_type: 'message',
+                  timestamp: '2026-03-14T10:00:05.000Z',
+                  message: 'Poll update',
+                }),
+              ],
+              trace_status: 'RUNNING',
+              has_more: false,
+              poll_cursor: 'cursor-running',
+            });
+          }
+
+          return jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'bootstrap-running-event',
+                span_id: 'running-root',
+                span_name: 'Running root',
+                event_type: 'message',
+                timestamp: '2026-03-14T10:00:00.000Z',
+                message: 'Initial event',
+              }),
+            ],
+            trace_status: 'RUNNING',
+            has_more: false,
+            poll_cursor: 'cursor-running',
+          });
+        },
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(
+      await screen.findByRole('button', { name: 'Select span Running child' })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Select span Running child' })
+    );
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Running child')
+    ).toBeInTheDocument();
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3100));
+      });
+
+      expect(await screen.findByText('Poll update')).toBeInTheDocument();
+      expect(
+        within(screen.getByLabelText('Span breadcrumb')).getByText('Running child')
+      ).toBeInTheDocument();
+    },
+    10000
+  );
+
+  it(
+    'refetches trace and span data when a running trace transitions to failed and then auto-selects the refreshed failed span',
+    async () => {
+    const runningTraceDetail: TraceDetail = {
+      ...TRACE_DETAIL,
+      status: 'RUNNING',
+      ended_at: undefined,
+      error_count: 0,
+    };
+    const failedTraceDetail: TraceDetail = {
+      ...TRACE_DETAIL,
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:20.000Z',
+      error_count: 1,
+    };
+    const rootSpan = createSpan({
+      span_id: 'transition-root',
+      name: 'Transition root',
+      status: 'STARTED',
+    });
+    const inFlightSpan = createSpan({
+      span_id: 'in-flight',
+      name: 'In-flight work',
+      parent_span_id: 'transition-root',
+      status: 'STARTED',
+    });
+    const failedSpan = createSpan({
+      span_id: 'transition-failed',
+      name: 'Transition failed',
+      parent_span_id: 'transition-root',
+      kind: 'TOOL',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:05.000Z',
+      ended_at: '2026-03-14T10:00:12.000Z',
+      error_message: 'Transition failure preview',
+    });
+
+    let detailCalls = 0;
+    let spansCalls = 0;
+    let fullTimelineCalls = 0;
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => {
+          detailCalls += 1;
+          return jsonResponse(detailCalls === 1 ? runningTraceDetail : failedTraceDetail);
+        },
+        spans: () => {
+          spansCalls += 1;
+          return jsonResponse({
+            spans:
+              spansCalls === 1 ? [rootSpan, inFlightSpan] : [rootSpan, failedSpan],
+          });
+        },
+        timeline: (url) => {
+          if (url.searchParams.get('after') === 'cursor-transition') {
+            return jsonResponse({
+              events: [
+                createTimelineEvent({
+                  id: 'transition-error',
+                  span_id: 'transition-failed',
+                  span_name: 'Transition failed',
+                  event_type: 'error',
+                  timestamp: '2026-03-14T10:00:12.000Z',
+                  message: 'Transition failure preview',
+                }),
+              ],
+              trace_status: 'FAILED',
+              has_more: false,
+              poll_cursor: 'cursor-terminal',
+            });
+          }
+
+          fullTimelineCalls += 1;
+          if (fullTimelineCalls === 1) {
+            return jsonResponse({
+              events: [],
+              trace_status: 'RUNNING',
+              has_more: false,
+              poll_cursor: 'cursor-transition',
+            });
+          }
+
+          return jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'terminal-error',
+                span_id: 'transition-failed',
+                span_name: 'Transition failed',
+                event_type: 'error',
+                timestamp: '2026-03-14T10:00:12.000Z',
+                message: 'Transition failure preview',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+            poll_cursor: 'cursor-terminal',
+          });
+        },
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3100));
+      });
+
+      expect(
+        await screen.findByRole('button', {
+          name: 'Jump to failed span Transition failed',
+        })
+      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(detailCalls).toBeGreaterThanOrEqual(2);
+        expect(spansCalls).toBeGreaterThanOrEqual(2);
+      });
+      expect(
+        within(screen.getByLabelText('Span breadcrumb')).getByText('Transition failed')
+      ).toBeInTheDocument();
+    },
+    10000
+  );
+
+  it('resets selection and timeline filter state when navigating between traces', async () => {
+    const user = userEvent.setup();
+    const traceADetail: TraceDetail = {
+      ...TRACE_DETAIL,
+      id: 'trace-a',
+      name: 'Trace A',
+    };
+    const traceBDetail: TraceDetail = {
+      ...TRACE_DETAIL,
+      id: 'trace-b',
+      name: 'Trace B',
+      status: 'COMPLETED',
+      ended_at: '2026-03-14T10:00:20.000Z',
+      error_count: 0,
+    };
+    const traceASpans = [
+      createSpan({
+        trace_id: 'trace-a',
+        span_id: 'trace-a-root',
+        name: 'Trace A root',
+        status: 'COMPLETED',
+      }),
+      createSpan({
+        trace_id: 'trace-a',
+        span_id: 'trace-a-failed',
+        name: 'Trace A failed child',
+        parent_span_id: 'trace-a-root',
+        status: 'FAILED',
+        ended_at: '2026-03-14T10:00:10.000Z',
+        error_message: 'Trace A failure',
+      }),
+    ];
+    const traceBSpans = [
+      createSpan({
+        trace_id: 'trace-b',
+        span_id: 'trace-b-root',
+        name: 'Trace B root',
+        status: 'COMPLETED',
+      }),
+    ];
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: (url) =>
+          url.pathname.endsWith('/trace-b')
+            ? jsonResponse(traceBDetail)
+            : jsonResponse(traceADetail),
+        spans: (url) =>
+          url.pathname.includes('/trace-b/')
+            ? jsonResponse({ spans: traceBSpans })
+            : jsonResponse({ spans: traceASpans }),
+        timeline: (url) =>
+          url.pathname.includes('/trace-b/')
+            ? jsonResponse({
+                events: [
+                  createTimelineEvent({
+                    trace_id: 'trace-b',
+                    span_id: 'trace-b-root',
+                    span_name: 'Trace B root',
+                    event_type: 'message',
+                    message: 'Beta info event',
+                    timestamp: '2026-03-14T10:00:15.000Z',
+                  }),
+                ],
+                trace_status: 'COMPLETED',
+                has_more: false,
+              })
+            : jsonResponse({
+                events: [
+                  createTimelineEvent({
+                    trace_id: 'trace-a',
+                    span_id: 'trace-a-failed',
+                    span_name: 'Trace A failed child',
+                    event_type: 'error',
+                    message: 'Trace A error event',
+                    timestamp: '2026-03-14T10:00:10.000Z',
+                  }),
+                  createTimelineEvent({
+                    trace_id: 'trace-a',
+                    span_id: 'trace-a-root',
+                    span_name: 'Trace A root',
+                    event_type: 'message',
+                    message: 'Trace A info event',
+                    timestamp: '2026-03-14T10:00:05.000Z',
+                  }),
+                ],
+                trace_status: 'FAILED',
+                has_more: false,
+              }),
+      })
+    );
+
+    const view = renderTraceRoutes(['/traces/trace-a']);
+    expect(await screen.findByText('Trace A')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Select span Trace A root' })
+    );
+    await user.click(screen.getByRole('button', { name: 'Show error events only' }));
+    expect(screen.getByRole('button', { name: 'Show error events only' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    await act(async () => {
+      await view.router.navigate('/traces/trace-b');
+    });
+
+    expect(await screen.findByText('Trace B')).toBeInTheDocument();
+    expect(screen.getByText('Select a span to view details')).toBeInTheDocument();
+    expect(screen.getByText('Beta info event')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show error events only' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('filters the timeline to error events only and restores all events when toggled off', async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'info-event',
+                event_type: 'message',
+                message: 'Informational update',
+                timestamp: '2026-03-14T10:00:05.000Z',
+              }),
+              createTimelineEvent({
+                id: 'error-event',
+                event_type: 'error',
+                message: 'Critical failure',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Informational update')).toBeInTheDocument();
+    expect(screen.getByText('Critical failure')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show error events only' }));
+
+    expect(screen.getByText('Critical failure')).toBeInTheDocument();
+    expect(screen.queryByText('Informational update')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show error events only' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Show error events only' }));
+
+    expect(await screen.findByText('Informational update')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show error events only' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('shows the filtered empty state when error-only mode has no matches', async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse({
+            ...TRACE_DETAIL,
+            status: 'COMPLETED',
+            error_count: 0,
+          }),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'message-only-event',
+                event_type: 'message',
+                message: 'Only info here',
+              }),
+            ],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Only info here')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show error events only' }));
+
+    expect(
+      screen.getByText('No error events for this trace.')
+    ).toBeInTheDocument();
+  });
+
+  it('supports keyboard activation for the summary jump, breadcrumb ancestor, and error-only toggle', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({
+      span_id: 'keyboard-root',
+      name: 'Keyboard root',
+      status: 'COMPLETED',
+      ended_at: '2026-03-14T10:00:05.000Z',
+    });
+    const failedSpan = createSpan({
+      span_id: 'keyboard-failed',
+      name: 'Keyboard failed',
+      parent_span_id: 'keyboard-root',
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Keyboard failure',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: [rootSpan, failedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'keyboard-info',
+                span_id: 'keyboard-root',
+                span_name: 'Keyboard root',
+                event_type: 'message',
+                message: 'Keyboard info',
+                timestamp: '2026-03-14T10:00:05.000Z',
+              }),
+              createTimelineEvent({
+                id: 'keyboard-error',
+                span_id: 'keyboard-failed',
+                span_name: 'Keyboard failed',
+                event_type: 'error',
+                message: 'Keyboard error',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(
+      await screen.findByRole('button', {
+        name: 'Jump to failed span Keyboard failed',
+      })
+    ).toBeInTheDocument();
+
+    const errorsOnlyToggle = screen.getByRole('button', {
+      name: 'Show error events only',
+    });
+    errorsOnlyToggle.focus();
+    await user.keyboard('{Enter}');
+    expect(errorsOnlyToggle).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByText('Keyboard info')).not.toBeInTheDocument();
+
+    const breadcrumbAncestor = within(
+      screen.getByLabelText('Span breadcrumb')
+    ).getByRole('button', {
+      name: 'Select ancestor span Keyboard root',
+    });
+    breadcrumbAncestor.focus();
+    await user.keyboard('{Enter}');
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Keyboard root')
+    ).toBeInTheDocument();
+
+    const jumpButton = screen.getByRole('button', {
+      name: 'Jump to failed span Keyboard failed',
+    });
+    jumpButton.focus();
+    await user.keyboard('{Enter}');
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Keyboard failed')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the generic failure summary when a failed trace has no failed spans', async () => {
+    const rootSpan = createSpan({
+      span_id: 'no-failed-root',
+      name: 'No failed root',
+      status: 'COMPLETED',
+      ended_at: '2026-03-14T10:00:05.000Z',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'no-failed-error-log',
+                event_type: 'log',
+                level: 'error',
+                message: 'Top-level failure log',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(
+      await screen.findByText(
+        'This trace is marked as failed, but no failed span could be identified from the current span data.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Jump to failed span/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Select a span to view details')).toBeInTheDocument();
+  });
+
+  it('falls back to the primary failed span when the selected span disappears after a refresh', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({
+      span_id: 'fallback-root',
+      name: 'Fallback root',
+      status: 'COMPLETED',
+      ended_at: '2026-03-14T10:00:05.000Z',
+    });
+    const disappearingSpan = createSpan({
+      span_id: 'disappearing-child',
+      name: 'Disappearing child',
+      parent_span_id: 'fallback-root',
+      status: 'COMPLETED',
+      ended_at: '2026-03-14T10:00:07.000Z',
+    });
+    const fallbackFailedSpan = createSpan({
+      span_id: 'fallback-failed',
+      name: 'Fallback failed',
+      parent_span_id: 'fallback-root',
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Fallback failure preview',
+    });
+    let currentSpans = [rootSpan, disappearingSpan, fallbackFailedSpan];
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: currentSpans }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'fallback-error',
+                span_id: 'fallback-failed',
+                span_name: 'Fallback failed',
+                event_type: 'error',
+                message: 'Fallback failure preview',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(
+      await screen.findByRole('button', { name: 'Select span Disappearing child' })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Select span Disappearing child' })
+    );
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Disappearing child')
+    ).toBeInTheDocument();
+
+    currentSpans = [rootSpan, fallbackFailedSpan];
+
+    await act(async () => {
+      await view.queryClient.invalidateQueries({ queryKey: ['spans', TRACE_ONE.id] });
+    });
+
+    await waitFor(() => {
+      expect(
+        within(screen.getByLabelText('Span breadcrumb')).getByText('Fallback failed')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('waits for the initial timeline snapshot before evaluating the stale trace signal', async () => {
+    const now = Date.now();
+    const staleStartedAt = new Date(now - 20 * 60 * 1000).toISOString();
+    const recentActivityAt = new Date(now - 60 * 1000).toISOString();
+    const timelineResponse = createDeferredResponse();
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse({
+            ...TRACE_DETAIL,
+            status: 'RUNNING',
+            started_at: staleStartedAt,
+            ended_at: undefined,
+            error_count: 0,
+          }),
+        spans: () =>
+          jsonResponse({
+            spans: [
+              createSpan({
+                span_id: 'deferred-stale-root',
+                name: 'Deferred stale root',
+                status: 'STARTED',
+                started_at: staleStartedAt,
+              }),
+            ],
+          }),
+        timeline: () => timelineResponse.promise,
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/still marked running\. recent activity is sparse/i)
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      timelineResponse.resolve(
+        jsonResponse({
+          events: [
+            createTimelineEvent({
+              id: 'deferred-recent-event',
+              span_id: 'deferred-stale-root',
+              span_name: 'Deferred stale root',
+              event_type: 'message',
+              message: 'Recent activity',
+              timestamp: recentActivityAt,
+            }),
+          ],
+          trace_status: 'RUNNING',
+          has_more: false,
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText('Recent activity')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/still marked running\. recent activity is sparse/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the stale trace signal as static informational text', async () => {
+    const now = Date.now();
+    const staleStartedAt = new Date(now - 20 * 60 * 1000).toISOString();
+    const latestActivityAt = new Date(now - 7 * 60 * 1000).toISOString();
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse({
+            ...TRACE_DETAIL,
+            status: 'RUNNING',
+            started_at: staleStartedAt,
+            ended_at: undefined,
+            error_count: 0,
+          }),
+        spans: () =>
+          jsonResponse({
+            spans: [
+              createSpan({
+                span_id: 'stale-root',
+                name: 'Stale root',
+                status: 'STARTED',
+                started_at: staleStartedAt,
+              }),
+            ],
+          }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'stale-event',
+                span_id: 'stale-root',
+                span_name: 'Stale root',
+                event_type: 'message',
+                timestamp: latestActivityAt,
+                message: 'Last known activity',
+              }),
+            ],
+            trace_status: 'RUNNING',
+            has_more: false,
+            poll_cursor: 'cursor-stale',
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    const staleSignal = await screen.findByText(
+      /still marked running\. recent activity is sparse/i
+    );
+    expect(staleSignal).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(staleSignal.closest('[aria-live]')).toBeNull();
   });
 });

--- a/web/src/pages/useTraceTimeline.ts
+++ b/web/src/pages/useTraceTimeline.ts
@@ -1,5 +1,5 @@
 import { startTransition, useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   fetchTimelineEvents,
   TimelineEvent,
@@ -19,6 +19,7 @@ interface TimelineSnapshot {
 export function useTraceTimeline(traceId: string) {
   const [timelineSnapshot, setTimelineSnapshot] = useState<TimelineSnapshot | null>(null);
   const [needsTerminalRefresh, setNeedsTerminalRefresh] = useState(false);
+  const queryClient = useQueryClient();
 
   const timelineBootstrapQuery = useQuery({
     queryKey: ['timeline', traceId, 'bootstrap'],
@@ -61,6 +62,10 @@ export function useTraceTimeline(traceId: string) {
     const pollResult = timelinePollQuery.data;
 
     if (pollResult.trace_status !== 'RUNNING') {
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['trace', traceId] }),
+        queryClient.invalidateQueries({ queryKey: ['spans', traceId] }),
+      ]);
       setNeedsTerminalRefresh(true);
     }
 
@@ -77,7 +82,7 @@ export function useTraceTimeline(traceId: string) {
         };
       });
     });
-  }, [timelinePollQuery.data]);
+  }, [queryClient, timelinePollQuery.data, traceId]);
 
   const timelineTerminalRefreshQuery = useQuery({
     queryKey: ['timeline', traceId, 'terminal-refresh', needsTerminalRefresh],
@@ -101,6 +106,7 @@ export function useTraceTimeline(traceId: string) {
   return {
     events: timelineSnapshot?.events ?? [],
     traceStatus: timelineSnapshot?.traceStatus ?? null,
+    hasSnapshot: timelineSnapshot !== null,
     isLive: pollingEnabled,
     isLoading: !timelineSnapshot && timelineBootstrapQuery.isLoading,
     error: resolveTimelineError(

--- a/web/src/utils/failureAnalysis.test.ts
+++ b/web/src/utils/failureAnalysis.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest';
+import type { Span, TimelineEvent } from '../api/client';
+import {
+  buildBreadcrumbPath,
+  buildFailureAnalysis,
+  buildFailureSummary,
+  buildSpanIndex,
+  evaluateStaleTraceSignal,
+  findPrimaryFailedSpan,
+  getInlineErrorPreview,
+  STALE_INACTIVITY_THRESHOLD_MS,
+  STALE_RUNTIME_THRESHOLD_MS,
+} from './failureAnalysis';
+
+function createSpan(overrides: Partial<Span> = {}): Span {
+  const spanId = overrides.span_id ?? `span-${Math.random().toString(36).slice(2)}`;
+
+  return {
+    id: overrides.id ?? `uuid-${spanId}`,
+    trace_id: overrides.trace_id ?? 'trace-1',
+    span_id: spanId,
+    name: overrides.name ?? spanId,
+    kind: overrides.kind ?? 'CHAIN',
+    status: overrides.status ?? 'COMPLETED',
+    started_at: overrides.started_at ?? '2026-03-14T10:00:00.000Z',
+    ended_at: overrides.ended_at,
+    tokens_in: overrides.tokens_in,
+    tokens_out: overrides.tokens_out,
+    cost_usd: overrides.cost_usd,
+    latency_ms: overrides.latency_ms,
+    error_message: overrides.error_message,
+    model: overrides.model,
+    provider: overrides.provider,
+    input: overrides.input,
+    input_truncated: overrides.input_truncated,
+    input_original_size_bytes: overrides.input_original_size_bytes,
+    input_truncation_reason: overrides.input_truncation_reason,
+    output: overrides.output,
+    output_truncated: overrides.output_truncated,
+    output_original_size_bytes: overrides.output_original_size_bytes,
+    output_truncation_reason: overrides.output_truncation_reason,
+    metadata: overrides.metadata,
+    parent_span_id: overrides.parent_span_id,
+  };
+}
+
+function createEvent(overrides: Partial<TimelineEvent> = {}): TimelineEvent {
+  return {
+    id: overrides.id ?? `event-${Math.random().toString(36).slice(2)}`,
+    trace_id: overrides.trace_id ?? 'trace-1',
+    event_type: overrides.event_type ?? 'message',
+    timestamp: overrides.timestamp ?? '2026-03-14T10:00:00.000Z',
+    source: overrides.source ?? 'explicit',
+    span_id: overrides.span_id,
+    span_name: overrides.span_name,
+    level: overrides.level,
+    sequence: overrides.sequence,
+    message: overrides.message,
+    payload: overrides.payload,
+  };
+}
+
+describe('failureAnalysis', () => {
+  it('builds a span index keyed by external span id', () => {
+    const root = createSpan({ span_id: 'root', name: 'Root' });
+    const child = createSpan({ span_id: 'child', name: 'Child' });
+
+    const spanIndex = buildSpanIndex([root, child]);
+
+    expect(spanIndex.get('root')).toBe(root);
+    expect(spanIndex.get('child')).toBe(child);
+  });
+
+  it('finds the primary failed span using deterministic tie-breaking', () => {
+    const spans = [
+      createSpan({
+        span_id: 'late-missing-end',
+        status: 'FAILED',
+        started_at: '2026-03-14T10:04:00.000Z',
+      }),
+      createSpan({
+        span_id: 'same-end-later-start',
+        status: 'FAILED',
+        started_at: '2026-03-14T10:03:00.000Z',
+        ended_at: '2026-03-14T10:05:00.000Z',
+      }),
+      createSpan({
+        span_id: 'same-end-earlier-start',
+        status: 'FAILED',
+        started_at: '2026-03-14T10:02:00.000Z',
+        ended_at: '2026-03-14T10:05:00.000Z',
+      }),
+      createSpan({
+        span_id: 'earliest-end',
+        status: 'FAILED',
+        started_at: '2026-03-14T10:01:00.000Z',
+        ended_at: '2026-03-14T10:04:00.000Z',
+      }),
+    ];
+
+    expect(findPrimaryFailedSpan(spans)?.span_id).toBe('earliest-end');
+  });
+
+  it('falls back to original array order when ended_at and started_at are identical', () => {
+    const first = createSpan({
+      span_id: 'first',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:00.000Z',
+      ended_at: '2026-03-14T10:01:00.000Z',
+    });
+    const second = createSpan({
+      span_id: 'second',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:00.000Z',
+      ended_at: '2026-03-14T10:01:00.000Z',
+    });
+
+    expect(findPrimaryFailedSpan([first, second])).toBe(first);
+  });
+
+  it('builds a breadcrumb path for normal, cyclic, and broken parent chains', () => {
+    const root = createSpan({ span_id: 'root', name: 'Root' });
+    const child = createSpan({
+      span_id: 'child',
+      name: 'Child',
+      parent_span_id: 'root',
+    });
+    const grandchild = createSpan({
+      span_id: 'grandchild',
+      name: 'Grandchild',
+      parent_span_id: 'child',
+    });
+    const broken = createSpan({
+      span_id: 'broken',
+      name: 'Broken',
+      parent_span_id: 'missing',
+    });
+    const cycleA = createSpan({
+      span_id: 'cycle-a',
+      name: 'Cycle A',
+      parent_span_id: 'cycle-b',
+    });
+    const cycleB = createSpan({
+      span_id: 'cycle-b',
+      name: 'Cycle B',
+      parent_span_id: 'cycle-a',
+    });
+    const spanIndex = buildSpanIndex([
+      root,
+      child,
+      grandchild,
+      broken,
+      cycleA,
+      cycleB,
+    ]);
+
+    expect(buildBreadcrumbPath(grandchild, spanIndex)).toEqual([
+      { spanId: 'root', name: 'Root' },
+      { spanId: 'child', name: 'Child' },
+      { spanId: 'grandchild', name: 'Grandchild' },
+    ]);
+    expect(buildBreadcrumbPath(broken, spanIndex)).toEqual([
+      { spanId: 'broken', name: 'Broken' },
+    ]);
+    expect(buildBreadcrumbPath(cycleA, spanIndex)).toEqual([
+      { spanId: 'cycle-b', name: 'Cycle B' },
+      { spanId: 'cycle-a', name: 'Cycle A' },
+    ]);
+  });
+
+  it('prefers span.error_message for inline previews and truncates the first line', () => {
+    const span = createSpan({
+      span_id: 'failed',
+      status: 'FAILED',
+      error_message:
+        '   First line that is intentionally made very long to exceed the one hundred and twenty character preview limit by a noticeable margin.\nSecond line   ',
+    });
+
+    expect(getInlineErrorPreview(span, [])).toBe(
+      'First line that is intentionally made very long to exceed the one hundred and twenty character preview limit by a not...'
+    );
+  });
+
+  it('falls back to the first matching error or exception timeline message', () => {
+    const span = createSpan({
+      span_id: 'failed',
+      status: 'FAILED',
+    });
+    const events = [
+      createEvent({
+        span_id: 'failed',
+        event_type: 'span_failed',
+        message: 'Synthetic failure event',
+      }),
+      createEvent({
+        span_id: 'failed',
+        event_type: 'error',
+        message: '\n  Real failure details  \nMore context',
+      }),
+      createEvent({
+        span_id: 'failed',
+        event_type: 'exception',
+        message: 'Later exception',
+      }),
+    ];
+
+    expect(getInlineErrorPreview(span, events)).toBe('Real failure details');
+  });
+
+  it('builds a failure summary and failure analysis with consistent counts and previews', () => {
+    const root = createSpan({
+      span_id: 'root',
+      name: 'Root',
+      status: 'COMPLETED',
+      ended_at: '2026-03-14T10:01:00.000Z',
+    });
+    const failed = createSpan({
+      span_id: 'failed',
+      name: 'Failed child',
+      parent_span_id: 'root',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:01:00.000Z',
+      ended_at: '2026-03-14T10:02:00.000Z',
+    });
+    const laterFailed = createSpan({
+      span_id: 'later-failed',
+      name: 'Later failed child',
+      parent_span_id: 'root',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:02:30.000Z',
+      ended_at: '2026-03-14T10:03:00.000Z',
+      error_message: 'Later failure',
+    });
+    const events = [
+      createEvent({
+        span_id: 'failed',
+        span_name: 'Failed child',
+        event_type: 'error',
+        timestamp: '2026-03-14T10:02:00.000Z',
+        message: 'The first failure',
+      }),
+      createEvent({
+        span_id: 'failed',
+        event_type: 'message',
+        timestamp: '2026-03-14T10:02:01.000Z',
+        message: 'Not an error',
+      }),
+      createEvent({
+        event_type: 'log',
+        level: 'error',
+        timestamp: '2026-03-14T10:02:02.000Z',
+        message: 'Top-level error log',
+      }),
+      createEvent({
+        span_id: 'later-failed',
+        event_type: 'span_failed',
+        timestamp: '2026-03-14T10:03:00.000Z',
+        message: 'Later failed synthetic',
+      }),
+    ];
+
+    const summary = buildFailureSummary({
+      spans: [root, failed, laterFailed],
+      events,
+    });
+    const analysis = buildFailureAnalysis([root, failed, laterFailed], events);
+
+    expect(summary).toMatchObject({
+      primaryFailedSpan: failed,
+      failedSpanCount: 2,
+      errorEventCount: 3,
+      errorPreview: 'The first failure',
+      failureTimestamp: '2026-03-14T10:02:00.000Z',
+    });
+    expect(summary.breadcrumbPath).toEqual([
+      { spanId: 'root', name: 'Root' },
+      { spanId: 'failed', name: 'Failed child' },
+    ]);
+    expect(analysis.failedSpanIds).toEqual(new Set(['failed', 'later-failed']));
+    expect(analysis.inlineErrorPreviews.get('failed')).toBe('The first failure');
+    expect(analysis.inlineErrorPreviews.get('later-failed')).toBe('Later failure');
+    expect(analysis.primaryAncestorPath).toEqual(new Set(['root', 'failed']));
+  });
+
+  it('returns an empty failure summary when no spans are failed', () => {
+    const summary = buildFailureSummary({
+      spans: [
+        createSpan({
+          span_id: 'completed',
+          status: 'COMPLETED',
+        }),
+      ],
+      events: [],
+    });
+
+    expect(summary).toEqual({
+      primaryFailedSpan: null,
+      failedSpanCount: 0,
+      errorEventCount: 0,
+      errorPreview: null,
+      failureTimestamp: null,
+      breadcrumbPath: [],
+    });
+  });
+
+  it('shows the stale trace signal only when both thresholds are exceeded', () => {
+    const now = new Date('2026-03-14T10:30:00.000Z');
+    const staleSignal = evaluateStaleTraceSignal({
+      traceStatus: 'RUNNING',
+      traceStartedAt: '2026-03-14T10:00:00.000Z',
+      spans: [
+        createSpan({
+          span_id: 'active-span',
+          started_at: '2026-03-14T10:05:00.000Z',
+          ended_at: '2026-03-14T10:20:00.000Z',
+        }),
+      ],
+      events: [
+        createEvent({
+          event_type: 'message',
+          timestamp: '2026-03-14T10:22:00.000Z',
+        }),
+      ],
+      now,
+    });
+
+    expect(staleSignal.shouldDisplay).toBe(true);
+    expect(staleSignal.latestActivityAt).toBe('2026-03-14T10:22:00.000Z');
+    expect(staleSignal.runtimeMs).toBeGreaterThanOrEqual(STALE_RUNTIME_THRESHOLD_MS);
+    expect(staleSignal.inactivityMs).toBeGreaterThanOrEqual(
+      STALE_INACTIVITY_THRESHOLD_MS
+    );
+
+    expect(
+      evaluateStaleTraceSignal({
+        traceStatus: 'RUNNING',
+        traceStartedAt: '2026-03-14T10:20:00.000Z',
+        spans: [],
+        events: [],
+        now,
+      }).shouldDisplay
+    ).toBe(false);
+
+    expect(
+      evaluateStaleTraceSignal({
+        traceStatus: 'COMPLETED',
+        traceStartedAt: '2026-03-14T10:00:00.000Z',
+        spans: [],
+        events: [],
+        now,
+      }).shouldDisplay
+    ).toBe(false);
+  });
+});

--- a/web/src/utils/failureAnalysis.ts
+++ b/web/src/utils/failureAnalysis.ts
@@ -1,0 +1,350 @@
+import type {
+  Span,
+  TimelineEvent,
+  TimelineTraceStatus,
+} from '../api/client';
+import { isTimelineErrorEvent } from './timeline';
+
+const ERROR_PREVIEW_MAX_LENGTH = 120;
+export const STALE_RUNTIME_THRESHOLD_MS = 15 * 60 * 1000;
+export const STALE_INACTIVITY_THRESHOLD_MS = 5 * 60 * 1000;
+
+export type SpanIndex = Map<string, Span>;
+export type TimelineEventsBySpanId = Map<string, TimelineEvent[]>;
+
+export interface BreadcrumbSegment {
+  spanId: string;
+  name: string;
+}
+
+export interface FailureSummary {
+  primaryFailedSpan: Span | null;
+  failedSpanCount: number;
+  errorEventCount: number;
+  errorPreview: string | null;
+  failureTimestamp: string | null;
+  breadcrumbPath: BreadcrumbSegment[];
+}
+
+export interface FailureAnalysis {
+  spanIndex: SpanIndex;
+  failedSpanIds: Set<string>;
+  inlineErrorPreviews: Map<string, string>;
+  primaryAncestorPath: Set<string>;
+  summary: FailureSummary;
+}
+
+export interface StaleTraceSignal {
+  shouldDisplay: boolean;
+  latestActivityAt: string | null;
+  runtimeMs: number | null;
+  inactivityMs: number | null;
+}
+
+interface BuildFailureSummaryOptions {
+  spans: Span[];
+  events: TimelineEvent[];
+  spanIndex?: SpanIndex;
+  eventsBySpanId?: TimelineEventsBySpanId;
+}
+
+interface EvaluateStaleTraceSignalOptions {
+  traceStatus: TimelineTraceStatus | null;
+  traceStartedAt: string | undefined;
+  spans: Span[];
+  events: TimelineEvent[];
+  now?: Date | number;
+}
+
+export function buildSpanIndex(spans: Span[]): SpanIndex {
+  const spanIndex: SpanIndex = new Map();
+
+  for (const span of spans) {
+    spanIndex.set(span.span_id, span);
+  }
+
+  return spanIndex;
+}
+
+export function buildTimelineEventsBySpanId(
+  events: TimelineEvent[]
+): TimelineEventsBySpanId {
+  const eventsBySpanId: TimelineEventsBySpanId = new Map();
+
+  for (const event of events) {
+    if (!event.span_id) {
+      continue;
+    }
+
+    const spanEvents = eventsBySpanId.get(event.span_id);
+    if (spanEvents) {
+      spanEvents.push(event);
+      continue;
+    }
+
+    eventsBySpanId.set(event.span_id, [event]);
+  }
+
+  return eventsBySpanId;
+}
+
+export function findPrimaryFailedSpan(spans: Span[]): Span | null {
+  const failedSpans = spans
+    .map((span, index) => ({ span, index }))
+    .filter(({ span }) => span.status === 'FAILED');
+
+  if (failedSpans.length === 0) {
+    return null;
+  }
+
+  failedSpans.sort((left, right) => {
+    const endedAtDelta = compareTimestamps(
+      left.span.ended_at,
+      right.span.ended_at,
+      'last'
+    );
+    if (endedAtDelta !== 0) {
+      return endedAtDelta;
+    }
+
+    const startedAtDelta = compareTimestamps(
+      left.span.started_at,
+      right.span.started_at,
+      'last'
+    );
+    if (startedAtDelta !== 0) {
+      return startedAtDelta;
+    }
+
+    return left.index - right.index;
+  });
+
+  return failedSpans[0]?.span ?? null;
+}
+
+export function buildBreadcrumbPath(
+  span: Span | null | undefined,
+  spanIndex: SpanIndex
+): BreadcrumbSegment[] {
+  if (!span) {
+    return [];
+  }
+
+  const path: BreadcrumbSegment[] = [];
+  const visited = new Set<string>();
+  let current: Span | undefined = span;
+
+  while (current && !visited.has(current.span_id)) {
+    path.push({
+      spanId: current.span_id,
+      name: current.name,
+    });
+    visited.add(current.span_id);
+
+    if (!current.parent_span_id) {
+      break;
+    }
+
+    current = spanIndex.get(current.parent_span_id);
+  }
+
+  return path.reverse();
+}
+
+export function getInlineErrorPreview(
+  span: Span | null | undefined,
+  eventsOrIndex: TimelineEvent[] | TimelineEventsBySpanId
+): string | null {
+  if (!span) {
+    return null;
+  }
+
+  const spanErrorPreview = normalizeErrorPreview(span.error_message);
+  if (spanErrorPreview) {
+    return spanErrorPreview;
+  }
+
+  const spanEvents =
+    eventsOrIndex instanceof Map
+      ? eventsOrIndex.get(span.span_id) ?? []
+      : eventsOrIndex;
+
+  for (const event of spanEvents) {
+    if (
+      event.span_id !== span.span_id ||
+      (event.event_type !== 'error' && event.event_type !== 'exception')
+    ) {
+      continue;
+    }
+
+    const eventPreview = normalizeErrorPreview(event.message);
+    if (eventPreview) {
+      return eventPreview;
+    }
+  }
+
+  return null;
+}
+
+export function buildFailureSummary({
+  spans,
+  events,
+  spanIndex = buildSpanIndex(spans),
+  eventsBySpanId = buildTimelineEventsBySpanId(events),
+}: BuildFailureSummaryOptions): FailureSummary {
+  const primaryFailedSpan = findPrimaryFailedSpan(spans);
+  const breadcrumbPath = buildBreadcrumbPath(primaryFailedSpan, spanIndex);
+
+  return {
+    primaryFailedSpan,
+    failedSpanCount: spans.filter((span) => span.status === 'FAILED').length,
+    errorEventCount: events.filter(isTimelineErrorEvent).length,
+    errorPreview: getInlineErrorPreview(primaryFailedSpan, eventsBySpanId),
+    failureTimestamp: primaryFailedSpan?.ended_at ?? null,
+    breadcrumbPath,
+  };
+}
+
+export function buildFailureAnalysis(
+  spans: Span[],
+  events: TimelineEvent[],
+  spanIndex: SpanIndex = buildSpanIndex(spans)
+): FailureAnalysis {
+  const eventsBySpanId = buildTimelineEventsBySpanId(events);
+  const summary = buildFailureSummary({
+    spans,
+    events,
+    spanIndex,
+    eventsBySpanId,
+  });
+
+  const failedSpanIds = new Set<string>();
+  const inlineErrorPreviews = new Map<string, string>();
+
+  for (const span of spans) {
+    if (span.status !== 'FAILED') {
+      continue;
+    }
+
+    failedSpanIds.add(span.span_id);
+    const preview = getInlineErrorPreview(span, eventsBySpanId);
+    if (preview) {
+      inlineErrorPreviews.set(span.span_id, preview);
+    }
+  }
+
+  return {
+    spanIndex,
+    failedSpanIds,
+    inlineErrorPreviews,
+    primaryAncestorPath: new Set(
+      summary.breadcrumbPath.map((segment) => segment.spanId)
+    ),
+    summary,
+  };
+}
+
+export function evaluateStaleTraceSignal({
+  traceStatus,
+  traceStartedAt,
+  spans,
+  events,
+  now = new Date(),
+}: EvaluateStaleTraceSignalOptions): StaleTraceSignal {
+  const traceStartedAtMs = parseTimestamp(traceStartedAt);
+  const latestActivityAt =
+    getLatestTimestamp(events.map((event) => event.timestamp)) ??
+    getLatestTimestamp(spans.map((span) => span.ended_at)) ??
+    getLatestTimestamp(spans.map((span) => span.started_at)) ??
+    traceStartedAt ??
+    null;
+  const latestActivityAtMs = parseTimestamp(latestActivityAt);
+  const nowMs = now instanceof Date ? now.getTime() : now;
+  const runtimeMs =
+    traceStartedAtMs === null ? null : Math.max(0, nowMs - traceStartedAtMs);
+  const inactivityMs =
+    latestActivityAtMs === null ? null : Math.max(0, nowMs - latestActivityAtMs);
+
+  return {
+    shouldDisplay:
+      traceStatus === 'RUNNING' &&
+      runtimeMs !== null &&
+      inactivityMs !== null &&
+      runtimeMs >= STALE_RUNTIME_THRESHOLD_MS &&
+      inactivityMs >= STALE_INACTIVITY_THRESHOLD_MS,
+    latestActivityAt,
+    runtimeMs,
+    inactivityMs,
+  };
+}
+
+function normalizeErrorPreview(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const firstNonEmptyLine = value
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  if (!firstNonEmptyLine) {
+    return null;
+  }
+
+  if (firstNonEmptyLine.length <= ERROR_PREVIEW_MAX_LENGTH) {
+    return firstNonEmptyLine;
+  }
+
+  return `${firstNonEmptyLine.slice(0, ERROR_PREVIEW_MAX_LENGTH - 3)}...`;
+}
+
+function compareTimestamps(
+  left: string | undefined,
+  right: string | undefined,
+  missingPlacement: 'first' | 'last'
+): number {
+  const leftTimestamp = parseTimestamp(left);
+  const rightTimestamp = parseTimestamp(right);
+
+  if (leftTimestamp === null && rightTimestamp === null) {
+    return 0;
+  }
+  if (leftTimestamp === null) {
+    return missingPlacement === 'first' ? -1 : 1;
+  }
+  if (rightTimestamp === null) {
+    return missingPlacement === 'first' ? 1 : -1;
+  }
+
+  return leftTimestamp - rightTimestamp;
+}
+
+function parseTimestamp(timestamp: string | undefined | null): number | null {
+  if (!timestamp) {
+    return null;
+  }
+
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function getLatestTimestamp(timestamps: Array<string | undefined>): string | null {
+  let latestTimestamp: string | null = null;
+  let latestTimestampMs: number | null = null;
+
+  for (const timestamp of timestamps) {
+    const parsedTimestamp = parseTimestamp(timestamp);
+    if (parsedTimestamp === null) {
+      continue;
+    }
+
+    if (latestTimestampMs === null || parsedTimestamp > latestTimestampMs) {
+      latestTimestamp = timestamp ?? null;
+      latestTimestampMs = parsedTimestamp;
+    }
+  }
+
+  return latestTimestamp;
+}

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -53,6 +53,14 @@ export function formatRelativeTime(dateStr: string | undefined | null): string {
 }
 
 /**
+ * Format a timestamp as an absolute ISO string.
+ */
+export function formatTimestamp(dateStr: string | undefined | null): string {
+  if (!dateStr) return '-';
+  return new Date(dateStr).toISOString();
+}
+
+/**
  * Calculate duration from start and end times.
  */
 export function calculateDuration(


### PR DESCRIPTION
## Summary
- implement the Phase 7 failure-first trace detail flow and supporting OpenSpec change artifacts
- add failure analysis helpers, failure summary UI, breadcrumb navigation, tree/path highlighting, timeline error filtering, and stale running signal handling
- expand frontend coverage for auto-selection, polling transitions, keyboard interactions, fallback behavior, and stale-signal gating

## Validation
- pnpm --filter web test
- pnpm --filter web type-check
- pnpm --filter web lint
- openspec validate add-failure-first-trace-detail --strict

## Notes
- OpenSpec manual accessibility task 8.4 remains unchecked because no manual browser keyboard pass was performed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**

* Failure-first trace detail experience with visual highlighting of failed spans and inline error previews
* Errors-only timeline filter to focus on error events
* Breadcrumb navigation in span detail panels for easier path exploration
* Auto-selection of the primary failed span when trace transitions to failure state
* Stale trace indicator for long-running traces with sparse recent activity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->