### PR TITLE
feat: add payload inspection and deep navigation

### DIFF
--- a/openspec/changes/add-payload-inspection-deep-navigation/design.md
+++ b/openspec/changes/add-payload-inspection-deep-navigation/design.md
@@ -1,0 +1,117 @@
+# Design: Payload Inspection & Deep Navigation
+
+## 1. Inspector Rendering Model
+
+### Decision: Memoized tree with lazy child rendering
+
+Build an in-memory tree of typed nodes (`ObjectNode`, `ArrayNode`, `PrimitiveNode`) once per payload change. Render children only when a node is expanded. Never call `JSON.stringify` on the full payload during normal rendering.
+
+**Why not virtualized lists?** Observability payloads are typically wide (many keys) rather than deep (thousands of siblings). The initial collapse rules (depth >= 2 collapsed, shallow-size > 200 collapsed) bound the rendered node count well within React's capacity. Virtualization adds significant complexity for scroll-position management inside nested trees and is deferred to a future phase if profiling shows need.
+
+### Collapse Thresholds
+
+Two rules cooperate:
+
+| Rule | Condition | Initial State |
+|------|-----------|---------------|
+| Depth rule | `depth >= 2` | Collapsed |
+| Shallow-size rule | `> 200 immediate children` at depth 0 or 1 | Collapsed with count badge |
+
+The shallow-size rule exists because depth-only rules still eagerly render large top-level arrays — common in batch LLM responses. The 200-child threshold is chosen to keep initial DOM node count below ~1000 for any single inspector instance.
+
+### Expand All Gating
+
+`Expand all` is disabled when total tree node count exceeds 5,000. This is a hard gate, not a warning. The count is computed once during tree construction and cached.
+
+## 2. URL State and Phase 7 Interaction
+
+### Decision: `?span=<external-span-id>` with `replace` semantics
+
+Following Phase 6's URL-driven filter pattern, the selected span is persisted in the URL as `?span=<external-span-id>`.
+
+**Key interaction with Phase 7 auto-selection:**
+
+```
+Page load with ?span=abc
+  → Treat as explicit user intent
+  → Set userHasSelected = true
+  → Skip failure-first auto-selection
+
+Page load without ?span=
+  → Phase 7 auto-selects primary failed span (if applicable)
+  → userHasSelected remains false
+  → URL is NOT back-written (no ?span= appears)
+  → But "Copy Trace URL" DOES include the effective span
+
+User clicks a span
+  → userHasSelected = true
+  → URL updated with replace (no new history entry)
+  → Back button returns to referrer, not prior span
+```
+
+### Why `replace` not `push`?
+
+Span-to-span navigation within a trace is browsing, not destination-setting. If each span click pushed a history entry, back-button would step through every span the user glanced at instead of returning to the trace list. Note: Phase 6 uses `push` for user-driven filter changes and `replace` only for normalization. Here, `replace` is the right choice because span clicks are high-frequency inspection actions, not deliberate filter-setting actions that users would want to step back through.
+
+### Stale Span Handling
+
+If the selected span (from URL or state) is not found in the fetched span data:
+1. Clear `selectedSpanExternalId`
+2. Reset `userHasSelected = false`
+3. Remove `?span=` from URL with `replace`
+4. Let Phase 7 auto-selection re-run if applicable
+
+This handles traces where spans are still being ingested or where a shared link references a span that was removed.
+
+## 3. Search State Scoping
+
+### Decision: Per-inspector, not page-global
+
+Each `PayloadInspector` instance owns its own search state. The trace detail page may render 4+ inspectors simultaneously (trace input, trace output, span input, span output, metadata, timeline payload). A global search would be confusing because:
+
+- Users typically search within a specific payload (e.g., "find the `temperature` key in the LLM request")
+- Global search would need cross-inspector result navigation UI
+- Match highlighting across collapsed inspectors creates UX complexity
+
+### Search Behavior
+
+- `useDeferredValue` defers the search rendering so that typing remains responsive while the tree re-renders with matches in a lower-priority update
+- Matching branches auto-expand while search is active
+- Clearing search restores prior manual expansion state (saved before search began)
+- Search covers object keys and scalar values (stringified). No JSONPath in v1.
+- Match navigation: next/previous buttons cycle through matches within that inspector. The active match gets a distinct highlight and is scrolled into view via `scrollIntoView`. DOM focus stays on the search input, not on the match element.
+
+## 4. Unified Selection Callback
+
+### Decision: Single page-level callback for all span selection
+
+All entry points (tree row, breadcrumb, failure summary, parent button, timeline) call one shared callback. This callback:
+
+1. Updates `selectedSpanExternalId` state
+2. Sets `userHasSelected = true`
+3. Computes and sets `revealPath` for tree auto-expand
+4. Writes `?span=` with `replace`
+
+This prevents divergence where some entry points forget URL updates or reveal-path computation. The callback lives in `TraceDetailPage.tsx` and is passed down via props.
+
+## 5. Component Hierarchy
+
+```
+TraceDetailPage
+├── FailureSummary (onSelectSpan → unified callback)
+├── TraceContext
+│   ├── PayloadInspector (trace input)
+│   └── PayloadInspector (trace output)
+├── SpanTree (onSelectSpan → unified callback)
+├── SpanDetail
+│   ├── SpanBreadcrumb (onSelectSpan → unified callback)
+│   ├── Parent Span Button (→ unified callback)
+│   ├── PayloadInspector (span input) + TruncationBanner
+│   ├── PayloadInspector (span output) + TruncationBanner
+│   ├── PayloadInspector (metadata)
+│   └── CopyButton (span ID, parent ID)
+├── Timeline
+│   ├── Span buttons (onSelectSpan → unified callback)
+│   └── PayloadInspector (event payload)
+└── CopyButton (trace UUID, external trace ID, session ID, trace URL)
+```

--- a/openspec/changes/add-payload-inspection-deep-navigation/proposal.md
+++ b/openspec/changes/add-payload-inspection-deep-navigation/proposal.md
@@ -1,0 +1,67 @@
+# Phase 8: Payload Inspection & Deep Navigation
+
+## Status: DRAFT
+
+## Summary
+
+Replace the static `<pre>` JSON renderer with an interactive payload inspector and add URL-driven span deep-linking, copy utilities, unified navigation callbacks, and truncation banners. All changes are frontend-only.
+
+## Motivation
+
+The current `JsonViewer` renders payloads as raw `JSON.stringify` output in a `<pre>` tag. This is unusable for large observability payloads (LLM prompts, tool responses) where users need to expand/collapse subtrees, search for keys, and copy values. Additionally, span selection is not URL-persisted, so users cannot share or bookmark links to specific spans.
+
+Phase 6 established URL-driven filter state for the trace list. Phase 7 added failure-first auto-selection and breadcrumb navigation. Phase 8 extends both patterns: URL-driven span state on the trace detail page and an interactive inspector for every payload surface.
+
+## Scope
+
+- **In scope**: PayloadInspector component, span deep-linking via `?span=`, copy/clipboard utilities, unified span selection callback, truncation banners, per-inspector search.
+- **Out of scope**: Backend changes, virtualized rendering, file export, OS share sheets, JSONPath query language, global cross-inspector search.
+
+## Capabilities
+
+| Capability | Spec | Description |
+|------------|------|-------------|
+| Payload Inspector | `payload-inspector/spec.md` | Interactive JSON tree with expand/collapse, search, copy, multiline rendering |
+| Span Deep-Linking | `span-deep-linking/spec.md` | URL-driven selected span state with `?span=<external-span-id>` |
+| Clipboard Utilities | `clipboard-utilities/spec.md` | Reusable CopyButton component and clipboard helper |
+| Navigation Continuity | `navigation-continuity/spec.md` | Unified selection callback, parent span navigation button |
+| Truncation Indicators | `truncation-indicators/spec.md` | Banners for truncated span payloads using existing API metadata |
+
+## Delivery Order
+
+1. **Payload Inspector** - Hardest part; unlocks every payload surface
+2. **Span Deep-Linking** - High-value; isolated to trace detail state management
+3. **Clipboard Utilities** - Simple shared infrastructure
+4. **Navigation Continuity** - Refactors existing selection entry points through one path
+5. **Truncation Indicators + Inspector Rollout** - Swap all payload surfaces once core is stable
+
+## Design Decisions
+
+See `design.md` for architectural reasoning on:
+- Inspector rendering model and performance thresholds
+- URL state interaction with Phase 7 auto-selection
+- Search state scoping
+
+## Files Affected
+
+### New Files
+- `web/src/components/PayloadInspector.tsx` - Interactive JSON tree
+- `web/src/components/CopyButton.tsx` - Reusable copy control
+- `web/src/utils/clipboard.ts` - Clipboard helper
+- `web/src/utils/traceDetailSearchParams.ts` - URL param parse/serialize
+- `web/src/hooks/useTraceDetailSearchParams.ts` - Hook wrapping useSearchParams
+
+### Modified Files
+- `web/src/pages/TraceDetailPage.tsx` - URL-driven span state, unified selection callback
+- `web/src/components/SpanDetail.tsx` - PayloadInspector integration, truncation banners, parent navigation
+- `web/src/components/Timeline.tsx` - PayloadInspector integration
+- `web/src/components/JsonViewer.tsx` - Thin wrapper or removal
+
+## Assumptions
+
+- Scope stays frontend-only
+- External `span_id` is the only deep-link identifier
+- Search is per-inspector, not page-global
+- Automatic failure-first selection remains local state; only explicit user-driven selection mutates the browser URL
+- Existing Phase 6 back-link behavior and Phase 7 failure-first behavior remain unchanged
+- React Query fetch keys remain trace-id based; changing `?span=` does not trigger refetches

--- a/openspec/changes/add-payload-inspection-deep-navigation/specs/clipboard-utilities/spec.md
+++ b/openspec/changes/add-payload-inspection-deep-navigation/specs/clipboard-utilities/spec.md
@@ -1,0 +1,77 @@
+# Clipboard Utilities
+
+Reusable copy infrastructure: a `CopyButton` component and a `clipboard.ts` helper.
+
+## ADDED Requirements
+
+### Requirement: Clipboard Helper
+
+The system MUST provide a shared `clipboard.ts` utility that handles clipboard interaction and error fallback.
+
+#### Scenario: Successful copy
+
+Given the browser supports `navigator.clipboard.writeText`
+When `copyToClipboard(text)` is called
+Then the text is written to the clipboard and the function resolves successfully
+
+#### Scenario: Clipboard API unavailable
+
+Given the browser does not support `navigator.clipboard.writeText`
+When `copyToClipboard(text)` is called
+Then the function rejects with an error (no silent failure)
+
+### Requirement: CopyButton Component
+
+The system MUST provide a reusable `CopyButton` component that shows transient feedback after copying.
+
+#### Scenario: Copy success feedback
+
+Given a CopyButton with value "some-id"
+When the user clicks the button
+Then the clipboard receives "some-id" and the button shows a transient success indicator (e.g., checkmark) for ~2 seconds before reverting
+
+#### Scenario: Copy failure feedback
+
+Given a CopyButton and the clipboard write fails
+When the user clicks the button
+Then the button shows a transient error indicator before reverting
+
+#### Scenario: Keyboard activation
+
+Given focus on a CopyButton
+When the user presses Enter or Space
+Then the copy action triggers as if clicked
+
+### Requirement: Copy Targets
+
+The system MUST add copy controls for the following values on the trace detail page.
+
+#### Scenario: Trace identifiers
+
+Given a trace detail page
+When the user views trace metadata
+Then copy controls are available for: trace internal UUID, external trace ID, and session ID
+
+#### Scenario: Span identifiers
+
+Given a selected span
+When the user views span detail
+Then copy controls are available for: span external `span_id` and parent span ID (when present)
+
+#### Scenario: Payload values
+
+Given a PayloadInspector rendering a payload
+When the user interacts with the inspector
+Then copy controls are available for: full payload JSON, subtree JSON, and individual leaf values
+
+#### Scenario: Trace URL
+
+Given a trace detail page with or without a selected span
+When the user clicks "Copy Trace URL"
+Then an absolute URL is copied, constructed from the current trace route plus the effective selected span (if any), regardless of whether `?span=` is currently in the browser URL
+
+#### Scenario: Copied URL preserves non-span params
+
+Given the current URL is `/traces/123?debug=true` with effective selected span `abc`
+When the user clicks "Copy Trace URL"
+Then the copied URL includes both `debug=true` and `span=abc`

--- a/openspec/changes/add-payload-inspection-deep-navigation/specs/navigation-continuity/spec.md
+++ b/openspec/changes/add-payload-inspection-deep-navigation/specs/navigation-continuity/spec.md
@@ -1,0 +1,79 @@
+# Navigation Continuity
+
+Unified span selection callback and parent span navigation for consistent cross-surface behavior.
+
+## ADDED Requirements
+
+### Requirement: Unified Selection Callback
+
+All span-selection entry points MUST go through one shared page-level selection callback. The callback is defined in `TraceDetailPage.tsx` and passed down via props.
+
+#### Scenario: Callback responsibilities
+
+Given any span selection event from any entry point
+When the unified callback fires
+Then it: (1) updates `selectedSpanExternalId`, (2) sets `userHasSelected = true`, (3) computes and sets `revealPath` for tree auto-expand, (4) writes `?span=` with `replace`
+
+#### Scenario: Span tree row selection
+
+Given the user clicks a span in the span tree
+When the click handler fires
+Then it calls the unified selection callback
+
+#### Scenario: Breadcrumb ancestor selection
+
+Given the user clicks an ancestor in the span breadcrumb
+When the click handler fires
+Then it calls the unified selection callback
+
+#### Scenario: Failure summary jump
+
+Given the user clicks "Jump to failed span" in the failure summary
+When the click handler fires
+Then it calls the unified selection callback
+
+#### Scenario: Timeline span button
+
+Given a timeline event with a `span_id` that resolves to a known span in the current span index
+When the event renders
+Then the span reference is a clickable button (using `span_name` as label when available, falling back to the `span_id` when `span_name` is absent), and clicking it calls the unified selection callback
+
+#### Scenario: Timeline event with unresolvable span_id
+
+Given a timeline event with a `span_id` that does NOT resolve to a known span in the current span index
+When the event renders
+Then the span reference renders as plain text (not clickable)
+
+#### Scenario: Parent span button
+
+Given the user clicks the parent span navigation button in span detail
+When the click handler fires
+Then it calls the unified selection callback
+
+### Requirement: Parent Span Navigation
+
+The system MUST render the parent span ID as a navigable button when the parent exists in the current span index.
+
+#### Scenario: Parent exists in index
+
+Given a selected span whose `parent_span_id` references a span in the current trace's span data
+When the parent span ID is rendered in SpanDetail
+Then it renders as a clickable button that triggers the unified selection callback
+
+#### Scenario: Parent not resolvable
+
+Given a selected span whose `parent_span_id` is a non-null value that does NOT resolve to a span in the current trace's span data
+When the parent span ID is rendered in SpanDetail
+Then it renders as plain text (not clickable)
+
+#### Scenario: Root span (no parent)
+
+Given a selected span with `parent_span_id` that is null or absent
+When SpanDetail renders
+Then no parent span row is shown
+
+#### Scenario: Keyboard activation
+
+Given focus on the parent span navigation button
+When the user presses Enter or Space
+Then the navigation activates as if clicked

--- a/openspec/changes/add-payload-inspection-deep-navigation/specs/payload-inspector/spec.md
+++ b/openspec/changes/add-payload-inspection-deep-navigation/specs/payload-inspector/spec.md
@@ -1,0 +1,237 @@
+# Payload Inspector
+
+Replaces the static `JsonViewer` `<pre>` renderer with an interactive JSON tree component used across all payload surfaces.
+
+## ADDED Requirements
+
+### Requirement: Payload Tree Construction
+
+The system MUST build a typed, memoized tree structure from any JSON payload. The tree consists of `ObjectNode`, `ArrayNode`, and `PrimitiveNode` types. The tree is recomputed only when the payload reference changes.
+
+#### Scenario: Object payload
+
+Given a JSON object payload
+When the tree is constructed
+Then the root is an `ObjectNode` with one child per key
+
+#### Scenario: Array payload
+
+Given a JSON array payload
+When the tree is constructed
+Then the root is an `ArrayNode` with one child per element
+
+#### Scenario: Primitive payload
+
+Given a JSON primitive payload (string, number, boolean)
+When the tree is constructed
+Then the root is a `PrimitiveNode` rendered directly without expand/collapse
+
+#### Scenario: JSON null payload
+
+Given a JSON `null` payload
+When the tree is constructed
+Then the root is a `PrimitiveNode` rendering the literal text `null`
+
+#### Scenario: Empty collection
+
+Given an empty object `{}` or empty array `[]`
+When the tree is constructed
+Then the root node renders with a count badge showing `0 keys` or `0 items`
+
+#### Scenario: Undefined payload (no data)
+
+Given an `undefined` payload (field absent from the API response)
+When the inspector is rendered
+Then it displays a placeholder message (e.g., "No data") instead of a tree
+
+### Requirement: Initial Expansion Rules
+
+The system MUST apply deterministic initial expansion rules based on depth and shallow size.
+
+#### Scenario: Root with few children
+
+Given a root object or array with <= 200 immediate children
+When the inspector first renders
+Then the root is expanded
+
+#### Scenario: Root with many children
+
+Given a root object or array with > 200 immediate children
+When the inspector first renders
+Then the root is collapsed with a count badge showing the child count
+
+#### Scenario: Depth-1 nodes with many children
+
+Given a depth-1 object or array node with > 200 immediate children
+When the inspector first renders
+Then the node is collapsed with a count badge
+
+#### Scenario: Nodes at depth >= 2
+
+Given any object or array node at depth >= 2
+When the inspector first renders
+Then the node is collapsed
+
+### Requirement: Expand and Collapse Interaction
+
+The system MUST allow users to expand and collapse object and array nodes individually.
+
+#### Scenario: Expanding a collapsed node
+
+Given a collapsed object or array node
+When the user clicks the expand toggle
+Then the node's children are rendered
+
+#### Scenario: Collapsing an expanded node
+
+Given an expanded object or array node
+When the user clicks the collapse toggle
+Then the node's children are hidden
+
+#### Scenario: Keyboard activation
+
+Given focus on an expand/collapse toggle
+When the user presses Enter or Space
+Then the toggle activates as if clicked
+
+### Requirement: Inspector Toolbar
+
+Each inspector instance MUST render a toolbar with: search input, next/previous match buttons, expand all, collapse all, and copy full JSON.
+
+#### Scenario: Toolbar layout
+
+Given a rendered inspector
+When the user views the inspector
+Then the toolbar is visible above the tree with all five controls
+
+#### Scenario: Expand all within threshold
+
+Given a payload with total node count <= 5,000
+When the user clicks "Expand all"
+Then all object and array nodes expand
+
+#### Scenario: Expand all exceeding threshold
+
+Given a payload with total node count > 5,000
+When the user views the toolbar
+Then the "Expand all" button is disabled with a tooltip explaining the limit
+
+#### Scenario: Collapse all
+
+Given an inspector with some nodes expanded
+When the user clicks "Collapse all"
+Then all nodes return to their initial expansion state
+
+### Requirement: Per-Inspector Search
+
+Each inspector instance MUST maintain independent search state. Search covers object keys and scalar values (stringified). No JSONPath or path-segment queries.
+
+#### Scenario: Key match
+
+Given a payload containing key `"temperature"`
+When the user types "temperature" in the search input
+Then the key is highlighted and its ancestor nodes auto-expand
+
+#### Scenario: Scalar value match
+
+Given a payload containing value `42`
+When the user types "42" in the search input
+Then the value is highlighted and its ancestor nodes auto-expand
+
+#### Scenario: No match
+
+Given a payload not containing "nonexistent"
+When the user types "nonexistent" in the search input
+Then no highlights appear and match count shows "0 matches"
+
+#### Scenario: Match navigation
+
+Given a search with 5 matches
+When the user clicks "Next"
+Then the active match index advances to the next match in document order, cycling after the last
+
+#### Scenario: Active match highlighting
+
+Given a search with multiple matches
+When the active match index points to match 3 of 5
+Then match 3 has a distinct "active" highlight style (e.g., stronger background) while matches 1, 2, 4, 5 have a standard match highlight style
+
+#### Scenario: Active match scroll into view
+
+Given the active match is outside the visible scroll area of the inspector
+When the active match changes (via next/previous or initial search)
+Then the inspector scrolls the active match row into view using `scrollIntoView`. DOM focus remains on the search input (not moved to the match element).
+
+#### Scenario: Deferred search input
+
+Given a large payload
+When the user types rapidly in the search input
+Then the search filtering uses `useDeferredValue` to defer tree re-rendering, keeping the input responsive
+
+#### Scenario: Search expansion restoration
+
+Given the user manually expanded nodes A and B, then searched and the search auto-expanded nodes C and D
+When the user clears the search input
+Then nodes A and B remain expanded and nodes C and D return to their pre-search state
+
+### Requirement: Value Rendering
+
+The inspector MUST render values according to their type with appropriate formatting.
+
+#### Scenario: Multiline string
+
+Given a string value containing newlines
+When the value is rendered
+Then it displays in a bounded `white-space: pre-wrap` block with inner scrolling
+
+#### Scenario: Long single-line string
+
+Given a long string value without newlines
+When the value is rendered
+Then it wraps within the row view
+
+#### Scenario: Object and array count badges
+
+Given a collapsed object with 15 keys
+When the row is rendered
+Then it shows `{15 keys}` as a count badge
+
+#### Scenario: Leaf value copy
+
+Given a rendered primitive value
+When the user activates the row's copy action
+Then the raw leaf value is copied to clipboard
+
+#### Scenario: Subtree copy
+
+Given a rendered object or array node
+When the user activates the row's copy action
+Then the JSON-serialized subtree is copied to clipboard
+
+### Requirement: Inspector Rollout
+
+By the end of this phase, all payload surfaces MUST use the `PayloadInspector` component. The legacy `JsonViewer` `<pre>` renderer MUST NOT remain as a separate divergent component.
+
+#### Scenario: Trace context payloads
+
+Given the trace detail page with trace input and output
+When the page renders
+Then both trace input and trace output use `PayloadInspector`
+
+#### Scenario: Span detail payloads
+
+Given a selected span with input, output, and metadata
+When SpanDetail renders
+Then all three sections use `PayloadInspector`
+
+#### Scenario: Timeline event payloads
+
+Given an expanded timeline event with a payload
+When the payload section renders
+Then it uses `PayloadInspector`
+
+#### Scenario: JsonViewer removal
+
+Given the phase is complete
+When auditing the codebase
+Then `JsonViewer.tsx` either delegates entirely to `PayloadInspector` or is removed

--- a/openspec/changes/add-payload-inspection-deep-navigation/specs/span-deep-linking/spec.md
+++ b/openspec/changes/add-payload-inspection-deep-navigation/specs/span-deep-linking/spec.md
@@ -1,0 +1,159 @@
+# Span Deep-Linking
+
+URL-driven selected span state on the trace detail page using `?span=<external-span-id>`.
+
+## ADDED Requirements
+
+### Requirement: URL Span Parameter Parsing
+
+The URL utility layer (`traceDetailSearchParams.ts`) MUST parse the `span` query parameter as a raw string. It MUST NOT perform semantic validation (e.g., checking whether the span exists in the data). Semantic validation is the responsibility of `TraceDetailPage` after span data has loaded.
+
+#### Scenario: Parse present span parameter
+
+Given URL `/traces/123?span=abc`
+When `parseSpanParam(searchParams)` is called
+Then it returns `"abc"`
+
+#### Scenario: Parse missing span parameter
+
+Given URL `/traces/123` with no `span` parameter
+When `parseSpanParam(searchParams)` is called
+Then it returns `null`
+
+#### Scenario: Parse empty span parameter
+
+Given URL `/traces/123?span=`
+When `parseSpanParam(searchParams)` is called
+Then it returns `null` (empty string normalized to absent)
+
+#### Scenario: Unrelated params preserved on write
+
+Given URL `/traces/123?span=abc&debug=true`
+When `serializeSpanParam(searchParams, "def")` is called
+Then the result contains `span=def` and `debug=true`
+
+### Requirement: Semantic Span Validation
+
+`TraceDetailPage` MUST validate the parsed `span` value against the loaded `spanIndex`. Unknown spans MUST be cleaned up only after span data is available.
+
+#### Scenario: Valid span on load
+
+Given URL `/traces/123?span=abc` and span `abc` exists in the fetched span data
+When the trace detail page renders with span data
+Then span `abc` is selected and `userHasSelected` is set to `true`
+
+#### Scenario: No span parameter on load
+
+Given URL `/traces/123` with no `span` parameter
+When the trace detail page renders
+Then no URL-driven selection occurs and Phase 7 auto-selection runs if applicable
+
+#### Scenario: Unknown span on load
+
+Given URL `/traces/123?span=nonexistent` where `nonexistent` is not in the span data
+When the trace detail page renders with span data available
+Then `TraceDetailPage` removes `?span=` from the URL with `replace`, sets `userHasSelected` to `false`, and Phase 7 auto-selection runs
+
+#### Scenario: Unrelated params preserved during cleanup
+
+Given URL `/traces/123?span=nonexistent&debug=true`
+When `TraceDetailPage` removes the unknown span
+Then `debug=true` is preserved in the resulting URL
+
+### Requirement: URL Span Parameter Writing
+
+The system MUST update the `span` query parameter when the user explicitly selects a span. Automatic selections MUST NOT write to the URL.
+
+#### Scenario: User selects span via tree
+
+Given the user clicks a span in the span tree
+When the selection callback fires
+Then the URL is updated to include `?span=<selected-external-id>` using `replace`
+
+#### Scenario: Unrelated params preserved on user selection
+
+Given the current URL is `/traces/123?debug=true` and the user clicks a span
+When the selection callback writes `?span=abc`
+Then the resulting URL is `/traces/123?debug=true&span=abc` (unrelated params preserved)
+
+#### Scenario: User selects span via breadcrumb
+
+Given the user clicks an ancestor in the span breadcrumb
+When the selection callback fires
+Then the URL is updated to include `?span=<selected-external-id>` using `replace`
+
+#### Scenario: Failure-first auto-selection
+
+Given Phase 7 auto-selects the primary failed span on page load
+When the auto-selection occurs
+Then the URL is NOT modified (no `?span=` added)
+
+#### Scenario: Copy Trace URL with auto-selected span
+
+Given Phase 7 auto-selected span `abc` (URL does not contain `?span=`)
+When the user clicks "Copy Trace URL"
+Then the copied URL includes `?span=abc` (the effective selected span)
+
+### Requirement: Reactive URL Span Changes
+
+The system MUST react to `?span=` changes while the trace detail component remains mounted (e.g., browser back/forward or manual URL edits). It MUST NOT only read the span parameter on initial mount.
+
+#### Scenario: Browser back changes span param
+
+Given the user is viewing `/traces/123?span=abc` and browser back navigates to `/traces/123?span=def` (same trace, different span)
+When the URL changes while the component stays mounted
+Then the selection updates to span `def` (if it exists in `spanIndex`)
+
+#### Scenario: Browser back removes span param
+
+Given the user is viewing `/traces/123?span=abc` and browser back navigates to `/traces/123` (no span param)
+When the URL changes while the component stays mounted
+Then the selection clears, `userHasSelected` resets to `false`, and Phase 7 auto-selection re-runs
+
+#### Scenario: Manual URL edit
+
+Given the user manually edits the URL bar to change `?span=abc` to `?span=xyz`
+When the URL change is committed
+Then the selection updates to span `xyz` if it exists, or clears with fallback if it does not
+
+### Requirement: History Behavior
+
+Internal span changes MUST use `replace` to avoid polluting browser history with span-by-span navigation.
+
+#### Scenario: Back button after span navigation
+
+Given the user navigated from the trace list to trace detail, then selected 3 different spans
+When the user presses the browser back button
+Then the browser returns to the trace list (not to a prior span selection)
+
+#### Scenario: External deep link
+
+Given a user opens `/traces/123?span=abc` from a shared link
+When the page loads
+Then span `abc` is selected and the user can press back to return to their previous page
+
+### Requirement: Stale Span Fallback
+
+When the selected span disappears from the data (e.g., after a polling refresh), the system MUST fall back gracefully.
+
+#### Scenario: Selected span disappears
+
+Given span `abc` is selected via URL and a data refresh no longer includes span `abc`
+When the refresh completes
+Then the selection clears, `userHasSelected` resets to `false`, `?span=` is removed from the URL, and Phase 7 auto-selection re-runs
+
+#### Scenario: Span remains across polling
+
+Given span `abc` is selected via URL and a polling refresh still includes span `abc`
+When the refresh completes
+Then span `abc` remains selected and the URL is unchanged
+
+### Requirement: No Refetch on Span Change
+
+Changing the `?span=` parameter MUST NOT trigger React Query refetches. Query keys remain trace-id-based.
+
+#### Scenario: Span parameter change
+
+Given the trace detail page is loaded with trace data cached
+When the user selects a different span (updating `?span=`)
+Then no new API requests are made for trace or span data

--- a/openspec/changes/add-payload-inspection-deep-navigation/specs/truncation-indicators/spec.md
+++ b/openspec/changes/add-payload-inspection-deep-navigation/specs/truncation-indicators/spec.md
@@ -1,0 +1,61 @@
+# Truncation Indicators
+
+Banners for truncated span payloads using existing API metadata fields.
+
+## ADDED Requirements
+
+### Requirement: Truncation Banner for Span Payloads
+
+The system MUST render a truncation banner above span input and output PayloadInspector instances when the span's truncation metadata indicates the payload was truncated.
+
+#### Scenario: Full truncation metadata
+
+Given a span with `input_truncated: true`, `input_original_size_bytes: 524288`, and `input_truncation_reason: "size_limit"`
+When the span input PayloadInspector renders
+Then a banner is shown indicating truncation, the original size (formatted), and the reason
+
+#### Scenario: Partial truncation metadata
+
+Given a span with `output_truncated: true` and `output_original_size_bytes: 1048576` but no `output_truncation_reason`
+When the span output PayloadInspector renders
+Then a banner is shown indicating truncation and the original size, without a reason
+
+#### Scenario: Truncated flag only
+
+Given a span with `input_truncated: true` but no `input_original_size_bytes` and no `input_truncation_reason`
+When the span input PayloadInspector renders
+Then a banner is shown indicating the payload was truncated
+
+#### Scenario: Not truncated
+
+Given a span with `input_truncated: false` (or field absent)
+When the span input PayloadInspector renders
+Then no truncation banner is shown
+
+#### Scenario: Trace-level payloads excluded
+
+Given the trace context section with trace input and output
+When the trace-level PayloadInspectors render
+Then no truncation banners are shown (the API does not expose truncation metadata for trace-level payloads)
+
+#### Scenario: Timeline payloads excluded
+
+Given a timeline event with an expanded payload
+When the timeline PayloadInspector renders
+Then no truncation banner is shown
+
+### Requirement: Truncation Formatting
+
+The truncation banner MUST format metadata for readability.
+
+#### Scenario: Size formatting
+
+Given original size of 1048576 bytes
+When the truncation banner renders
+Then the size is displayed as "1.0 MB" (human-readable)
+
+#### Scenario: Small size formatting
+
+Given original size of 2048 bytes
+When the truncation banner renders
+Then the size is displayed as "2.0 KB"

--- a/openspec/changes/add-payload-inspection-deep-navigation/tasks.md
+++ b/openspec/changes/add-payload-inspection-deep-navigation/tasks.md
@@ -1,0 +1,136 @@
+# Tasks: Payload Inspection & Deep Navigation
+
+## 1. Payload Inspector Foundation
+
+### 1.1 Build payload tree data structure
+- [x] Create tree node types (`ObjectNode`, `ArrayNode`, `PrimitiveNode`) with `depth`, `key`, `path`, `childCount`
+- [x] Implement `buildPayloadTree(data: unknown): TreeNode` with total node counting
+- [x] Apply initial expansion rules: depth >= 2 collapsed, > 200 children collapsed at depth 0-1
+- [x] Unit test: primitives, objects, arrays, nulls, empty collections, deep nesting, wide arrays
+
+### 1.2 Build PayloadInspector component
+- [x] Create `PayloadInspector.tsx` with expand/collapse toggle per node
+- [x] Render count badges for collapsed objects/arrays
+- [x] Render JSON `null` as a `PrimitiveNode` showing literal `null`
+- [x] Render `undefined` (absent field) with "No data" placeholder
+- [x] Multiline string rendering with `white-space: pre-wrap` and bounded height
+- [x] Long single-line string wrapping
+- [x] Keyboard activation (Enter/Space) for expand/collapse toggles
+
+### 1.3 Add inspector toolbar
+- [x] Toolbar with: search input, next/prev match, expand all, collapse all, copy full JSON
+- [x] Gate "Expand all" when total node count > 5,000
+- [x] "Collapse all" restores initial expansion state
+
+### 1.4 Add per-inspector search
+- [x] Search over object keys and stringified scalar values
+- [x] `useDeferredValue` to defer tree re-rendering during search input
+- [x] Auto-expand ancestor branches for matches
+- [x] Match count display and next/previous navigation
+- [x] Active match gets distinct highlight style; other matches get standard highlight
+- [x] Active match scrolled into view via `scrollIntoView`; DOM focus stays on search input
+- [x] Clearing search restores pre-search expansion state
+- [x] Unit test: key matches, value matches, match ordering, no-match case, active-match highlight distinct from other matches, active match scrolled into view
+
+## 2. Span Deep-Linking
+
+### 2.1 Create URL param utilities
+- [x] Create `traceDetailSearchParams.ts` with `parseSpanParam` and `serializeSpanParam`
+- [x] Preserve unrelated query params
+- [x] Unit test: present span, empty span (normalized to null), missing span, unrelated params preserved
+
+### 2.2 Create useTraceDetailSearchParams hook
+- [x] Create `useTraceDetailSearchParams.ts` wrapping `useSearchParams`
+- [x] Expose parsed `spanParam` (raw string or null) and `setSpanParam(id | null)` writer
+- [x] Writer preserves unrelated query params and uses `replace`
+- [x] Hook does NOT perform semantic validation (no spanIndex dependency)
+- [x] Follow Phase 6 hook patterns
+
+### 2.3 Integrate URL span state into TraceDetailPage
+- [x] Read `spanParam` from hook and validate against `spanIndex` after span data loads
+- [x] On valid span: set `selectedSpanExternalId`, set `userHasSelected = true`
+- [x] On unknown span (after data available): remove param via hook, reset `userHasSelected`, re-run auto-selection
+- [x] React to `spanParam` changes while mounted (browser back/forward, manual URL edits)
+- [x] Write `?span=` with `replace` on explicit user selection (via unified callback)
+- [x] Do NOT write URL on Phase 7 auto-selection
+- [x] Handle stale span on polling refresh: clear selection, remove param, reset `userHasSelected`, re-run auto-selection
+- [x] Verify React Query keys do not include `?span=` (no refetch on span change)
+- [x] Integration test: load with valid span, load with unknown span, span sticky across polling, stale span fallback
+- [x] Integration test: browser back changes `?span=` to a different span within same trace → selection updates
+- [x] Integration test: browser back removes `?span=` entirely within same trace → selection clears, `userHasSelected` resets, auto-selection re-runs
+
+## 3. Clipboard Utilities
+
+### 3.1 Create clipboard helper
+- [x] Create `clipboard.ts` with `copyToClipboard(text: string): Promise<void>`
+- [x] Handle clipboard API unavailability with rejection
+- [x] Unit test: success and failure paths
+
+### 3.2 Create CopyButton component
+- [x] Create `CopyButton.tsx` with transient success/error feedback (~2s)
+- [x] Keyboard activation (Enter/Space)
+- [x] Accept `value: string` or `getValue: () => string` prop
+
+### 3.3 Add copy targets to trace detail page
+- [x] Trace identifiers: internal UUID, external trace ID, session ID
+- [x] "Copy Trace URL" button constructing absolute URL with effective selected span
+- [x] Integration test: Copy Trace URL includes effective span
+- [x] Integration test: Copy Trace URL preserves existing non-span params (e.g., `debug=true`)
+
+## 4. Navigation Continuity
+
+### 4.1 Unify selection callback
+- [x] Create single `handleSelectSpan` in TraceDetailPage that: updates state, sets `userHasSelected`, computes `revealPath`, writes `?span=`
+- [x] Wire all entry points through it: span tree, breadcrumb, failure summary, timeline
+- [x] Fix timeline navigability: render span button when `span_id` resolves in `spanIndex` (regardless of `span_name` presence); use `span_name` as label with `span_id` fallback
+- [x] Integration test: all entry points keep tree/detail/URL synchronized
+
+### 4.2 Add parent span navigation
+- [x] Render parent span ID as button when parent exists in span index
+- [x] Render as plain text when non-null `parent_span_id` does not resolve in span index
+- [x] Show no parent row when `parent_span_id` is null or absent (root span)
+- [x] Unit test: root span (null parent) → no parent row; unresolvable parent → plain text; resolvable parent → button
+- [x] Wire through unified selection callback
+- [x] Keyboard activation (Enter/Space)
+
+### 4.3 Add span identifier copy controls
+- [x] CopyButton for span external `span_id` in SpanDetail
+- [x] CopyButton for parent span ID in SpanDetail (when present)
+
+## 5. Truncation Indicators & Inspector Rollout
+
+### 5.1 Add truncation banner component
+- [x] Create truncation banner rendering: truncated flag, original size (human-readable), reason
+- [x] Handle partial metadata (flag only, flag + size, full metadata)
+- [x] Format sizes: bytes → KB/MB/GB
+- [x] Unit test: full metadata, partial metadata, not truncated, explicit false
+
+### 5.2 Wire truncation banners to span payloads
+- [x] Show above span input PayloadInspector when `input_truncated`
+- [x] Show above span output PayloadInspector when `output_truncated`
+- [x] Do NOT show for trace-level or timeline payloads
+- [x] Integration test: banner renders for span payloads only
+
+### 5.3 Roll out PayloadInspector to all surfaces
+- [x] Trace context input/output
+- [x] Span detail input/output/metadata
+- [x] Timeline event payload
+- [x] Remove or reduce `JsonViewer.tsx` to thin wrapper (no divergent renderers)
+
+## 6. Final Verification
+
+### 6.1 Cross-phase regression integration tests
+- [x] Integration test: navigate from filtered trace list (`/traces?status=failed`) → trace detail → select span → press back → lands on filtered trace list (Phase 6 back-link preserved)
+- [x] Integration test: load `/traces/:id` (no `?span=`) for a failed trace → Phase 7 auto-selects primary failed span → URL does NOT contain `?span=`
+- [x] Integration test: navigate from trace A with `?span=x` → trace B (different `traceId`) → `selectedSpanExternalId` resets to `null`, `userHasSelected` resets to `false`, `?span=` is absent (Phase 7 cross-trace reset)
+- [x] Integration test: Phase 7 failure-first auto-selection + Phase 8 URL span coexistence — load with `?span=abc` on a failed trace → auto-selection does NOT override URL-driven selection
+
+### 6.2 Keyboard activation
+- [x] Inspector expand/collapse toggles respond to Enter/Space
+- [x] Copy buttons respond to Enter/Space
+- [x] Parent span button responds to Enter/Space
+
+### 6.3 Type checking and lint
+- [x] `make type-check` passes
+- [ ] `make lint` passes (`golangci-lint` remains blocked locally: the available binary reports Go 1.23 while the repo targets Go 1.24.11)
+- [x] All new tests pass

--- a/web/src/components/CopyButton.test.tsx
+++ b/web/src/components/CopyButton.test.tsx
@@ -1,0 +1,47 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CopyButton } from './CopyButton';
+import { copyToClipboard } from '../utils/clipboard';
+
+vi.mock('../utils/clipboard', () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+describe('CopyButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('shows error feedback when clipboard writes fail and recovers after the timeout', async () => {
+    vi.mocked(copyToClipboard)
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockResolvedValueOnce(undefined);
+
+    render(<CopyButton value="hello" />);
+
+    const button = screen.getByRole('button', { name: 'Copy' });
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(button).toHaveTextContent('Failed');
+    expect(button).toHaveAttribute('data-copy-status', 'error');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(button).toHaveAttribute('data-copy-status', 'idle');
+    expect(button).toHaveTextContent('Copy');
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(button).toHaveTextContent('Copied');
+    expect(button).toHaveAttribute('data-copy-status', 'success');
+  });
+});

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import { copyToClipboard } from '../utils/clipboard';
+
+const FEEDBACK_DURATION_MS = 2000;
+
+type CopyButtonProps =
+  | ({
+      getValue: () => string;
+      value?: never;
+    } & CopyButtonBaseProps)
+  | ({
+      getValue?: never;
+      value: string;
+    } & CopyButtonBaseProps);
+
+interface CopyButtonBaseProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  errorLabel?: ReactNode;
+  idleLabel?: ReactNode;
+  successLabel?: ReactNode;
+}
+
+type CopyStatus = 'idle' | 'success' | 'error';
+
+export function CopyButton({
+  className = '',
+  errorLabel = 'Failed',
+  getValue,
+  idleLabel = 'Copy',
+  successLabel = 'Copied',
+  type = 'button',
+  value,
+  ...buttonProps
+}: CopyButtonProps) {
+  const timeoutRef = useRef<number | null>(null);
+  const [status, setStatus] = useState<CopyStatus>('idle');
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleClick = async () => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+    }
+
+    try {
+      await copyToClipboard(getValue ? getValue() : value);
+      setStatus('success');
+    } catch {
+      setStatus('error');
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      setStatus('idle');
+      timeoutRef.current = null;
+    }, FEEDBACK_DURATION_MS);
+  };
+
+  const label =
+    status === 'success'
+      ? successLabel
+      : status === 'error'
+        ? errorLabel
+        : idleLabel;
+
+  return (
+    <button
+      {...buttonProps}
+      type={type}
+      className={`inline-flex items-center justify-center rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60 ${className}`.trim()}
+      data-copy-status={status}
+      onClick={handleClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/web/src/components/JsonViewer.tsx
+++ b/web/src/components/JsonViewer.tsx
@@ -1,3 +1,5 @@
+import { PayloadInspector } from './PayloadInspector';
+
 interface JsonViewerProps {
   data: unknown;
   className?: string;
@@ -7,11 +9,5 @@ interface JsonViewerProps {
  * Shared JSON viewer for structured payloads.
  */
 export function JsonViewer({ data, className = '' }: JsonViewerProps) {
-  return (
-    <pre
-      className={`overflow-x-auto rounded border bg-gray-50 p-3 text-xs font-mono leading-5 text-gray-800 ${className}`.trim()}
-    >
-      {JSON.stringify(data ?? null, null, 2)}
-    </pre>
-  );
+  return <PayloadInspector data={data} className={className} />;
 }

--- a/web/src/components/PayloadInspector.test.tsx
+++ b/web/src/components/PayloadInspector.test.tsx
@@ -1,0 +1,393 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PayloadInspector } from './PayloadInspector';
+
+const scrollIntoViewMock = vi.fn();
+
+describe('PayloadInspector', () => {
+  beforeEach(() => {
+    scrollIntoViewMock.mockReset();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it('renders a placeholder for undefined payloads', () => {
+    render(<PayloadInspector data={undefined} />);
+
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+
+  it('finds key matches and value matches independently', async () => {
+    render(
+      <PayloadInspector
+        data={{
+          temperature: 42,
+          prompt: 'temperature high',
+        }}
+      />
+    );
+
+    const searchInput = screen.getByLabelText('Search payload');
+
+    fireEvent.change(searchInput, { target: { value: 'temp' } });
+    await waitFor(() => {
+      expect(screen.getByText('2 matches')).toBeInTheDocument();
+    });
+    expect(screen.getByText('temperature')).toHaveAttribute(
+      'data-match-state',
+      'active'
+    );
+    expect(screen.getByText('"temperature high"')).toHaveAttribute(
+      'data-match-state',
+      'match'
+    );
+
+    fireEvent.change(searchInput, { target: { value: '42' } });
+    await waitFor(() => {
+      expect(screen.getByText('1 match')).toBeInTheDocument();
+    });
+    expect(screen.getByText('42')).toHaveAttribute('data-match-state', 'active');
+  });
+
+  it('supports match ordering and distinct active highlighting', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PayloadInspector
+        data={{
+          first: 'match first',
+          second: 'match second',
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Search payload'), {
+      target: { value: 'match' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('"match first"')).toHaveAttribute(
+        'data-match-state',
+        'active'
+      );
+    });
+    expect(screen.getByText('"match second"')).toHaveAttribute(
+      'data-match-state',
+      'match'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(screen.getByText('"match first"')).toHaveAttribute(
+      'data-match-state',
+      'match'
+    );
+    expect(screen.getByText('"match second"')).toHaveAttribute(
+      'data-match-state',
+      'active'
+    );
+  });
+
+  it('preserves the active match while toggling nodes during an active search', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PayloadInspector
+        data={{
+          nested: {
+            first: 'match first',
+            second: 'match second',
+          },
+          unrelated: {
+            child: 'other value',
+          },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Search payload'), {
+      target: { value: 'match' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('"match first"')).toHaveAttribute(
+        'data-match-state',
+        'active'
+      );
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    expect(screen.getByText('"match second"')).toHaveAttribute(
+      'data-match-state',
+      'active'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Collapse unrelated' }));
+    await user.click(screen.getByRole('button', { name: 'Expand unrelated' }));
+
+    expect(screen.getByText('"match second"')).toHaveAttribute(
+      'data-match-state',
+      'active'
+    );
+  });
+
+  it('keeps object keys and array paths with similar shapes isolated during search', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PayloadInspector
+        data={{
+          'a[0]': {
+            nested: 'match first',
+          },
+          a: [
+            {
+              nested: 'match second',
+            },
+          ],
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Search payload'), {
+      target: { value: 'match' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('2 matches')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('"match first"')).toHaveAttribute(
+      'data-match-state',
+      'active'
+    );
+    expect(screen.getByText('"match second"')).toHaveAttribute(
+      'data-match-state',
+      'match'
+    );
+    expect(document.querySelectorAll('[data-match-state="active"]')).toHaveLength(1);
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(screen.getByText('"match first"')).toHaveAttribute(
+      'data-match-state',
+      'match'
+    );
+    expect(screen.getByText('"match second"')).toHaveAttribute(
+      'data-match-state',
+      'active'
+    );
+  });
+
+  it('shows the no-match state when the query is absent from the payload', async () => {
+    render(<PayloadInspector data={{ model: 'gpt-4' }} />);
+
+    fireEvent.change(screen.getByLabelText('Search payload'), {
+      target: { value: 'nonexistent' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('0 matches')).toBeInTheDocument();
+    });
+    expect(document.querySelector('[data-match-state]')).toBeNull();
+  });
+
+  it('scrolls the active match into view without moving focus away from the input', async () => {
+    render(
+      <PayloadInspector
+        data={{
+          first: 'match first',
+          second: 'match second',
+        }}
+      />
+    );
+
+    const searchInput = screen.getByLabelText('Search payload');
+    searchInput.focus();
+
+    fireEvent.change(searchInput, { target: { value: 'match' } });
+
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalled();
+    });
+    expect(searchInput).toHaveFocus();
+  });
+
+  it('supports keyboard activation for expand and collapse toggles', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PayloadInspector
+        data={{
+          nested: {
+            child: 'value',
+          },
+        }}
+      />
+    );
+
+    const toggle = screen.getByRole('button', { name: 'Collapse payload' });
+    toggle.focus();
+
+    await user.keyboard('{Enter}');
+    expect(screen.queryByText('nested')).not.toBeInTheDocument();
+
+    const expandToggle = screen.getByRole('button', { name: 'Expand payload' });
+    expandToggle.focus();
+    await user.keyboard(' ');
+
+    expect(screen.getByText('nested')).toBeInTheDocument();
+  });
+
+  it('disables expand all for very large payloads', () => {
+    render(
+      <PayloadInspector
+        data={Array.from({ length: 5001 }, (_, index) => index)}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Expand all' })).toBeDisabled();
+  });
+
+  it('copies full JSON and leaf values via the shared copy button', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<PayloadInspector data={{ prompt: 'hello' }} />);
+
+    await user.click(screen.getByRole('button', { name: 'Copy value for prompt' }));
+    await user.click(screen.getByRole('button', { name: 'Copy full JSON' }));
+
+    expect(writeText).toHaveBeenNthCalledWith(1, 'hello');
+    expect(writeText).toHaveBeenNthCalledWith(
+      2,
+      JSON.stringify({ prompt: 'hello' }, null, 2)
+    );
+  });
+
+  it('copies subtree JSON for collection nodes', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <PayloadInspector
+        data={{
+          nested: {
+            child: 'hello',
+          },
+        }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Copy JSON for nested' }));
+
+    expect(writeText).toHaveBeenCalledWith(
+      JSON.stringify({ child: 'hello' }, null, 2)
+    );
+  });
+
+  it('supports keyboard activation for copy buttons', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<PayloadInspector data={{ prompt: 'hello' }} />);
+
+    const copyValueButton = screen.getByRole('button', {
+      name: 'Copy value for prompt',
+    });
+    copyValueButton.focus();
+    await user.keyboard('{Enter}');
+
+    const copyJsonButton = screen.getByRole('button', { name: 'Copy full JSON' });
+    copyJsonButton.focus();
+    await user.keyboard(' ');
+
+    expect(writeText).toHaveBeenNthCalledWith(1, 'hello');
+    expect(writeText).toHaveBeenNthCalledWith(
+      2,
+      JSON.stringify({ prompt: 'hello' }, null, 2)
+    );
+  });
+
+  it('renders primitive and null root payloads without placeholders', () => {
+    const { rerender } = render(<PayloadInspector data={null} />);
+
+    expect(screen.getByText('null')).toBeInTheDocument();
+    expect(screen.queryByText('No data')).not.toBeInTheDocument();
+
+    rerender(<PayloadInspector data="hello" />);
+    expect(screen.getByText('"hello"')).toBeInTheDocument();
+  });
+
+  it('keeps search state isolated between inspector instances', async () => {
+    render(
+      <>
+        <PayloadInspector data={{ first: 'match me' }} />
+        <PayloadInspector data={{ second: 'stay idle' }} />
+      </>
+    );
+
+    const [firstSearchInput, secondSearchInput] =
+      screen.getAllByLabelText('Search payload');
+
+    fireEvent.change(firstSearchInput, {
+      target: { value: 'match' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('1 match')).toBeInTheDocument();
+    });
+
+    expect(secondSearchInput).toHaveValue('');
+    expect(screen.getAllByText('Search keys and values')).toHaveLength(1);
+  });
+
+  it('renders multiline strings with wrapped scrollable styling', () => {
+    render(
+      <PayloadInspector
+        data={{
+          prompt: 'line 1\nline 2',
+        }}
+      />
+    );
+
+    const value = screen.getByText(
+      (_, element) => element?.textContent === '"line 1\nline 2"'
+    );
+    expect(value).toHaveClass('max-h-36');
+    expect(value).toHaveClass('overflow-auto');
+    expect(value).toHaveClass('whitespace-pre-wrap');
+    expect(value).toHaveClass('break-words');
+  });
+});

--- a/web/src/components/PayloadInspector.tsx
+++ b/web/src/components/PayloadInspector.tsx
@@ -1,0 +1,455 @@
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type HTMLAttributes,
+} from 'react';
+import { CopyButton } from './CopyButton';
+import {
+  MAX_EXPAND_ALL_NODE_COUNT,
+  buildPayloadTree,
+  collectExpandablePaths,
+  collectInitiallyExpandedPaths,
+  describeCollection,
+  findPayloadMatches,
+  formatLeafValueForClipboard,
+  formatLeafValueForDisplay,
+  isCollectionNode,
+  serializeJsonForClipboard,
+  type PayloadMatch,
+  type TreeNode,
+} from '../utils/payloadTree';
+
+interface PayloadInspectorProps {
+  data: unknown;
+  className?: string;
+}
+
+export function PayloadInspector({
+  data,
+  className = '',
+}: PayloadInspectorProps) {
+  const tree = useMemo(
+    () => (data === undefined ? null : buildPayloadTree(data)),
+    [data]
+  );
+  const initialExpandedPaths = useMemo(
+    () => (tree ? collectInitiallyExpandedPaths(tree) : new Set<string>()),
+    [tree]
+  );
+  const [searchQuery, setSearchQuery] = useState('');
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
+    () => new Set(initialExpandedPaths)
+  );
+  const [activeMatchIndex, setActiveMatchIndex] = useState(0);
+  const searchInputId = useId();
+  const preSearchExpandedPathsRef = useRef<Set<string> | null>(null);
+  const previousDeferredSearchQueryRef = useRef('');
+  const expandedPathsRef = useRef(expandedPaths);
+  const matchElementsRef = useRef(new Map<string, HTMLElement>());
+
+  useEffect(() => {
+    expandedPathsRef.current = expandedPaths;
+  }, [expandedPaths]);
+
+  useEffect(() => {
+    setExpandedPaths(new Set(initialExpandedPaths));
+    setSearchQuery('');
+    setActiveMatchIndex(0);
+    preSearchExpandedPathsRef.current = null;
+    matchElementsRef.current.clear();
+  }, [initialExpandedPaths]);
+
+  const searchResult = useMemo(
+    () => (tree ? findPayloadMatches(tree, deferredSearchQuery) : emptySearchResult()),
+    [deferredSearchQuery, tree]
+  );
+  const hasActiveSearch = deferredSearchQuery.trim().length > 0;
+  const effectiveExpandedPaths = useMemo(() => {
+    if (!hasActiveSearch) {
+      return expandedPaths;
+    }
+
+    const mergedPaths = new Set(expandedPaths);
+    searchResult.expandedPaths.forEach((path) => {
+      mergedPaths.add(path);
+    });
+    return mergedPaths;
+  }, [expandedPaths, hasActiveSearch, searchResult.expandedPaths]);
+  const activeMatch =
+    searchResult.matches.length > 0
+      ? searchResult.matches[activeMatchIndex % searchResult.matches.length] ?? null
+      : null;
+
+  useEffect(() => {
+    const previousDeferredSearchQuery = previousDeferredSearchQueryRef.current;
+    previousDeferredSearchQueryRef.current = deferredSearchQuery;
+
+    if (!hasActiveSearch) {
+      if (preSearchExpandedPathsRef.current) {
+        setExpandedPaths(new Set(preSearchExpandedPathsRef.current));
+        preSearchExpandedPathsRef.current = null;
+      }
+      setActiveMatchIndex(0);
+      return;
+    }
+
+    if (previousDeferredSearchQuery.trim().length === 0) {
+      preSearchExpandedPathsRef.current = new Set(expandedPathsRef.current);
+    }
+
+    if (previousDeferredSearchQuery !== deferredSearchQuery) {
+      setActiveMatchIndex(0);
+    }
+  }, [deferredSearchQuery, hasActiveSearch]);
+
+  useEffect(() => {
+    if (searchResult.matches.length === 0) {
+      if (activeMatchIndex !== 0) {
+        setActiveMatchIndex(0);
+      }
+      return;
+    }
+
+    if (activeMatchIndex >= searchResult.matches.length) {
+      setActiveMatchIndex(0);
+    }
+  }, [activeMatchIndex, searchResult.matches.length]);
+
+  useEffect(() => {
+    if (!activeMatch) {
+      return;
+    }
+
+    const activeMatchElement = matchElementsRef.current.get(activeMatch.id);
+    activeMatchElement?.scrollIntoView({
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  }, [activeMatch]);
+
+  const toggleExpanded = useCallback((path: string) => {
+    setExpandedPaths((current) => {
+      const next = new Set(current);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleExpandAll = useCallback(() => {
+    if (!tree || tree.subtreeNodeCount > MAX_EXPAND_ALL_NODE_COUNT) {
+      return;
+    }
+
+    setExpandedPaths(collectExpandablePaths(tree));
+  }, [tree]);
+
+  const handleCollapseAll = useCallback(() => {
+    setExpandedPaths(new Set(initialExpandedPaths));
+  }, [initialExpandedPaths]);
+
+  const registerMatchElement = useCallback(
+    (matchId: string, element: HTMLElement | null) => {
+      if (element) {
+        matchElementsRef.current.set(matchId, element);
+        return;
+      }
+
+      matchElementsRef.current.delete(matchId);
+    },
+    []
+  );
+
+  if (tree === null) {
+    return (
+      <div
+        className={`rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500 ${className}`.trim()}
+      >
+        No data
+      </div>
+    );
+  }
+
+  const expandAllDisabled = tree.subtreeNodeCount > MAX_EXPAND_ALL_NODE_COUNT;
+  const matchCount = searchResult.matches.length;
+  const matchSummary = hasActiveSearch
+    ? `${matchCount} ${matchCount === 1 ? 'match' : 'matches'}`
+    : 'Search keys and values';
+
+  return (
+    <section
+      className={`flex min-h-0 flex-col rounded-lg border border-gray-200 bg-white ${className}`.trim()}
+    >
+      <div className="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-gray-50 p-3">
+        <label className="sr-only" htmlFor={searchInputId}>
+          Search payload
+        </label>
+        <input
+          id={searchInputId}
+          type="search"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder="Search payload"
+          aria-label="Search payload"
+          className="min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+        />
+        <button
+          type="button"
+          className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={matchCount === 0}
+          onClick={() =>
+            setActiveMatchIndex((index) =>
+              matchCount === 0 ? 0 : (index - 1 + matchCount) % matchCount
+            )
+          }
+        >
+          Prev
+        </button>
+        <button
+          type="button"
+          className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={matchCount === 0}
+          onClick={() =>
+            setActiveMatchIndex((index) =>
+              matchCount === 0 ? 0 : (index + 1) % matchCount
+            )
+          }
+        >
+          Next
+        </button>
+        <button
+          type="button"
+          className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60"
+          title={
+            expandAllDisabled
+              ? 'Expand all is disabled for payloads with more than 5,000 nodes.'
+              : undefined
+          }
+          disabled={expandAllDisabled}
+          onClick={handleExpandAll}
+        >
+          Expand all
+        </button>
+        <button
+          type="button"
+          className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          onClick={handleCollapseAll}
+        >
+          Collapse all
+        </button>
+        <CopyButton
+          aria-label="Copy full JSON"
+          getValue={() => serializeJsonForClipboard(data)}
+          idleLabel="Copy full JSON"
+          successLabel="Copied JSON"
+        />
+        <span className="ml-auto text-xs text-gray-500">{matchSummary}</span>
+      </div>
+
+      <div className="min-h-0 overflow-auto p-3">
+        <div className="font-mono text-xs leading-6 text-gray-800">
+          <PayloadNodeRow
+            node={tree}
+            activeMatchId={activeMatch?.id ?? null}
+            expandedPaths={effectiveExpandedPaths}
+            matches={searchResult.matches}
+            onToggleExpanded={toggleExpanded}
+            registerMatchElement={registerMatchElement}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface PayloadNodeRowProps {
+  activeMatchId: string | null;
+  expandedPaths: Set<string>;
+  matches: PayloadMatch[];
+  node: TreeNode;
+  onToggleExpanded: (path: string) => void;
+  registerMatchElement: (matchId: string, element: HTMLElement | null) => void;
+}
+
+function PayloadNodeRow({
+  activeMatchId,
+  expandedPaths,
+  matches,
+  node,
+  onToggleExpanded,
+  registerMatchElement,
+}: PayloadNodeRowProps) {
+  const isExpanded = isCollectionNode(node) ? expandedPaths.has(node.path) : false;
+  const keyMatchId = `${node.path}:key`;
+  const valueMatchId = `${node.path}:value`;
+  const keyMatch = matches.some((match) => match.id === keyMatchId);
+  const valueMatch = matches.some((match) => match.id === valueMatchId);
+
+  return (
+    <div>
+      <div
+        className="flex items-start gap-2 py-1"
+        style={{ paddingLeft: `${node.depth * 16}px` }}
+      >
+        {isCollectionNode(node) ? (
+          <button
+            type="button"
+            aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${describeNode(node)}`}
+            className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            onClick={() => onToggleExpanded(node.path)}
+          >
+            {isExpanded ? '-' : '+'}
+          </button>
+        ) : (
+          <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-gray-300">
+            -
+          </span>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-start gap-2">
+            {node.key !== null && (
+              <>
+                <HighlightableText
+                  activeMatchId={activeMatchId}
+                  className="break-all text-blue-700"
+                  isMatch={keyMatch}
+                  matchId={keyMatchId}
+                  registerMatchElement={registerMatchElement}
+                >
+                  {String(node.key)}
+                </HighlightableText>
+                <span className="text-gray-400">:</span>
+              </>
+            )}
+
+            {isCollectionNode(node) ? (
+              <CollectionSummary node={node} />
+            ) : (
+              <HighlightableText
+                activeMatchId={activeMatchId}
+                className={
+                  typeof node.value === 'string'
+                    ? 'max-h-36 overflow-auto whitespace-pre-wrap break-words text-emerald-700'
+                    : 'break-all text-gray-800'
+                }
+                isMatch={valueMatch}
+                matchId={valueMatchId}
+                registerMatchElement={registerMatchElement}
+              >
+                {formatLeafValueForDisplay(node.value)}
+              </HighlightableText>
+            )}
+
+            <CopyButton
+              aria-label={
+                isCollectionNode(node)
+                  ? `Copy JSON for ${describeNode(node)}`
+                  : `Copy value for ${describeNode(node)}`
+              }
+              className="ml-auto"
+              getValue={() =>
+                isCollectionNode(node)
+                  ? serializeJsonForClipboard(node.value)
+                  : formatLeafValueForClipboard(node.value)
+              }
+              idleLabel="Copy"
+              successLabel="Copied"
+            />
+          </div>
+        </div>
+      </div>
+
+      {isCollectionNode(node) && isExpanded && (
+        <div>
+          {node.children.map((child) => (
+            <PayloadNodeRow
+              key={child.path}
+              node={child}
+              activeMatchId={activeMatchId}
+              expandedPaths={expandedPaths}
+              matches={matches}
+              onToggleExpanded={onToggleExpanded}
+              registerMatchElement={registerMatchElement}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CollectionSummary({ node }: { node: TreeNode }) {
+  if (!isCollectionNode(node)) {
+    return null;
+  }
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-2">
+      <span className="text-gray-500">{node.type === 'object' ? '{}' : '[]'}</span>
+      <span className="rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-600">
+        {describeCollection(node)}
+      </span>
+    </span>
+  );
+}
+
+interface HighlightableTextProps extends HTMLAttributes<HTMLSpanElement> {
+  activeMatchId: string | null;
+  isMatch: boolean;
+  matchId: string;
+  registerMatchElement: (matchId: string, element: HTMLElement | null) => void;
+}
+
+function HighlightableText({
+  activeMatchId,
+  children,
+  className = '',
+  isMatch,
+  matchId,
+  registerMatchElement,
+  ...spanProps
+}: HighlightableTextProps) {
+  return (
+    <span
+      {...spanProps}
+      ref={(element) => registerMatchElement(matchId, element)}
+      className={`${className} ${
+        isMatch
+          ? activeMatchId === matchId
+            ? 'rounded bg-amber-200 px-1'
+            : 'rounded bg-yellow-100 px-1'
+          : ''
+      }`.trim()}
+      data-match-state={
+        isMatch ? (activeMatchId === matchId ? 'active' : 'match') : undefined
+      }
+    >
+      {children}
+    </span>
+  );
+}
+
+function describeNode(node: TreeNode): string {
+  if (node.key !== null) {
+    return String(node.key);
+  }
+
+  return 'payload';
+}
+
+function emptySearchResult() {
+  return {
+    expandedPaths: new Set<string>(),
+    matches: [],
+  };
+}

--- a/web/src/components/SpanDetail.test.tsx
+++ b/web/src/components/SpanDetail.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { Span } from '../api/client';
+import { SpanDetail } from './SpanDetail';
+
+function createSpan(overrides: Partial<Span> = {}): Span {
+  const spanId = overrides.span_id ?? 'span-1';
+
+  return {
+    id: overrides.id ?? `uuid-${spanId}`,
+    trace_id: overrides.trace_id ?? 'trace-1',
+    span_id: spanId,
+    parent_span_id: overrides.parent_span_id,
+    name: overrides.name ?? spanId,
+    kind: overrides.kind ?? 'CHAIN',
+    status: overrides.status ?? 'COMPLETED',
+    started_at: overrides.started_at ?? '2026-03-14T10:00:00.000Z',
+    ended_at: overrides.ended_at,
+    tokens_in: overrides.tokens_in,
+    tokens_out: overrides.tokens_out,
+    cost_usd: overrides.cost_usd,
+    latency_ms: overrides.latency_ms,
+    error_message: overrides.error_message,
+    model: overrides.model,
+    provider: overrides.provider,
+    input: overrides.input,
+    input_truncated: overrides.input_truncated,
+    input_original_size_bytes: overrides.input_original_size_bytes,
+    input_truncation_reason: overrides.input_truncation_reason,
+    output: overrides.output,
+    output_truncated: overrides.output_truncated,
+    output_original_size_bytes: overrides.output_original_size_bytes,
+    output_truncation_reason: overrides.output_truncation_reason,
+    metadata: overrides.metadata,
+  };
+}
+
+describe('SpanDetail parent navigation', () => {
+  it('omits the parent row for root spans', () => {
+    render(
+      <SpanDetail
+        span={createSpan({ span_id: 'root', name: 'Root span' })}
+        breadcrumbPath={[{ spanId: 'root', name: 'Root span' }]}
+        onSelectSpan={vi.fn()}
+        spanIndex={new Map()}
+      />
+    );
+
+    expect(screen.queryByText('Parent Span ID:')).not.toBeInTheDocument();
+  });
+
+  it('renders unresolved parent IDs as plain text', () => {
+    render(
+      <SpanDetail
+        span={createSpan({
+          span_id: 'child',
+          name: 'Child span',
+          parent_span_id: 'missing-parent',
+        })}
+        breadcrumbPath={[{ spanId: 'child', name: 'Child span' }]}
+        onSelectSpan={vi.fn()}
+        spanIndex={new Map()}
+      />
+    );
+
+    expect(screen.getByText('missing-parent')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'missing-parent' })).not.toBeInTheDocument();
+  });
+
+  it('renders resolvable parent IDs as buttons wired to selection', () => {
+    const onSelectSpan = vi.fn();
+    const parentSpan = createSpan({ span_id: 'root', name: 'Root span' });
+    const childSpan = createSpan({
+      span_id: 'child',
+      name: 'Child span',
+      parent_span_id: 'root',
+    });
+
+    render(
+      <SpanDetail
+        span={childSpan}
+        breadcrumbPath={[
+          { spanId: 'root', name: 'Root span' },
+          { spanId: 'child', name: 'Child span' },
+        ]}
+        onSelectSpan={onSelectSpan}
+        spanIndex={new Map([['root', parentSpan], ['child', childSpan]])}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select parent span root' }));
+
+    expect(onSelectSpan).toHaveBeenCalledWith('root');
+  });
+
+  it('supports keyboard activation for the parent span button', async () => {
+    const user = userEvent.setup();
+    const onSelectSpan = vi.fn();
+    const parentSpan = createSpan({ span_id: 'root', name: 'Root span' });
+    const childSpan = createSpan({
+      span_id: 'child',
+      name: 'Child span',
+      parent_span_id: 'root',
+    });
+
+    render(
+      <SpanDetail
+        span={childSpan}
+        breadcrumbPath={[
+          { spanId: 'root', name: 'Root span' },
+          { spanId: 'child', name: 'Child span' },
+        ]}
+        onSelectSpan={onSelectSpan}
+        spanIndex={new Map([['root', parentSpan], ['child', childSpan]])}
+      />
+    );
+
+    const parentButton = screen.getByRole('button', {
+      name: 'Select parent span root',
+    });
+    parentButton.focus();
+    await user.keyboard('{Enter}');
+
+    expect(onSelectSpan).toHaveBeenCalledWith('root');
+  });
+});

--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react';
 import { Span } from '../api/client';
+import { CopyButton } from './CopyButton';
 import { StatusBadge } from './StatusBadge';
 import { JsonViewer } from './JsonViewer';
 import {
@@ -10,11 +11,13 @@ import {
 } from '../utils/format';
 import type { BreadcrumbSegment } from '../utils/failureAnalysis';
 import { SpanBreadcrumb } from './SpanBreadcrumb';
+import { TruncationBanner } from './TruncationBanner';
 
 interface SpanDetailProps {
   span: Span | null;
   breadcrumbPath: BreadcrumbSegment[];
   onSelectSpan: (spanId: string) => void;
+  spanIndex: Map<string, Span>;
 }
 
 /**
@@ -24,6 +27,7 @@ export function SpanDetail({
   span,
   breadcrumbPath,
   onSelectSpan,
+  spanIndex,
 }: SpanDetailProps) {
   if (!span) {
     return (
@@ -37,6 +41,9 @@ export function SpanDetail({
   const showLLMContext =
     span.kind === 'LLM' &&
     (span.model !== undefined || span.provider !== undefined);
+  const parentSpan = span.parent_span_id
+    ? spanIndex.get(span.parent_span_id) ?? null
+    : null;
 
   return (
     <div className="h-full overflow-y-auto p-4">
@@ -103,6 +110,12 @@ export function SpanDetail({
       {span.input !== undefined && (
         <div className="mb-6">
           <h3 className="text-sm font-medium text-gray-700 mb-2">Input</h3>
+          <TruncationBanner
+            title="Input payload"
+            truncated={span.input_truncated}
+            originalSizeBytes={span.input_original_size_bytes}
+            reason={span.input_truncation_reason}
+          />
           <JsonViewer data={span.input} />
         </div>
       )}
@@ -111,6 +124,12 @@ export function SpanDetail({
       {span.output !== undefined && (
         <div className="mb-6">
           <h3 className="text-sm font-medium text-gray-700 mb-2">Output</h3>
+          <TruncationBanner
+            title="Output payload"
+            truncated={span.output_truncated}
+            originalSizeBytes={span.output_original_size_bytes}
+            reason={span.output_truncation_reason}
+          />
           <JsonViewer data={span.output} />
         </div>
       )}
@@ -127,14 +146,45 @@ export function SpanDetail({
       <div className="mb-6">
         <h3 className="text-sm font-medium text-gray-700 mb-2">Identifiers</h3>
         <div className="bg-gray-50 rounded p-3 text-sm">
-          <DetailRow label="Span ID" value={span.id} mono />
+          <DetailRow label="Span UUID" value={span.id} mono />
+          <DetailRow
+            label="Span ID"
+            value={span.span_id}
+            mono
+            className="mt-1"
+            action={
+              <CopyButton
+                aria-label="Copy span ID"
+                value={span.span_id}
+              />
+            }
+          />
           <DetailRow label="Trace ID" value={span.trace_id} mono className="mt-1" />
           {span.parent_span_id && (
             <DetailRow
               label="Parent Span ID"
-              value={span.parent_span_id}
+              value={
+                parentSpan ? (
+                  <button
+                    type="button"
+                    aria-label={`Select parent span ${span.parent_span_id}`}
+                    className="rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    onClick={() => onSelectSpan(parentSpan.span_id)}
+                  >
+                    {span.parent_span_id}
+                  </button>
+                ) : (
+                  span.parent_span_id
+                )
+              }
               mono
               className="mt-1"
+              action={
+                <CopyButton
+                  aria-label="Copy parent span ID"
+                  value={span.parent_span_id}
+                />
+              }
             />
           )}
         </div>
@@ -182,17 +232,27 @@ interface DetailRowProps {
   value?: ReactNode;
   mono?: boolean;
   className?: string;
+  action?: ReactNode;
 }
 
-function DetailRow({ label, value, mono = false, className = '' }: DetailRowProps) {
+function DetailRow({
+  label,
+  value,
+  mono = false,
+  className = '',
+  action,
+}: DetailRowProps) {
   const hasValue = value !== undefined && value !== null && value !== '';
 
   return (
     <div className={`flex justify-between gap-4 ${className}`.trim()}>
       <span className="text-gray-600">{label}:</span>
       {hasValue ? (
-        <span className={mono ? 'font-mono text-xs text-right' : 'text-right'}>
-          {value}
+        <span className="flex min-w-0 items-center justify-end gap-2">
+          <span className={mono ? 'font-mono text-xs text-right' : 'text-right'}>
+            {value}
+          </span>
+          {action}
         </span>
       ) : (
         <span className="text-gray-400">-</span>

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { TimelineEvent, TimelineTraceStatus } from '../api/client';
+import { Span, TimelineEvent, TimelineTraceStatus } from '../api/client';
 import { JsonViewer } from './JsonViewer';
 import {
   isTimelineErrorEvent,
@@ -14,6 +14,7 @@ interface TimelineProps {
   error?: string | null;
   selectedSpanId?: string | null;
   onSelectSpan: (spanId: string) => void;
+  spanIndex: Map<string, Span>;
 }
 
 /**
@@ -27,6 +28,7 @@ export function Timeline({
   error = null,
   selectedSpanId = null,
   onSelectSpan,
+  spanIndex,
 }: TimelineProps) {
   const [showErrorsOnly, setShowErrorsOnly] = useState(false);
   const visibleEvents = showErrorsOnly
@@ -93,6 +95,7 @@ export function Timeline({
               event={event}
               isSelectedSpan={selectedSpanId === event.span_id}
               onSelectSpan={onSelectSpan}
+              spanIndex={spanIndex}
             />
           ))}
         </div>
@@ -105,12 +108,18 @@ interface TimelineRowProps {
   event: TimelineEvent;
   isSelectedSpan: boolean;
   onSelectSpan: (spanId: string) => void;
+  spanIndex: Map<string, Span>;
 }
 
-function TimelineRow({ event, isSelectedSpan, onSelectSpan }: TimelineRowProps) {
+function TimelineRow({
+  event,
+  isSelectedSpan,
+  onSelectSpan,
+  spanIndex,
+}: TimelineRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const hasDetails = Boolean(event.message || event.payload);
-  const hasNavigableSpan = Boolean(event.span_id && event.span_name);
+  const hasNavigableSpan = Boolean(event.span_id && spanIndex.has(event.span_id));
   const isError = isTimelineErrorEvent(event);
   const rowAccent = isError
     ? 'border-red-200 bg-red-50/70'
@@ -169,7 +178,7 @@ function TimelineRow({ event, isSelectedSpan, onSelectSpan }: TimelineRowProps) 
                       }`}
                       onClick={() => onSelectSpan(event.span_id!)}
                     >
-                      {event.span_name}
+                      {event.span_name ?? event.span_id}
                     </button>
                   ) : (
                     <span className="rounded-full bg-white px-3 py-1 font-mono text-gray-600 ring-1 ring-gray-200">

--- a/web/src/components/TruncationBanner.test.tsx
+++ b/web/src/components/TruncationBanner.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TruncationBanner } from './TruncationBanner';
+
+describe('TruncationBanner', () => {
+  it('renders full metadata', () => {
+    render(
+      <TruncationBanner
+        title="Input payload"
+        truncated
+        originalSizeBytes={524288}
+        reason="size_limit"
+      />
+    );
+
+    expect(screen.getByText('Payload truncated')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Input payload was truncated before storage\./)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Original size: 512.0 KB/)).toBeInTheDocument();
+    expect(screen.getByText(/Reason: size limit/)).toBeInTheDocument();
+  });
+
+  it('renders partial metadata', () => {
+    render(
+      <TruncationBanner
+        title="Output payload"
+        truncated
+        originalSizeBytes={1048576}
+      />
+    );
+
+    expect(screen.getByText(/Original size: 1.0 MB/)).toBeInTheDocument();
+    expect(screen.queryByText(/Reason:/)).not.toBeInTheDocument();
+  });
+
+  it('renders flag-only metadata', () => {
+    render(<TruncationBanner title="Input payload" truncated />);
+
+    expect(screen.getByText(/Input payload was truncated before storage\./)).toBeInTheDocument();
+  });
+
+  it('renders nothing when truncation is false or absent', () => {
+    const { rerender, container } = render(
+      <TruncationBanner
+        title="Input payload"
+        truncated={false}
+        originalSizeBytes={2048}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+
+    rerender(<TruncationBanner title="Input payload" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/components/TruncationBanner.tsx
+++ b/web/src/components/TruncationBanner.tsx
@@ -1,0 +1,42 @@
+import { formatBytes } from '../utils/format';
+
+interface TruncationBannerProps {
+  originalSizeBytes?: number;
+  reason?: string;
+  title: string;
+  truncated?: boolean;
+}
+
+export function TruncationBanner({
+  originalSizeBytes,
+  reason,
+  title,
+  truncated,
+}: TruncationBannerProps) {
+  if (!truncated) {
+    return null;
+  }
+
+  const details = [
+    originalSizeBytes !== undefined
+      ? `Original size: ${formatBytes(originalSizeBytes)}`
+      : null,
+    reason ? `Reason: ${formatReason(reason)}` : null,
+  ].filter((detail): detail is string => detail !== null);
+
+  return (
+    <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-800">
+        Payload truncated
+      </div>
+      <p className="mt-1">{title} was truncated before storage.</p>
+      {details.length > 0 && (
+        <p className="mt-1 text-xs text-amber-800">{details.join(' | ')}</p>
+      )}
+    </div>
+  );
+}
+
+function formatReason(reason: string): string {
+  return reason.replaceAll('_', ' ');
+}

--- a/web/src/hooks/useTraceDetailSearchParams.ts
+++ b/web/src/hooks/useTraceDetailSearchParams.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  parseSpanParam,
+  serializeSpanParam,
+} from '../utils/traceDetailSearchParams';
+
+export function useTraceDetailSearchParams() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawSpanParam = searchParams.get('span');
+  const spanParam = parseSpanParam(searchParams);
+
+  useEffect(() => {
+    if (rawSpanParam !== '') {
+      return;
+    }
+
+    setSearchParams(serializeSpanParam(searchParams, null), { replace: true });
+  }, [rawSpanParam, searchParams, setSearchParams]);
+
+  const setSpanParam = useCallback(
+    (spanId: string | null) => {
+      setSearchParams(serializeSpanParam(searchParams, spanId), { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
+
+  return {
+    spanParam,
+    setSpanParam,
+  };
+}

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchSpans, fetchTrace, type Span } from '../api/client';
+import { CopyButton } from '../components/CopyButton';
 import { FailureSummary } from '../components/FailureSummary';
 import { JsonViewer } from '../components/JsonViewer';
 import { SpanDetail } from '../components/SpanDetail';
@@ -9,6 +10,7 @@ import { SpanTree } from '../components/SpanTree';
 import { StatusBadge } from '../components/StatusBadge';
 import { Timeline } from '../components/Timeline';
 import { useRequireApiKey } from '../hooks/useRequireApiKey';
+import { useTraceDetailSearchParams } from '../hooks/useTraceDetailSearchParams';
 import { useTraceTimeline } from './useTraceTimeline';
 import {
   calculateDuration,
@@ -25,6 +27,7 @@ import {
   evaluateStaleTraceSignal,
   type StaleTraceSignal,
 } from '../utils/failureAnalysis';
+import { serializeSpanParam } from '../utils/traceDetailSearchParams';
 
 /**
  * Trace detail page with span tree, detail panel, and merged event timeline.
@@ -85,9 +88,11 @@ function TraceDetailContent({
   traceId,
 }: TraceDetailContentProps) {
   const location = useLocation();
+  const { spanParam, setSpanParam } = useTraceDetailSearchParams();
   const [selectedSpanExternalId, setSelectedSpanExternalId] = useState<string | null>(
     null
   );
+  const [revealPath, setRevealPath] = useState<Set<string>>(new Set());
   const [revealPathVersion, setRevealPathVersion] = useState(0);
   const [userHasSelected, setUserHasSelected] = useState(false);
   const traceQuery = useQuery({
@@ -120,10 +125,6 @@ function TraceDetailContent({
     () => buildBreadcrumbPath(selectedSpan, spanIndex),
     [selectedSpan, spanIndex]
   );
-  const revealPath = useMemo(
-    () => new Set(selectedBreadcrumbPath.map((segment) => segment.spanId)),
-    [selectedBreadcrumbPath]
-  );
   const staleTraceSignal = useMemo(
     () =>
       timeline.hasSnapshot
@@ -137,41 +138,97 @@ function TraceDetailContent({
     [spans, timeline.events, timeline.hasSnapshot, timelineStatus, trace?.started_at]
   );
 
-  const selectSpan = (spanId: string | null, manualSelection: boolean) => {
+  const updateSelectedSpan = useCallback((spanId: string | null) => {
     setSelectedSpanExternalId(spanId);
+
     if (spanId) {
+      const breadcrumbPath = buildBreadcrumbPath(spanIndex.get(spanId), spanIndex);
+      setRevealPath(new Set(breadcrumbPath.map((segment) => segment.spanId)));
       setRevealPathVersion((version) => version + 1);
+      return;
     }
-    if (manualSelection) {
-      setUserHasSelected(true);
-    }
-  };
+
+    setRevealPath(new Set());
+  }, [spanIndex]);
+
+  const handleSelectSpan = useCallback((spanId: string) => {
+    updateSelectedSpan(spanId);
+    setUserHasSelected(true);
+    setSpanParam(spanId);
+  }, [setSpanParam, updateSelectedSpan]);
+
+  const buildCopyTraceUrl = useCallback(() => {
+    const searchParams = serializeSpanParam(
+      new URLSearchParams(location.search),
+      selectedSpanExternalId
+    );
+    const nextSearch = searchParams.toString();
+
+    return new URL(
+      `${location.pathname}${nextSearch ? `?${nextSearch}` : ''}`,
+      window.location.origin
+    ).toString();
+  }, [location.pathname, location.search, selectedSpanExternalId]);
 
   useEffect(() => {
-    if (!selectedSpanExternalId) {
+    if (!spansQuery.isSuccess) {
       return;
     }
 
-    if (spanIndex.has(selectedSpanExternalId)) {
+    if (spanParam !== null) {
+      if (spanIndex.has(spanParam)) {
+        if (selectedSpanExternalId !== spanParam || !userHasSelected) {
+          updateSelectedSpan(spanParam);
+        }
+        if (!userHasSelected) {
+          setUserHasSelected(true);
+        }
+        return;
+      }
+
+      updateSelectedSpan(null);
+      setUserHasSelected(false);
+      setSpanParam(null);
       return;
     }
 
-    const nextSelectedSpanId =
-      failureAnalysis.summary.primaryFailedSpan?.span_id ?? null;
-
-    setSelectedSpanExternalId(nextSelectedSpanId);
-    if (nextSelectedSpanId) {
-      setRevealPathVersion((version) => version + 1);
+    if (!userHasSelected) {
+      return;
     }
+
+    updateSelectedSpan(null);
     setUserHasSelected(false);
   }, [
-    failureAnalysis.summary.primaryFailedSpan,
     selectedSpanExternalId,
+    setSpanParam,
     spanIndex,
+    spanParam,
+    spansQuery.isSuccess,
+    updateSelectedSpan,
+    userHasSelected,
   ]);
 
   useEffect(() => {
-    if (timelineStatus !== 'FAILED' || userHasSelected) {
+    if (!selectedSpanExternalId || spanIndex.has(selectedSpanExternalId)) {
+      return;
+    }
+
+    updateSelectedSpan(null);
+    setUserHasSelected(false);
+
+    if (spanParam !== null) {
+      setSpanParam(null);
+    }
+  }, [
+    selectedSpanExternalId,
+    setSpanParam,
+    spanIndex,
+    spanParam,
+    updateSelectedSpan,
+  ]);
+
+  useEffect(() => {
+    if (timelineStatus !== 'FAILED' || userHasSelected || spanParam !== null) {
       return;
     }
 
@@ -182,14 +239,13 @@ function TraceDetailContent({
       return;
     }
 
-    setSelectedSpanExternalId(nextSelectedSpanId);
-    if (nextSelectedSpanId) {
-      setRevealPathVersion((version) => version + 1);
-    }
+    updateSelectedSpan(nextSelectedSpanId);
   }, [
     failureAnalysis.summary.primaryFailedSpan,
     selectedSpanExternalId,
+    spanParam,
     timelineStatus,
+    updateSelectedSpan,
     userHasSelected,
   ]);
 
@@ -266,7 +322,7 @@ function TraceDetailContent({
           {timelineStatus === 'FAILED' && (
             <FailureSummary
               summary={failureAnalysis.summary}
-              onJumpToPrimaryFailedSpan={(spanId) => selectSpan(spanId, true)}
+              onJumpToPrimaryFailedSpan={handleSelectSpan}
             />
           )}
 
@@ -289,20 +345,31 @@ function TraceDetailContent({
           )}
 
           <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-            <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3">
               <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-gray-600">
                 Trace Context
               </h2>
+              <CopyButton
+                aria-label="Copy Trace URL"
+                className="shrink-0"
+                getValue={buildCopyTraceUrl}
+                idleLabel="Copy Trace URL"
+                successLabel="Copied URL"
+              />
             </div>
             <div className="space-y-6 p-4">
               <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                 <TraceContextField
                   label="ID"
                   value={renderContextText(trace.id, true)}
+                  copyValue={trace.id}
+                  copyButtonLabel="Copy trace UUID"
                 />
                 <TraceContextField
                   label="External Trace ID"
                   value={renderContextText(trace.trace_id, true)}
+                  copyValue={trace.trace_id}
+                  copyButtonLabel="Copy external trace ID"
                 />
                 <TraceContextField
                   label="Session UUID"
@@ -316,6 +383,8 @@ function TraceDetailContent({
                   ) : (
                     renderContextText(undefined)
                   )}
+                  copyValue={trace.session_id}
+                  copyButtonLabel="Copy session UUID"
                 />
                 <TraceContextField
                   label="User ID"
@@ -373,7 +442,7 @@ function TraceDetailContent({
                 <SpanTree
                   spans={spans}
                   selectedSpanId={selectedSpanExternalId}
-                  onSelectSpan={(spanId) => selectSpan(spanId, true)}
+                  onSelectSpan={handleSelectSpan}
                   failedSpanIds={failureAnalysis.failedSpanIds}
                   primaryAncestorPath={failureAnalysis.primaryAncestorPath}
                   revealPath={revealPath}
@@ -393,7 +462,8 @@ function TraceDetailContent({
                 <SpanDetail
                   span={selectedSpan}
                   breadcrumbPath={selectedBreadcrumbPath}
-                  onSelectSpan={(spanId) => selectSpan(spanId, true)}
+                  onSelectSpan={handleSelectSpan}
+                  spanIndex={spanIndex}
                 />
               </div>
             </section>
@@ -406,7 +476,8 @@ function TraceDetailContent({
             isLoading={timeline.isLoading}
             error={timeline.error}
             selectedSpanId={selectedSpanExternalId}
-            onSelectSpan={(spanId) => selectSpan(spanId, true)}
+            onSelectSpan={handleSelectSpan}
+            spanIndex={spanIndex}
           />
         </div>
       </div>
@@ -418,15 +489,32 @@ interface TraceContextFieldProps {
   label: string;
   value: ReactNode;
   className?: string;
+  copyValue?: string;
+  copyButtonLabel?: string;
 }
 
-function TraceContextField({ label, value, className = '' }: TraceContextFieldProps) {
+function TraceContextField({
+  label,
+  value,
+  className = '',
+  copyValue,
+  copyButtonLabel,
+}: TraceContextFieldProps) {
   return (
     <div className={`rounded-lg border border-gray-200 bg-gray-50 p-4 ${className}`.trim()}>
       <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-500">
         {label}
       </div>
-      <div className="mt-2 text-sm text-gray-900">{value}</div>
+      <div className="mt-2 flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 text-sm text-gray-900">{value}</div>
+        {copyValue && copyButtonLabel ? (
+          <CopyButton
+            aria-label={copyButtonLabel}
+            className="shrink-0"
+            value={copyValue}
+          />
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/web/src/pages/TracesPage.test.tsx
+++ b/web/src/pages/TracesPage.test.tsx
@@ -225,14 +225,20 @@ function createQueryClient() {
   });
 }
 
-function renderTraceRoutes(initialEntries: Array<string | { pathname: string; state?: unknown }>) {
+function renderTraceRoutes(
+  initialEntries: Array<string | { pathname: string; state?: unknown }>,
+  options: { initialIndex?: number } = {}
+) {
   const queryClient = createQueryClient();
   const router = createMemoryRouter(
     [
       { path: '/traces', element: <TracesPage /> },
       { path: '/traces/:id', element: <TraceDetailPage /> },
     ],
-    { initialEntries }
+    {
+      initialEntries,
+      initialIndex: options.initialIndex,
+    }
   );
 
   const view = render(
@@ -242,6 +248,17 @@ function renderTraceRoutes(initialEntries: Array<string | { pathname: string; st
   );
 
   return { ...view, queryClient, router };
+}
+
+function mockClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+
+  return writeText;
 }
 
 async function waitForListFetch(search: string) {
@@ -282,6 +299,10 @@ afterEach(() => {
   localStorage.clear();
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: undefined,
+  });
 });
 
 describe('TracesPage', () => {
@@ -819,11 +840,12 @@ describe('TraceDetailPage', () => {
       })
     );
 
-    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
 
     expect(
       await screen.findByRole('heading', { name: 'Failure Summary' })
     ).toBeInTheDocument();
+    expect(view.router.state.location.search).toBe('');
 
     const detailBreadcrumb = screen.getByLabelText('Span breadcrumb');
     expect(within(detailBreadcrumb).getByText('Failed tool')).toBeInTheDocument();
@@ -875,6 +897,480 @@ describe('TraceDetailPage', () => {
     ).toBeInTheDocument();
     expect(
       within(screen.getByLabelText('Span breadcrumb')).getByText('Failed tool')
+    ).toBeInTheDocument();
+  });
+
+  it('selects a valid span from the URL and does not let failure-first auto-selection override it', async () => {
+    const rootSpan = createSpan({
+      span_id: 'url-root',
+      name: 'URL root',
+      status: 'COMPLETED',
+    });
+    const requestedSpan = createSpan({
+      span_id: 'url-child',
+      name: 'URL child',
+      parent_span_id: 'url-root',
+      status: 'COMPLETED',
+    });
+    const failedSpan = createSpan({
+      span_id: 'url-failed',
+      name: 'URL failed',
+      parent_span_id: 'url-root',
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Failure preview',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: [rootSpan, requestedSpan, failedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'url-error',
+                span_id: 'url-failed',
+                span_name: 'URL failed',
+                event_type: 'error',
+                message: 'Failure preview',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}?span=url-child`]);
+
+    expect(
+      await screen.findByRole('button', { name: 'Select span URL child' })
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('URL child')
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).queryByText('URL failed')
+    ).not.toBeInTheDocument();
+    expect(view.router.state.location.search).toBe('?span=url-child');
+  });
+
+  it('removes unknown span params while preserving unrelated params and re-running failure-first selection', async () => {
+    const rootSpan = createSpan({
+      span_id: 'cleanup-root',
+      name: 'Cleanup root',
+      status: 'COMPLETED',
+    });
+    const failedSpan = createSpan({
+      span_id: 'cleanup-failed',
+      name: 'Cleanup failed',
+      parent_span_id: 'cleanup-root',
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Cleanup failure',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: [rootSpan, failedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'cleanup-error',
+                span_id: 'cleanup-failed',
+                span_name: 'Cleanup failed',
+                event_type: 'error',
+                message: 'Cleanup failure',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes([
+      `/traces/${TRACE_ONE.id}?debug=true&span=missing-span`,
+    ]);
+
+    await waitFor(() => {
+      expect(view.router.state.location.search).toBe('?debug=true');
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Select span Cleanup failed' })
+      ).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
+  it('reacts to browser back and forward span changes while staying on the same trace', async () => {
+    const rootSpan = createSpan({
+      span_id: 'history-root',
+      name: 'History root',
+      status: 'COMPLETED',
+    });
+    const alphaSpan = createSpan({
+      span_id: 'history-alpha',
+      name: 'History alpha',
+      parent_span_id: 'history-root',
+      status: 'COMPLETED',
+    });
+    const betaSpan = createSpan({
+      span_id: 'history-beta',
+      name: 'History beta',
+      parent_span_id: 'history-root',
+      status: 'COMPLETED',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse({
+            ...TRACE_DETAIL,
+            status: 'COMPLETED',
+            error_count: 0,
+          }),
+        spans: () => jsonResponse({ spans: [rootSpan, alphaSpan, betaSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes(
+      [
+        `/traces/${TRACE_ONE.id}?span=history-alpha`,
+        `/traces/${TRACE_ONE.id}?span=history-beta`,
+      ],
+      { initialIndex: 1 }
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Select span History beta' })
+    ).toHaveAttribute('aria-pressed', 'true');
+
+    await act(async () => {
+      await view.router.navigate(-1);
+    });
+
+    await waitFor(() => {
+      expect(
+        within(screen.getByLabelText('Span breadcrumb')).getByText('History alpha')
+      ).toBeInTheDocument();
+    });
+    expect(view.router.state.location.search).toBe('?span=history-alpha');
+  });
+
+  it('re-runs auto-selection when browser back removes the span param', async () => {
+    const rootSpan = createSpan({
+      span_id: 'back-root',
+      name: 'Back root',
+      status: 'COMPLETED',
+    });
+    const manualSpan = createSpan({
+      span_id: 'back-manual',
+      name: 'Back manual',
+      parent_span_id: 'back-root',
+      status: 'COMPLETED',
+    });
+    const failedSpan = createSpan({
+      span_id: 'back-failed',
+      name: 'Back failed',
+      parent_span_id: 'back-root',
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Back failure',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: [rootSpan, manualSpan, failedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'back-error',
+                span_id: 'back-failed',
+                span_name: 'Back failed',
+                event_type: 'error',
+                message: 'Back failure',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes(
+      [
+        `/traces/${TRACE_ONE.id}`,
+        `/traces/${TRACE_ONE.id}?span=back-manual`,
+      ],
+      { initialIndex: 1 }
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Select span Back manual' })
+    ).toHaveAttribute('aria-pressed', 'true');
+
+    await act(async () => {
+      await view.router.navigate(-1);
+    });
+
+    await waitFor(() => {
+      expect(
+        within(screen.getByLabelText('Span breadcrumb')).getByText('Back failed')
+      ).toBeInTheDocument();
+    });
+    expect(view.router.state.location.search).toBe('');
+  });
+
+  it('keeps trace detail selection changes local and does not refetch trace or span data', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({
+      span_id: 'query-root',
+      name: 'Query root',
+      status: 'COMPLETED',
+    });
+    const childSpan = createSpan({
+      span_id: 'query-child',
+      name: 'Query child',
+      parent_span_id: 'query-root',
+      status: 'COMPLETED',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse({
+            ...TRACE_DETAIL,
+            status: 'COMPLETED',
+            error_count: 0,
+          }),
+        spans: () => jsonResponse({ spans: [rootSpan, childSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+
+    fetchMock.mockClear();
+
+    await user.click(screen.getByRole('button', { name: 'Select span Query child' }));
+
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Query child')
+    ).toBeInTheDocument();
+    expect(view.router.state.location.search).toBe('?span=query-child');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('copies an absolute trace URL that preserves unrelated params and includes the effective selected span', async () => {
+    const user = userEvent.setup();
+    const writeText = mockClipboard();
+    const rootSpan = createSpan({
+      span_id: 'copy-root',
+      name: 'Copy root',
+      status: 'COMPLETED',
+    });
+    const failedSpan = createSpan({
+      span_id: 'copy-failed',
+      name: 'Copy failed',
+      parent_span_id: 'copy-root',
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Copy failure',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: [rootSpan, failedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'copy-error',
+                span_id: 'copy-failed',
+                span_name: 'Copy failed',
+                event_type: 'error',
+                message: 'Copy failure',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}?debug=true`]);
+    expect(
+      await screen.findByRole('button', { name: 'Select span Copy failed' })
+    ).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(screen.getByRole('button', { name: 'Copy Trace URL' }));
+
+    expect(writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/traces/trace-checkout?debug=true&span=copy-failed`
+    );
+  });
+
+  it('returns to the filtered trace list after span inspection without stepping through span history', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({
+      span_id: 'history-return-root',
+      name: 'History return root',
+      status: 'COMPLETED',
+    });
+    const failedSpan = createSpan({
+      span_id: 'history-return-failed',
+      name: 'History return failed',
+      parent_span_id: 'history-return-root',
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'History return failure',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: [rootSpan, failedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'history-return-error',
+                span_id: 'history-return-failed',
+                span_name: 'History return failed',
+                event_type: 'error',
+                message: 'History return failure',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes(['/traces?status=failed']);
+    await user.click(await screen.findByRole('link', { name: 'Checkout Trace' }));
+    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Select span History return root' })
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'Select span History return failed' })
+    );
+
+    await act(async () => {
+      await view.router.navigate(-1);
+    });
+
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    expect(view.router.state.location.pathname).toBe('/traces');
+    expect(view.router.state.location.search).toBe('?status=failed');
+  });
+
+  it('keeps tree, detail, parent navigation, failure summary, and timeline selections synchronized with the URL', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({
+      span_id: 'sync-root',
+      name: 'Sync root',
+      status: 'COMPLETED',
+    });
+    const failedSpan = createSpan({
+      span_id: 'sync-failed',
+      name: 'Sync failed',
+      parent_span_id: 'sync-root',
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Sync failure',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () => jsonResponse({ spans: [rootSpan, failedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'sync-root-event',
+                span_id: 'sync-root',
+                event_type: 'message',
+                message: 'Root event',
+                timestamp: '2026-03-14T10:00:05.000Z',
+              }),
+              createTimelineEvent({
+                id: 'sync-error-event',
+                span_id: 'sync-failed',
+                span_name: 'Sync failed',
+                event_type: 'error',
+                message: 'Sync failure',
+                timestamp: '2026-03-14T10:00:10.000Z',
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(
+      await screen.findByRole('button', { name: 'Select span Sync failed' })
+    ).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(
+      screen.getByRole('button', { name: 'Select parent span sync-root' })
+    );
+    expect(view.router.state.location.search).toBe('?span=sync-root');
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Sync root')
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Select span Sync failed' }));
+    expect(view.router.state.location.search).toBe('?span=sync-failed');
+
+    const timelineSection = screen
+      .getByRole('heading', { name: 'Timeline' })
+      .closest('section');
+    if (!timelineSection) {
+      throw new Error('Expected timeline section');
+    }
+
+    await user.click(within(timelineSection).getByRole('button', { name: 'sync-root' }));
+    expect(view.router.state.location.search).toBe('?span=sync-root');
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Sync root')
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Jump to failed span Sync failed' })
+    );
+    expect(view.router.state.location.search).toBe('?span=sync-failed');
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Sync failed')
     ).toBeInTheDocument();
   });
 
@@ -942,7 +1438,7 @@ describe('TraceDetailPage', () => {
       })
     );
 
-    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
     expect(
       await screen.findByRole('button', { name: 'Select span Running child' })
     ).toBeInTheDocument();
@@ -953,6 +1449,7 @@ describe('TraceDetailPage', () => {
     expect(
       within(screen.getByLabelText('Span breadcrumb')).getByText('Running child')
     ).toBeInTheDocument();
+    expect(view.router.state.location.search).toBe('?span=running-child');
 
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 3100));
@@ -962,6 +1459,7 @@ describe('TraceDetailPage', () => {
       expect(
         within(screen.getByLabelText('Span breadcrumb')).getByText('Running child')
       ).toBeInTheDocument();
+      expect(view.router.state.location.search).toBe('?span=running-child');
     },
     10000
   );
@@ -1189,6 +1687,7 @@ describe('TraceDetailPage', () => {
     await user.click(
       screen.getByRole('button', { name: 'Select span Trace A root' })
     );
+    expect(view.router.state.location.search).toBe('?span=trace-a-root');
     await user.click(screen.getByRole('button', { name: 'Show error events only' }));
     expect(screen.getByRole('button', { name: 'Show error events only' })).toHaveAttribute(
       'aria-pressed',
@@ -1200,6 +1699,7 @@ describe('TraceDetailPage', () => {
     });
 
     expect(await screen.findByText('Trace B')).toBeInTheDocument();
+    expect(view.router.state.location.search).toBe('');
     expect(screen.getByText('Select a span to view details')).toBeInTheDocument();
     expect(screen.getByText('Beta info event')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Show error events only' })).toHaveAttribute(
@@ -1419,8 +1919,68 @@ describe('TraceDetailPage', () => {
     expect(screen.getByText('Select a span to view details')).toBeInTheDocument();
   });
 
+  it('renders truncation banners for span payloads only', async () => {
+    const rootSpan = createSpan({
+      span_id: 'trunc-root',
+      name: 'Trunc root',
+      status: 'COMPLETED',
+    });
+    const failedSpan = createSpan({
+      span_id: 'trunc-failed',
+      name: 'Trunc failed',
+      parent_span_id: 'trunc-root',
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Trunc failure',
+      input: { prompt: 'large input' },
+      input_truncated: true,
+      input_original_size_bytes: 2048,
+      input_truncation_reason: 'size_limit',
+      output: { answer: 'large output' },
+      output_truncated: true,
+      output_original_size_bytes: 1048576,
+      metadata: { mode: 'debug' },
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse({
+            ...TRACE_DETAIL,
+            input: { trace: 'input' },
+            output: { trace: 'output' },
+          }),
+        spans: () => jsonResponse({ spans: [rootSpan, failedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'trunc-error',
+                span_id: 'trunc-failed',
+                span_name: 'Trunc failed',
+                event_type: 'error',
+                message: 'Trunc failure',
+                timestamp: '2026-03-14T10:00:10.000Z',
+                payload: { trace: 'timeline payload' },
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(
+      await screen.findByRole('button', { name: 'Select span Trunc failed' })
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getAllByText('Payload truncated')).toHaveLength(2);
+    expect(screen.getByText(/Original size: 2.0 KB/)).toBeInTheDocument();
+    expect(screen.getByText(/Original size: 1.0 MB/)).toBeInTheDocument();
+  });
+
   it('falls back to the primary failed span when the selected span disappears after a refresh', async () => {
-    const user = userEvent.setup();
     const rootSpan = createSpan({
       span_id: 'fallback-root',
       name: 'Fallback root',
@@ -1466,14 +2026,12 @@ describe('TraceDetailPage', () => {
       })
     );
 
-    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    const view = renderTraceRoutes([
+      `/traces/${TRACE_ONE.id}?span=disappearing-child`,
+    ]);
     expect(
       await screen.findByRole('button', { name: 'Select span Disappearing child' })
     ).toBeInTheDocument();
-
-    await user.click(
-      screen.getByRole('button', { name: 'Select span Disappearing child' })
-    );
     expect(
       within(screen.getByLabelText('Span breadcrumb')).getByText('Disappearing child')
     ).toBeInTheDocument();
@@ -1489,6 +2047,7 @@ describe('TraceDetailPage', () => {
         within(screen.getByLabelText('Span breadcrumb')).getByText('Fallback failed')
       ).toBeInTheDocument();
     });
+    expect(view.router.state.location.search).toBe('');
   });
 
   it('waits for the initial timeline snapshot before evaluating the stale trace signal', async () => {

--- a/web/src/utils/clipboard.test.ts
+++ b/web/src/utils/clipboard.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { copyToClipboard } from './clipboard';
+
+describe('copyToClipboard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it('writes text when the clipboard API is available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await copyToClipboard('trace-123');
+
+    expect(writeText).toHaveBeenCalledWith('trace-123');
+  });
+
+  it('rejects when the clipboard API is unavailable', async () => {
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+
+    await expect(copyToClipboard('trace-123')).rejects.toThrow(
+      'Clipboard API is unavailable'
+    );
+  });
+});

--- a/web/src/utils/clipboard.ts
+++ b/web/src/utils/clipboard.ts
@@ -1,0 +1,11 @@
+export async function copyToClipboard(text: string): Promise<void> {
+  if (
+    typeof navigator === 'undefined' ||
+    navigator.clipboard === undefined ||
+    typeof navigator.clipboard.writeText !== 'function'
+  ) {
+    throw new Error('Clipboard API is unavailable');
+  }
+
+  await navigator.clipboard.writeText(text);
+}

--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { formatBytes } from './format';
+
+describe('formatBytes', () => {
+  it('formats byte counts across supported units', () => {
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(2048)).toBe('2.0 KB');
+    expect(formatBytes(1048576)).toBe('1.0 MB');
+    expect(formatBytes(1073741824)).toBe('1.0 GB');
+  });
+});

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -33,6 +33,17 @@ export function formatCost(amount: number | undefined | null): string {
 }
 
 /**
+ * Format a byte count using binary units.
+ */
+export function formatBytes(bytes: number | undefined | null): string {
+  if (bytes === undefined || bytes === null) return '-';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
+  return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+}
+
+/**
  * Format a date to relative time (e.g., "2m ago").
  */
 export function formatRelativeTime(dateStr: string | undefined | null): string {

--- a/web/src/utils/payloadTree.test.ts
+++ b/web/src/utils/payloadTree.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPayloadTree,
+  collectExpandablePaths,
+  collectInitiallyExpandedPaths,
+  findPayloadMatches,
+} from './payloadTree';
+
+describe('payloadTree', () => {
+  it('builds object and array nodes with stable metadata', () => {
+    const tree = buildPayloadTree({
+      model: 'gpt-4',
+      messages: [{ role: 'user' }],
+    });
+
+    expect(tree.type).toBe('object');
+    expect(tree.childCount).toBe(2);
+    expect(tree.subtreeNodeCount).toBe(5);
+
+    if (tree.type !== 'object') {
+      throw new Error('Expected object root');
+    }
+
+    expect(tree.children[0]).toMatchObject({
+      key: 'model',
+      path: '$.model',
+      type: 'primitive',
+    });
+    expect(tree.children[1]).toMatchObject({
+      key: 'messages',
+      path: '$.messages',
+      type: 'array',
+    });
+  });
+
+  it('uses collision-safe paths for object keys that look like array accessors', () => {
+    const tree = buildPayloadTree({
+      'a[0]': {
+        nested: 'match first',
+      },
+      a: [
+        {
+          nested: 'match second',
+        },
+      ],
+      '0': 'string key',
+    });
+
+    if (tree.type !== 'object') {
+      throw new Error('Expected object root');
+    }
+
+    const bracketKeyNode = tree.children.find((child) => child.key === 'a[0]');
+    const arrayNode = tree.children.find((child) => child.key === 'a');
+    const numericStringNode = tree.children.find((child) => child.key === '0');
+
+    expect(bracketKeyNode).toMatchObject({
+      key: 'a[0]',
+      path: '$["a[0]"]',
+      type: 'object',
+    });
+    expect(arrayNode).toMatchObject({
+      key: 'a',
+      path: '$.a',
+      type: 'array',
+    });
+    expect(numericStringNode).toMatchObject({
+      key: '0',
+      path: '$["0"]',
+      type: 'primitive',
+    });
+
+    if (
+      !bracketKeyNode ||
+      !arrayNode ||
+      !numericStringNode ||
+      bracketKeyNode.type !== 'object' ||
+      arrayNode.type !== 'array'
+    ) {
+      throw new Error('Expected collection children');
+    }
+
+    expect(bracketKeyNode.children[0]).toMatchObject({
+      key: 'nested',
+      path: '$["a[0]"].nested',
+      type: 'primitive',
+    });
+    expect(arrayNode.children[0]).toMatchObject({
+      key: 0,
+      path: '$.a[0]',
+      type: 'object',
+    });
+
+    if (arrayNode.children[0].type !== 'object') {
+      throw new Error('Expected nested object node');
+    }
+
+    expect(arrayNode.children[0].children[0]).toMatchObject({
+      key: 'nested',
+      path: '$.a[0].nested',
+      type: 'primitive',
+    });
+
+    const matchIds = findPayloadMatches(tree, 'match').matches.map((match) => match.id);
+    expect(matchIds).toEqual([
+      '$["a[0]"].nested:value',
+      '$.a[0].nested:value',
+    ]);
+    expect(new Set(matchIds).size).toBe(matchIds.length);
+  });
+
+  it('builds primitive nodes for scalars and null values', () => {
+    expect(buildPayloadTree('hello')).toMatchObject({
+      type: 'primitive',
+      value: 'hello',
+      path: '$',
+    });
+    expect(buildPayloadTree(42)).toMatchObject({
+      type: 'primitive',
+      value: 42,
+      path: '$',
+    });
+    expect(buildPayloadTree(false)).toMatchObject({
+      type: 'primitive',
+      value: false,
+      path: '$',
+    });
+    expect(buildPayloadTree(null)).toMatchObject({
+      type: 'primitive',
+      value: null,
+      path: '$',
+    });
+  });
+
+  it('handles empty collections with expanded roots', () => {
+    const emptyObject = buildPayloadTree({});
+    const emptyArray = buildPayloadTree([]);
+
+    expect(emptyObject).toMatchObject({
+      type: 'object',
+      childCount: 0,
+      defaultExpanded: true,
+    });
+    expect(emptyArray).toMatchObject({
+      type: 'array',
+      childCount: 0,
+      defaultExpanded: true,
+    });
+  });
+
+  it('applies initial expansion rules for deep nesting and wide arrays', () => {
+    const wideArray = Array.from({ length: 201 }, (_, index) => index);
+    const tree = buildPayloadTree({
+      nested: {
+        deeper: {
+          leaf: true,
+        },
+      },
+      wide: wideArray,
+    });
+
+    if (tree.type !== 'object') {
+      throw new Error('Expected object root');
+    }
+
+    const nestedNode = tree.children[0];
+    const wideNode = tree.children[1];
+
+    expect(tree.defaultExpanded).toBe(true);
+    expect(nestedNode).toMatchObject({
+      type: 'object',
+      defaultExpanded: true,
+      depth: 1,
+    });
+    expect(wideNode).toMatchObject({
+      type: 'array',
+      defaultExpanded: false,
+      depth: 1,
+      childCount: 201,
+    });
+
+    if (nestedNode.type !== 'object') {
+      throw new Error('Expected nested object node');
+    }
+
+    const deeperNode = nestedNode.children[0];
+    expect(deeperNode).toMatchObject({
+      type: 'object',
+      defaultExpanded: false,
+      depth: 2,
+    });
+
+    expect(Array.from(collectInitiallyExpandedPaths(tree))).toEqual([
+      '$',
+      '$.nested',
+    ]);
+  });
+
+  it('finds case-insensitive key and value matches and expands ancestors', () => {
+    const tree = buildPayloadTree({
+      outer: {
+        Temperature: 42,
+        nested: {
+          message: 'Hello world',
+        },
+      },
+      plain: 'no match here',
+    });
+
+    const keyMatches = findPayloadMatches(tree, 'temp');
+    expect(keyMatches.matches).toEqual([
+      {
+        id: '$.outer.Temperature:key',
+        path: '$.outer.Temperature',
+        target: 'key',
+      },
+    ]);
+    expect(Array.from(keyMatches.expandedPaths)).toEqual(['$.outer', '$']);
+
+    const valueMatches = findPayloadMatches(tree, 'hello');
+    expect(valueMatches.matches).toEqual([
+      {
+        id: '$.outer.nested.message:value',
+        path: '$.outer.nested.message',
+        target: 'value',
+      },
+    ]);
+    expect(Array.from(valueMatches.expandedPaths)).toEqual([
+      '$.outer.nested',
+      '$.outer',
+      '$',
+    ]);
+  });
+
+  it('returns no matches for empty queries or collection values', () => {
+    const tree = buildPayloadTree({
+      payload: {
+        child: true,
+      },
+    });
+
+    expect(findPayloadMatches(tree, '   ')).toEqual({
+      expandedPaths: new Set<string>(),
+      matches: [],
+    });
+
+    const noCollectionMatches = findPayloadMatches(tree, '[object object]');
+    expect(noCollectionMatches.matches).toEqual([]);
+    expect(noCollectionMatches.expandedPaths.size).toBe(0);
+  });
+
+  it('collects all expandable paths and accurate subtree counts', () => {
+    const tree = buildPayloadTree({
+      outer: {
+        inner: [1, 2],
+      },
+    });
+
+    expect(tree.subtreeNodeCount).toBe(5);
+    expect(Array.from(collectExpandablePaths(tree))).toEqual([
+      '$',
+      '$.outer',
+      '$.outer.inner',
+    ]);
+  });
+});

--- a/web/src/utils/payloadTree.ts
+++ b/web/src/utils/payloadTree.ts
@@ -1,0 +1,298 @@
+export const INITIAL_COLLAPSE_DEPTH = 2;
+export const INITIAL_COLLAPSE_CHILD_COUNT = 200;
+export const MAX_EXPAND_ALL_NODE_COUNT = 5000;
+const SIMPLE_OBJECT_KEY_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+export type PayloadPathSegment = string | number;
+
+interface PayloadTreeNodeBase {
+  childCount: number;
+  defaultExpanded: boolean;
+  depth: number;
+  key: PayloadPathSegment | null;
+  path: string;
+  subtreeNodeCount: number;
+}
+
+export interface ObjectNode extends PayloadTreeNodeBase {
+  type: 'object';
+  children: TreeNode[];
+  value: Record<string, unknown>;
+}
+
+export interface ArrayNode extends PayloadTreeNodeBase {
+  type: 'array';
+  children: TreeNode[];
+  value: unknown[];
+}
+
+export interface PrimitiveNode extends PayloadTreeNodeBase {
+  type: 'primitive';
+  value: string | number | boolean | null;
+}
+
+export type TreeNode = ObjectNode | ArrayNode | PrimitiveNode;
+
+export interface PayloadMatch {
+  id: string;
+  path: string;
+  target: 'key' | 'value';
+}
+
+export interface PayloadSearchResult {
+  expandedPaths: Set<string>;
+  matches: PayloadMatch[];
+}
+
+export function buildPayloadTree(data: unknown): TreeNode {
+  return buildNode(data, null, '$', 0);
+}
+
+export function isCollectionNode(node: TreeNode): node is ObjectNode | ArrayNode {
+  return node.type === 'object' || node.type === 'array';
+}
+
+export function collectInitiallyExpandedPaths(root: TreeNode): Set<string> {
+  return collectPaths(root, (node) => node.defaultExpanded);
+}
+
+export function collectExpandablePaths(root: TreeNode): Set<string> {
+  return collectPaths(root, () => true);
+}
+
+export function findPayloadMatches(
+  root: TreeNode,
+  query: string
+): PayloadSearchResult {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return {
+      expandedPaths: new Set<string>(),
+      matches: [],
+    };
+  }
+
+  const matches: PayloadMatch[] = [];
+  const expandedPaths = new Set<string>();
+
+  walkMatches(root, normalizedQuery, matches, expandedPaths);
+
+  return {
+    expandedPaths,
+    matches,
+  };
+}
+
+export function describeCollection(node: ObjectNode | ArrayNode): string {
+  if (node.type === 'object') {
+    return `{${node.childCount} ${pluralize(node.childCount, 'key')}}`;
+  }
+
+  return `[${node.childCount} ${pluralize(node.childCount, 'item')}]`;
+}
+
+export function formatLeafValueForDisplay(
+  value: PrimitiveNode['value']
+): string {
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+
+  return String(value);
+}
+
+export function formatLeafValueForClipboard(
+  value: PrimitiveNode['value']
+): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return String(value);
+}
+
+export function serializeJsonForClipboard(value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value, null, 2);
+    return serialized ?? 'null';
+  } catch {
+    return String(value);
+  }
+}
+
+function buildNode(
+  value: unknown,
+  key: PayloadPathSegment | null,
+  path: string,
+  depth: number
+): TreeNode {
+  if (Array.isArray(value)) {
+    const children = value.map((item, index) =>
+      buildNode(item, index, appendPathSegment(path, index), depth + 1)
+    );
+
+    return {
+      type: 'array',
+      childCount: children.length,
+      children,
+      defaultExpanded: shouldDefaultExpand(depth, children.length),
+      depth,
+      key,
+      path,
+      subtreeNodeCount:
+        1 + children.reduce((total, child) => total + child.subtreeNodeCount, 0),
+      value,
+    };
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    const children = entries.map(([childKey, childValue]) =>
+      buildNode(childValue, childKey, appendPathSegment(path, childKey), depth + 1)
+    );
+
+    return {
+      type: 'object',
+      childCount: children.length,
+      children,
+      defaultExpanded: shouldDefaultExpand(depth, children.length),
+      depth,
+      key,
+      path,
+      subtreeNodeCount:
+        1 + children.reduce((total, child) => total + child.subtreeNodeCount, 0),
+      value: value as Record<string, unknown>,
+    };
+  }
+
+  return {
+    type: 'primitive',
+    childCount: 0,
+    defaultExpanded: false,
+    depth,
+    key,
+    path,
+    subtreeNodeCount: 1,
+    value: normalizePrimitive(value),
+  };
+}
+
+function normalizePrimitive(value: unknown): PrimitiveNode['value'] {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  return String(value);
+}
+
+function shouldDefaultExpand(depth: number, childCount: number): boolean {
+  if (depth >= INITIAL_COLLAPSE_DEPTH) {
+    return false;
+  }
+
+  return childCount <= INITIAL_COLLAPSE_CHILD_COUNT;
+}
+
+function collectPaths(
+  node: TreeNode,
+  predicate: (node: ObjectNode | ArrayNode) => boolean
+): Set<string> {
+  const paths = new Set<string>();
+  collectPathsRecursive(node, predicate, paths);
+  return paths;
+}
+
+function collectPathsRecursive(
+  node: TreeNode,
+  predicate: (node: ObjectNode | ArrayNode) => boolean,
+  paths: Set<string>
+) {
+  if (!isCollectionNode(node)) {
+    return;
+  }
+
+  if (predicate(node)) {
+    paths.add(node.path);
+  }
+
+  node.children.forEach((child) => {
+    collectPathsRecursive(child, predicate, paths);
+  });
+}
+
+function walkMatches(
+  node: TreeNode,
+  query: string,
+  matches: PayloadMatch[],
+  expandedPaths: Set<string>
+): boolean {
+  let hasMatch = false;
+
+  if (node.key !== null && String(node.key).toLowerCase().includes(query)) {
+    matches.push({
+      id: buildMatchId(node.path, 'key'),
+      path: node.path,
+      target: 'key',
+    });
+    hasMatch = true;
+  }
+
+  if (
+    node.type === 'primitive' &&
+    formatLeafValueForClipboard(node.value).toLowerCase().includes(query)
+  ) {
+    matches.push({
+      id: buildMatchId(node.path, 'value'),
+      path: node.path,
+      target: 'value',
+    });
+    hasMatch = true;
+  }
+
+  if (!isCollectionNode(node)) {
+    return hasMatch;
+  }
+
+  let childHasMatch = false;
+
+  for (const child of node.children) {
+    if (walkMatches(child, query, matches, expandedPaths)) {
+      childHasMatch = true;
+    }
+  }
+
+  if (childHasMatch) {
+    expandedPaths.add(node.path);
+  }
+
+  return hasMatch || childHasMatch;
+}
+
+function buildMatchId(path: string, target: PayloadMatch['target']): string {
+  return `${path}:${target}`;
+}
+
+function appendPathSegment(
+  path: string,
+  segment: PayloadPathSegment
+): string {
+  if (typeof segment === 'number') {
+    return `${path}[${segment}]`;
+  }
+
+  if (SIMPLE_OBJECT_KEY_PATTERN.test(segment)) {
+    return `${path}.${segment}`;
+  }
+
+  return `${path}[${JSON.stringify(segment)}]`;
+}
+
+function pluralize(value: number, label: string): string {
+  return `${label}${value === 1 ? '' : 's'}`;
+}

--- a/web/src/utils/traceDetailSearchParams.test.ts
+++ b/web/src/utils/traceDetailSearchParams.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSpanParam,
+  serializeSpanParam,
+} from './traceDetailSearchParams';
+
+describe('traceDetailSearchParams', () => {
+  it('parses a present span parameter', () => {
+    expect(parseSpanParam(new URLSearchParams('span=abc'))).toBe('abc');
+  });
+
+  it('normalizes empty and missing span parameters to null', () => {
+    expect(parseSpanParam(new URLSearchParams('span='))).toBeNull();
+    expect(parseSpanParam(new URLSearchParams('debug=true'))).toBeNull();
+  });
+
+  it('preserves unrelated params when serializing span changes', () => {
+    const next = serializeSpanParam(
+      new URLSearchParams('debug=true&span=abc'),
+      'def'
+    );
+
+    expect(next.toString()).toBe('debug=true&span=def');
+  });
+
+  it('removes span while preserving unrelated params', () => {
+    const next = serializeSpanParam(
+      new URLSearchParams('debug=true&span=abc'),
+      null
+    );
+
+    expect(next.toString()).toBe('debug=true');
+  });
+});

--- a/web/src/utils/traceDetailSearchParams.ts
+++ b/web/src/utils/traceDetailSearchParams.ts
@@ -1,0 +1,21 @@
+const SPAN_QUERY_PARAM = 'span';
+
+export function parseSpanParam(searchParams: URLSearchParams): string | null {
+  const span = searchParams.get(SPAN_QUERY_PARAM);
+  return span === null || span === '' ? null : span;
+}
+
+export function serializeSpanParam(
+  searchParams: URLSearchParams,
+  spanId: string | null
+): URLSearchParams {
+  const nextSearchParams = new URLSearchParams(searchParams);
+
+  if (spanId === null || spanId === '') {
+    nextSearchParams.delete(SPAN_QUERY_PARAM);
+    return nextSearchParams;
+  }
+
+  nextSearchParams.set(SPAN_QUERY_PARAM, spanId);
+  return nextSearchParams;
+}


### PR DESCRIPTION
## Summary
- add the Phase 8 payload inspector with local search, match navigation, copy actions, and truncation banners
- add deep-link span selection helpers and wire all trace detail selection entry points through the shared callback
- cover the new behavior with payload tree, inspector, copy button, truncation, and trace detail regression tests

## Validation
- pnpm --dir web type-check
- pnpm --dir web test
- pnpm --dir web lint
- openspec validate add-payload-inspection-deep-navigation --strict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**New Features**
* **Interactive Payload Inspector**: Explore JSON payloads with expandable/collapsible tree view, search across keys and values, and keyboard navigation.
* **Span Deep-Linking**: Navigate directly to specific spans via URL parameters with browser history support.
* **Copy Utilities**: Copy trace URLs, span IDs, and payload values to clipboard with visual feedback.
* **Truncation Indicators**: Display original payload sizes when payloads have been truncated.
* **Unified Span Navigation**: Select spans consistently across trace trees, breadcrumbs, timeline, and failure summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->