### PR TITLE
Implement session scale UX

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -151,6 +151,29 @@ const (
 	TraceDetailStatusRUNNING   TraceDetailStatus = "RUNNING"
 )
 
+// Defines values for ListSessionsParamsSortBy.
+const (
+	CreatedAt  ListSessionsParamsSortBy = "created_at"
+	TraceCount ListSessionsParamsSortBy = "trace_count"
+)
+
+// Defines values for ListSessionsParamsSortDir.
+const (
+	ListSessionsParamsSortDirAsc  ListSessionsParamsSortDir = "asc"
+	ListSessionsParamsSortDirDesc ListSessionsParamsSortDir = "desc"
+)
+
+// Defines values for ListTracesParamsSortBy.
+const (
+	StartedAt ListTracesParamsSortBy = "started_at"
+)
+
+// Defines values for ListTracesParamsSortDir.
+const (
+	ListTracesParamsSortDirAsc  ListTracesParamsSortDir = "asc"
+	ListTracesParamsSortDirDesc ListTracesParamsSortDir = "desc"
+)
+
 // Defines values for ListTracesParamsStatus.
 const (
 	Completed ListTracesParamsStatus = "completed"
@@ -445,16 +468,17 @@ type Trace struct {
 	EndedAt *time.Time `json:"ended_at,omitempty"`
 
 	// ErrorCount Count of failed spans in this trace
-	ErrorCount     *int                    `json:"error_count,omitempty"`
-	Id             openapi_types.UUID      `json:"id"`
-	Metadata       *map[string]interface{} `json:"metadata,omitempty"`
-	Name           string                  `json:"name"`
-	SessionId      *openapi_types.UUID     `json:"session_id,omitempty"`
-	StartedAt      time.Time               `json:"started_at"`
-	Status         TraceStatus             `json:"status"`
-	TotalCostUsd   *float32                `json:"total_cost_usd,omitempty"`
-	TotalTokensIn  *int                    `json:"total_tokens_in,omitempty"`
-	TotalTokensOut *int                    `json:"total_tokens_out,omitempty"`
+	ErrorCount        *int                    `json:"error_count,omitempty"`
+	Id                openapi_types.UUID      `json:"id"`
+	Metadata          *map[string]interface{} `json:"metadata,omitempty"`
+	Name              string                  `json:"name"`
+	SessionExternalId *string                 `json:"session_external_id,omitempty"`
+	SessionId         *openapi_types.UUID     `json:"session_id,omitempty"`
+	StartedAt         time.Time               `json:"started_at"`
+	Status            TraceStatus             `json:"status"`
+	TotalCostUsd      *float32                `json:"total_cost_usd,omitempty"`
+	TotalTokensIn     *int                    `json:"total_tokens_in,omitempty"`
+	TotalTokensOut    *int                    `json:"total_tokens_out,omitempty"`
 }
 
 // TraceStatus defines model for Trace.Status.
@@ -475,17 +499,18 @@ type TraceDetail struct {
 	Name     string                  `json:"name"`
 
 	// Output Trace output payload (any valid JSON)
-	Output         interface{}         `json:"output,omitempty"`
-	Release        *string             `json:"release,omitempty"`
-	SessionId      *openapi_types.UUID `json:"session_id,omitempty"`
-	StartedAt      time.Time           `json:"started_at"`
-	Status         TraceDetailStatus   `json:"status"`
-	Tags           *[]string           `json:"tags,omitempty"`
-	TotalCostUsd   *float32            `json:"total_cost_usd,omitempty"`
-	TotalTokensIn  *int                `json:"total_tokens_in,omitempty"`
-	TotalTokensOut *int                `json:"total_tokens_out,omitempty"`
-	TraceId        *string             `json:"trace_id,omitempty"`
-	UserId         *string             `json:"user_id,omitempty"`
+	Output            interface{}         `json:"output,omitempty"`
+	Release           *string             `json:"release,omitempty"`
+	SessionExternalId *string             `json:"session_external_id,omitempty"`
+	SessionId         *openapi_types.UUID `json:"session_id,omitempty"`
+	StartedAt         time.Time           `json:"started_at"`
+	Status            TraceDetailStatus   `json:"status"`
+	Tags              *[]string           `json:"tags,omitempty"`
+	TotalCostUsd      *float32            `json:"total_cost_usd,omitempty"`
+	TotalTokensIn     *int                `json:"total_tokens_in,omitempty"`
+	TotalTokensOut    *int                `json:"total_tokens_out,omitempty"`
+	TraceId           *string             `json:"trace_id,omitempty"`
+	UserId            *string             `json:"user_id,omitempty"`
 }
 
 // TraceDetailStatus defines model for TraceDetail.Status.
@@ -501,7 +526,25 @@ type TraceList struct {
 type ListSessionsParams struct {
 	Limit  *int `form:"limit,omitempty" json:"limit,omitempty"`
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// Q Search sessions by external ID or name
+	Q *string `form:"q,omitempty" json:"q,omitempty"`
+
+	// UserId Filter sessions by exact user ID
+	UserId *string `form:"user_id,omitempty" json:"user_id,omitempty"`
+
+	// SortBy Sort sessions by creation time or trace count. Ignored when q is present.
+	SortBy *ListSessionsParamsSortBy `form:"sort_by,omitempty" json:"sort_by,omitempty"`
+
+	// SortDir Sort direction for the selected session sort field. Ignored when q is present.
+	SortDir *ListSessionsParamsSortDir `form:"sort_dir,omitempty" json:"sort_dir,omitempty"`
 }
+
+// ListSessionsParamsSortBy defines parameters for ListSessions.
+type ListSessionsParamsSortBy string
+
+// ListSessionsParamsSortDir defines parameters for ListSessions.
+type ListSessionsParamsSortDir string
 
 // ListTracesParams defines parameters for ListTraces.
 type ListTracesParams struct {
@@ -511,6 +554,12 @@ type ListTracesParams struct {
 
 	// Q Full-text search query (searches trace name and user_id)
 	Q *string `form:"q,omitempty" json:"q,omitempty"`
+
+	// SortBy Sort traces by started time. Ignored when q is present.
+	SortBy *ListTracesParamsSortBy `form:"sort_by,omitempty" json:"sort_by,omitempty"`
+
+	// SortDir Sort direction for started time. Ignored when q is present.
+	SortDir *ListTracesParamsSortDir `form:"sort_dir,omitempty" json:"sort_dir,omitempty"`
 
 	// Status Filter by trace status
 	Status *ListTracesParamsStatus `form:"status,omitempty" json:"status,omitempty"`
@@ -530,6 +579,12 @@ type ListTracesParams struct {
 	// MinDurationMs Filter traces with duration >= this value in milliseconds
 	MinDurationMs *int64 `form:"min_duration_ms,omitempty" json:"min_duration_ms,omitempty"`
 }
+
+// ListTracesParamsSortBy defines parameters for ListTraces.
+type ListTracesParamsSortBy string
+
+// ListTracesParamsSortDir defines parameters for ListTraces.
+type ListTracesParamsSortDir string
 
 // ListTracesParamsStatus defines parameters for ListTraces.
 type ListTracesParamsStatus string
@@ -676,6 +731,38 @@ func (siw *ServerInterfaceWrapper) ListSessions(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// ------------- Optional query parameter "q" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "q", r.URL.Query(), &params.Q)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "user_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "user_id", r.URL.Query(), &params.UserId)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "user_id", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sort_by" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sort_by", r.URL.Query(), &params.SortBy)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sort_dir" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sort_dir", r.URL.Query(), &params.SortDir)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListSessions(w, r, params)
 	}))
@@ -761,6 +848,22 @@ func (siw *ServerInterfaceWrapper) ListTraces(w http.ResponseWriter, r *http.Req
 	err = runtime.BindQueryParameter("form", true, false, "q", r.URL.Query(), &params.Q)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sort_by" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sort_by", r.URL.Query(), &params.SortBy)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sort_dir" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sort_dir", r.URL.Query(), &params.SortDir)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
 		return
 	}
 

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -167,6 +167,7 @@ export interface components {
             id: string;
             /** Format: uuid */
             session_id?: string;
+            session_external_id?: string;
             name: string;
             /** @enum {string} */
             status: "RUNNING" | "COMPLETED" | "FAILED";
@@ -579,6 +580,10 @@ export interface operations {
                 session_id?: string;
                 /** @description Full-text search query (searches trace name and user_id) */
                 q?: string;
+                /** @description Sort traces by started time. Ignored when q is present. */
+                sort_by?: "started_at";
+                /** @description Sort direction for started time. Ignored when q is present. */
+                sort_dir?: "asc" | "desc";
                 /** @description Filter by trace status */
                 status?: "running" | "completed" | "failed";
                 /** @description Filter traces starting at or after this time */
@@ -757,6 +762,14 @@ export interface operations {
             query?: {
                 limit?: number;
                 offset?: number;
+                /** @description Search sessions by external ID or name */
+                q?: string;
+                /** @description Filter sessions by exact user ID */
+                user_id?: string;
+                /** @description Sort sessions by creation time or trace count. Ignored when q is present. */
+                sort_by?: "created_at" | "trace_count";
+                /** @description Sort direction for the selected session sort field. Ignored when q is present. */
+                sort_dir?: "asc" | "desc";
             };
             header?: never;
             path?: never;

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -134,6 +134,21 @@ paths:
           description: Full-text search query (searches trace name and user_id)
           schema:
             type: string
+        - name: sort_by
+          in: query
+          description: Sort traces by started time. Ignored when q is present.
+          schema:
+            type: string
+            enum:
+              - started_at
+        - name: sort_dir
+          in: query
+          description: Sort direction for started time. Ignored when q is present.
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
         - name: status
           in: query
           description: Filter by trace status
@@ -316,6 +331,32 @@ paths:
           schema:
             type: integer
             default: 0
+        - name: q
+          in: query
+          description: Search sessions by external ID or name
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: Filter sessions by exact user ID
+          schema:
+            type: string
+        - name: sort_by
+          in: query
+          description: Sort sessions by creation time or trace count. Ignored when q is present.
+          schema:
+            type: string
+            enum:
+              - created_at
+              - trace_count
+        - name: sort_dir
+          in: query
+          description: Sort direction for the selected session sort field. Ignored when q is present.
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
       responses:
         '200':
           description: List of sessions
@@ -402,6 +443,8 @@ components:
         session_id:
           type: string
           format: uuid
+        session_external_id:
+          type: string
         name:
           type: string
         status:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -139,6 +139,18 @@ paths:
           description: Full-text search query (searches trace name and user_id)
           schema:
             type: string
+        - name: sort_by
+          in: query
+          description: Sort traces by started time. Ignored when q is present.
+          schema:
+            type: string
+            enum: [started_at]
+        - name: sort_dir
+          in: query
+          description: Sort direction for started time. Ignored when q is present.
+          schema:
+            type: string
+            enum: [asc, desc]
         - name: status
           in: query
           description: Filter by trace status
@@ -318,6 +330,28 @@ paths:
           schema:
             type: integer
             default: 0
+        - name: q
+          in: query
+          description: Search sessions by external ID or name
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: Filter sessions by exact user ID
+          schema:
+            type: string
+        - name: sort_by
+          in: query
+          description: Sort sessions by creation time or trace count. Ignored when q is present.
+          schema:
+            type: string
+            enum: [created_at, trace_count]
+        - name: sort_dir
+          in: query
+          description: Sort direction for the selected session sort field. Ignored when q is present.
+          schema:
+            type: string
+            enum: [asc, desc]
       responses:
         '200':
           description: List of sessions
@@ -401,6 +435,8 @@ components:
         session_id:
           type: string
           format: uuid
+        session_external_id:
+          type: string
         name:
           type: string
         status:

--- a/db/gen/go/platform/sessions.sql.go
+++ b/db/gen/go/platform/sessions.sql.go
@@ -147,7 +147,7 @@ func (q *Queries) GetSessionWithTraceCount(ctx context.Context, id uuid.UUID) (G
 const listSessions = `-- name: ListSessions :many
 SELECT id, project_id, name, user_id, metadata, created_at, updated_at, external_id FROM sessions
 WHERE project_id = $1
-ORDER BY created_at DESC
+ORDER BY created_at DESC, id DESC
 LIMIT $2 OFFSET $3
 `
 
@@ -191,7 +191,7 @@ SELECT s.id, s.project_id, s.name, s.user_id, s.metadata, s.created_at, s.update
     (SELECT COUNT(*) FROM traces t WHERE t.session_id = s.id AND t.project_id = s.project_id) as trace_count
 FROM sessions s
 WHERE s.project_id = $1
-ORDER BY s.created_at DESC
+ORDER BY s.created_at DESC, s.id DESC
 LIMIT $2 OFFSET $3
 `
 

--- a/db/gen/go/platform/traces.sql.go
+++ b/db/gen/go/platform/traces.sql.go
@@ -116,39 +116,48 @@ func (q *Queries) CreateTrace(ctx context.Context, arg CreateTraceParams) (Trace
 }
 
 const getTrace = `-- name: GetTrace :one
-SELECT id, project_id, session_id, trace_id, name, user_id, tags, environment, release, metadata, input, output, status, start_time, end_time, server_received_at, duration_ms, total_spans, total_cost, error_count, version, created_at, updated_at, search_vector, total_tokens_in, total_tokens_out FROM traces WHERE id = $1
+SELECT t.id, t.project_id, t.session_id, t.trace_id, t.name, t.user_id, t.tags, t.environment, t.release, t.metadata, t.input, t.output, t.status, t.start_time, t.end_time, t.server_received_at, t.duration_ms, t.total_spans, t.total_cost, t.error_count, t.version, t.created_at, t.updated_at, t.search_vector, t.total_tokens_in, t.total_tokens_out, s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.id = $1
 `
 
-func (q *Queries) GetTrace(ctx context.Context, id uuid.UUID) (Trace, error) {
+type GetTraceRow struct {
+	Trace             Trace   `json:"trace"`
+	SessionExternalID *string `json:"session_external_id"`
+}
+
+func (q *Queries) GetTrace(ctx context.Context, id uuid.UUID) (GetTraceRow, error) {
 	row := q.db.QueryRow(ctx, getTrace, id)
-	var i Trace
+	var i GetTraceRow
 	err := row.Scan(
-		&i.ID,
-		&i.ProjectID,
-		&i.SessionID,
-		&i.TraceID,
-		&i.Name,
-		&i.UserID,
-		&i.Tags,
-		&i.Environment,
-		&i.Release,
-		&i.Metadata,
-		&i.Input,
-		&i.Output,
-		&i.Status,
-		&i.StartTime,
-		&i.EndTime,
-		&i.ServerReceivedAt,
-		&i.DurationMs,
-		&i.TotalSpans,
-		&i.TotalCost,
-		&i.ErrorCount,
-		&i.Version,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SearchVector,
-		&i.TotalTokensIn,
-		&i.TotalTokensOut,
+		&i.Trace.ID,
+		&i.Trace.ProjectID,
+		&i.Trace.SessionID,
+		&i.Trace.TraceID,
+		&i.Trace.Name,
+		&i.Trace.UserID,
+		&i.Trace.Tags,
+		&i.Trace.Environment,
+		&i.Trace.Release,
+		&i.Trace.Metadata,
+		&i.Trace.Input,
+		&i.Trace.Output,
+		&i.Trace.Status,
+		&i.Trace.StartTime,
+		&i.Trace.EndTime,
+		&i.Trace.ServerReceivedAt,
+		&i.Trace.DurationMs,
+		&i.Trace.TotalSpans,
+		&i.Trace.TotalCost,
+		&i.Trace.ErrorCount,
+		&i.Trace.Version,
+		&i.Trace.CreatedAt,
+		&i.Trace.UpdatedAt,
+		&i.Trace.SearchVector,
+		&i.Trace.TotalTokensIn,
+		&i.Trace.TotalTokensOut,
+		&i.SessionExternalID,
 	)
 	return i, err
 }
@@ -225,9 +234,11 @@ func (q *Queries) GetTraceVersion(ctx context.Context, id uuid.UUID) (*int32, er
 }
 
 const listTraces = `-- name: ListTraces :many
-SELECT id, project_id, session_id, trace_id, name, user_id, tags, environment, release, metadata, input, output, status, start_time, end_time, server_received_at, duration_ms, total_spans, total_cost, error_count, version, created_at, updated_at, search_vector, total_tokens_in, total_tokens_out FROM traces
-WHERE project_id = $1
-ORDER BY COALESCE(start_time, server_received_at) DESC
+SELECT t.id, t.project_id, t.session_id, t.trace_id, t.name, t.user_id, t.tags, t.environment, t.release, t.metadata, t.input, t.output, t.status, t.start_time, t.end_time, t.server_received_at, t.duration_ms, t.total_spans, t.total_cost, t.error_count, t.version, t.created_at, t.updated_at, t.search_vector, t.total_tokens_in, t.total_tokens_out, s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.project_id = $1
+ORDER BY COALESCE(t.start_time, t.server_received_at) DESC, t.id DESC
 LIMIT $2 OFFSET $3
 `
 
@@ -237,42 +248,116 @@ type ListTracesParams struct {
 	Offset    int32     `json:"offset"`
 }
 
-func (q *Queries) ListTraces(ctx context.Context, arg ListTracesParams) ([]Trace, error) {
+type ListTracesRow struct {
+	Trace             Trace   `json:"trace"`
+	SessionExternalID *string `json:"session_external_id"`
+}
+
+func (q *Queries) ListTraces(ctx context.Context, arg ListTracesParams) ([]ListTracesRow, error) {
 	rows, err := q.db.Query(ctx, listTraces, arg.ProjectID, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Trace{}
+	items := []ListTracesRow{}
 	for rows.Next() {
-		var i Trace
+		var i ListTracesRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.ProjectID,
-			&i.SessionID,
-			&i.TraceID,
-			&i.Name,
-			&i.UserID,
-			&i.Tags,
-			&i.Environment,
-			&i.Release,
-			&i.Metadata,
-			&i.Input,
-			&i.Output,
-			&i.Status,
-			&i.StartTime,
-			&i.EndTime,
-			&i.ServerReceivedAt,
-			&i.DurationMs,
-			&i.TotalSpans,
-			&i.TotalCost,
-			&i.ErrorCount,
-			&i.Version,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.SearchVector,
-			&i.TotalTokensIn,
-			&i.TotalTokensOut,
+			&i.Trace.ID,
+			&i.Trace.ProjectID,
+			&i.Trace.SessionID,
+			&i.Trace.TraceID,
+			&i.Trace.Name,
+			&i.Trace.UserID,
+			&i.Trace.Tags,
+			&i.Trace.Environment,
+			&i.Trace.Release,
+			&i.Trace.Metadata,
+			&i.Trace.Input,
+			&i.Trace.Output,
+			&i.Trace.Status,
+			&i.Trace.StartTime,
+			&i.Trace.EndTime,
+			&i.Trace.ServerReceivedAt,
+			&i.Trace.DurationMs,
+			&i.Trace.TotalSpans,
+			&i.Trace.TotalCost,
+			&i.Trace.ErrorCount,
+			&i.Trace.Version,
+			&i.Trace.CreatedAt,
+			&i.Trace.UpdatedAt,
+			&i.Trace.SearchVector,
+			&i.Trace.TotalTokensIn,
+			&i.Trace.TotalTokensOut,
+			&i.SessionExternalID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTracesAsc = `-- name: ListTracesAsc :many
+SELECT t.id, t.project_id, t.session_id, t.trace_id, t.name, t.user_id, t.tags, t.environment, t.release, t.metadata, t.input, t.output, t.status, t.start_time, t.end_time, t.server_received_at, t.duration_ms, t.total_spans, t.total_cost, t.error_count, t.version, t.created_at, t.updated_at, t.search_vector, t.total_tokens_in, t.total_tokens_out, s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.project_id = $1
+ORDER BY COALESCE(t.start_time, t.server_received_at) ASC, t.id ASC
+LIMIT $2 OFFSET $3
+`
+
+type ListTracesAscParams struct {
+	ProjectID uuid.UUID `json:"project_id"`
+	Limit     int32     `json:"limit"`
+	Offset    int32     `json:"offset"`
+}
+
+type ListTracesAscRow struct {
+	Trace             Trace   `json:"trace"`
+	SessionExternalID *string `json:"session_external_id"`
+}
+
+func (q *Queries) ListTracesAsc(ctx context.Context, arg ListTracesAscParams) ([]ListTracesAscRow, error) {
+	rows, err := q.db.Query(ctx, listTracesAsc, arg.ProjectID, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListTracesAscRow{}
+	for rows.Next() {
+		var i ListTracesAscRow
+		if err := rows.Scan(
+			&i.Trace.ID,
+			&i.Trace.ProjectID,
+			&i.Trace.SessionID,
+			&i.Trace.TraceID,
+			&i.Trace.Name,
+			&i.Trace.UserID,
+			&i.Trace.Tags,
+			&i.Trace.Environment,
+			&i.Trace.Release,
+			&i.Trace.Metadata,
+			&i.Trace.Input,
+			&i.Trace.Output,
+			&i.Trace.Status,
+			&i.Trace.StartTime,
+			&i.Trace.EndTime,
+			&i.Trace.ServerReceivedAt,
+			&i.Trace.DurationMs,
+			&i.Trace.TotalSpans,
+			&i.Trace.TotalCost,
+			&i.Trace.ErrorCount,
+			&i.Trace.Version,
+			&i.Trace.CreatedAt,
+			&i.Trace.UpdatedAt,
+			&i.Trace.SearchVector,
+			&i.Trace.TotalTokensIn,
+			&i.Trace.TotalTokensOut,
+			&i.SessionExternalID,
 		); err != nil {
 			return nil, err
 		}
@@ -285,9 +370,11 @@ func (q *Queries) ListTraces(ctx context.Context, arg ListTracesParams) ([]Trace
 }
 
 const listTracesBySession = `-- name: ListTracesBySession :many
-SELECT id, project_id, session_id, trace_id, name, user_id, tags, environment, release, metadata, input, output, status, start_time, end_time, server_received_at, duration_ms, total_spans, total_cost, error_count, version, created_at, updated_at, search_vector, total_tokens_in, total_tokens_out FROM traces
-WHERE project_id = $1 AND session_id = $2
-ORDER BY COALESCE(start_time, server_received_at) DESC
+SELECT t.id, t.project_id, t.session_id, t.trace_id, t.name, t.user_id, t.tags, t.environment, t.release, t.metadata, t.input, t.output, t.status, t.start_time, t.end_time, t.server_received_at, t.duration_ms, t.total_spans, t.total_cost, t.error_count, t.version, t.created_at, t.updated_at, t.search_vector, t.total_tokens_in, t.total_tokens_out, s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.project_id = $1 AND t.session_id = $2
+ORDER BY COALESCE(t.start_time, t.server_received_at) DESC, t.id DESC
 LIMIT $3 OFFSET $4
 `
 
@@ -298,7 +385,12 @@ type ListTracesBySessionParams struct {
 	Offset    int32       `json:"offset"`
 }
 
-func (q *Queries) ListTracesBySession(ctx context.Context, arg ListTracesBySessionParams) ([]Trace, error) {
+type ListTracesBySessionRow struct {
+	Trace             Trace   `json:"trace"`
+	SessionExternalID *string `json:"session_external_id"`
+}
+
+func (q *Queries) ListTracesBySession(ctx context.Context, arg ListTracesBySessionParams) ([]ListTracesBySessionRow, error) {
 	rows, err := q.db.Query(ctx, listTracesBySession,
 		arg.ProjectID,
 		arg.SessionID,
@@ -309,36 +401,111 @@ func (q *Queries) ListTracesBySession(ctx context.Context, arg ListTracesBySessi
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Trace{}
+	items := []ListTracesBySessionRow{}
 	for rows.Next() {
-		var i Trace
+		var i ListTracesBySessionRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.ProjectID,
-			&i.SessionID,
-			&i.TraceID,
-			&i.Name,
-			&i.UserID,
-			&i.Tags,
-			&i.Environment,
-			&i.Release,
-			&i.Metadata,
-			&i.Input,
-			&i.Output,
-			&i.Status,
-			&i.StartTime,
-			&i.EndTime,
-			&i.ServerReceivedAt,
-			&i.DurationMs,
-			&i.TotalSpans,
-			&i.TotalCost,
-			&i.ErrorCount,
-			&i.Version,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.SearchVector,
-			&i.TotalTokensIn,
-			&i.TotalTokensOut,
+			&i.Trace.ID,
+			&i.Trace.ProjectID,
+			&i.Trace.SessionID,
+			&i.Trace.TraceID,
+			&i.Trace.Name,
+			&i.Trace.UserID,
+			&i.Trace.Tags,
+			&i.Trace.Environment,
+			&i.Trace.Release,
+			&i.Trace.Metadata,
+			&i.Trace.Input,
+			&i.Trace.Output,
+			&i.Trace.Status,
+			&i.Trace.StartTime,
+			&i.Trace.EndTime,
+			&i.Trace.ServerReceivedAt,
+			&i.Trace.DurationMs,
+			&i.Trace.TotalSpans,
+			&i.Trace.TotalCost,
+			&i.Trace.ErrorCount,
+			&i.Trace.Version,
+			&i.Trace.CreatedAt,
+			&i.Trace.UpdatedAt,
+			&i.Trace.SearchVector,
+			&i.Trace.TotalTokensIn,
+			&i.Trace.TotalTokensOut,
+			&i.SessionExternalID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTracesBySessionAsc = `-- name: ListTracesBySessionAsc :many
+SELECT t.id, t.project_id, t.session_id, t.trace_id, t.name, t.user_id, t.tags, t.environment, t.release, t.metadata, t.input, t.output, t.status, t.start_time, t.end_time, t.server_received_at, t.duration_ms, t.total_spans, t.total_cost, t.error_count, t.version, t.created_at, t.updated_at, t.search_vector, t.total_tokens_in, t.total_tokens_out, s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.project_id = $1 AND t.session_id = $2
+ORDER BY COALESCE(t.start_time, t.server_received_at) ASC, t.id ASC
+LIMIT $3 OFFSET $4
+`
+
+type ListTracesBySessionAscParams struct {
+	ProjectID uuid.UUID   `json:"project_id"`
+	SessionID pgtype.UUID `json:"session_id"`
+	Limit     int32       `json:"limit"`
+	Offset    int32       `json:"offset"`
+}
+
+type ListTracesBySessionAscRow struct {
+	Trace             Trace   `json:"trace"`
+	SessionExternalID *string `json:"session_external_id"`
+}
+
+func (q *Queries) ListTracesBySessionAsc(ctx context.Context, arg ListTracesBySessionAscParams) ([]ListTracesBySessionAscRow, error) {
+	rows, err := q.db.Query(ctx, listTracesBySessionAsc,
+		arg.ProjectID,
+		arg.SessionID,
+		arg.Limit,
+		arg.Offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListTracesBySessionAscRow{}
+	for rows.Next() {
+		var i ListTracesBySessionAscRow
+		if err := rows.Scan(
+			&i.Trace.ID,
+			&i.Trace.ProjectID,
+			&i.Trace.SessionID,
+			&i.Trace.TraceID,
+			&i.Trace.Name,
+			&i.Trace.UserID,
+			&i.Trace.Tags,
+			&i.Trace.Environment,
+			&i.Trace.Release,
+			&i.Trace.Metadata,
+			&i.Trace.Input,
+			&i.Trace.Output,
+			&i.Trace.Status,
+			&i.Trace.StartTime,
+			&i.Trace.EndTime,
+			&i.Trace.ServerReceivedAt,
+			&i.Trace.DurationMs,
+			&i.Trace.TotalSpans,
+			&i.Trace.TotalCost,
+			&i.Trace.ErrorCount,
+			&i.Trace.Version,
+			&i.Trace.CreatedAt,
+			&i.Trace.UpdatedAt,
+			&i.Trace.SearchVector,
+			&i.Trace.TotalTokensIn,
+			&i.Trace.TotalTokensOut,
+			&i.SessionExternalID,
 		); err != nil {
 			return nil, err
 		}

--- a/db/platform/migrations/postgres/000012_sessions_created_pagination_index.down.sql
+++ b/db/platform/migrations/postgres/000012_sessions_created_pagination_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_sessions_project_created_id_desc;

--- a/db/platform/migrations/postgres/000012_sessions_created_pagination_index.up.sql
+++ b/db/platform/migrations/postgres/000012_sessions_created_pagination_index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_sessions_project_created_id_desc
+    ON sessions(project_id, created_at DESC, id DESC);

--- a/db/platform/queries/sessions.sql
+++ b/db/platform/queries/sessions.sql
@@ -10,7 +10,7 @@ WHERE s.id = $1;
 -- name: ListSessions :many
 SELECT * FROM sessions
 WHERE project_id = $1
-ORDER BY created_at DESC
+ORDER BY created_at DESC, id DESC
 LIMIT $2 OFFSET $3;
 
 -- name: ListSessionsWithTraceCount :many
@@ -18,7 +18,7 @@ SELECT s.*,
     (SELECT COUNT(*) FROM traces t WHERE t.session_id = s.id AND t.project_id = s.project_id) as trace_count
 FROM sessions s
 WHERE s.project_id = $1
-ORDER BY s.created_at DESC
+ORDER BY s.created_at DESC, s.id DESC
 LIMIT $2 OFFSET $3;
 
 -- name: CountSessions :one

--- a/db/platform/queries/traces.sql
+++ b/db/platform/queries/traces.sql
@@ -1,5 +1,8 @@
 -- name: GetTrace :one
-SELECT * FROM traces WHERE id = $1;
+SELECT sqlc.embed(t), s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.id = $1;
 
 -- name: GetTraceVersion :one
 -- Get trace version for optimistic concurrency checks (e.g., rollup re-enqueue).
@@ -12,15 +15,35 @@ SELECT * FROM traces WHERE project_id = $1 AND trace_id = $2;
 SELECT id FROM traces WHERE project_id = $1 AND trace_id = $2;
 
 -- name: ListTraces :many
-SELECT * FROM traces
-WHERE project_id = $1
-ORDER BY COALESCE(start_time, server_received_at) DESC
+SELECT sqlc.embed(t), s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.project_id = $1
+ORDER BY COALESCE(t.start_time, t.server_received_at) DESC, t.id DESC
+LIMIT $2 OFFSET $3;
+
+-- name: ListTracesAsc :many
+SELECT sqlc.embed(t), s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.project_id = $1
+ORDER BY COALESCE(t.start_time, t.server_received_at) ASC, t.id ASC
 LIMIT $2 OFFSET $3;
 
 -- name: ListTracesBySession :many
-SELECT * FROM traces
-WHERE project_id = $1 AND session_id = $2
-ORDER BY COALESCE(start_time, server_received_at) DESC
+SELECT sqlc.embed(t), s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.project_id = $1 AND t.session_id = $2
+ORDER BY COALESCE(t.start_time, t.server_received_at) DESC, t.id DESC
+LIMIT $3 OFFSET $4;
+
+-- name: ListTracesBySessionAsc :many
+SELECT sqlc.embed(t), s.external_id AS session_external_id
+FROM traces t
+LEFT JOIN sessions s ON s.id = t.session_id AND s.project_id = t.project_id
+WHERE t.project_id = $1 AND t.session_id = $2
+ORDER BY COALESCE(t.start_time, t.server_received_at) ASC, t.id ASC
 LIMIT $3 OFFSET $4;
 
 -- name: CountTraces :one

--- a/internal/api/mapper.go
+++ b/internal/api/mapper.go
@@ -8,10 +8,11 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/store"
 )
 
 // traceToAPI converts a database trace to an API trace.
-func traceToAPI(t *platform.Trace) Trace {
+func traceToAPI(t *store.TraceRead) Trace {
 	trace := Trace{
 		Id:     t.ID,
 		Name:   deref(t.Name),
@@ -22,6 +23,9 @@ func traceToAPI(t *platform.Trace) Trace {
 	if t.SessionID.Valid {
 		id := openapi_types.UUID(t.SessionID.Bytes)
 		trace.SessionId = &id
+	}
+	if t.SessionExternalID != nil {
+		trace.SessionExternalId = t.SessionExternalID
 	}
 
 	// Start time
@@ -71,20 +75,21 @@ func traceToAPI(t *platform.Trace) Trace {
 // composing the summary mapper output with debugger-specific fields.
 // NOTE: oapi-codegen currently flattens TraceDetail's allOf shape, so any new
 // summary fields added to traceToAPI must also be copied into TraceDetail here.
-func traceDetailToAPI(t *platform.Trace) TraceDetail {
+func traceDetailToAPI(t *store.TraceRead) TraceDetail {
 	summary := traceToAPI(t)
 	trace := TraceDetail{
-		Id:             summary.Id,
-		Name:           summary.Name,
-		Status:         TraceDetailStatus(summary.Status),
-		StartedAt:      summary.StartedAt,
-		EndedAt:        summary.EndedAt,
-		SessionId:      summary.SessionId,
-		TotalTokensIn:  summary.TotalTokensIn,
-		TotalTokensOut: summary.TotalTokensOut,
-		TotalCostUsd:   summary.TotalCostUsd,
-		ErrorCount:     summary.ErrorCount,
-		Metadata:       summary.Metadata,
+		Id:                summary.Id,
+		Name:              summary.Name,
+		Status:            TraceDetailStatus(summary.Status),
+		StartedAt:         summary.StartedAt,
+		EndedAt:           summary.EndedAt,
+		SessionId:         summary.SessionId,
+		SessionExternalId: summary.SessionExternalId,
+		TotalTokensIn:     summary.TotalTokensIn,
+		TotalTokensOut:    summary.TotalTokensOut,
+		TotalCostUsd:      summary.TotalCostUsd,
+		ErrorCount:        summary.ErrorCount,
+		Metadata:          summary.Metadata,
 	}
 
 	if t.TraceID != "" {

--- a/internal/api/mapper_trace_test.go
+++ b/internal/api/mapper_trace_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/store"
 	"github.com/continua-ai/continua/internal/testutil"
 )
 
@@ -19,6 +20,7 @@ func TestTraceDetailToAPI_MapsSummaryAndDetailFields(t *testing.T) {
 	end := start.Add(45 * time.Second)
 	sessionID := uuid.New()
 	name := "Debugger Trace"
+	sessionExternalID := "conv-123"
 	userID := "user@example.com"
 	environment := "production"
 	release := "v1.2.3"
@@ -42,7 +44,10 @@ func TestTraceDetailToAPI_MapsSummaryAndDetailFields(t *testing.T) {
 		ServerReceivedAt: start.Add(-time.Second),
 	}
 
-	detail := traceDetailToAPI(&trace)
+	detail := traceDetailToAPI(&store.TraceRead{
+		Trace:             trace,
+		SessionExternalID: &sessionExternalID,
+	})
 
 	assert.Equal(t, trace.ID, detail.Id)
 	assert.Equal(t, name, detail.Name)
@@ -52,6 +57,8 @@ func TestTraceDetailToAPI_MapsSummaryAndDetailFields(t *testing.T) {
 	assert.Equal(t, end, *detail.EndedAt)
 	require.NotNil(t, detail.SessionId)
 	assert.Equal(t, sessionID, *detail.SessionId)
+	require.NotNil(t, detail.SessionExternalId)
+	assert.Equal(t, sessionExternalID, *detail.SessionExternalId)
 	require.NotNil(t, detail.TotalTokensIn)
 	assert.Equal(t, 12, *detail.TotalTokensIn)
 	require.NotNil(t, detail.TotalTokensOut)
@@ -81,7 +88,7 @@ func TestTraceDetailToAPI_TagsMapping(t *testing.T) {
 			Tags:      []string{},
 		}
 
-		detail := traceDetailToAPI(&trace)
+		detail := traceDetailToAPI(&store.TraceRead{Trace: trace})
 		assert.Nil(t, detail.Tags)
 	})
 
@@ -95,7 +102,7 @@ func TestTraceDetailToAPI_TagsMapping(t *testing.T) {
 			Tags:      []string{"prod", "v2"},
 		}
 
-		detail := traceDetailToAPI(&trace)
+		detail := traceDetailToAPI(&store.TraceRead{Trace: trace})
 		require.NotNil(t, detail.Tags)
 		assert.Equal(t, []string{"prod", "v2"}, *detail.Tags)
 	})
@@ -126,7 +133,7 @@ func TestTraceDetailToAPI_PreservesArbitraryJSON(t *testing.T) {
 				Output:    []byte(tc.json),
 			}
 
-			detail := traceDetailToAPI(&trace)
+			detail := traceDetailToAPI(&store.TraceRead{Trace: trace})
 
 			payload, err := json.Marshal(detail)
 			require.NoError(t, err)

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -288,7 +288,7 @@ func TestMultiTenancy_ListTracesScoped(t *testing.T) {
 
 	// Should only see project A's trace
 	assert.Len(t, tracesA, 1)
-	assert.Equal(t, "trace-project-a", tracesA[0].TraceID)
+	assert.Equal(t, "trace-project-a", tracesA[0].Trace.TraceID)
 
 	// Query traces for project B
 	tracesB, err := q.ListTraces(ctx, platform.ListTracesParams{
@@ -300,7 +300,7 @@ func TestMultiTenancy_ListTracesScoped(t *testing.T) {
 
 	// Should only see project B's trace
 	assert.Len(t, tracesB, 1)
-	assert.Equal(t, "trace-project-b", tracesB[0].TraceID)
+	assert.Equal(t, "trace-project-b", tracesB[0].Trace.TraceID)
 }
 
 func TestMultiTenancy_GetTraceReturns404ForOtherProject(t *testing.T) {

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -151,6 +151,29 @@ const (
 	TraceDetailStatusRUNNING   TraceDetailStatus = "RUNNING"
 )
 
+// Defines values for ListSessionsParamsSortBy.
+const (
+	CreatedAt  ListSessionsParamsSortBy = "created_at"
+	TraceCount ListSessionsParamsSortBy = "trace_count"
+)
+
+// Defines values for ListSessionsParamsSortDir.
+const (
+	ListSessionsParamsSortDirAsc  ListSessionsParamsSortDir = "asc"
+	ListSessionsParamsSortDirDesc ListSessionsParamsSortDir = "desc"
+)
+
+// Defines values for ListTracesParamsSortBy.
+const (
+	StartedAt ListTracesParamsSortBy = "started_at"
+)
+
+// Defines values for ListTracesParamsSortDir.
+const (
+	ListTracesParamsSortDirAsc  ListTracesParamsSortDir = "asc"
+	ListTracesParamsSortDirDesc ListTracesParamsSortDir = "desc"
+)
+
 // Defines values for ListTracesParamsStatus.
 const (
 	Completed ListTracesParamsStatus = "completed"
@@ -445,16 +468,17 @@ type Trace struct {
 	EndedAt *time.Time `json:"ended_at,omitempty"`
 
 	// ErrorCount Count of failed spans in this trace
-	ErrorCount     *int                    `json:"error_count,omitempty"`
-	Id             openapi_types.UUID      `json:"id"`
-	Metadata       *map[string]interface{} `json:"metadata,omitempty"`
-	Name           string                  `json:"name"`
-	SessionId      *openapi_types.UUID     `json:"session_id,omitempty"`
-	StartedAt      time.Time               `json:"started_at"`
-	Status         TraceStatus             `json:"status"`
-	TotalCostUsd   *float32                `json:"total_cost_usd,omitempty"`
-	TotalTokensIn  *int                    `json:"total_tokens_in,omitempty"`
-	TotalTokensOut *int                    `json:"total_tokens_out,omitempty"`
+	ErrorCount        *int                    `json:"error_count,omitempty"`
+	Id                openapi_types.UUID      `json:"id"`
+	Metadata          *map[string]interface{} `json:"metadata,omitempty"`
+	Name              string                  `json:"name"`
+	SessionExternalId *string                 `json:"session_external_id,omitempty"`
+	SessionId         *openapi_types.UUID     `json:"session_id,omitempty"`
+	StartedAt         time.Time               `json:"started_at"`
+	Status            TraceStatus             `json:"status"`
+	TotalCostUsd      *float32                `json:"total_cost_usd,omitempty"`
+	TotalTokensIn     *int                    `json:"total_tokens_in,omitempty"`
+	TotalTokensOut    *int                    `json:"total_tokens_out,omitempty"`
 }
 
 // TraceStatus defines model for Trace.Status.
@@ -475,17 +499,18 @@ type TraceDetail struct {
 	Name     string                  `json:"name"`
 
 	// Output Trace output payload (any valid JSON)
-	Output         interface{}         `json:"output,omitempty"`
-	Release        *string             `json:"release,omitempty"`
-	SessionId      *openapi_types.UUID `json:"session_id,omitempty"`
-	StartedAt      time.Time           `json:"started_at"`
-	Status         TraceDetailStatus   `json:"status"`
-	Tags           *[]string           `json:"tags,omitempty"`
-	TotalCostUsd   *float32            `json:"total_cost_usd,omitempty"`
-	TotalTokensIn  *int                `json:"total_tokens_in,omitempty"`
-	TotalTokensOut *int                `json:"total_tokens_out,omitempty"`
-	TraceId        *string             `json:"trace_id,omitempty"`
-	UserId         *string             `json:"user_id,omitempty"`
+	Output            interface{}         `json:"output,omitempty"`
+	Release           *string             `json:"release,omitempty"`
+	SessionExternalId *string             `json:"session_external_id,omitempty"`
+	SessionId         *openapi_types.UUID `json:"session_id,omitempty"`
+	StartedAt         time.Time           `json:"started_at"`
+	Status            TraceDetailStatus   `json:"status"`
+	Tags              *[]string           `json:"tags,omitempty"`
+	TotalCostUsd      *float32            `json:"total_cost_usd,omitempty"`
+	TotalTokensIn     *int                `json:"total_tokens_in,omitempty"`
+	TotalTokensOut    *int                `json:"total_tokens_out,omitempty"`
+	TraceId           *string             `json:"trace_id,omitempty"`
+	UserId            *string             `json:"user_id,omitempty"`
 }
 
 // TraceDetailStatus defines model for TraceDetail.Status.
@@ -501,7 +526,25 @@ type TraceList struct {
 type ListSessionsParams struct {
 	Limit  *int `form:"limit,omitempty" json:"limit,omitempty"`
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// Q Search sessions by external ID or name
+	Q *string `form:"q,omitempty" json:"q,omitempty"`
+
+	// UserId Filter sessions by exact user ID
+	UserId *string `form:"user_id,omitempty" json:"user_id,omitempty"`
+
+	// SortBy Sort sessions by creation time or trace count. Ignored when q is present.
+	SortBy *ListSessionsParamsSortBy `form:"sort_by,omitempty" json:"sort_by,omitempty"`
+
+	// SortDir Sort direction for the selected session sort field. Ignored when q is present.
+	SortDir *ListSessionsParamsSortDir `form:"sort_dir,omitempty" json:"sort_dir,omitempty"`
 }
+
+// ListSessionsParamsSortBy defines parameters for ListSessions.
+type ListSessionsParamsSortBy string
+
+// ListSessionsParamsSortDir defines parameters for ListSessions.
+type ListSessionsParamsSortDir string
 
 // ListTracesParams defines parameters for ListTraces.
 type ListTracesParams struct {
@@ -511,6 +554,12 @@ type ListTracesParams struct {
 
 	// Q Full-text search query (searches trace name and user_id)
 	Q *string `form:"q,omitempty" json:"q,omitempty"`
+
+	// SortBy Sort traces by started time. Ignored when q is present.
+	SortBy *ListTracesParamsSortBy `form:"sort_by,omitempty" json:"sort_by,omitempty"`
+
+	// SortDir Sort direction for started time. Ignored when q is present.
+	SortDir *ListTracesParamsSortDir `form:"sort_dir,omitempty" json:"sort_dir,omitempty"`
 
 	// Status Filter by trace status
 	Status *ListTracesParamsStatus `form:"status,omitempty" json:"status,omitempty"`
@@ -530,6 +579,12 @@ type ListTracesParams struct {
 	// MinDurationMs Filter traces with duration >= this value in milliseconds
 	MinDurationMs *int64 `form:"min_duration_ms,omitempty" json:"min_duration_ms,omitempty"`
 }
+
+// ListTracesParamsSortBy defines parameters for ListTraces.
+type ListTracesParamsSortBy string
+
+// ListTracesParamsSortDir defines parameters for ListTraces.
+type ListTracesParamsSortDir string
 
 // ListTracesParamsStatus defines parameters for ListTraces.
 type ListTracesParamsStatus string
@@ -676,6 +731,38 @@ func (siw *ServerInterfaceWrapper) ListSessions(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// ------------- Optional query parameter "q" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "q", r.URL.Query(), &params.Q)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "user_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "user_id", r.URL.Query(), &params.UserId)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "user_id", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sort_by" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sort_by", r.URL.Query(), &params.SortBy)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sort_dir" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sort_dir", r.URL.Query(), &params.SortDir)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListSessions(w, r, params)
 	}))
@@ -761,6 +848,22 @@ func (siw *ServerInterfaceWrapper) ListTraces(w http.ResponseWriter, r *http.Req
 	err = runtime.BindQueryParameter("form", true, false, "q", r.URL.Query(), &params.Q)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sort_by" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sort_by", r.URL.Query(), &params.SortBy)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort_by", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sort_dir" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sort_dir", r.URL.Query(), &params.SortDir)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort_dir", Err: err})
 		return
 	}
 

--- a/internal/api/server_helpers.go
+++ b/internal/api/server_helpers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
-	"github.com/continua-ai/continua/db/gen/go/platform"
 	"github.com/continua-ai/continua/internal/api/middleware"
 	"github.com/continua-ai/continua/internal/ingest"
 	"github.com/continua-ai/continua/internal/store"
@@ -90,49 +89,116 @@ func projectIDOrUnauthorized(w http.ResponseWriter, r *http.Request) (uuid.UUID,
 	return projectID, true
 }
 
-func traceFilterFromParams(projectID uuid.UUID, params *ListTracesParams, limit, offset int32) (store.TraceFilter, bool) {
+func traceSortDirectionFromParams(params *ListTracesParams) store.SortDirection {
+	if params.SortBy != nil && *params.SortBy != StartedAt {
+		return store.SortDirectionDesc
+	}
+	if params.SortDir != nil && *params.SortDir == ListTracesParamsSortDirAsc {
+		return store.SortDirectionAsc
+	}
+	return store.SortDirectionDesc
+}
+
+func traceFilterFromParams(projectID uuid.UUID, params *ListTracesParams, limit, offset int32) store.TraceFilter {
 	filter := store.TraceFilter{
 		ProjectID: projectID,
+		SortDir:   traceSortDirectionFromParams(params),
 		Limit:     limit,
 		Offset:    offset,
 	}
-	hasFilters := false
 
 	if params.Q != nil {
 		filter.Query = *params.Q
-		hasFilters = true
 	}
 	if params.Status != nil {
 		filter.Status = string(*params.Status)
-		hasFilters = true
 	}
 	if params.StartTimeFrom != nil {
 		filter.StartTimeFrom = params.StartTimeFrom
-		hasFilters = true
 	}
 	if params.StartTimeTo != nil {
 		filter.StartTimeTo = params.StartTimeTo
-		hasFilters = true
 	}
 	if params.UserId != nil {
 		filter.UserID = *params.UserId
-		hasFilters = true
 	}
 	if params.SessionId != nil {
 		id := *params.SessionId
 		filter.SessionID = &id
-		hasFilters = true
 	}
 	if params.HasErrors != nil {
 		filter.HasErrors = params.HasErrors
-		hasFilters = true
 	}
 	if params.MinDurationMs != nil {
 		filter.MinDurationMs = params.MinDurationMs
-		hasFilters = true
 	}
 
-	return filter, hasFilters
+	return filter
+}
+
+func traceHasSearchQuery(filter *store.TraceFilter) bool {
+	return strings.TrimSpace(filter.Query) != ""
+}
+
+func traceNeedsDynamicQuery(filter *store.TraceFilter) bool {
+	return traceHasSearchQuery(filter) ||
+		filter.Status != "" ||
+		filter.StartTimeFrom != nil ||
+		filter.StartTimeTo != nil ||
+		filter.UserID != "" ||
+		filter.HasErrors != nil ||
+		filter.MinDurationMs != nil
+}
+
+func sessionSortFromParams(params *ListSessionsParams) (store.SessionSortBy, store.SortDirection) {
+	if params.SortBy != nil {
+		switch *params.SortBy {
+		case CreatedAt:
+			if params.SortDir != nil && *params.SortDir == ListSessionsParamsSortDirAsc {
+				return store.SessionSortByCreatedAt, store.SortDirectionAsc
+			}
+			return store.SessionSortByCreatedAt, store.SortDirectionDesc
+		case TraceCount:
+			if params.SortDir != nil && *params.SortDir == ListSessionsParamsSortDirAsc {
+				return store.SessionSortByTraceCount, store.SortDirectionAsc
+			}
+			return store.SessionSortByTraceCount, store.SortDirectionDesc
+		default:
+			return store.SessionSortByCreatedAt, store.SortDirectionDesc
+		}
+	}
+
+	if params.SortDir != nil && *params.SortDir == ListSessionsParamsSortDirAsc {
+		return store.SessionSortByCreatedAt, store.SortDirectionAsc
+	}
+	return store.SessionSortByCreatedAt, store.SortDirectionDesc
+}
+
+func sessionFilterFromParams(projectID uuid.UUID, params *ListSessionsParams, limit, offset int32) store.SessionFilter {
+	sortBy, sortDir := sessionSortFromParams(params)
+	filter := store.SessionFilter{
+		ProjectID: projectID,
+		SortBy:    sortBy,
+		SortDir:   sortDir,
+		Limit:     limit,
+		Offset:    offset,
+	}
+
+	if params.Q != nil {
+		filter.Query = *params.Q
+	}
+	if params.UserId != nil {
+		filter.UserID = *params.UserId
+	}
+
+	return filter
+}
+
+func sessionNeedsDynamicQuery(filter *store.SessionFilter) bool {
+	return strings.TrimSpace(filter.Query) != "" ||
+		filter.UserID != "" ||
+		filter.SortBy != store.SessionSortByCreatedAt ||
+		filter.SortDir != store.SortDirectionDesc
 }
 
 func apiIngestResponse(result *ingest.IngestResponse, includeCounts bool) IngestResponse {
@@ -184,19 +250,19 @@ func apiBatchStatus(status *ingest.BatchStatus) BatchStatusResponse {
 	return resp
 }
 
-func (s *Server) getScopedTrace(ctx context.Context, w http.ResponseWriter, projectID, traceID openapi_types.UUID) (platform.Trace, bool) {
+func (s *Server) getScopedTrace(ctx context.Context, w http.ResponseWriter, projectID, traceID openapi_types.UUID) (store.TraceRead, bool) {
 	trace, err := s.store.GetTrace(ctx, traceID)
 	if store.IsNotFound(err) {
 		writeError(w, http.StatusNotFound, "not_found", "Trace not found")
-		return platform.Trace{}, false
+		return store.TraceRead{}, false
 	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to get trace")
-		return platform.Trace{}, false
+		return store.TraceRead{}, false
 	}
 	if trace.ProjectID != projectID {
 		writeError(w, http.StatusNotFound, "not_found", "Trace not found")
-		return platform.Trace{}, false
+		return store.TraceRead{}, false
 	}
 
 	return trace, true

--- a/internal/api/sessions_handlers.go
+++ b/internal/api/sessions_handlers.go
@@ -17,16 +17,32 @@ func (s *Server) ListSessions(w http.ResponseWriter, r *http.Request, params Lis
 
 	limit, offset := normalizePagination(params.Limit, params.Offset)
 
-	sessions, err := s.store.ListSessionsWithTraceCount(r.Context(), projectID, limit, offset)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list sessions")
-		return
-	}
+	filter := sessionFilterFromParams(projectID, &params, limit, offset)
 
-	total, err := s.store.CountSessions(r.Context(), projectID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to count sessions")
-		return
+	var sessions []store.SessionWithCount
+	var total int64
+	var err error
+
+	if sessionNeedsDynamicQuery(&filter) {
+		result, err := s.store.ListSessionsFiltered(r.Context(), filter)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list sessions")
+			return
+		}
+		sessions = result.Sessions
+		total = result.Total
+	} else {
+		sessions, err = s.store.ListSessionsWithTraceCount(r.Context(), projectID, limit, offset)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list sessions")
+			return
+		}
+
+		total, err = s.store.CountSessions(r.Context(), projectID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to count sessions")
+			return
+		}
 	}
 
 	apiSessions := make([]Session, len(sessions))

--- a/internal/api/sessions_handlers_integration_test.go
+++ b/internal/api/sessions_handlers_integration_test.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/api/middleware"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestListSessions_FiltersAndSortsByTraceCount(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	base := time.Date(2026, 3, 9, 9, 0, 0, 0, time.UTC)
+
+	lowCount := createSessionRecord(t, ctx, s, projectID, "conv-low", "Low", "user-42", base)
+	highCount := createSessionRecord(t, ctx, s, projectID, "conv-high", "High", "user-42", base.Add(time.Hour))
+	_ = createSessionRecord(t, ctx, s, projectID, "conv-other", "Other", "user-99", base.Add(2*time.Hour))
+
+	createSessionTraceRecords(t, ctx, q, projectID, lowCount.ID, 1)
+	createSessionTraceRecords(t, ctx, q, projectID, highCount.ID, 3)
+
+	rec := invokeListSessions(t, server, projectID, ListSessionsParams{
+		UserId:  testutil.StrPtr("user-42"),
+		SortBy:  testutil.Ptr(TraceCount),
+		SortDir: testutil.Ptr(ListSessionsParamsSortDirDesc),
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[SessionList](t, rec)
+	assert.Equal(t, 2, resp.Total)
+	require.Len(t, resp.Sessions, 2)
+	assert.Equal(t, []uuid.UUID{highCount.ID, lowCount.ID}, apiSessionIDs(resp.Sessions))
+	require.NotNil(t, resp.Sessions[0].TraceCount)
+	assert.Equal(t, 3, *resp.Sessions[0].TraceCount)
+	require.NotNil(t, resp.Sessions[1].TraceCount)
+	assert.Equal(t, 1, *resp.Sessions[1].TraceCount)
+}
+
+func TestListSessions_SearchOverridesSortAndKeepsFilteredTotal(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	base := time.Date(2026, 3, 9, 12, 0, 0, 0, time.UTC)
+
+	exact := createSessionRecord(t, ctx, s, projectID, "conv-123", "Exact", "user-42", base)
+	prefix := createSessionRecord(t, ctx, s, projectID, "conv-1234", "Prefix", "user-42", base.Add(time.Hour))
+	nameOnly := createSessionRecord(t, ctx, s, projectID, "sess-001", "conv-123 discussion", "user-42", base.Add(2*time.Hour))
+	newestNameOnly := createSessionRecord(t, ctx, s, projectID, "sess-002", "conv-123 notes", "user-42", base.Add(3*time.Hour))
+
+	rec := invokeListSessions(t, server, projectID, ListSessionsParams{
+		Q:       testutil.StrPtr("conv-123"),
+		SortBy:  testutil.Ptr(CreatedAt),
+		SortDir: testutil.Ptr(ListSessionsParamsSortDirAsc),
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[SessionList](t, rec)
+	assert.Equal(t, 4, resp.Total)
+	assert.Equal(
+		t,
+		[]uuid.UUID{exact.ID, prefix.ID, newestNameOnly.ID, nameOnly.ID},
+		apiSessionIDs(resp.Sessions),
+	)
+}
+
+func TestGetSession_ProjectScopingReturns404(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectAID := testutil.CreateTestProject(t, ctx, q)
+	projectBID := testutil.CreateTestProject(t, ctx, q)
+
+	session := createSessionRecord(
+		t,
+		ctx,
+		s,
+		projectBID,
+		"scoped-session",
+		"Scoped",
+		"user-42",
+		time.Date(2026, 3, 9, 14, 0, 0, 0, time.UTC),
+	)
+
+	rec := invokeGetSession(t, server, projectAID, session.ID)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	resp := decodeJSONBody[Error](t, rec)
+	assert.Equal(t, "not_found", resp.Code)
+}
+
+func invokeListSessions(t *testing.T, server *Server, projectID uuid.UUID, params ListSessionsParams) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	ctx := context.WithValue(req.Context(), middleware.ProjectIDKey, projectID)
+	rec := httptest.NewRecorder()
+
+	server.ListSessions(rec, req.WithContext(ctx), params)
+
+	return rec
+}
+
+func invokeGetSession(t *testing.T, server *Server, projectID, sessionID uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+sessionID.String(), nil)
+	ctx := context.WithValue(req.Context(), middleware.ProjectIDKey, projectID)
+	rec := httptest.NewRecorder()
+
+	server.GetSession(rec, req.WithContext(ctx), sessionID)
+
+	return rec
+}
+
+//nolint:revive // Keep testing.T first in shared test helper signatures.
+func createSessionRecord(
+	t *testing.T,
+	ctx context.Context,
+	s *store.Store,
+	projectID uuid.UUID,
+	externalID string,
+	name string,
+	userID string,
+	createdAt time.Time,
+) platform.Session {
+	t.Helper()
+
+	session, err := s.Queries().CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectID,
+		ExternalID: externalID,
+		Name:       testutil.StrPtr(name),
+		UserID:     testutil.StrPtr(userID),
+	})
+	require.NoError(t, err)
+
+	_, err = s.Pool().Exec(ctx, "UPDATE sessions SET created_at = $2, updated_at = $2 WHERE id = $1", session.ID, createdAt)
+	require.NoError(t, err)
+
+	session.CreatedAt = createdAt
+	session.UpdatedAt = createdAt
+	return session
+}
+
+//nolint:revive // Keep testing.T first in shared test helper signatures.
+func createSessionTraceRecords(
+	t *testing.T,
+	ctx context.Context,
+	q *platform.Queries,
+	projectID uuid.UUID,
+	sessionID uuid.UUID,
+	count int,
+) {
+	t.Helper()
+
+	for i := 0; i < count; i++ {
+		_, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+			ProjectID: projectID,
+			SessionID: testutil.PgtypeUUID(sessionID),
+			TraceID:   uuid.NewString(),
+			Name:      testutil.StrPtr("Trace"),
+		})
+		require.NoError(t, err)
+	}
+}
+
+func apiSessionIDs(sessions []Session) []uuid.UUID {
+	ids := make([]uuid.UUID, len(sessions))
+	for i := range sessions {
+		ids[i] = sessions[i].Id
+	}
+	return ids
+}

--- a/internal/api/traces_handlers.go
+++ b/internal/api/traces_handlers.go
@@ -5,7 +5,7 @@ import (
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
-	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/store"
 )
 
 // ListTraces returns a paginated list of traces with optional filtering.
@@ -19,12 +19,13 @@ func (s *Server) ListTraces(w http.ResponseWriter, r *http.Request, params ListT
 
 	limit, offset := normalizePagination(params.Limit, params.Offset)
 
-	var traces []platform.Trace
+	var traces []store.TraceRead
 	var total int64
 	var err error
 
-	filter, hasFilters := traceFilterFromParams(projectID, &params, limit, offset)
-	if hasFilters {
+	filter := traceFilterFromParams(projectID, &params, limit, offset)
+	switch {
+	case traceNeedsDynamicQuery(&filter):
 		result, err := s.store.ListTracesFiltered(r.Context(), filter)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to search traces")
@@ -32,8 +33,19 @@ func (s *Server) ListTraces(w http.ResponseWriter, r *http.Request, params ListT
 		}
 		traces = result.Traces
 		total = result.Total
-	} else {
-		traces, err = s.store.ListTraces(r.Context(), projectID, limit, offset)
+	case filter.SessionID != nil:
+		traces, err = s.store.ListTracesBySession(r.Context(), projectID, *filter.SessionID, limit, offset, filter.SortDir)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list traces")
+			return
+		}
+		total, err = s.store.CountTracesBySession(r.Context(), projectID, *filter.SessionID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to count traces")
+			return
+		}
+	default:
+		traces, err = s.store.ListTraces(r.Context(), projectID, limit, offset, filter.SortDir)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list traces")
 			return

--- a/internal/api/traces_handlers_test.go
+++ b/internal/api/traces_handlers_test.go
@@ -450,6 +450,158 @@ func TestListTraces_OmitsDetailFields(t *testing.T) {
 	}
 }
 
+func TestListTracesAndGetTrace_IncludeSessionExternalID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	session, err := q.CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectID,
+		ExternalID: "conv-abc-123",
+	})
+	require.NoError(t, err)
+
+	withSession := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		SessionID: testutil.PgtypeUUID(session.ID),
+		TraceID:   "trace-with-session",
+		Name:      testutil.StrPtr("Trace With Session"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 8, 9, 0, 0, 0, time.UTC)),
+	})
+
+	withoutSession := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "trace-without-session",
+		Name:      testutil.StrPtr("Trace Without Session"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 8, 10, 0, 0, 0, time.UTC)),
+	})
+
+	listRec := invokeListTraces(t, server, projectID, ListTracesParams{})
+	require.Equal(t, http.StatusOK, listRec.Code)
+
+	listResp := decodeJSONBody[TraceList](t, listRec)
+	withSessionAPI := findTraceByID(t, listResp.Traces, withSession.ID)
+	withoutSessionAPI := findTraceByID(t, listResp.Traces, withoutSession.ID)
+
+	require.NotNil(t, withSessionAPI.SessionExternalId)
+	assert.Equal(t, session.ExternalID, *withSessionAPI.SessionExternalId)
+	assert.Nil(t, withoutSessionAPI.SessionExternalId)
+
+	detailRec := invokeGetTrace(t, server, projectID, withSession.ID)
+	require.Equal(t, http.StatusOK, detailRec.Code)
+
+	detailResp := decodeJSONBody[TraceDetail](t, detailRec)
+	require.NotNil(t, detailResp.SessionExternalId)
+	assert.Equal(t, session.ExternalID, *detailResp.SessionExternalId)
+}
+
+func TestListTraces_SortDirectionAndDefaultOrdering(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	earliest := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "trace-earliest",
+		Name:      testutil.StrPtr("Earliest"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 8, 9, 0, 0, 0, time.UTC)),
+	})
+	middle := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "trace-middle",
+		Name:      testutil.StrPtr("Middle"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 8, 10, 0, 0, 0, time.UTC)),
+	})
+	latest := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "trace-latest",
+		Name:      testutil.StrPtr("Latest"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 8, 11, 0, 0, 0, time.UTC)),
+	})
+
+	defaultRec := invokeListTraces(t, server, projectID, ListTracesParams{})
+	require.Equal(t, http.StatusOK, defaultRec.Code)
+	defaultResp := decodeJSONBody[TraceList](t, defaultRec)
+	assert.Equal(t, []uuid.UUID{latest.ID, middle.ID, earliest.ID}, apiTraceIDs(defaultResp.Traces))
+
+	ascRec := invokeListTraces(t, server, projectID, ListTracesParams{
+		SortBy:  testutil.Ptr(StartedAt),
+		SortDir: testutil.Ptr(ListTracesParamsSortDirAsc),
+	})
+	require.Equal(t, http.StatusOK, ascRec.Code)
+	ascResp := decodeJSONBody[TraceList](t, ascRec)
+	assert.Equal(t, []uuid.UUID{earliest.ID, middle.ID, latest.ID}, apiTraceIDs(ascResp.Traces))
+
+	descRec := invokeListTraces(t, server, projectID, ListTracesParams{
+		SortBy:  testutil.Ptr(StartedAt),
+		SortDir: testutil.Ptr(ListTracesParamsSortDirDesc),
+	})
+	require.Equal(t, http.StatusOK, descRec.Code)
+	descResp := decodeJSONBody[TraceList](t, descRec)
+	assert.Equal(t, []uuid.UUID{latest.ID, middle.ID, earliest.ID}, apiTraceIDs(descResp.Traces))
+}
+
+func TestListTraces_SearchOverridesSortParams(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	base := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+
+	nameMatch := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "trace-name-match",
+		Name:      testutil.StrPtr("checkout"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(base),
+	})
+
+	spanOnlyMatch := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "trace-span-only",
+		Name:      testutil.StrPtr("background work"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(base.Add(2 * time.Hour)),
+	})
+
+	upsertSpanRecord(ctx, t, q, platform.UpsertSpanParams{
+		ProjectID: projectID,
+		TraceID:   spanOnlyMatch.ID,
+		SpanID:    "span-checkout",
+		Name:      "checkout",
+		Type:      "tool",
+		Status:    "completed",
+		Level:     "default",
+		StartTime: base.Add(2 * time.Hour),
+		TotalCost: testutil.PgtypeNumericFromFloat64(0),
+	})
+
+	rec := invokeListTraces(t, server, projectID, ListTracesParams{
+		Q:       testutil.StrPtr("checkout"),
+		SortBy:  testutil.Ptr(StartedAt),
+		SortDir: testutil.Ptr(ListTracesParamsSortDirAsc),
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[TraceList](t, rec)
+	require.Len(t, resp.Traces, 2)
+	assert.Equal(t, []uuid.UUID{nameMatch.ID, spanOnlyMatch.ID}, apiTraceIDs(resp.Traces))
+}
+
 func TestGetTrace_ProjectScopingReturns404(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ctx := context.Background()
@@ -546,6 +698,27 @@ func invokeListTraces(t *testing.T, server *Server, projectID uuid.UUID, params 
 	server.ListTraces(rec, req.WithContext(ctx), params)
 
 	return rec
+}
+
+func findTraceByID(t *testing.T, traces []Trace, traceID uuid.UUID) Trace {
+	t.Helper()
+
+	for i := range traces {
+		if traces[i].Id == traceID {
+			return traces[i]
+		}
+	}
+
+	t.Fatalf("trace %s not found in response", traceID)
+	return Trace{}
+}
+
+func apiTraceIDs(traces []Trace) []uuid.UUID {
+	ids := make([]uuid.UUID, len(traces))
+	for i := range traces {
+		ids[i] = traces[i].Id
+	}
+	return ids
 }
 
 func createTimelineTrace(

--- a/internal/ingest/rollups_test.go
+++ b/internal/ingest/rollups_test.go
@@ -64,8 +64,8 @@ func TestRollups_TokenAggregation(t *testing.T) {
 	updatedTrace, err := q.GetTrace(ctx, trace.ID)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(225), updatedTrace.TotalTokensIn, "total_tokens_in should equal sum of prompt_tokens")
-	assert.Equal(t, int64(225), updatedTrace.TotalTokensOut, "total_tokens_out should equal sum of completion_tokens")
+	assert.Equal(t, int64(225), updatedTrace.Trace.TotalTokensIn, "total_tokens_in should equal sum of prompt_tokens")
+	assert.Equal(t, int64(225), updatedTrace.Trace.TotalTokensOut, "total_tokens_out should equal sum of completion_tokens")
 }
 
 func TestRollups_CostAggregation(t *testing.T) {
@@ -108,7 +108,7 @@ func TestRollups_CostAggregation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Note: TotalCost is pgtype.Numeric, compare validity instead of exact value
-	assert.True(t, updatedTrace.TotalCost.Valid, "total_cost should be set")
+	assert.True(t, updatedTrace.Trace.TotalCost.Valid, "total_cost should be set")
 }
 
 func TestRollups_SpanCount(t *testing.T) {
@@ -148,8 +148,8 @@ func TestRollups_SpanCount(t *testing.T) {
 	updatedTrace, err := q.GetTrace(ctx, trace.ID)
 	require.NoError(t, err)
 
-	require.NotNil(t, updatedTrace.TotalSpans)
-	assert.Equal(t, int32(5), *updatedTrace.TotalSpans, "total_spans should be 5")
+	require.NotNil(t, updatedTrace.Trace.TotalSpans)
+	assert.Equal(t, int32(5), *updatedTrace.Trace.TotalSpans, "total_spans should be 5")
 }
 
 func TestRollups_ErrorCounting(t *testing.T) {
@@ -192,8 +192,8 @@ func TestRollups_ErrorCounting(t *testing.T) {
 	require.NoError(t, err)
 
 	// 3 failed/error spans
-	require.NotNil(t, updatedTrace.ErrorCount)
-	assert.Equal(t, int32(3), *updatedTrace.ErrorCount, "error_count should be 3")
+	require.NotNil(t, updatedTrace.Trace.ErrorCount)
+	assert.Equal(t, int32(3), *updatedTrace.Trace.ErrorCount, "error_count should be 3")
 }
 
 func TestRollups_DurationComputation(t *testing.T) {
@@ -228,8 +228,8 @@ func TestRollups_DurationComputation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Duration should be approximately 5000ms
-	require.NotNil(t, updatedTrace.DurationMs)
-	assert.InDelta(t, 5000, *updatedTrace.DurationMs, 100, "duration should be ~5000ms")
+	require.NotNil(t, updatedTrace.Trace.DurationMs)
+	assert.InDelta(t, 5000, *updatedTrace.Trace.DurationMs, 100, "duration should be ~5000ms")
 }
 
 func TestRollups_FailureNonBlocking(t *testing.T) {
@@ -261,7 +261,7 @@ func TestRollups_FailureNonBlocking(t *testing.T) {
 	// Trace should exist regardless of rollup computation
 	fetchedTrace, err := q.GetTrace(ctx, trace.ID)
 	require.NoError(t, err)
-	assert.Equal(t, traceID, fetchedTrace.TraceID)
+	assert.Equal(t, traceID, fetchedTrace.Trace.TraceID)
 }
 
 // =============================================================================

--- a/internal/jobs/ingest_batch_test.go
+++ b/internal/jobs/ingest_batch_test.go
@@ -341,9 +341,9 @@ func TestLegacyDefaultQueueRollupJobExecutesDuringTransition(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		updatedTrace, getErr := q.GetTrace(ctx, trace.ID)
-		if getErr != nil || updatedTrace.TotalSpans == nil {
+		if getErr != nil || updatedTrace.Trace.TotalSpans == nil {
 			return false
 		}
-		return *updatedTrace.TotalSpans == 1 && updatedTrace.TotalTokensIn == 11 && updatedTrace.TotalTokensOut == 7
+		return *updatedTrace.Trace.TotalSpans == 1 && updatedTrace.Trace.TotalTokensIn == 11 && updatedTrace.Trace.TotalTokensOut == 7
 	}, 5*time.Second, 100*time.Millisecond)
 }

--- a/internal/jobs/rollup_test.go
+++ b/internal/jobs/rollup_test.go
@@ -90,12 +90,12 @@ func TestRollupJob_Execution(t *testing.T) {
 	updatedTrace, err := q.GetTrace(ctx, trace.ID)
 	require.NoError(t, err)
 
-	require.NotNil(t, updatedTrace.TotalSpans)
-	assert.Equal(t, int32(4), *updatedTrace.TotalSpans, "total_spans should be 4")
-	assert.Equal(t, int64(300), updatedTrace.TotalTokensIn, "total_tokens_in should be 300 (100 * 3)")
-	assert.Equal(t, int64(150), updatedTrace.TotalTokensOut, "total_tokens_out should be 150 (50 * 3)")
-	require.NotNil(t, updatedTrace.ErrorCount)
-	assert.Equal(t, int32(1), *updatedTrace.ErrorCount, "error_count should be 1")
+	require.NotNil(t, updatedTrace.Trace.TotalSpans)
+	assert.Equal(t, int32(4), *updatedTrace.Trace.TotalSpans, "total_spans should be 4")
+	assert.Equal(t, int64(300), updatedTrace.Trace.TotalTokensIn, "total_tokens_in should be 300 (100 * 3)")
+	assert.Equal(t, int64(150), updatedTrace.Trace.TotalTokensOut, "total_tokens_out should be 150 (50 * 3)")
+	require.NotNil(t, updatedTrace.Trace.ErrorCount)
+	assert.Equal(t, int32(1), *updatedTrace.Trace.ErrorCount, "error_count should be 1")
 }
 
 func TestRollupJob_RetryDoesNotDoubleCount(t *testing.T) {
@@ -147,10 +147,10 @@ func TestRollupJob_RetryDoesNotDoubleCount(t *testing.T) {
 	updatedTrace, err := q.GetTrace(ctx, trace.ID)
 	require.NoError(t, err)
 
-	require.NotNil(t, updatedTrace.TotalSpans)
-	assert.Equal(t, int32(2), *updatedTrace.TotalSpans, "total_spans should be 2, not 4")
-	assert.Equal(t, int64(60), updatedTrace.TotalTokensIn, "total_tokens_in should be 60, not 120")
-	assert.Equal(t, int64(40), updatedTrace.TotalTokensOut, "total_tokens_out should be 40, not 80")
+	require.NotNil(t, updatedTrace.Trace.TotalSpans)
+	assert.Equal(t, int32(2), *updatedTrace.Trace.TotalSpans, "total_spans should be 2, not 4")
+	assert.Equal(t, int64(60), updatedTrace.Trace.TotalTokensIn, "total_tokens_in should be 60, not 120")
+	assert.Equal(t, int64(40), updatedTrace.Trace.TotalTokensOut, "total_tokens_out should be 40, not 80")
 }
 
 func TestRollupJob_EmptyTrace(t *testing.T) {
@@ -181,8 +181,8 @@ func TestRollupJob_EmptyTrace(t *testing.T) {
 	updatedTrace, err := q.GetTrace(ctx, trace.ID)
 	require.NoError(t, err)
 
-	require.NotNil(t, updatedTrace.TotalSpans)
-	assert.Equal(t, int32(0), *updatedTrace.TotalSpans, "total_spans should be 0")
+	require.NotNil(t, updatedTrace.Trace.TotalSpans)
+	assert.Equal(t, int32(0), *updatedTrace.Trace.TotalSpans, "total_spans should be 0")
 }
 
 func TestRollupJob_MultipleLLMCalls(t *testing.T) {
@@ -228,6 +228,6 @@ func TestRollupJob_MultipleLLMCalls(t *testing.T) {
 	updatedTrace, err := q.GetTrace(ctx, trace.ID)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(550), updatedTrace.TotalTokensIn, "total_tokens_in should be sum of prompt_tokens")
-	assert.Equal(t, int64(375), updatedTrace.TotalTokensOut, "total_tokens_out should be sum of completion_tokens")
+	assert.Equal(t, int64(550), updatedTrace.Trace.TotalTokensIn, "total_tokens_in should be sum of prompt_tokens")
+	assert.Equal(t, int64(375), updatedTrace.Trace.TotalTokensOut, "total_tokens_out should be sum of completion_tokens")
 }

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
-	"github.com/continua-ai/continua/db/gen/go/platform"
 )
 
 // TraceFilter defines filter options for trace search.
@@ -22,19 +20,14 @@ type TraceFilter struct {
 	SessionID     *uuid.UUID // Filter by session_id
 	HasErrors     *bool      // Filter by error_count > 0
 	MinDurationMs *int64     // Filter by duration in milliseconds
+	SortDir       SortDirection
 	Limit         int32
 	Offset        int32
 }
 
-// TraceWithTotal represents a trace with the total count for pagination.
-type TraceWithTotal struct {
-	platform.Trace
-	Total int64
-}
-
 // TraceSearchResult contains the results of a trace search.
 type TraceSearchResult struct {
-	Traces []platform.Trace
+	Traces []TraceRead
 	Total  int64
 }
 
@@ -50,7 +43,7 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 	var whereClauses []string
 	var args []any
 	argNum := 1
-	fromClause := "FROM traces t"
+	fromClause := "FROM traces t LEFT JOIN sessions sess ON sess.id = t.session_id AND sess.project_id = t.project_id"
 
 	// Always filter by project
 	whereClauses = append(whereClauses, fmt.Sprintf("t.project_id = $%d", argNum))
@@ -65,7 +58,7 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 	// Full-text search query - searches both trace fields and span names
 	if hasSearchQuery {
 		searchArgNum = argNum
-		fromClause = fmt.Sprintf("FROM traces t CROSS JOIN (SELECT plainto_tsquery('english', $%d) AS search_query) q", searchArgNum)
+		fromClause = fmt.Sprintf("%s CROSS JOIN (SELECT plainto_tsquery('english', $%d) AS search_query) q", fromClause, searchArgNum)
 		// Search traces.search_vector OR any span.search_vector matches
 		// Use EXISTS for efficient span search with proper project scoping
 		whereClauses = append(whereClauses, `(
@@ -169,9 +162,15 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 			CASE WHEN %s > 0 THEN 1 ELSE 0 END AS trace_match_priority,
 			GREATEST(%s, %s) AS combined_rank
 		`, traceRankExpr, traceRankExpr, spanRankExpr)
-		orderByClause = "trace_match_priority DESC, combined_rank DESC, sort_time DESC"
+		orderByClause = "trace_match_priority DESC, combined_rank DESC, sort_time DESC, t.id DESC"
 	} else {
-		orderByClause = "sort_time DESC"
+		sortDirectionSQL := "DESC"
+		idDirectionSQL := "DESC"
+		if normalizeSortDirection(filter.SortDir) == SortDirectionAsc {
+			sortDirectionSQL = "ASC"
+			idDirectionSQL = "ASC"
+		}
+		orderByClause = fmt.Sprintf("sort_time %s, t.id %s", sortDirectionSQL, idDirectionSQL)
 	}
 
 	// Main query with limit and offset
@@ -179,9 +178,10 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 	offsetArg := argNum + 1
 
 	selectQuery := fmt.Sprintf(`
-		SELECT DISTINCT t.id, t.project_id, t.session_id, t.trace_id, t.name, t.status, t.user_id, t.tags, t.environment, t.release,
-		       t.metadata, t.start_time, t.end_time, t.server_received_at, t.total_spans, t.total_tokens_in, t.total_tokens_out, t.total_cost,
-		       t.error_count, t.created_at, t.updated_at%s%s
+		SELECT DISTINCT t.id, t.project_id, t.session_id, t.trace_id, t.name, t.user_id, t.tags, t.environment, t.release,
+		       t.metadata, t.input, t.output, t.status, t.start_time, t.end_time, t.server_received_at, t.duration_ms, t.total_spans, t.total_cost,
+		       t.error_count, t.version, t.created_at, t.updated_at, t.search_vector, t.total_tokens_in, t.total_tokens_out,
+		       sess.external_id AS session_external_id%s%s
 		%s
 		WHERE %s
 		ORDER BY %s
@@ -197,16 +197,17 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 	defer rows.Close()
 
 	for rows.Next() {
-		var t platform.Trace
+		var trace TraceRead
 		var traceMatchPriority int
 		var combinedRank float32
 		var sortTime time.Time
 
 		scanArgs := []any{
-			&t.ID, &t.ProjectID, &t.SessionID, &t.TraceID, &t.Name, &t.Status, &t.UserID,
-			&t.Tags, &t.Environment, &t.Release, &t.Metadata, &t.StartTime, &t.EndTime,
-			&t.ServerReceivedAt, &t.TotalSpans, &t.TotalTokensIn, &t.TotalTokensOut, &t.TotalCost, &t.ErrorCount,
-			&t.CreatedAt, &t.UpdatedAt,
+			&trace.ID, &trace.ProjectID, &trace.SessionID, &trace.TraceID, &trace.Name, &trace.UserID,
+			&trace.Tags, &trace.Environment, &trace.Release, &trace.Metadata, &trace.Input, &trace.Output,
+			&trace.Status, &trace.StartTime, &trace.EndTime, &trace.ServerReceivedAt, &trace.DurationMs,
+			&trace.TotalSpans, &trace.TotalCost, &trace.ErrorCount, &trace.Version, &trace.CreatedAt,
+			&trace.UpdatedAt, &trace.SearchVector, &trace.TotalTokensIn, &trace.TotalTokensOut, &trace.SessionExternalID,
 		}
 		if hasSearchQuery {
 			scanArgs = append(scanArgs, &traceMatchPriority, &combinedRank)
@@ -217,7 +218,7 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 		if err != nil {
 			return result, fmt.Errorf("scan trace: %w", err)
 		}
-		result.Traces = append(result.Traces, t)
+		result.Traces = append(result.Traces, trace)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/store/session_search.go
+++ b/internal/store/session_search.go
@@ -1,0 +1,176 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// SessionSortBy controls session list sorting.
+type SessionSortBy string
+
+const (
+	SessionSortByCreatedAt  SessionSortBy = "created_at"
+	SessionSortByTraceCount SessionSortBy = "trace_count"
+)
+
+// SessionFilter defines filter and sorting options for session listing.
+type SessionFilter struct {
+	ProjectID uuid.UUID
+	Query     string
+	UserID    string
+	SortBy    SessionSortBy
+	SortDir   SortDirection
+	Limit     int32
+	Offset    int32
+}
+
+// SessionSearchResult contains session rows and the filtered total.
+type SessionSearchResult struct {
+	Sessions []SessionWithCount
+	Total    int64
+}
+
+type sessionQueryPlan struct {
+	whereClause  string
+	countArgs    []any
+	listArgs     []any
+	hasSearch    bool
+	exactArgNum  int
+	prefixArgNum int
+}
+
+func normalizeSessionSortBy(sortBy SessionSortBy) SessionSortBy {
+	if sortBy == SessionSortByTraceCount {
+		return SessionSortByTraceCount
+	}
+	return SessionSortByCreatedAt
+}
+
+func buildSessionQueryPlan(filter *SessionFilter) sessionQueryPlan {
+	projectIDArg := []any{filter.ProjectID}
+	whereClauses := []string{"s.project_id = $1"}
+	nextArgNum := 2
+
+	trimmedQuery := strings.TrimSpace(filter.Query)
+	hasSearch := trimmedQuery != ""
+	if hasSearch {
+		whereClauses = append(whereClauses,
+			fmt.Sprintf("(s.external_id ILIKE $%d OR COALESCE(s.name, '') ILIKE $%d)", nextArgNum, nextArgNum))
+		projectIDArg = append(projectIDArg, "%"+trimmedQuery+"%")
+		nextArgNum++
+	}
+
+	if filter.UserID != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("s.user_id = $%d", nextArgNum))
+		projectIDArg = append(projectIDArg, filter.UserID)
+	}
+
+	listArgs := append([]any{}, projectIDArg...)
+	plan := sessionQueryPlan{
+		whereClause: strings.Join(whereClauses, " AND "),
+		countArgs:   projectIDArg,
+		listArgs:    listArgs,
+		hasSearch:   hasSearch,
+	}
+
+	if hasSearch {
+		plan.exactArgNum = len(plan.listArgs) + 1
+		plan.listArgs = append(plan.listArgs, trimmedQuery)
+		plan.prefixArgNum = len(plan.listArgs) + 1
+		plan.listArgs = append(plan.listArgs, trimmedQuery+"%")
+	}
+
+	return plan
+}
+
+func buildSessionOrderBy(filter *SessionFilter, plan *sessionQueryPlan) string {
+	if plan.hasSearch {
+		return fmt.Sprintf(`CASE
+			WHEN LOWER(s.external_id) = LOWER($%d) THEN 0
+			WHEN s.external_id ILIKE $%d THEN 1
+			ELSE 2
+		END ASC, s.created_at DESC, s.id DESC`, plan.exactArgNum, plan.prefixArgNum)
+	}
+
+	sortBy := normalizeSessionSortBy(filter.SortBy)
+	sortDir := normalizeSortDirection(filter.SortDir)
+
+	switch sortBy {
+	case SessionSortByTraceCount:
+		if sortDir == SortDirectionAsc {
+			return "COALESCE(tc.cnt, 0) ASC, s.created_at DESC, s.id DESC"
+		}
+		return "COALESCE(tc.cnt, 0) DESC, s.created_at DESC, s.id DESC"
+	default:
+		if sortDir == SortDirectionAsc {
+			return "s.created_at ASC, s.id ASC"
+		}
+		return "s.created_at DESC, s.id DESC"
+	}
+}
+
+// ListSessionsFiltered returns sessions with dynamic filters, sorting, and accurate totals.
+//
+//nolint:gocritic // Pass-by-value keeps this immutable and avoids accidental caller mutation.
+func (s *Store) ListSessionsFiltered(ctx context.Context, filter SessionFilter) (SessionSearchResult, error) {
+	result := SessionSearchResult{}
+	plan := buildSessionQueryPlan(&filter)
+
+	countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM sessions s WHERE %s`, plan.whereClause)
+	if err := s.pool.QueryRow(ctx, countQuery, plan.countArgs...).Scan(&result.Total); err != nil {
+		return result, fmt.Errorf("count sessions: %w", err)
+	}
+
+	orderByClause := buildSessionOrderBy(&filter, &plan)
+	limitArgNum := len(plan.listArgs) + 1
+	offsetArgNum := len(plan.listArgs) + 2
+
+	listQuery := fmt.Sprintf(`
+		SELECT s.id, s.project_id, s.name, s.user_id, s.metadata, s.created_at, s.updated_at, s.external_id,
+		       COALESCE(tc.cnt, 0) AS trace_count
+		FROM sessions s
+		LEFT JOIN (
+			SELECT session_id, COUNT(*) AS cnt
+			FROM traces
+			WHERE project_id = $1
+			GROUP BY session_id
+		) tc ON tc.session_id = s.id
+		WHERE %s
+		ORDER BY %s
+		LIMIT $%d OFFSET $%d
+	`, plan.whereClause, orderByClause, limitArgNum, offsetArgNum)
+
+	args := append(plan.listArgs, filter.Limit, filter.Offset)
+	rows, err := s.pool.Query(ctx, listQuery, args...)
+	if err != nil {
+		return result, fmt.Errorf("query sessions: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var session SessionWithCount
+		if err := rows.Scan(
+			&session.ID,
+			&session.ProjectID,
+			&session.Name,
+			&session.UserID,
+			&session.Metadata,
+			&session.CreatedAt,
+			&session.UpdatedAt,
+			&session.ExternalID,
+			&session.TraceCount,
+		); err != nil {
+			return result, fmt.Errorf("scan session: %w", err)
+		}
+		result.Sessions = append(result.Sessions, session)
+	}
+
+	if err := rows.Err(); err != nil {
+		return result, fmt.Errorf("iterate sessions: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/store/session_search_test.go
+++ b/internal/store/session_search_test.go
@@ -1,0 +1,241 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestListSessionsFiltered_CreatedAtSortAndTotal(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	base := time.Date(2026, 3, 10, 9, 0, 0, 0, time.UTC)
+
+	older := createSessionAt(t, ctx, s, projectID, "sess-older", "Older", "user-1", base)
+	middle := createSessionAt(t, ctx, s, projectID, "sess-middle", "Middle", "user-1", base.Add(time.Hour))
+	newer := createSessionAt(t, ctx, s, projectID, "sess-newer", "Newer", "user-1", base.Add(2*time.Hour))
+
+	defaultResult, err := s.ListSessionsFiltered(ctx, store.SessionFilter{
+		ProjectID: projectID,
+		Limit:     10,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), defaultResult.Total)
+	assert.Equal(t, []uuid.UUID{newer.ID, middle.ID, older.ID}, sessionIDs(defaultResult.Sessions))
+
+	ascendingResult, err := s.ListSessionsFiltered(ctx, store.SessionFilter{
+		ProjectID: projectID,
+		SortBy:    store.SessionSortByCreatedAt,
+		SortDir:   store.SortDirectionAsc,
+		Limit:     10,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []uuid.UUID{older.ID, middle.ID, newer.ID}, sessionIDs(ascendingResult.Sessions))
+}
+
+func TestListSessionsFiltered_TraceCountSort(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	base := time.Date(2026, 3, 11, 9, 0, 0, 0, time.UTC)
+
+	zero := createSessionAt(t, ctx, s, projectID, "sess-zero", "Zero", "user-1", base)
+	one := createSessionAt(t, ctx, s, projectID, "sess-one", "One", "user-1", base.Add(time.Hour))
+	two := createSessionAt(t, ctx, s, projectID, "sess-two", "Two", "user-1", base.Add(2*time.Hour))
+
+	createSessionTraces(t, ctx, q, projectID, one.ID, 1)
+	createSessionTraces(t, ctx, q, projectID, two.ID, 2)
+
+	descending, err := s.ListSessionsFiltered(ctx, store.SessionFilter{
+		ProjectID: projectID,
+		SortBy:    store.SessionSortByTraceCount,
+		SortDir:   store.SortDirectionDesc,
+		Limit:     10,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []uuid.UUID{two.ID, one.ID, zero.ID}, sessionIDs(descending.Sessions))
+
+	ascending, err := s.ListSessionsFiltered(ctx, store.SessionFilter{
+		ProjectID: projectID,
+		SortBy:    store.SessionSortByTraceCount,
+		SortDir:   store.SortDirectionAsc,
+		Limit:     10,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []uuid.UUID{zero.ID, one.ID, two.ID}, sessionIDs(ascending.Sessions))
+}
+
+func TestListSessionsFiltered_SearchRankingAndUserFilter(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	base := time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC)
+
+	exact := createSessionAt(t, ctx, s, projectID, "conv-123", "Exact", "user-42", base)
+	prefix := createSessionAt(t, ctx, s, projectID, "conv-1234", "Prefix", "user-42", base.Add(time.Hour))
+	nameOnly := createSessionAt(t, ctx, s, projectID, "sess-001", "conv-123 discussion", "user-42", base.Add(2*time.Hour))
+	_ = createSessionAt(t, ctx, s, projectID, "conv-1239", "Filtered Out", "user-99", base.Add(3*time.Hour))
+
+	result, err := s.ListSessionsFiltered(ctx, store.SessionFilter{
+		ProjectID: projectID,
+		Query:     "conv-123",
+		UserID:    "user-42",
+		SortBy:    store.SessionSortByCreatedAt,
+		SortDir:   store.SortDirectionAsc,
+		Limit:     10,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), result.Total)
+	assert.Equal(t, []uuid.UUID{exact.ID, prefix.ID, nameOnly.ID}, sessionIDs(result.Sessions))
+}
+
+func TestListSessionsFiltered_ProjectScopingAndStablePagination(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectAID := testutil.CreateTestProject(t, ctx, q)
+	projectBID := testutil.CreateTestProject(t, ctx, q)
+	stableTimestamp := time.Date(2026, 3, 13, 9, 0, 0, 0, time.UTC)
+
+	projectASessionIDs := make([]uuid.UUID, 0, 5)
+	for i := 0; i < 5; i++ {
+		session := createSessionAt(
+			t,
+			ctx,
+			s,
+			projectAID,
+			fmt.Sprintf("stable-%d", i),
+			fmt.Sprintf("Stable %d", i),
+			"user-a",
+			stableTimestamp,
+		)
+		projectASessionIDs = append(projectASessionIDs, session.ID)
+		createSessionTraces(t, ctx, q, projectAID, session.ID, 1)
+	}
+
+	otherProjectSession := createSessionAt(t, ctx, s, projectBID, "other-project", "Other", "user-b", stableTimestamp)
+	createSessionTraces(t, ctx, q, projectBID, otherProjectSession.ID, 3)
+
+	pageOne, err := s.ListSessionsFiltered(ctx, store.SessionFilter{
+		ProjectID: projectAID,
+		SortBy:    store.SessionSortByTraceCount,
+		SortDir:   store.SortDirectionDesc,
+		Limit:     2,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), pageOne.Total)
+	require.Len(t, pageOne.Sessions, 2)
+
+	pageTwo, err := s.ListSessionsFiltered(ctx, store.SessionFilter{
+		ProjectID: projectAID,
+		SortBy:    store.SessionSortByTraceCount,
+		SortDir:   store.SortDirectionDesc,
+		Limit:     2,
+		Offset:    2,
+	})
+	require.NoError(t, err)
+	require.Len(t, pageTwo.Sessions, 2)
+
+	pageOneIDs := sessionIDs(pageOne.Sessions)
+	pageTwoIDs := sessionIDs(pageTwo.Sessions)
+	for _, pageTwoID := range pageTwoIDs {
+		assert.NotContains(t, pageOneIDs, pageTwoID)
+	}
+	for _, id := range append(pageOneIDs, pageTwoIDs...) {
+		assert.Contains(t, projectASessionIDs, id)
+		assert.NotEqual(t, otherProjectSession.ID, id)
+	}
+}
+
+//nolint:revive // Keep testing.T first in shared test helper signatures.
+func createSessionAt(
+	t *testing.T,
+	ctx context.Context,
+	s *store.Store,
+	projectID uuid.UUID,
+	externalID string,
+	name string,
+	userID string,
+	createdAt time.Time,
+) platform.Session {
+	t.Helper()
+
+	session, err := s.Queries().CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectID,
+		ExternalID: externalID,
+		Name:       optionalString(name),
+		UserID:     optionalString(userID),
+	})
+	require.NoError(t, err)
+
+	_, err = s.Pool().Exec(ctx, "UPDATE sessions SET created_at = $2, updated_at = $2 WHERE id = $1", session.ID, createdAt)
+	require.NoError(t, err)
+
+	session.CreatedAt = createdAt
+	session.UpdatedAt = createdAt
+	return session
+}
+
+//nolint:revive // Keep testing.T first in shared test helper signatures.
+func createSessionTraces(
+	t *testing.T,
+	ctx context.Context,
+	q *platform.Queries,
+	projectID uuid.UUID,
+	sessionID uuid.UUID,
+	count int,
+) {
+	t.Helper()
+
+	for i := 0; i < count; i++ {
+		_, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+			ProjectID: projectID,
+			SessionID: testutil.PgtypeUUID(sessionID),
+			TraceID:   fmt.Sprintf("trace-%s-%d", sessionID.String()[:8], i),
+			Name:      testutil.StrPtr(fmt.Sprintf("Trace %d", i)),
+		})
+		require.NoError(t, err)
+	}
+}
+
+func optionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func sessionIDs(sessions []store.SessionWithCount) []uuid.UUID {
+	ids := make([]uuid.UUID, len(sessions))
+	for i := range sessions {
+		ids[i] = sessions[i].ID
+	}
+	return ids
+}

--- a/internal/store/sort.go
+++ b/internal/store/sort.go
@@ -1,0 +1,16 @@
+package store
+
+// SortDirection controls ascending or descending ordering.
+type SortDirection string
+
+const (
+	SortDirectionAsc  SortDirection = "asc"
+	SortDirectionDesc SortDirection = "desc"
+)
+
+func normalizeSortDirection(direction SortDirection) SortDirection {
+	if direction == SortDirectionAsc {
+		return SortDirectionAsc
+	}
+	return SortDirectionDesc
+}

--- a/internal/store/traces.go
+++ b/internal/store/traces.go
@@ -6,9 +6,64 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/continua-ai/continua/db/gen/go/platform"
 )
+
+// TraceRead is the unified trace read model across sqlc and handwritten search paths.
+type TraceRead struct {
+	platform.Trace
+	SessionExternalID *string
+}
+
+type traceReadRow interface {
+	platform.GetTraceRow |
+		platform.ListTracesRow |
+		platform.ListTracesAscRow |
+		platform.ListTracesBySessionRow |
+		platform.ListTracesBySessionAscRow
+}
+
+func mapTraceReadRow[T traceReadRow](row T) TraceRead {
+	switch row := any(row).(type) {
+	case platform.GetTraceRow:
+		return TraceRead{
+			Trace:             row.Trace,
+			SessionExternalID: row.SessionExternalID,
+		}
+	case platform.ListTracesRow:
+		return TraceRead{
+			Trace:             row.Trace,
+			SessionExternalID: row.SessionExternalID,
+		}
+	case platform.ListTracesAscRow:
+		return TraceRead{
+			Trace:             row.Trace,
+			SessionExternalID: row.SessionExternalID,
+		}
+	case platform.ListTracesBySessionRow:
+		return TraceRead{
+			Trace:             row.Trace,
+			SessionExternalID: row.SessionExternalID,
+		}
+	case platform.ListTracesBySessionAscRow:
+		return TraceRead{
+			Trace:             row.Trace,
+			SessionExternalID: row.SessionExternalID,
+		}
+	default:
+		return TraceRead{}
+	}
+}
+
+func mapTraceReadRows[T traceReadRow](rows []T) []TraceRead {
+	result := make([]TraceRead, len(rows))
+	for i := range rows {
+		result[i] = mapTraceReadRow(rows[i])
+	}
+	return result
+}
 
 // CreateTraceTx creates a new trace within a transaction.
 func (t *Tx) CreateTrace(ctx context.Context, params *platform.CreateTraceParams) (platform.Trace, error) {
@@ -16,12 +71,15 @@ func (t *Tx) CreateTrace(ctx context.Context, params *platform.CreateTraceParams
 }
 
 // GetTrace retrieves a trace by its internal UUID.
-func (s *Store) GetTrace(ctx context.Context, id uuid.UUID) (platform.Trace, error) {
+func (s *Store) GetTrace(ctx context.Context, id uuid.UUID) (TraceRead, error) {
 	trace, err := s.q.GetTrace(ctx, id)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return platform.Trace{}, ErrNotFound
+		return TraceRead{}, ErrNotFound
 	}
-	return trace, err
+	if err != nil {
+		return TraceRead{}, err
+	}
+	return mapTraceReadRow(trace), nil
 }
 
 // GetTraceByExternalIDTx retrieves a trace by external ID within a transaction.
@@ -62,17 +120,72 @@ func (t *Tx) GetTraceUUID(ctx context.Context, projectID uuid.UUID, traceID stri
 }
 
 // ListTraces returns paginated traces for a project.
-func (s *Store) ListTraces(ctx context.Context, projectID uuid.UUID, limit, offset int32) ([]platform.Trace, error) {
-	return s.q.ListTraces(ctx, platform.ListTracesParams{
+func (s *Store) ListTraces(ctx context.Context, projectID uuid.UUID, limit, offset int32, sortDir SortDirection) ([]TraceRead, error) {
+	if normalizeSortDirection(sortDir) == SortDirectionAsc {
+		rows, err := s.q.ListTracesAsc(ctx, platform.ListTracesAscParams{
+			ProjectID: projectID,
+			Limit:     limit,
+			Offset:    offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return mapTraceReadRows(rows), nil
+	}
+
+	rows, err := s.q.ListTraces(ctx, platform.ListTracesParams{
 		ProjectID: projectID,
 		Limit:     limit,
 		Offset:    offset,
 	})
+	if err != nil {
+		return nil, err
+	}
+	return mapTraceReadRows(rows), nil
+}
+
+// ListTracesBySession returns paginated traces for a session.
+func (s *Store) ListTracesBySession(
+	ctx context.Context,
+	projectID uuid.UUID,
+	sessionID uuid.UUID,
+	limit,
+	offset int32,
+	sortDir SortDirection,
+) ([]TraceRead, error) {
+	params := platform.ListTracesBySessionParams{
+		ProjectID: projectID,
+		SessionID: pgtype.UUID{Bytes: sessionID, Valid: true},
+		Limit:     limit,
+		Offset:    offset,
+	}
+
+	if normalizeSortDirection(sortDir) == SortDirectionAsc {
+		rows, err := s.q.ListTracesBySessionAsc(ctx, platform.ListTracesBySessionAscParams(params))
+		if err != nil {
+			return nil, err
+		}
+		return mapTraceReadRows(rows), nil
+	}
+
+	rows, err := s.q.ListTracesBySession(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return mapTraceReadRows(rows), nil
 }
 
 // CountTraces returns the total number of traces for a project.
 func (s *Store) CountTraces(ctx context.Context, projectID uuid.UUID) (int64, error) {
 	return s.q.CountTraces(ctx, projectID)
+}
+
+// CountTracesBySession returns the total number of traces for a session.
+func (s *Store) CountTracesBySession(ctx context.Context, projectID, sessionID uuid.UUID) (int64, error) {
+	return s.q.CountTracesBySession(ctx, platform.CountTracesBySessionParams{
+		ProjectID: projectID,
+		SessionID: pgtype.UUID{Bytes: sessionID, Valid: true},
+	})
 }
 
 // UpdateTraceStatusTx updates trace status within a transaction.

--- a/internal/store/traces_read_test.go
+++ b/internal/store/traces_read_test.go
@@ -1,0 +1,282 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestListTraces_SortDirectionAndSessionIdentity(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	session, err := q.CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectID,
+		ExternalID: "conv-123",
+	})
+	require.NoError(t, err)
+
+	older := time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC)
+	newer := older.Add(2 * time.Hour)
+
+	traceWithSession, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		SessionID: testutil.PgtypeUUID(session.ID),
+		TraceID:   "trace-with-session",
+		Name:      testutil.StrPtr("Trace With Session"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(older),
+	})
+	require.NoError(t, err)
+
+	traceWithoutSession, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "trace-without-session",
+		Name:      testutil.StrPtr("Trace Without Session"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(newer),
+	})
+	require.NoError(t, err)
+
+	ascending, err := s.ListTraces(ctx, projectID, 10, 0, store.SortDirectionAsc)
+	require.NoError(t, err)
+	require.Len(t, ascending, 2)
+	assert.Equal(t, traceWithSession.ID, ascending[0].ID)
+	require.NotNil(t, ascending[0].SessionExternalID)
+	assert.Equal(t, session.ExternalID, *ascending[0].SessionExternalID)
+	assert.Nil(t, ascending[1].SessionExternalID)
+
+	descending, err := s.ListTraces(ctx, projectID, 10, 0, store.SortDirectionDesc)
+	require.NoError(t, err)
+	require.Len(t, descending, 2)
+	assert.Equal(t, traceWithoutSession.ID, descending[0].ID)
+	assert.Equal(t, traceWithSession.ID, descending[1].ID)
+
+	sessionScoped, err := s.ListTracesBySession(ctx, projectID, session.ID, 10, 0, store.SortDirectionDesc)
+	require.NoError(t, err)
+	require.Len(t, sessionScoped, 1)
+	assert.Equal(t, traceWithSession.ID, sessionScoped[0].ID)
+	require.NotNil(t, sessionScoped[0].SessionExternalID)
+	assert.Equal(t, session.ExternalID, *sessionScoped[0].SessionExternalID)
+
+	total, err := s.CountTracesBySession(ctx, projectID, session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+}
+
+func TestListTracesFiltered_SearchIncludesSessionIdentityAndUsesRanking(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	base := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+
+	nameMatchSession, err := q.CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectID,
+		ExternalID: "conv-name-match",
+	})
+	require.NoError(t, err)
+
+	spanMatchSession, err := q.CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectID,
+		ExternalID: "conv-span-match",
+	})
+	require.NoError(t, err)
+
+	nameMatchTrace, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		SessionID: testutil.PgtypeUUID(nameMatchSession.ID),
+		TraceID:   "trace-name-match",
+		Name:      testutil.StrPtr("checkout"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(base),
+	})
+	require.NoError(t, err)
+
+	spanMatchTrace, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		SessionID: testutil.PgtypeUUID(spanMatchSession.ID),
+		TraceID:   "trace-span-match",
+		Name:      testutil.StrPtr("background work"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(base.Add(2 * time.Hour)),
+	})
+	require.NoError(t, err)
+
+	_, err = q.UpsertSpan(ctx, platform.UpsertSpanParams{
+		ProjectID: projectID,
+		TraceID:   spanMatchTrace.ID,
+		SpanID:    "span-checkout",
+		Name:      "checkout",
+		Type:      "tool",
+		Status:    "completed",
+		Level:     "default",
+		StartTime: base.Add(2 * time.Hour),
+		TotalCost: testutil.PgtypeNumericFromFloat64(0),
+	})
+	require.NoError(t, err)
+
+	result, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID: projectID,
+		Query:     "checkout",
+		SortDir:   store.SortDirectionAsc,
+		Limit:     10,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Traces, 2)
+
+	assert.Equal(t, nameMatchTrace.ID, result.Traces[0].ID, "trace-name match should rank ahead of span-only match")
+	assert.Equal(t, spanMatchTrace.ID, result.Traces[1].ID)
+	require.NotNil(t, result.Traces[0].SessionExternalID)
+	require.NotNil(t, result.Traces[1].SessionExternalID)
+	assert.Equal(t, nameMatchSession.ExternalID, *result.Traces[0].SessionExternalID)
+	assert.Equal(t, spanMatchSession.ExternalID, *result.Traces[1].SessionExternalID)
+	assert.Equal(t, int64(2), result.Total)
+}
+
+func TestListTraces_PaginationRemainsStableWhenTimestampsTie(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	session, err := q.CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectID,
+		ExternalID: "conv-stable-order",
+	})
+	require.NoError(t, err)
+
+	tiedStart := time.Date(2026, 3, 12, 15, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		_, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+			ProjectID: projectID,
+			SessionID: testutil.PgtypeUUID(session.ID),
+			TraceID:   fmt.Sprintf("trace-tied-%d", i),
+			Name:      testutil.StrPtr(fmt.Sprintf("Trace %d", i)),
+			Status:    "completed",
+			StartTime: testutil.PgtypeTimestamptz(tiedStart),
+		})
+		require.NoError(t, err)
+	}
+
+	fullDescending, err := s.ListTraces(ctx, projectID, 10, 0, store.SortDirectionDesc)
+	require.NoError(t, err)
+	firstDescendingPage, err := s.ListTraces(ctx, projectID, 2, 0, store.SortDirectionDesc)
+	require.NoError(t, err)
+	secondDescendingPage, err := s.ListTraces(ctx, projectID, 2, 2, store.SortDirectionDesc)
+	require.NoError(t, err)
+	assertStableTracePagination(t, fullDescending, firstDescendingPage, secondDescendingPage)
+
+	fullAscending, err := s.ListTraces(ctx, projectID, 10, 0, store.SortDirectionAsc)
+	require.NoError(t, err)
+	firstAscendingPage, err := s.ListTraces(ctx, projectID, 2, 0, store.SortDirectionAsc)
+	require.NoError(t, err)
+	secondAscendingPage, err := s.ListTraces(ctx, projectID, 2, 2, store.SortDirectionAsc)
+	require.NoError(t, err)
+	assertStableTracePagination(t, fullAscending, firstAscendingPage, secondAscendingPage)
+
+	fullSessionDescending, err := s.ListTracesBySession(ctx, projectID, session.ID, 10, 0, store.SortDirectionDesc)
+	require.NoError(t, err)
+	firstSessionDescendingPage, err := s.ListTracesBySession(ctx, projectID, session.ID, 2, 0, store.SortDirectionDesc)
+	require.NoError(t, err)
+	secondSessionDescendingPage, err := s.ListTracesBySession(ctx, projectID, session.ID, 2, 2, store.SortDirectionDesc)
+	require.NoError(t, err)
+	assertStableTracePagination(t, fullSessionDescending, firstSessionDescendingPage, secondSessionDescendingPage)
+
+	fullSessionAscending, err := s.ListTracesBySession(ctx, projectID, session.ID, 10, 0, store.SortDirectionAsc)
+	require.NoError(t, err)
+	firstSessionAscendingPage, err := s.ListTracesBySession(ctx, projectID, session.ID, 2, 0, store.SortDirectionAsc)
+	require.NoError(t, err)
+	secondSessionAscendingPage, err := s.ListTracesBySession(ctx, projectID, session.ID, 2, 2, store.SortDirectionAsc)
+	require.NoError(t, err)
+	assertStableTracePagination(t, fullSessionAscending, firstSessionAscendingPage, secondSessionAscendingPage)
+}
+
+func TestListTracesFiltered_SearchPaginationRemainsStableWhenSortKeysTie(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	tiedStart := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 4; i++ {
+		_, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+			ProjectID: projectID,
+			TraceID:   fmt.Sprintf("trace-search-tied-%d", i),
+			Name:      testutil.StrPtr("checkout"),
+			Status:    "completed",
+			StartTime: testutil.PgtypeTimestamptz(tiedStart),
+		})
+		require.NoError(t, err)
+	}
+
+	fullResult, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID: projectID,
+		Query:     "checkout",
+		Limit:     10,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	firstPageResult, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID: projectID,
+		Query:     "checkout",
+		Limit:     2,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	secondPageResult, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID: projectID,
+		Query:     "checkout",
+		Limit:     2,
+		Offset:    2,
+	})
+	require.NoError(t, err)
+
+	assertStableTracePagination(t, fullResult.Traces, firstPageResult.Traces, secondPageResult.Traces)
+	assert.Equal(t, int64(4), fullResult.Total)
+}
+
+func assertStableTracePagination(t *testing.T, full []store.TraceRead, pages ...[]store.TraceRead) {
+	t.Helper()
+
+	var combined []string
+	seen := make(map[string]struct{}, len(full))
+	for _, page := range pages {
+		for _, trace := range page {
+			traceID := trace.ID.String()
+			if _, exists := seen[traceID]; exists {
+				t.Fatalf("duplicate trace returned across pages: %s", traceID)
+			}
+			seen[traceID] = struct{}{}
+			combined = append(combined, traceID)
+		}
+	}
+
+	assert.Equal(t, traceIDStrings(full), combined)
+	assert.Len(t, seen, len(full))
+}
+
+func traceIDStrings(traces []store.TraceRead) []string {
+	ids := make([]string, len(traces))
+	for i := range traces {
+		ids[i] = traces[i].ID.String()
+	}
+	return ids
+}

--- a/openspec/changes/add-session-scale-ux/design.md
+++ b/openspec/changes/add-session-scale-ux/design.md
@@ -1,0 +1,59 @@
+## Context
+The debugger currently has URL-driven filtering and pagination on `/traces` but not on `/sessions`. Session list has no search, filtering, or sorting. Trace reads don't surface session external IDs. Pagination everywhere is minimal. Phase 10 needs to bring sessions to parity with traces for scale UX while keeping the scope contained.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Sessions list with search, filtering, sorting, and URL-driven state
+- Trace reads include `session_external_id` from a join
+- Consistent advanced pagination across all list views
+- External-first session identity throughout the debugger
+
+**Non-Goals:**
+- Cursor pagination (offset stays in Phase 10)
+- Session mutation APIs
+- Separate batch lookup API for session external IDs
+- Trigram search or Postgres FTS for sessions
+- Broader trace search/filter expansion
+
+## Decisions
+
+### Traces keep sqlc with two static queries for sort direction; sessions get handwritten queries
+- **Decision**: Trace fast-path queries stay in sqlc. Since sqlc cannot parameterize SQL keywords like `ASC`/`DESC`, the implementation uses two static queries: the existing `ListTraces` (DESC, the default) and a new `ListTracesAsc` (ASC). The same applies to `ListTracesBySession` / `ListTracesBySessionAsc`. The handler picks the correct query based on the parsed `sort_dir` param. Sessions get a handwritten dynamic query file parallel to `search.go`.
+- **Why**: sqlc binds values, not SQL keywords, so a single parameterized query cannot toggle sort direction. Two static queries is the simplest sqlc-compatible approach and avoids introducing a handwritten path for traces when the only variation is sort direction. Sessions need handwritten SQL because they have dynamic WHERE clauses and dynamic ORDER BY (`q`, `user_id`, `trace_count` sorting), which sqlc is not a good fit for.
+
+### `trace_count` via derived-table aggregate join
+- **Decision**: Implement `trace_count` sorting with `LEFT JOIN (SELECT session_id, COUNT(*) AS cnt FROM traces WHERE project_id = $1 GROUP BY session_id) tc ON tc.session_id = s.id`, using `COALESCE(tc.cnt, 0)`.
+- **Why**: Joining traces directly on the outer query would cause row multiplication that breaks pagination and counting. A derived table keeps the session row cardinality stable.
+
+### Search overrides user sorting
+- **Decision**: When `q` is present on either traces or sessions, `sort_by` and `sort_dir` are ignored server-side and relevance/rank ordering is used instead.
+- **Why**: Relevance ordering is the correct behavior during search. Allowing user sort on top of search results produces confusing results where exact matches appear far from the top.
+
+### Session search ranking tiers
+- **Decision**: `external_id exact match > external_id prefix match > all other ILIKE matches > created_at desc`. No trigram indexes or FTS.
+- **Why**: Sessions are lower cardinality than traces, `external_id` is the primary lookup key, and the three-tier ranking is implementable with a simple CASE expression in ORDER BY.
+
+### Single `session_external_id` field on trace reads
+- **Decision**: Add `session_external_id` as an optional string field on both `Trace` and `TraceDetail` API schemas, populated by a `LEFT JOIN sessions` in every trace read query.
+- **Why**: Avoids a separate API call to resolve session external IDs, and the join is cheap because `session_id` is already an FK on traces with an existing index.
+
+### One new index only
+- **Decision**: Add `(project_id, created_at DESC, id DESC)` on sessions. Reuse existing `(project_id, user_id)` for `user_id` filtering. No new trace indexes.
+- **Why**: The existing `idx_sessions_project` is a single-column index that can't serve sorted pagination efficiently. The composite index with `id DESC` as tiebreaker ensures stable offset pagination. Trace queries sort on `COALESCE(start_time, server_received_at)`, which does not have an exact composite index today, but Phase 10 intentionally adds no new trace index unless measurement shows regression from the new sort direction support.
+
+## Risks / Trade-offs
+- **Offset pagination at scale**: Large offset values have O(N) seek cost. Acceptable for Phase 10 given session cardinality is low; cursor pagination is a known future improvement.
+- **`trace_count` subquery cost**: The derived-table join scans the traces table grouped by session_id. For projects with many traces, this may be slow. Mitigation: the `project_id` filter on the subquery uses the existing `idx_traces_project_session` index.
+- **Session search without FTS**: ILIKE-based search won't scale to millions of sessions. Acceptable for current usage; FTS can be added later if needed.
+
+### Session detail trace table state in URL params
+- **Decision**: The session detail page (`/sessions/:id`) SHALL manage its trace table state (`offset`, `limit`, `sort_by`, `sort_dir`) via URL search params on the session detail route itself (e.g., `/sessions/abc-def?sort_by=started_at&sort_dir=asc&limit=50&offset=20`). The `returnTo` link captures the full URL including these params, enabling exact restoration of table state when navigating back from trace detail.
+- **Why**: Today `SessionDetailPage` keeps `offset` in local `useState`, which is lost on navigation. Moving state to URL params is required for the `returnTo` round-trip promise to be achievable.
+
+### Pagination limits are UI defaults, not API contract changes
+- **Decision**: The page-size options `20`, `50`, `100` are UI-only defaults and selector choices. The backend API continues to accept any `limit` value within the existing range (`defaultPageLimit=50`, `maxPageLimit=200`). The UI defaults its page size to `20` but the API does not enforce this whitelist.
+- **Why**: Restricting the API to only three limit values would be an unnecessary contract change that could break existing API consumers. The UI can present curated options without constraining the API.
+
+## Open Questions
+- None. All decisions are locked per the proposal spec.

--- a/openspec/changes/add-session-scale-ux/proposal.md
+++ b/openspec/changes/add-session-scale-ux/proposal.md
@@ -1,0 +1,23 @@
+# Change: Add Session & Scale UX
+
+## Why
+The sessions list page lacks search, filtering, sorting, and URL-driven state, making it unusable at scale. Trace reads also lack session identity context (`session_external_id`), forcing users to navigate between pages to correlate traces with sessions. Pagination across the debugger is minimal (no page-size control, no first/last navigation). These gaps become blocking as production usage grows beyond a handful of sessions.
+
+## What Changes
+- **Trace API sorting**: `/api/traces` gains `sort_by=started_at` and `sort_dir=asc|desc`. Implemented via two static sqlc queries (`ListTraces` for DESC, `ListTracesAsc` for ASC) since sqlc cannot parameterize SQL keywords. When `q` is present, sort params are ignored and relevance ordering is preserved.
+- **Trace session identity**: All trace read paths (`ListTraces`, `ListTracesBySession`, `GetTrace`, trace search) return `session_external_id` via a `LEFT JOIN sessions` on the query layer. API `Trace` and `TraceDetail` schemas gain an optional `session_external_id` field.
+- **Session API filtering and sorting**: `/api/sessions` gains `q`, exact-match `user_id`, `sort_by=created_at|trace_count`, and `sort_dir=asc|desc`. (`limit` and `offset` already exist in the live contract and are not new.)
+- **Dynamic session query path**: A handwritten dynamic query file (parallel to `search.go`) handles session search (`q` matches `external_id` and `name`), `user_id` exact filtering, and dynamic sorting including `trace_count` via derived-table aggregate join.
+- **Session search ranking**: `external_id exact > external_id prefix > all other matches > created_at desc`. No trigram or FTS.
+- **Advanced shared pagination**: Replace `PaginationControls` with a shared paginator supporting First/Previous/Next/Last, current page, total pages, page-size selector (UI options: 20/50/100; API keeps existing `maxPageLimit=200`), "showing X-Y of Z", previous-row preservation during refetch, and stale-offset repair.
+- **Sessions page URL-driven state**: Rebuild `/sessions` around URL search params (`q`, `user_id`, `sort_by`, `sort_dir`, `limit`, `offset`).
+- **Session detail trace UX**: Move session-detail trace table state (`offset`, `limit`, `sort_by`, `sort_dir`) from local `useState` into URL search params on `/sessions/:id`. Add trace sorting, page-size control, keep-previous-data, stale-offset repair, and `returnTo` state links that capture the full URL for exact table state restoration.
+- **External-first session identity**: Sessions list, session detail, trace list, and trace detail all render external ID as primary label with UUID as secondary.
+- **Session index**: Add `(project_id, created_at DESC, id DESC)` on `sessions`.
+
+## Impact
+- Affected specs: `trace-sorting`, `trace-session-identity`, `session-filtering-sorting`, `session-search`, `advanced-pagination`, `session-url-state`, `external-first-identity`
+- Affected code:
+  - Backend: `contracts/openapi/openapi.yaml`, `db/platform/queries/traces.sql`, `db/platform/queries/sessions.sql`, `internal/store/search.go` (extend), new `internal/store/session_search.go`, `internal/store/store.go`, `internal/api/traces_handlers.go`, `internal/api/sessions_handlers.go`, `internal/api/mapper.go`, new migration for session index
+  - Frontend: `web/src/api/client.ts`, `web/src/components/PaginationControls.tsx` (rewrite), `web/src/pages/SessionsPage.tsx` (rewrite), `web/src/pages/SessionDetailPage.tsx`, `web/src/pages/TracesPage.tsx`, `web/src/pages/TraceDetailPage.tsx`
+- No new dependencies

--- a/openspec/changes/add-session-scale-ux/specs/advanced-pagination/spec.md
+++ b/openspec/changes/add-session-scale-ux/specs/advanced-pagination/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Shared Advanced Paginator
+A shared advanced pagination component SHALL replace the current minimal `PaginationControls` and be used by `/traces`, `/sessions`, and session-detail trace tables. It SHALL provide First, Previous, Next, and Last navigation buttons, current page number, total pages, a page-size selector, and a "showing X-Y of Z" label.
+
+#### Scenario: Full pagination controls render
+- **WHEN** a list view renders the advanced paginator with `total=150`, `limit=20`, `offset=0`
+- **THEN** the paginator displays "Showing 1-20 of 150", "Page 1 of 8"
+- **AND** First and Previous buttons are disabled
+- **AND** Next and Last buttons are enabled
+- **AND** a page-size selector shows options 20, 50, 100
+
+#### Scenario: Navigate to last page
+- **WHEN** the user clicks the Last button with `total=150`, `limit=20`, `offset=0`
+- **THEN** the offset updates to `140` (last page)
+- **AND** the paginator displays "Showing 141-150 of 150", "Page 8 of 8"
+- **AND** Next and Last buttons are disabled
+
+### Requirement: Page Size Selector
+The paginator SHALL offer page sizes of 20, 50, and 100 in the UI selector. The UI default page size SHALL be 20. Changing the page size SHALL reset the offset to 0. These are UI-only choices; the backend API continues to accept any `limit` within the existing server-wide range (up to `maxPageLimit=200`).
+
+#### Scenario: Change page size resets offset
+- **WHEN** the user is on page 3 (offset=40, limit=20) and changes page size to 50
+- **THEN** the offset resets to 0
+- **AND** the URL updates with `limit=50&offset=0`
+
+### Requirement: Previous Row Preservation
+List views using the advanced paginator SHALL preserve previous rows during refetch so that the table does not flash empty while new data loads.
+
+#### Scenario: Data preserved during refetch
+- **WHEN** the user changes the sort order on a list view
+- **THEN** the previous rows remain visible until the new data arrives
+- **AND** the table then updates with the new data
+
+### Requirement: Stale Offset Repair
+When the total shrinks such that the current offset exceeds the total, the paginator SHALL automatically repair the offset to the last valid page.
+
+#### Scenario: Offset exceeds new total
+- **WHEN** the user is at `offset=80` with `limit=20` and the total shrinks from 100 to 60
+- **THEN** the offset automatically repairs to `40` (last valid page)
+- **AND** the URL updates to reflect the repaired offset

--- a/openspec/changes/add-session-scale-ux/specs/external-first-identity/spec.md
+++ b/openspec/changes/add-session-scale-ux/specs/external-first-identity/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: External-First Session Identity
+Session identity SHALL be displayed external-first throughout the debugger. External ID SHALL be the primary clickable label and UUID SHALL be secondary muted text. This applies to the sessions list, session detail header, trace list session links, and trace detail session field.
+
+#### Scenario: Sessions list shows external ID as primary label
+- **WHEN** the sessions list renders a session row
+- **THEN** the external ID is the primary clickable label linking to session detail
+- **AND** the UUID is displayed as secondary muted text
+
+#### Scenario: Session detail header shows external ID first
+- **WHEN** the session detail page renders
+- **THEN** the header displays external ID first and UUID second
+- **AND** both are copyable
+
+#### Scenario: Trace list shows session external ID
+- **WHEN** the trace list renders a trace that belongs to a session
+- **THEN** the session link shows the external ID as primary text
+- **AND** the UUID is available as secondary support text
+
+#### Scenario: Trace detail shows session external ID
+- **WHEN** the trace detail page renders for a trace with a session
+- **THEN** the session field shows external ID first
+- **AND** the UUID is available for copy/debugging

--- a/openspec/changes/add-session-scale-ux/specs/session-filtering-sorting/spec.md
+++ b/openspec/changes/add-session-scale-ux/specs/session-filtering-sorting/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Session List Filtering
+The `/api/sessions` endpoint SHALL accept optional `q` and `user_id` query parameters. `q` SHALL perform fuzzy search on `external_id` and `name`. `user_id` SHALL be an exact-match structured filter and is not part of fuzzy ranking. Both filters MAY be combined.
+
+#### Scenario: Filter sessions by search query
+- **WHEN** a client requests `GET /api/sessions?q=conv`
+- **THEN** sessions whose `external_id` or `name` match "conv" are returned in ranked order
+
+#### Scenario: Filter sessions by exact user_id
+- **WHEN** a client requests `GET /api/sessions?user_id=user-42`
+- **THEN** only sessions with `user_id = 'user-42'` are returned
+
+#### Scenario: Combine search and user_id filter
+- **WHEN** a client requests `GET /api/sessions?q=test&user_id=user-42`
+- **THEN** only sessions matching both the search query and exact `user_id` are returned
+- **AND** results are ordered by search ranking
+
+#### Scenario: Empty query returns all sessions
+- **WHEN** a client requests `GET /api/sessions` without `q` or `user_id`
+- **THEN** all sessions for the project are returned in default order
+
+### Requirement: Session List Sorting
+The `/api/sessions` endpoint SHALL accept optional `sort_by` and `sort_dir` query parameters. `sort_by` SHALL accept `created_at` or `trace_count`. `sort_dir` SHALL accept `asc` or `desc` and default to `desc`. When `q` is present, the server SHALL ignore `sort_by` and `sort_dir` and use search ranking instead.
+
+#### Scenario: Sort sessions by created_at ascending
+- **WHEN** a client requests `GET /api/sessions?sort_by=created_at&sort_dir=asc`
+- **THEN** sessions are returned ordered by `created_at ASC`
+
+#### Scenario: Sort sessions by trace_count descending
+- **WHEN** a client requests `GET /api/sessions?sort_by=trace_count&sort_dir=desc`
+- **THEN** sessions are returned ordered by trace count descending
+- **AND** trace count is computed via a derived-table aggregate join
+
+#### Scenario: Default sort when no sort params
+- **WHEN** a client requests `GET /api/sessions` without `sort_by` or `sort_dir`
+- **THEN** sessions are returned in default order: `created_at DESC`
+
+#### Scenario: Search overrides user sorting on sessions
+- **WHEN** a client requests `GET /api/sessions?q=test&sort_by=created_at&sort_dir=asc`
+- **THEN** the server ignores `sort_by` and `sort_dir`
+- **AND** sessions are returned in search ranking order
+
+### Requirement: Session List Pagination
+The `/api/sessions` endpoint SHALL accept `limit` and `offset` query parameters. The API SHALL use the existing server-wide pagination defaults (`defaultPageLimit=50`, `maxPageLimit=200`) and SHALL NOT restrict `limit` to a whitelist of values. The response SHALL include a `total` field reflecting the count after filters are applied. The UI page-size selector offers `20`, `50`, and `100` as options with a UI default of `20`, but these are UI-only choices and are not enforced by the API.
+
+#### Scenario: Paginated session list with filters
+- **WHEN** a client requests `GET /api/sessions?q=test&limit=50&offset=50`
+- **THEN** the response contains up to 50 sessions starting at offset 50
+- **AND** `total` reflects the total count of sessions matching the search query
+
+#### Scenario: API accepts arbitrary limit within server max
+- **WHEN** a client requests `GET /api/sessions?limit=75`
+- **THEN** the server accepts the limit and returns up to 75 sessions
+
+### Requirement: Session Sorting UI
+The sessions list page SHALL render `Traces` and `Created` column headers as sortable. Clicking a sortable header SHALL toggle sort direction and update URL search params. `Session`, `User ID`, and `Name` columns SHALL remain visible but non-sortable. When search is active, sortable headers SHALL become non-clickable and visually muted.
+
+#### Scenario: Click Traces header to sort by trace_count
+- **WHEN** the user clicks the `Traces` column header
+- **THEN** the URL updates to include `sort_by=trace_count` with toggled `sort_dir`
+- **AND** the table re-fetches with the new sort order
+
+#### Scenario: Sort headers disabled during search
+- **WHEN** the user has an active search query
+- **THEN** the `Traces` and `Created` sortable headers are visually muted and non-clickable
+
+### Requirement: Dynamic Session Query Path
+The store layer SHALL use a handwritten dynamic query file for session search, user_id filtering, and non-default sorting. The default session listing (no search, no user_id, default sort) MAY continue to use sqlc.
+
+#### Scenario: trace_count sorting uses derived-table aggregate
+- **WHEN** sorting sessions by `trace_count`
+- **THEN** the query uses `LEFT JOIN (SELECT session_id, COUNT(*) AS cnt FROM traces WHERE project_id = $1 GROUP BY session_id) tc ON tc.session_id = s.id`
+- **AND** uses `COALESCE(tc.cnt, 0)` as the sort value
+- **AND** never joins traces directly on the outer query
+
+### Requirement: Session Index for Sorted Pagination
+A database index `(project_id, created_at DESC, id DESC)` SHALL be added on the `sessions` table to support efficient sorted pagination. The existing `(project_id, user_id)` index SHALL be reused for `user_id` filtering.
+
+#### Scenario: Index supports default session listing
+- **WHEN** sessions are listed with default `created_at DESC` sorting
+- **THEN** the query uses the composite index for efficient sequential access

--- a/openspec/changes/add-session-scale-ux/specs/session-search/spec.md
+++ b/openspec/changes/add-session-scale-ux/specs/session-search/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Session Search Ranking
+Session search SHALL match against `external_id` and `name` using case-insensitive matching. Results SHALL be ranked in the following tiers: (1) exact `external_id` match, (2) `external_id` prefix match, (3) all other ILIKE matches, (4) `created_at DESC` as tiebreaker within each tier.
+
+#### Scenario: Exact external_id match ranks first
+- **WHEN** a session has `external_id = "conv-123"` and the user searches `q=conv-123`
+- **THEN** that session appears before sessions with `external_id = "conv-1234"` or `name = "conv-123 discussion"`
+
+#### Scenario: Prefix match on external_id ranks second
+- **WHEN** sessions exist with `external_id` values `"conv-123"`, `"conv-1234"`, and `name = "conv-123 test"`
+- **AND** the user searches `q=conv-123`
+- **THEN** exact match `"conv-123"` ranks first
+- **AND** prefix match `"conv-1234"` ranks second
+- **AND** name-only match ranks third
+
+#### Scenario: Name-only match ranks below external_id matches
+- **WHEN** a session has `name = "test session"` but `external_id = "sess-001"`
+- **AND** another session has `external_id = "test-session"` and `name = "other"`
+- **AND** the user searches `q=test`
+- **THEN** the `external_id` prefix match ranks above the name-only match
+
+### Requirement: Session Search Simplicity
+Session search SHALL NOT use trigram indexes, Postgres full-text search, or multi-tier scoring beyond the three tiers defined in the ranking requirement. The implementation SHALL use ILIKE matching with a CASE expression for tier ordering.
+
+#### Scenario: Search implementation uses ILIKE
+- **WHEN** a session search query is executed
+- **THEN** the query uses ILIKE for matching against `external_id` and `name`
+- **AND** uses a CASE expression in ORDER BY for tier-based ranking
+- **AND** does not use `tsvector`, `tsquery`, or `pg_trgm` operators

--- a/openspec/changes/add-session-scale-ux/specs/session-url-state/spec.md
+++ b/openspec/changes/add-session-scale-ux/specs/session-url-state/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Sessions Page URL-Driven State
+The `/sessions` page SHALL manage all filter, sort, and pagination state via URL search parameters. The URL SHALL include `q`, `user_id`, `sort_by`, `sort_dir`, `limit`, and `offset`. Any filter, sort, or page-size change SHALL reset `offset` to 0. Malformed parameters SHALL be normalized away and replaced in the URL.
+
+#### Scenario: Deep-link rehydrates controls
+- **WHEN** a user navigates to `/sessions?q=test&user_id=user-42&sort_by=trace_count&sort_dir=desc&limit=50&offset=100`
+- **THEN** the search input shows "test"
+- **AND** the user_id filter shows "user-42"
+- **AND** sorting is set to trace_count descending
+- **AND** page size is 50
+- **AND** the table shows results from offset 100
+
+#### Scenario: Filter change resets pagination
+- **WHEN** the user changes the search query while on page 3
+- **THEN** the offset resets to 0
+- **AND** the URL updates to reflect the new query and `offset=0`
+
+#### Scenario: Malformed params are normalized
+- **WHEN** a user navigates to `/sessions?sort_by=invalid&limit=999`
+- **THEN** `sort_by=invalid` is stripped from the URL
+- **AND** `limit=999` is normalized down to the nearest lower allowed UI page-size option (20, 50, or 100), defaulting to 20 if the value is below all options, and replaced in the URL
+
+### Requirement: FetchSessionsParams Web Client Type
+The web API client SHALL define a `FetchSessionsParams` interface mirroring the object-parameter pattern used by `FetchTracesParams`, supporting `q`, `user_id`, `sort_by`, `sort_dir`, `limit`, and `offset`.
+
+#### Scenario: Sessions fetch uses typed params
+- **WHEN** the sessions page fetches data
+- **THEN** it passes a `FetchSessionsParams` object to the API client
+- **AND** only non-default parameters are included in the request URL
+
+### Requirement: Session Detail Trace Table URL State
+The session detail page (`/sessions/:id`) SHALL manage trace table state (`offset`, `limit`, `sort_by`, `sort_dir`) via URL search params on the session detail route. This enables exact restoration of table state via `returnTo` links. Today `SessionDetailPage` keeps `offset` in local `useState`, which is lost on navigation; Phase 10 moves this state to the URL.
+
+#### Scenario: Session detail trace table state in URL
+- **WHEN** a user sorts traces on session detail and navigates to page 3
+- **THEN** the URL updates to `/sessions/a1b2c3d4-e5f6-7890-abcd-ef1234567890?sort_by=started_at&sort_dir=asc&limit=20&offset=40`
+
+#### Scenario: Session detail URL rehydrates trace table state
+- **WHEN** a user navigates directly to `/sessions/a1b2c3d4-e5f6-7890-abcd-ef1234567890?sort_dir=asc&offset=40`
+- **THEN** the trace table renders with ascending sort and offset 40
+
+### Requirement: Session Detail Trace Navigation
+Session detail trace links SHALL pass `state={{ returnTo: currentSessionDetailUrl }}` when linking to trace detail, where `currentSessionDetailUrl` includes the full path and search params. The trace detail `returnTo` validator SHALL accept paths starting with `/sessions/` in addition to existing allowed paths.
+
+#### Scenario: Session detail trace link includes returnTo with table state
+- **WHEN** a user clicks a trace link on `/sessions/a1b2c3d4-e5f6-7890-abcd-ef1234567890?sort_by=started_at&sort_dir=asc&offset=20`
+- **THEN** the trace detail page receives `returnTo = "/sessions/a1b2c3d4-e5f6-7890-abcd-ef1234567890?sort_by=started_at&sort_dir=asc&offset=20"` via location state
+
+#### Scenario: Trace detail accepts session returnTo
+- **WHEN** the trace detail page receives a `returnTo` starting with `/sessions/`
+- **THEN** the back navigation uses this URL instead of the default traces list
+- **AND** navigating back restores the exact session detail table state
+
+### Requirement: Session Detail Trace Table UX
+The session detail page SHALL provide trace sorting (by `started_at`), page-size control, keep-previous-data behavior, and stale-offset repair for the trace table. It SHALL NOT include the full trace filter bar.
+
+#### Scenario: Session detail trace sorting
+- **WHEN** the user clicks the Started column header on the session detail trace table
+- **THEN** the trace sort order toggles, the URL updates, and the table re-fetches
+
+#### Scenario: Session detail does not show trace filter bar
+- **WHEN** the session detail page renders its trace table
+- **THEN** no search input, status filter, or other trace filter controls are displayed

--- a/openspec/changes/add-session-scale-ux/specs/trace-session-identity/spec.md
+++ b/openspec/changes/add-session-scale-ux/specs/trace-session-identity/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Session External ID on Trace Reads
+All trace read paths SHALL return an optional `session_external_id` string field when the trace belongs to a session. This includes `ListTraces`, `ListTracesBySession`, `GetTrace` (detail), and trace search results. The field SHALL be populated via a `LEFT JOIN sessions` on the query layer.
+
+#### Scenario: Trace with session includes session_external_id
+- **WHEN** a trace belongs to a session with `external_id = "conv-abc-123"`
+- **THEN** the trace API response includes `"session_external_id": "conv-abc-123"`
+
+#### Scenario: Trace without session omits session_external_id
+- **WHEN** a trace has no associated session (`session_id` is NULL)
+- **THEN** the trace API response omits `session_external_id` (or returns null)
+
+#### Scenario: Trace search results include session_external_id
+- **WHEN** a trace search returns results via `GET /api/traces?q=something`
+- **THEN** each trace in the results includes `session_external_id` if the trace belongs to a session
+
+#### Scenario: Trace detail includes session_external_id
+- **WHEN** a client requests `GET /api/traces/{id}` for a trace with a session
+- **THEN** the `TraceDetail` response includes `session_external_id`
+
+### Requirement: Unified Trace Read Model
+The store layer SHALL use a single trace read model that carries trace data plus an optional `session_external_id` field. All trace read paths (sqlc fast-path and handwritten search) SHALL populate this model consistently so that API mapping stays uniform.
+
+#### Scenario: Store model consistency across read paths
+- **WHEN** the same trace is read via the fast-path `ListTraces` and via search `ListTracesFiltered`
+- **THEN** both paths return the same `session_external_id` value for that trace

--- a/openspec/changes/add-session-scale-ux/specs/trace-sorting/spec.md
+++ b/openspec/changes/add-session-scale-ux/specs/trace-sorting/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Trace List Sorting
+The `/api/traces` endpoint SHALL accept optional `sort_by` and `sort_dir` query parameters. `sort_by` SHALL accept only `started_at`. `sort_dir` SHALL accept `asc` or `desc` and default to `desc`. When `q` is present, the server SHALL ignore `sort_by` and `sort_dir` and use relevance ordering. The implementation SHALL use two static sqlc queries (`ListTraces` for DESC, `ListTracesAsc` for ASC) rather than dynamic SQL, since sqlc cannot parameterize SQL keywords.
+
+#### Scenario: Sort traces by started_at ascending
+- **WHEN** a client requests `GET /api/traces?sort_by=started_at&sort_dir=asc`
+- **THEN** traces are returned ordered by `COALESCE(start_time, server_received_at) ASC`
+
+#### Scenario: Sort traces by started_at descending (explicit)
+- **WHEN** a client requests `GET /api/traces?sort_by=started_at&sort_dir=desc`
+- **THEN** traces are returned ordered by `COALESCE(start_time, server_received_at) DESC`
+
+#### Scenario: Default sort when no sort params
+- **WHEN** a client requests `GET /api/traces` without `sort_by` or `sort_dir`
+- **THEN** traces are returned in the default order: `COALESCE(start_time, server_received_at) DESC`
+
+#### Scenario: Search overrides user sorting
+- **WHEN** a client requests `GET /api/traces?q=something&sort_by=started_at&sort_dir=asc`
+- **THEN** the server ignores `sort_by` and `sort_dir`
+- **AND** traces are returned in relevance order as defined by the existing search ranking
+
+#### Scenario: Invalid sort_by value
+- **WHEN** a client requests `GET /api/traces?sort_by=invalid_field`
+- **THEN** the server ignores the invalid `sort_by` and uses default ordering
+
+### Requirement: Trace List Sortable UI Header
+The traces list page SHALL render the `Started` column header as sortable. Clicking the header SHALL toggle between ascending and descending order and update the URL search params. When search is active, the sortable header SHALL be non-clickable and visually muted.
+
+#### Scenario: Click Started header to sort ascending
+- **WHEN** the user clicks the `Started` column header while traces are in default descending order
+- **THEN** the URL updates to include `sort_by=started_at&sort_dir=asc`
+- **AND** the table re-fetches with ascending order
+
+#### Scenario: Sort header disabled during search
+- **WHEN** the user has an active search query (`q` is non-empty)
+- **THEN** the `Started` column header is visually muted and non-clickable

--- a/openspec/changes/add-session-scale-ux/tasks.md
+++ b/openspec/changes/add-session-scale-ux/tasks.md
@@ -1,0 +1,95 @@
+## 1. Contract and codegen (foundation for all backend/frontend work)
+
+- [x] 1.1 Add `sort_by` (enum: `started_at`) and `sort_dir` (enum: `asc`, `desc`) query params to `GET /api/traces` in `contracts/openapi/openapi.yaml`
+- [x] 1.2 Add optional `session_external_id` string field to `Trace` and `TraceDetail` schemas in `contracts/openapi/openapi.yaml`
+- [x] 1.3 Add `q`, `user_id`, `sort_by` (enum: `created_at`, `trace_count`), `sort_dir` (enum: `asc`, `desc`) query params to `GET /api/sessions` in `contracts/openapi/openapi.yaml`
+- [x] 1.4 Run `make generate` and verify generated Go server and TypeScript types include new params and fields
+- [x] 1.5 Add `FetchSessionsParams` interface to `web/src/api/client.ts` mirroring the object-parameter pattern used by `FetchTracesParams`
+
+## 2. Database: session index migration
+
+- [x] 2.1 Create migration adding index `(project_id, created_at DESC, id DESC)` on `sessions`
+- [x] 2.2 Verify migration applies cleanly and existing `(project_id, user_id)` index is left untouched
+
+## 3. Trace session identity (atomic cross-layer change)
+
+- [x] 3.1 Update sqlc trace queries (`ListTraces`, `ListTracesBySession`, `GetTrace`) to `LEFT JOIN sessions` and select `sessions.external_id AS session_external_id`
+- [x] 3.2 Run `make generate` to produce updated row types with `session_external_id`
+- [x] 3.3 Add a unified trace read model in the store layer carrying trace data plus optional `session_external_id`
+- [x] 3.4 Extend the handwritten trace search path (`search.go`) to select `session_external_id` from the same join
+- [x] 3.5 Update store wrapper methods to populate the unified read model from both sqlc and search paths
+- [x] 3.6 Update `traceToAPI` and `traceDetailToAPI` in `mapper.go` to map `session_external_id`
+- [x] 3.7 Add/update trace read tests to verify `session_external_id` is present when session exists and absent when not
+
+## 4. Trace sorting (backend)
+
+- [x] 4.1 Add `ListTracesAsc` sqlc query: identical to `ListTraces` but with `ORDER BY COALESCE(start_time, server_received_at) ASC`; add matching `ListTracesBySessionAsc` query
+- [x] 4.2 Run `make generate` to produce the new query functions
+- [x] 4.3 Add store wrapper that selects the correct query (`ListTraces` vs `ListTracesAsc`, `ListTracesBySession` vs `ListTracesBySessionAsc`) based on a `sortDir` parameter
+- [x] 4.4 Update trace handlers to parse `sort_by` and `sort_dir` params, ignore them when `q` is present, and pass through to store
+- [x] 4.5 Add handler/store tests for `started_at asc`, `started_at desc`, default order, and search-overrides-sort behavior
+
+## 5. Dynamic session query path (backend)
+
+- [x] 5.1 Create `internal/store/session_search.go` with dynamic query builder supporting `q`, `user_id`, `sort_by`, `sort_dir`, `limit`, `offset`
+- [x] 5.2 Implement session search ranking with CASE expression: exact `external_id` match > prefix match > other ILIKE matches > `created_at DESC` tiebreaker
+- [x] 5.3 Implement `trace_count` sorting via derived-table aggregate join with `COALESCE(tc.cnt, 0)`
+- [x] 5.4 Implement total count query that applies the same filters for accurate pagination totals
+- [x] 5.5 Update session handlers to parse new params and route to dynamic query path when any non-default param is present
+- [x] 5.6 Add store tests: default order, `created_at asc|desc`, `trace_count asc|desc`, `q` exact/prefix ranking on `external_id`, `q + user_id` combination, project scoping, stable pagination with no duplicates
+
+## 6. Session API handler integration tests
+
+- [x] 6.1 Test new session params parse correctly and return expected results
+- [x] 6.2 Test search-active requests ignore sort params
+- [x] 6.3 Test session totals stay correct after filtering
+- [x] 6.4 Test cross-project session access returns 404
+
+## 7. Advanced shared pagination component (frontend, prerequisite for list page changes)
+
+- [x] 7.1 Rewrite `PaginationControls` with First/Previous/Next/Last buttons, current page, total pages, page-size selector (20/50/100), and "showing X-Y of Z" label
+- [x] 7.2 Implement stale-offset repair: when total shrinks below current offset, auto-repair to last valid page
+- [x] 7.3 Add Vitest tests for pagination math, button disabled states, page-size change resetting offset, and stale-offset repair
+- [x] 7.4 Integrate updated paginator into `/traces` page (replacing current PaginationControls)
+
+## 8. Traces page sorting and session identity (frontend)
+
+- [x] 8.1 Add sortable `Started` column header to traces list with sort direction toggle updating URL params
+- [x] 8.2 Disable sort header when search is active (visually muted, non-clickable)
+- [x] 8.3 Display `session_external_id` as primary session label on trace rows (external ID first, UUID as secondary)
+- [x] 8.4 Preserve existing `keepPreviousData` behavior on traces list while integrating sorting and pagination upgrades
+- [x] 8.5 Add Vitest tests for sort header toggle, search-disables-sort, and session external ID rendering
+
+## 9. Sessions page URL-driven state (frontend)
+
+- [x] 9.1 Create `useSessionsSearchParams` hook managing `q`, `user_id`, `sort_by`, `sort_dir`, `limit`, `offset` from URL
+- [x] 9.2 Rebuild `SessionsPage` around URL search params with filter/sort/page controls resetting offset to 0
+- [x] 9.3 Implement malformed param normalization (strip invalid values, replace in URL)
+- [x] 9.4 Add sortable `Traces` and `Created` column headers with search-active disabling
+- [x] 9.5 Add search input and user_id filter input
+- [x] 9.6 Wire `FetchSessionsParams` to TanStack Query with URL-derived query key
+- [x] 9.7 Add keep-previous-data behavior during refetch
+- [x] 9.8 Add Vitest tests: deep-link rehydration, sort/page-size changes reset offset, search strips sort from URL, stale-offset repair
+
+## 10. External-first session identity (frontend)
+
+- [x] 10.1 Sessions list: render external ID as primary clickable label, UUID as secondary muted text
+- [x] 10.2 Session detail header: external ID first, UUID second, both copyable
+- [x] 10.3 Trace detail session field: external ID first, UUID available for copy/debugging
+- [x] 10.4 Add Vitest tests for external-first rendering on sessions list, session detail, trace list, and trace detail
+
+## 11. Session detail URL-driven trace table UX (frontend)
+
+- [x] 11.1 Move session-detail trace table state (`offset`, `limit`, `sort_by`, `sort_dir`) from local `useState` into URL search params on the `/sessions/:id` route (e.g., `/sessions/:id?sort_by=started_at&sort_dir=asc&limit=50&offset=20`)
+- [x] 11.2 Add trace sorting (by `started_at`) to session detail trace table via URL params
+- [x] 11.3 Integrate advanced paginator with page-size control, wired to URL params
+- [x] 11.4 Add keep-previous-data and stale-offset repair
+- [x] 11.5 Build `returnTo` from the full current session-detail URL including search params: `state={{ returnTo: currentSessionDetailUrl }}`
+- [x] 11.6 Extend trace detail `returnTo` validator to accept paths starting with `/sessions/`
+- [x] 11.7 Add Vitest tests: trace sorting toggle, URL param round-trip, returnTo restores exact table state, no trace filter bar present
+
+## 12. End-to-end validation
+
+- [x] 12.1 Run `make generate` and verify no drift
+- [x] 12.2 Run `make test` (backend) and `pnpm --filter web test` (frontend) with all new and existing tests passing
+- [x] 12.3 Run `make lint` with no new warnings

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -7,10 +7,19 @@ import {
   buildCanonicalQueryString,
   type FetchTracesParams,
 } from '../utils/tracesSearchParams';
+import {
+  buildSessionsQueryString,
+  type FetchSessionsParams,
+} from '../utils/sessionsSearchParams';
 
 const API_KEY_STORAGE_KEY = 'continua_api_key';
 
 export type { FetchTracesParams } from '../utils/tracesSearchParams';
+export type {
+  FetchSessionsParams,
+  SessionSortBy,
+  SortDirection,
+} from '../utils/sessionsSearchParams';
 
 /**
  * Get the stored API key.
@@ -96,6 +105,7 @@ export type JsonValue =
 export interface Trace {
   id: string;
   session_id?: string;
+  session_external_id?: string;
   name: string;
   status: 'RUNNING' | 'COMPLETED' | 'FAILED';
   started_at: string;
@@ -251,10 +261,14 @@ export async function fetchTimelineEvents(
 }
 
 /**
- * Fetch sessions with pagination.
+ * Fetch sessions with filters and pagination.
  */
-export async function fetchSessions(limit = 20, offset = 0): Promise<SessionList> {
-  return fetchAPI<SessionList>(`/api/sessions?limit=${limit}&offset=${offset}`);
+export async function fetchSessions(
+  params: FetchSessionsParams = {}
+): Promise<SessionList> {
+  const query = buildSessionsQueryString(params);
+  const path = query ? `/api/sessions?${query}` : '/api/sessions';
+  return fetchAPI<SessionList>(path);
 }
 
 /**

--- a/web/src/components/PaginationControls.test.tsx
+++ b/web/src/components/PaginationControls.test.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { PaginationControls } from './PaginationControls';
+
+describe('PaginationControls', () => {
+  it('renders advanced pagination controls and disabled states', () => {
+    render(
+      <PaginationControls
+        offset={0}
+        pageSize={20}
+        total={150}
+        onOffsetChange={vi.fn()}
+        onPageSizeChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Showing 1-20 of 150')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 8')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'First page' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Last page' })).toBeEnabled();
+
+    const rowsPerPage = screen.getByRole('combobox', { name: 'Rows per page' });
+    expect(rowsPerPage).toHaveDisplayValue('20');
+    expect(screen.getByRole('option', { name: '20' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '50' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '100' })).toBeInTheDocument();
+  });
+
+  it('navigates to the last page', async () => {
+    const user = userEvent.setup();
+
+    function Wrapper() {
+      const [offset, setOffset] = useState(0);
+
+      return (
+        <PaginationControls
+          offset={offset}
+          pageSize={20}
+          total={150}
+          onOffsetChange={setOffset}
+          onPageSizeChange={vi.fn()}
+        />
+      );
+    }
+
+    render(<Wrapper />);
+    await user.click(screen.getByRole('button', { name: 'Last page' }));
+
+    expect(screen.getByText('Showing 141-150 of 150')).toBeInTheDocument();
+    expect(screen.getByText('Page 8 of 8')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Last page' })).toBeDisabled();
+  });
+
+  it('resets offset when the page size changes', async () => {
+    const user = userEvent.setup();
+
+    function Wrapper() {
+      const [offset, setOffset] = useState(40);
+      const [pageSize, setPageSize] = useState(20);
+
+      return (
+        <PaginationControls
+          offset={offset}
+          pageSize={pageSize}
+          total={150}
+          onOffsetChange={setOffset}
+          onPageSizeChange={(nextPageSize) => {
+            setPageSize(nextPageSize);
+            setOffset(0);
+          }}
+        />
+      );
+    }
+
+    render(<Wrapper />);
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Rows per page' }), '50');
+
+    expect(screen.getByText('Showing 1-50 of 150')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+  });
+
+  it('repairs stale offsets automatically', async () => {
+    function Wrapper() {
+      const [offset, setOffset] = useState(80);
+
+      return (
+        <PaginationControls
+          offset={offset}
+          pageSize={20}
+          total={60}
+          currentItemCount={0}
+          onOffsetChange={setOffset}
+          onPageSizeChange={vi.fn()}
+          onRepairOffset={setOffset}
+        />
+      );
+    }
+
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 41-60 of 60')).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/PaginationControls.tsx
+++ b/web/src/components/PaginationControls.tsx
@@ -1,52 +1,122 @@
+import { useEffect } from 'react';
+import {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
+  getLastValidOffset,
+} from '../utils/pagination';
+
 interface PaginationControlsProps {
   offset: number;
   pageSize: number;
   total: number;
+  currentItemCount?: number;
   onOffsetChange: (offset: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+  onRepairOffset?: (offset: number) => void;
+  pageSizeOptions?: readonly number[];
+}
+
+function buttonClassName(enabled: boolean): string {
+  return enabled
+    ? 'rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200'
+    : 'cursor-not-allowed rounded-lg bg-gray-200 px-3 py-2 text-sm font-medium text-gray-400';
 }
 
 export function PaginationControls({
   offset,
   pageSize,
   total,
+  currentItemCount,
   onOffsetChange,
+  onPageSizeChange,
+  onRepairOffset = onOffsetChange,
+  pageSizeOptions = PAGE_SIZE_OPTIONS,
 }: PaginationControlsProps) {
-  const hasNextPage = offset + pageSize < total;
-  const hasPrevPage = offset > 0;
-  const showingFrom = total === 0 ? 0 : offset + 1;
-  const showingTo = Math.min(offset + pageSize, total);
+  const lastValidOffset = getLastValidOffset(total, pageSize);
+  const currentOffset = Math.min(offset, lastValidOffset);
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const currentPage = total === 0 ? 1 : Math.floor(currentOffset / pageSize) + 1;
+  const showingFrom = total === 0 ? 0 : currentOffset + 1;
+  const showingTo = total === 0 ? 0 : Math.min(currentOffset + pageSize, total);
+  const hasPreviousPage = currentOffset > 0;
+  const hasNextPage = currentOffset + pageSize < total;
+
+  useEffect(() => {
+    if (
+      currentItemCount === undefined ||
+      currentItemCount > 0 ||
+      offset <= lastValidOffset
+    ) {
+      return;
+    }
+
+    onRepairOffset(lastValidOffset);
+  }, [currentItemCount, lastValidOffset, offset, onRepairOffset]);
 
   return (
-    <div className="mt-4 flex items-center justify-between">
-      <button
-        type="button"
-        aria-label="Previous page"
-        onClick={() => onOffsetChange(Math.max(0, offset - pageSize))}
-        disabled={!hasPrevPage}
-        className={`px-4 py-2 rounded-lg ${
-          hasPrevPage
-            ? 'bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200'
-            : 'bg-gray-200 text-gray-400 cursor-not-allowed'
-        }`}
-      >
-        Previous
-      </button>
-      <span className="text-sm text-gray-600">
-        Showing {showingFrom} - {showingTo} of {total}
-      </span>
-      <button
-        type="button"
-        aria-label="Next page"
-        onClick={() => onOffsetChange(offset + pageSize)}
-        disabled={!hasNextPage}
-        className={`px-4 py-2 rounded-lg ${
-          hasNextPage
-            ? 'bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200'
-            : 'bg-gray-200 text-gray-400 cursor-not-allowed'
-        }`}
-      >
-        Next
-      </button>
+    <div className="mt-4 flex flex-col gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm md:flex-row md:items-center md:justify-between">
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          aria-label="First page"
+          onClick={() => onOffsetChange(0)}
+          disabled={!hasPreviousPage}
+          className={buttonClassName(hasPreviousPage)}
+        >
+          First
+        </button>
+        <button
+          type="button"
+          aria-label="Previous page"
+          onClick={() => onOffsetChange(Math.max(0, currentOffset - pageSize))}
+          disabled={!hasPreviousPage}
+          className={buttonClassName(hasPreviousPage)}
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          aria-label="Next page"
+          onClick={() => onOffsetChange(currentOffset + pageSize)}
+          disabled={!hasNextPage}
+          className={buttonClassName(hasNextPage)}
+        >
+          Next
+        </button>
+        <button
+          type="button"
+          aria-label="Last page"
+          onClick={() => onOffsetChange(lastValidOffset)}
+          disabled={!hasNextPage}
+          className={buttonClassName(hasNextPage)}
+        >
+          Last
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-2 text-sm text-gray-600 md:items-end">
+        <span>
+          Showing {showingFrom}-{showingTo} of {total}
+        </span>
+        <div className="flex flex-wrap items-center gap-3">
+          <span>Page {currentPage} of {totalPages}</span>
+          <label className="flex items-center gap-2">
+            <span>Rows</span>
+            <select
+              aria-label="Rows per page"
+              value={pageSize}
+              onChange={(event) => onPageSizeChange(Number(event.target.value) || DEFAULT_PAGE_SIZE)}
+              className="rounded-lg border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            >
+              {pageSizeOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/src/components/SortableHeader.tsx
+++ b/web/src/components/SortableHeader.tsx
@@ -1,0 +1,45 @@
+interface SortableHeaderProps {
+  label: string;
+  isActive: boolean;
+  isAscending: boolean;
+  isDisabled?: boolean;
+  onClick: () => void;
+}
+
+function getIndicator(isActive: boolean, isAscending: boolean): string {
+  if (!isActive) {
+    return '↕';
+  }
+
+  return isAscending ? '↑' : '↓';
+}
+
+export function SortableHeader({
+  label,
+  isActive,
+  isAscending,
+  isDisabled = false,
+  onClick,
+}: SortableHeaderProps) {
+  const indicator = getIndicator(isActive, isAscending);
+
+  if (isDisabled) {
+    return (
+      <span className="inline-flex items-center gap-1 text-gray-300">
+        <span>{label}</span>
+        <span aria-hidden="true">{indicator}</span>
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1 text-gray-500 transition hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+    >
+      <span>{label}</span>
+      <span aria-hidden="true">{indicator}</span>
+    </button>
+  );
+}

--- a/web/src/hooks/useSessionsSearchParams.ts
+++ b/web/src/hooks/useSessionsSearchParams.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  parseSessionsParams,
+  serializeSessionsParams,
+  type SessionsSearchState,
+} from '../utils/sessionsSearchParams';
+
+type HistoryMode = 'push' | 'replace';
+
+function shouldResetOffset(
+  filters: SessionsSearchState,
+  updates: Partial<SessionsSearchState>
+): boolean {
+  return Object.entries(updates).some(
+    ([key, value]) =>
+      key !== 'offset' &&
+      filters[key as keyof SessionsSearchState] !== value
+  );
+}
+
+function stripSortWhenSearchActive(
+  filters: SessionsSearchState
+): SessionsSearchState {
+  if (!filters.q) {
+    return filters;
+  }
+
+  return {
+    ...filters,
+    sort_by: undefined,
+    sort_dir: undefined,
+  };
+}
+
+export function useSessionsSearchParams() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = stripSortWhenSearchActive(parseSessionsParams(searchParams));
+  const canonicalSearch = serializeSessionsParams(filters).toString();
+
+  useEffect(() => {
+    if (searchParams.toString() === canonicalSearch) {
+      return;
+    }
+
+    setSearchParams(new URLSearchParams(canonicalSearch), { replace: true });
+  }, [canonicalSearch, searchParams, setSearchParams]);
+
+  const setFilters = useCallback(
+    (updates: Partial<SessionsSearchState>, mode: HistoryMode = 'push') => {
+      const next = {
+        ...filters,
+        ...updates,
+      };
+
+      const resetNext = shouldResetOffset(filters, updates)
+        ? { ...next, offset: 0 }
+        : next;
+      const normalizedNext = stripSortWhenSearchActive(resetNext);
+
+      setSearchParams(serializeSessionsParams(normalizedNext), {
+        replace: mode === 'replace',
+      });
+    },
+    [filters, setSearchParams]
+  );
+
+  const clearAll = useCallback(() => {
+    setSearchParams(new URLSearchParams(), { replace: false });
+  }, [setSearchParams]);
+
+  return {
+    filters,
+    setFilters,
+    clearAll,
+  };
+}

--- a/web/src/pages/SessionDetailPage.test.tsx
+++ b/web/src/pages/SessionDetailPage.test.tsx
@@ -1,0 +1,106 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearApiKey, setApiKey } from '../api/client';
+import {
+  SESSION_EXTERNAL_ID,
+  SESSION_ID,
+  TRACE_ONE,
+  TRACE_TWO,
+  buildFetchHandler,
+  getRequests,
+  jsonResponse,
+  renderTraceRoutes,
+} from './testUtils';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function getTraceListRequests(): URL[] {
+  return getRequests(fetchMock, '/api/traces');
+}
+
+async function waitForSessionTraceFetch(search: string) {
+  await waitFor(() => {
+    expect(getTraceListRequests().at(-1)?.search).toBe(search);
+  });
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  localStorage.clear();
+  setApiKey('test-key');
+});
+
+afterEach(() => {
+  clearApiKey();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('SessionDetailPage', () => {
+  it('renders external-first identity and hides the trace filter bar', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes([`/sessions/${SESSION_ID}`]);
+
+    expect(await screen.findByRole('heading', { name: SESSION_EXTERNAL_ID })).toBeInTheDocument();
+    expect(screen.getByText(SESSION_ID)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy session external ID' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Search')).not.toBeInTheDocument();
+    await waitForSessionTraceFetch(`?limit=20&session_id=${SESSION_ID}`);
+  });
+
+  it('rehydrates URL state, toggles sorting, and updates page size', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: (url) =>
+          jsonResponse({
+            traces: url.searchParams.get('limit') === '50' ? [TRACE_TWO] : [TRACE_ONE],
+            total: 60,
+          }),
+      })
+    );
+
+    const { router } = renderTraceRoutes([
+      `/sessions/${SESSION_ID}?sort_by=started_at&sort_dir=asc&limit=50&offset=20`,
+    ]);
+
+    expect(await screen.findByText('Latency Trace')).toBeInTheDocument();
+    await waitForSessionTraceFetch(
+      `?limit=50&offset=20&session_id=${SESSION_ID}&sort_by=started_at&sort_dir=asc`
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Started' }));
+    await waitForSessionTraceFetch(
+      `?limit=50&session_id=${SESSION_ID}&sort_by=started_at&sort_dir=desc`
+    );
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?limit=50&sort_by=started_at&sort_dir=desc');
+    });
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Rows per page' }), '20');
+    await waitForSessionTraceFetch(
+      `?limit=20&session_id=${SESSION_ID}&sort_by=started_at&sort_dir=desc`
+    );
+  });
+
+  it('passes the full session detail URL as returnTo and trace detail accepts it', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes([
+      `/sessions/${SESSION_ID}?sort_by=started_at&sort_dir=asc&offset=20`,
+    ]);
+
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    await user.click(screen.getByRole('link', { name: 'Checkout Trace' }));
+
+    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Session' })).toHaveAttribute(
+      'href',
+      `/sessions/${SESSION_ID}?offset=20&sort_by=started_at&sort_dir=asc`
+    );
+  });
+});

--- a/web/src/pages/SessionDetailPage.tsx
+++ b/web/src/pages/SessionDetailPage.tsx
@@ -1,31 +1,105 @@
-import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Link, useParams } from 'react-router-dom';
-import {
-  fetchSession,
-  fetchTraces,
-  Trace,
-} from '../api/client';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect } from 'react';
+import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { CopyButton } from '../components/CopyButton';
 import { PaginationControls } from '../components/PaginationControls';
+import { SortableHeader } from '../components/SortableHeader';
 import { StatusBadge } from '../components/StatusBadge';
+import { fetchSession, fetchTraces, type Trace } from '../api/client';
 import { useRequireApiKey } from '../hooks/useRequireApiKey';
+import { DEFAULT_PAGE_SIZE, getLastValidOffset } from '../utils/pagination';
+import { buildCanonicalQueryString, parseTracesParams, serializeTracesParams } from '../utils/tracesSearchParams';
 import {
-  formatDuration,
-  formatTokens,
-  formatCost,
-  formatRelativeTime,
   calculateDuration,
+  formatCost,
+  formatDuration,
+  formatRelativeTime,
+  formatTokens,
 } from '../utils/format';
 
-const PAGE_SIZE = 20;
+type HistoryMode = 'push' | 'replace';
 
-/**
- * Session detail page showing session metadata and related traces.
- */
+function shouldResetOffset(
+  currentState: ReturnType<typeof getSessionTraceTableState>,
+  updates: Partial<ReturnType<typeof getSessionTraceTableState>>
+): boolean {
+  return Object.entries(updates).some(
+    ([key, value]) =>
+      key !== 'offset' &&
+      currentState[key as keyof ReturnType<typeof getSessionTraceTableState>] !== value
+  );
+}
+
+function getSessionTraceTableState(searchParams: URLSearchParams) {
+  const parsed = parseTracesParams(searchParams);
+
+  return {
+    limit: parsed.limit,
+    offset: parsed.offset,
+    sort_by: parsed.sort_by,
+    sort_dir: parsed.sort_dir,
+  };
+}
+
+function useSessionTraceTableSearchParams() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = getSessionTraceTableState(searchParams);
+  const canonicalSearch = serializeTracesParams(filters).toString();
+
+  useEffect(() => {
+    if (searchParams.toString() === canonicalSearch) {
+      return;
+    }
+
+    setSearchParams(new URLSearchParams(canonicalSearch), { replace: true });
+  }, [canonicalSearch, searchParams, setSearchParams]);
+
+  const setFilters = useCallback(
+    (
+      updates: Partial<ReturnType<typeof getSessionTraceTableState>>,
+      mode: HistoryMode = 'push'
+    ) => {
+      const next = {
+        ...filters,
+        ...updates,
+      };
+
+      const normalizedNext = shouldResetOffset(filters, updates)
+        ? { ...next, offset: 0 }
+        : next;
+
+      setSearchParams(serializeTracesParams(normalizedNext), {
+        replace: mode === 'replace',
+      });
+    },
+    [filters, setSearchParams]
+  );
+
+  return {
+    filters,
+    setFilters,
+  };
+}
+
+function getSessionsReturnToDestination(state: unknown): string {
+  if (
+    typeof state !== 'object' ||
+    state === null ||
+    !('returnTo' in state) ||
+    typeof state.returnTo !== 'string'
+  ) {
+    return '/sessions';
+  }
+
+  const { returnTo } = state;
+  return returnTo === '/sessions' || returnTo.startsWith('/sessions?')
+    ? returnTo
+    : '/sessions';
+}
+
 export function SessionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { hasApiKey, prompt } = useRequireApiKey();
-  const [offset, setOffset] = useState(0);
 
   if (!hasApiKey) {
     return prompt;
@@ -39,46 +113,61 @@ export function SessionDetailPage() {
     );
   }
 
-  return (
-    <SessionDetailContent sessionId={id} offset={offset} setOffset={setOffset} />
-  );
+  return <SessionDetailContent sessionId={id} />;
 }
 
-interface SessionDetailContentProps {
-  sessionId: string;
-  offset: number;
-  setOffset: (offset: number) => void;
-}
+function SessionDetailContent({ sessionId }: { sessionId: string }) {
+  const location = useLocation();
+  const { filters, setFilters } = useSessionTraceTableSearchParams();
+  const returnTo = getSessionsReturnToDestination(location.state);
+  const currentSessionDetailUrl = `${location.pathname}${location.search}`;
+  const isAscending = filters.sort_dir === 'asc';
 
-function SessionDetailContent({
-  sessionId,
-  offset,
-  setOffset,
-}: SessionDetailContentProps) {
-  const {
-    data: session,
-    isLoading: isSessionLoading,
-    error: sessionError,
-  } = useQuery({
+  const sessionQuery = useQuery({
     queryKey: ['session', sessionId],
     queryFn: () => fetchSession(sessionId),
   });
 
-  const {
-    data: tracesData,
-    isLoading: isTracesLoading,
-    error: tracesError,
-  } = useQuery({
-    queryKey: ['session-traces', sessionId, offset],
-    queryFn: () =>
-      fetchTraces({
-        session_id: sessionId,
-        limit: PAGE_SIZE,
-        offset,
-      }),
+  const traceQueryParams = {
+    session_id: sessionId,
+    limit: filters.limit,
+    offset: filters.offset,
+    sort_by: filters.sort_by,
+    sort_dir: filters.sort_dir,
+  };
+  const tracesQuery = useQuery({
+    queryKey: ['session-traces', sessionId, buildCanonicalQueryString(traceQueryParams)],
+    queryFn: () => fetchTraces(traceQueryParams),
+    placeholderData: keepPreviousData,
   });
+  const traces = tracesQuery.data?.traces ?? [];
+  const total = tracesQuery.data?.total ?? 0;
 
-  if (isSessionLoading) {
+  useEffect(() => {
+    if (traces.length !== 0 || total === 0 || filters.offset === 0) {
+      return;
+    }
+
+    const lastValidOffset = getLastValidOffset(total, filters.limit ?? DEFAULT_PAGE_SIZE);
+    if (lastValidOffset !== filters.offset) {
+      setFilters({ offset: lastValidOffset }, 'replace');
+    }
+  }, [filters.limit, filters.offset, setFilters, total, traces.length]);
+
+  const handleStartedSortToggle = useCallback(() => {
+    setFilters(
+      {
+        sort_by: 'started_at',
+        sort_dir:
+          filters.sort_by === 'started_at' && filters.sort_dir === 'asc'
+            ? 'desc'
+            : 'asc',
+      },
+      'push'
+    );
+  }, [filters.sort_by, filters.sort_dir, setFilters]);
+
+  if (sessionQuery.isLoading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-gray-500">Loading session...</div>
@@ -86,18 +175,20 @@ function SessionDetailContent({
     );
   }
 
-  if (sessionError) {
+  if (sessionQuery.error) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-red-600">
           Error loading session:{' '}
-          {sessionError instanceof Error ? sessionError.message : 'Unknown error'}
+          {sessionQuery.error instanceof Error
+            ? sessionQuery.error.message
+            : 'Unknown error'}
         </div>
       </div>
     );
   }
 
-  if (!session) {
+  if (!sessionQuery.data) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-gray-500">Session not found</div>
@@ -105,118 +196,155 @@ function SessionDetailContent({
     );
   }
 
-  const traces = tracesData?.traces ?? [];
-  const total = tracesData?.total ?? 0;
+  const session = sessionQuery.data;
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Back link */}
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <Link
-          to="/sessions"
+          to={returnTo}
           className="text-blue-600 hover:text-blue-800 text-sm mb-4 inline-block"
         >
           &larr; Back to Sessions
         </Link>
 
-        {/* Session Header */}
-        <div className="bg-white rounded-lg shadow p-6 mb-6">
-          <h1 className="text-2xl font-bold text-gray-900 mb-4">
-            {session.name || 'Unnamed Session'}
-          </h1>
-          <dl className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <section className="mb-6 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
-              <dt className="text-xs font-medium text-gray-500 uppercase">
-                Session ID
-              </dt>
-              <dd className="mt-1 text-sm text-gray-900 font-mono">
-                {session.id.slice(0, 12)}...
-              </dd>
+              <div className="flex flex-wrap items-center gap-3">
+                <h1 className="text-2xl font-bold text-gray-900">{session.external_id}</h1>
+                <CopyButton
+                  aria-label="Copy session external ID"
+                  value={session.external_id}
+                  idleLabel="Copy external ID"
+                  successLabel="Copied external ID"
+                />
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <span className="font-mono text-sm text-gray-500">{session.id}</span>
+                <CopyButton
+                  aria-label="Copy session UUID"
+                  value={session.id}
+                  idleLabel="Copy UUID"
+                  successLabel="Copied UUID"
+                />
+              </div>
+              {session.name ? (
+                <p className="mt-3 text-sm text-gray-600">{session.name}</p>
+              ) : null}
             </div>
-            <div>
-              <dt className="text-xs font-medium text-gray-500 uppercase">
-                User ID
-              </dt>
-              <dd className="mt-1 text-sm text-gray-900">
-                {session.user_id || '-'}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs font-medium text-gray-500 uppercase">
-                Trace Count
-              </dt>
-              <dd className="mt-1 text-sm text-gray-900">
-                {session.trace_count ?? 0}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs font-medium text-gray-500 uppercase">
-                Created
-              </dt>
-              <dd className="mt-1 text-sm text-gray-900">
-                {formatRelativeTime(session.created_at)}
-              </dd>
-            </div>
-          </dl>
+
+            <dl className="grid gap-4 sm:grid-cols-3">
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">
+                  User ID
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900">{session.user_id || '-'}</dd>
+              </div>
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">
+                  Trace Count
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900">{session.trace_count ?? 0}</dd>
+              </div>
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">
+                  Created
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900">
+                  {formatRelativeTime(session.created_at)}
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">Traces</h2>
+            <p className="mt-1 text-sm text-gray-500">
+              Sort by started time and preserve table state in the URL.
+            </p>
+          </div>
+          <div className="text-sm text-gray-500">
+            <span>{total} traces</span>
+            {tracesQuery.isFetching && !tracesQuery.isPending && (
+              <span className="ml-2 text-blue-600">Updating...</span>
+            )}
+          </div>
         </div>
 
-        {/* Traces Section */}
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Traces</h2>
-          <span className="text-sm text-gray-500">{total} traces</span>
-        </div>
+        {tracesQuery.error && (
+          <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700">
+            Error loading traces:{' '}
+            {tracesQuery.error instanceof Error
+              ? tracesQuery.error.message
+              : 'Unknown error'}
+          </div>
+        )}
 
-        {isTracesLoading ? (
-          <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+        {tracesQuery.isPending && !tracesQuery.data ? (
+          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-gray-500 shadow-sm">
             Loading traces...
           </div>
-        ) : tracesError ? (
-          <div className="bg-white rounded-lg shadow p-8 text-center text-red-600">
-            Error loading traces:{' '}
-            {tracesError instanceof Error ? tracesError.message : 'Unknown error'}
-          </div>
         ) : traces.length === 0 ? (
-          <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
-            No traces in this session.
+          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
+            <h2 className="text-lg font-semibold text-gray-900">No traces in this session</h2>
+            <p className="mt-2 text-sm text-gray-500">
+              Traces will appear here as they are ingested for this session.
+            </p>
           </div>
         ) : (
           <>
-            <div className="bg-white shadow overflow-hidden rounded-lg">
+            <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Name
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Status
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Duration
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Tokens
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Cost
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Started
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                      <SortableHeader
+                        label="Started"
+                        isActive={filters.sort_by === 'started_at'}
+                        isAscending={isAscending}
+                        onClick={handleStartedSortToggle}
+                      />
                     </th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
+                <tbody className="divide-y divide-gray-200 bg-white">
                   {traces.map((trace) => (
-                    <TraceRow key={trace.id} trace={trace} />
+                    <SessionTraceRow
+                      key={trace.id}
+                      returnTo={currentSessionDetailUrl}
+                      trace={trace}
+                    />
                   ))}
                 </tbody>
               </table>
             </div>
+
             <PaginationControls
-              offset={offset}
-              pageSize={PAGE_SIZE}
+              offset={filters.offset}
+              pageSize={filters.limit ?? DEFAULT_PAGE_SIZE}
               total={total}
-              onOffsetChange={setOffset}
+              currentItemCount={traces.length}
+              onOffsetChange={(offset) => setFilters({ offset }, 'push')}
+              onPageSizeChange={(limit) => setFilters({ limit }, 'push')}
+              onRepairOffset={(offset) => setFilters({ offset }, 'replace')}
             />
           </>
         )}
@@ -225,38 +353,40 @@ function SessionDetailContent({
   );
 }
 
-interface TraceRowProps {
+function SessionTraceRow({
+  trace,
+  returnTo,
+}: {
   trace: Trace;
-}
-
-function TraceRow({ trace }: TraceRowProps) {
+  returnTo: string;
+}) {
   const duration = calculateDuration(trace.started_at, trace.ended_at);
-  const totalTokens =
-    (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
+  const totalTokens = (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
 
   return (
-    <tr className="hover:bg-gray-50">
-      <td className="px-6 py-4 whitespace-nowrap">
+    <tr className="transition hover:bg-gray-50">
+      <td className="px-6 py-4 align-top">
         <Link
           to={`/traces/${trace.id}`}
-          className="text-blue-600 hover:text-blue-800 font-medium"
+          state={{ returnTo }}
+          className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
         >
           {trace.name}
         </Link>
       </td>
-      <td className="px-6 py-4 whitespace-nowrap">
+      <td className="px-6 py-4 whitespace-nowrap align-top">
         <StatusBadge status={trace.status} />
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
         {formatDuration(duration)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
         {formatTokens(totalTokens)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
         {formatCost(trace.total_cost_usd)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 align-top">
         {formatRelativeTime(trace.started_at)}
       </td>
     </tr>

--- a/web/src/pages/SessionsPage.test.tsx
+++ b/web/src/pages/SessionsPage.test.tsx
@@ -1,0 +1,150 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearApiKey, setApiKey } from '../api/client';
+import {
+  OTHER_SESSION_ID,
+  SESSION_ONE,
+  SESSION_TWO,
+  buildFetchHandler,
+  getRequests,
+  jsonResponse,
+  renderTraceRoutes,
+} from './testUtils';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function getSessionListRequests(): URL[] {
+  return getRequests(fetchMock, '/api/sessions');
+}
+
+async function waitForSessionListFetch(search: string) {
+  await waitFor(() => {
+    expect(getSessionListRequests().at(-1)?.search).toBe(search);
+  });
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  localStorage.clear();
+  setApiKey('test-key');
+});
+
+afterEach(() => {
+  clearApiKey();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('SessionsPage', () => {
+  it('rehydrates URL state and fetches with the typed sessions params', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        sessionsList: () => jsonResponse({ sessions: [SESSION_ONE], total: 1 }),
+      })
+    );
+
+    const { router } = renderTraceRoutes([
+      '/sessions?q=conv&user_id=user-42&sort_by=trace_count&sort_dir=desc&limit=50&offset=100',
+    ]);
+
+    expect(await screen.findByText('conv-checkout-123')).toBeInTheDocument();
+    await waitForSessionListFetch('?limit=50&offset=100&q=conv&user_id=user-42');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?limit=50&offset=100&q=conv&user_id=user-42');
+    });
+
+    expect(screen.getByLabelText('Search')).toHaveValue('conv');
+    expect(screen.getByLabelText('User ID')).toHaveValue('user-42');
+    expect(screen.getByRole('combobox', { name: 'Rows per page' })).toHaveDisplayValue('50');
+  });
+
+  it('normalizes malformed params in the URL', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const { router } = renderTraceRoutes(['/sessions?sort_by=invalid&limit=999']);
+    expect(await screen.findByText('conv-checkout-123')).toBeInTheDocument();
+
+    await waitForSessionListFetch('?limit=100');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?limit=100');
+    });
+  });
+
+  it('strips sort params from the URL while search is active', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const { router } = renderTraceRoutes(['/sessions?sort_by=trace_count&sort_dir=desc']);
+    expect(await screen.findByText('conv-checkout-123')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Search'), 'conv');
+    await waitForSessionListFetch('?limit=20&q=conv');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?q=conv');
+    });
+    expect(screen.queryByRole('button', { name: 'Traces' })).not.toBeInTheDocument();
+  });
+
+  it('repairs stale offsets and keeps external ID first in the row UI', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        sessionsList: (url) => {
+          const offset = url.searchParams.get('offset');
+          if (offset === '40') {
+            return jsonResponse({ sessions: [], total: 21 });
+          }
+          if (offset === '20') {
+            return jsonResponse({ sessions: [SESSION_TWO], total: 21 });
+          }
+          return jsonResponse({ sessions: [SESSION_ONE], total: 21 });
+        },
+      })
+    );
+
+    const { router } = renderTraceRoutes(['/sessions?offset=40']);
+    expect(await screen.findByText('conv-latency-456')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(getSessionListRequests().map((request) => request.search)).toEqual([
+        '?limit=20&offset=40',
+        '?limit=20&offset=20',
+      ]);
+    });
+    expect(router.state.location.search).toBe('?offset=20');
+    expect(screen.getByText('conv-latency-456')).toBeInTheDocument();
+    expect(screen.getByText(OTHER_SESSION_ID)).toBeInTheDocument();
+  });
+
+  it('resets offset when sort and page size change', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        sessionsList: (url) =>
+          jsonResponse({
+            sessions: url.searchParams.get('offset') === '20' ? [SESSION_TWO] : [SESSION_ONE],
+            total: 60,
+          }),
+      })
+    );
+
+    const { router } = renderTraceRoutes(['/sessions']);
+    expect(await screen.findByText('conv-checkout-123')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    await waitForSessionListFetch('?limit=20&offset=20');
+
+    await user.click(screen.getByRole('button', { name: 'Created' }));
+    await waitForSessionListFetch('?limit=20&sort_by=created_at&sort_dir=asc');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?sort_by=created_at&sort_dir=asc');
+    });
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Rows per page' }), '50');
+    await waitForSessionListFetch('?limit=50&sort_by=created_at&sort_dir=asc');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?limit=50&sort_by=created_at&sort_dir=asc');
+    });
+  });
+});

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -1,106 +1,289 @@
-import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
-import { fetchSessions, Session } from '../api/client';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { fetchSessions, type Session } from '../api/client';
 import { PaginationControls } from '../components/PaginationControls';
+import { SortableHeader } from '../components/SortableHeader';
 import { useRequireApiKey } from '../hooks/useRequireApiKey';
+import { useSessionsSearchParams } from '../hooks/useSessionsSearchParams';
+import { DEFAULT_PAGE_SIZE, getLastValidOffset } from '../utils/pagination';
+import { buildSessionsQueryString } from '../utils/sessionsSearchParams';
 import { formatRelativeTime } from '../utils/format';
 
-const PAGE_SIZE = 20;
+const DEBOUNCE_MS = 300;
 
-/**
- * Sessions list page with pagination.
- */
+function normalizeDraft(value: string): string {
+  return value.trim();
+}
+
 export function SessionsPage() {
   const { hasApiKey, prompt } = useRequireApiKey();
-  const [offset, setOffset] = useState(0);
 
   if (!hasApiKey) {
     return prompt;
   }
 
-  return <SessionsContent offset={offset} setOffset={setOffset} />;
+  return <SessionsContent />;
 }
 
-interface SessionsContentProps {
-  offset: number;
-  setOffset: (offset: number) => void;
-}
+function SessionsContent() {
+  const location = useLocation();
+  const { filters, setFilters, clearAll } = useSessionsSearchParams();
+  const [searchDraft, setSearchDraft] = useState(filters.q ?? '');
+  const [userIdDraft, setUserIdDraft] = useState(filters.user_id ?? '');
+  const isSearchActive = Boolean(filters.q);
+  const currentListUrl = `${location.pathname}${location.search}`;
 
-function SessionsContent({ offset, setOffset }: SessionsContentProps) {
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['sessions', offset],
-    queryFn: () => fetchSessions(PAGE_SIZE, offset),
+  useEffect(() => {
+    setSearchDraft(filters.q ?? '');
+  }, [filters.q]);
+
+  useEffect(() => {
+    setUserIdDraft(filters.user_id ?? '');
+  }, [filters.user_id]);
+
+  const commitSearch = useCallback(
+    (value: string) => {
+      setFilters({ q: normalizeDraft(value) || undefined }, 'replace');
+    },
+    [setFilters]
+  );
+
+  const commitUserId = useCallback(
+    (value: string) => {
+      setFilters({ user_id: normalizeDraft(value) || undefined }, 'replace');
+    },
+    [setFilters]
+  );
+
+  useEffect(() => {
+    if (normalizeDraft(searchDraft) === (filters.q ?? '')) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      commitSearch(searchDraft);
+    }, DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [commitSearch, filters.q, searchDraft]);
+
+  useEffect(() => {
+    if (normalizeDraft(userIdDraft) === (filters.user_id ?? '')) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      commitUserId(userIdDraft);
+    }, DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [commitUserId, filters.user_id, userIdDraft]);
+
+  const handleCreatedSortToggle = useCallback(() => {
+    if (isSearchActive) {
+      return;
+    }
+
+    setFilters(
+      {
+        sort_by: 'created_at',
+        sort_dir:
+          filters.sort_by === 'created_at' && filters.sort_dir === 'asc'
+            ? 'desc'
+            : 'asc',
+      },
+      'push'
+    );
+  }, [filters.sort_by, filters.sort_dir, isSearchActive, setFilters]);
+
+  const handleTraceCountSortToggle = useCallback(() => {
+    if (isSearchActive) {
+      return;
+    }
+
+    setFilters(
+      {
+        sort_by: 'trace_count',
+        sort_dir:
+          filters.sort_by === 'trace_count' && filters.sort_dir === 'asc'
+            ? 'desc'
+            : 'asc',
+      },
+      'push'
+    );
+  }, [filters.sort_by, filters.sort_dir, isSearchActive, setFilters]);
+
+  const queryParams = { ...filters };
+  const canonicalQueryString = buildSessionsQueryString(queryParams);
+  const sessionsQuery = useQuery({
+    queryKey: ['sessions', canonicalQueryString],
+    queryFn: () => fetchSessions(queryParams),
+    placeholderData: keepPreviousData,
   });
 
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-gray-500">Loading sessions...</div>
-      </div>
-    );
-  }
+  const sessions = sessionsQuery.data?.sessions ?? [];
+  const total = sessionsQuery.data?.total ?? 0;
+  const hasFilters = Boolean(filters.q || filters.user_id);
 
-  if (error) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-red-600">
-          Error loading sessions: {error instanceof Error ? error.message : 'Unknown error'}
-        </div>
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (sessions.length !== 0 || total === 0 || filters.offset === 0) {
+      return;
+    }
 
-  const sessions = data?.sessions ?? [];
-  const total = data?.total ?? 0;
+    const lastValidOffset = getLastValidOffset(total, filters.limit ?? DEFAULT_PAGE_SIZE);
+    if (lastValidOffset !== filters.offset) {
+      setFilters({ offset: lastValidOffset }, 'replace');
+    }
+  }, [filters.limit, filters.offset, sessions.length, setFilters, total]);
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold text-gray-900">Sessions</h1>
-          <span className="text-sm text-gray-500">{total} total</span>
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Sessions</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Search sessions by external ID, filter by user, and sort for scale.
+            </p>
+          </div>
+          <div className="text-sm text-gray-500">
+            <span>{total} total</span>
+            {sessionsQuery.isFetching && !sessionsQuery.isPending && (
+              <span className="ml-2 text-blue-600">Updating...</span>
+            )}
+          </div>
         </div>
 
-        {sessions.length === 0 ? (
-          <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
-            No sessions found. Sessions are created when traces include a session_id.
+        <section className="mb-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label
+                htmlFor="session-search"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                Search
+              </label>
+              <input
+                id="session-search"
+                type="text"
+                value={searchDraft}
+                onChange={(event) => setSearchDraft(event.target.value)}
+                placeholder="Search external ID or name"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="session-user-id"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                User ID
+              </label>
+              <input
+                id="session-user-id"
+                type="text"
+                value={userIdDraft}
+                onChange={(event) => setUserIdDraft(event.target.value)}
+                placeholder="Filter by exact user"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </div>
+          </div>
+
+          {hasFilters && (
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={clearAll}
+                className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:border-gray-400 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              >
+                Clear filters
+              </button>
+            </div>
+          )}
+        </section>
+
+        {sessionsQuery.error && (
+          <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700">
+            Error loading sessions:{' '}
+            {sessionsQuery.error instanceof Error
+              ? sessionsQuery.error.message
+              : 'Unknown error'}
+          </div>
+        )}
+
+        {sessionsQuery.isPending && !sessionsQuery.data ? (
+          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-gray-500 shadow-sm">
+            Loading sessions...
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
+            <h2 className="text-lg font-semibold text-gray-900">
+              {hasFilters ? 'No matching sessions' : 'No sessions yet'}
+            </h2>
+            <p className="mt-2 text-sm text-gray-500">
+              {hasFilters
+                ? 'Try broadening the filters or clearing them.'
+                : 'Sessions are created when traces include a session identifier.'}
+            </p>
           </div>
         ) : (
           <>
-            <div className="bg-white shadow overflow-hidden rounded-lg">
+            <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Session ID
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                      Session
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       Name
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
                       User ID
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Traces
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                      <SortableHeader
+                        label="Traces"
+                        isActive={filters.sort_by === 'trace_count'}
+                        isAscending={filters.sort_dir === 'asc'}
+                        isDisabled={isSearchActive}
+                        onClick={handleTraceCountSortToggle}
+                      />
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Created
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                      <SortableHeader
+                        label="Created"
+                        isActive={filters.sort_by === 'created_at'}
+                        isAscending={filters.sort_dir === 'asc'}
+                        isDisabled={isSearchActive}
+                        onClick={handleCreatedSortToggle}
+                      />
                     </th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
+                <tbody className="divide-y divide-gray-200 bg-white">
                   {sessions.map((session) => (
-                    <SessionRow key={session.id} session={session} />
+                    <SessionRow
+                      key={session.id}
+                      returnTo={currentListUrl}
+                      session={session}
+                    />
                   ))}
                 </tbody>
               </table>
             </div>
+
             <PaginationControls
-              offset={offset}
-              pageSize={PAGE_SIZE}
+              offset={filters.offset}
+              pageSize={filters.limit ?? DEFAULT_PAGE_SIZE}
               total={total}
-              onOffsetChange={setOffset}
+              currentItemCount={sessions.length}
+              onOffsetChange={(offset) => setFilters({ offset }, 'push')}
+              onPageSizeChange={(limit) => setFilters({ limit }, 'push')}
+              onRepairOffset={(offset) => setFilters({ offset }, 'replace')}
             />
           </>
         )}
@@ -109,31 +292,37 @@ function SessionsContent({ offset, setOffset }: SessionsContentProps) {
   );
 }
 
-interface SessionRowProps {
+function SessionRow({
+  session,
+  returnTo,
+}: {
   session: Session;
-}
-
-function SessionRow({ session }: SessionRowProps) {
+  returnTo: string;
+}) {
   return (
-    <tr className="hover:bg-gray-50">
-      <td className="px-6 py-4 whitespace-nowrap">
-        <Link
-          to={`/sessions/${session.id}`}
-          className="text-blue-600 hover:text-blue-800 font-mono text-sm"
-        >
-          {session.id.slice(0, 8)}...
-        </Link>
+    <tr className="transition hover:bg-gray-50">
+      <td className="px-6 py-4 align-top">
+        <div className="min-w-[14rem]">
+          <Link
+            to={`/sessions/${session.id}`}
+            state={{ returnTo }}
+            className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          >
+            {session.external_id}
+          </Link>
+          <div className="mt-1 font-mono text-xs text-gray-400">{session.id}</div>
+        </div>
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+      <td className="px-6 py-4 text-sm text-gray-900 align-top">
         {session.name || '-'}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+      <td className="px-6 py-4 text-sm text-gray-500 align-top">
         {session.user_id || '-'}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+      <td className="px-6 py-4 text-sm text-gray-900 align-top">
         {session.trace_count ?? 0}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+      <td className="px-6 py-4 text-sm text-gray-500 align-top">
         {formatRelativeTime(session.created_at)}
       </td>
     </tr>

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearApiKey, setApiKey, type TraceDetail } from '../api/client';
 import { setMatchMediaMatches } from '../test/matchMedia';
 import {
+  SESSION_EXTERNAL_ID,
+  SESSION_ID,
   TRACE_DETAIL,
   TRACE_ONE,
   buildFetchHandler,
@@ -1278,5 +1280,35 @@ describe('TraceDetailPage', () => {
         screen.queryByRole('button', { name: 'Select span Needle child' })
       ).not.toBeInTheDocument();
     });
+  });
+
+  it('accepts session-detail returnTo links', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes([
+      {
+        pathname: `/traces/${TRACE_ONE.id}`,
+        state: { returnTo: `/sessions/${SESSION_ID}?sort_by=started_at&offset=20` },
+      },
+    ]);
+
+    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Session' })).toHaveAttribute(
+      'href',
+      `/sessions/${SESSION_ID}?sort_by=started_at&offset=20`
+    );
+  });
+
+  it('shows session external ID before the UUID in trace context', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    await screen.findByText('Trace Context');
+
+    await user.click(screen.getByRole('button', { name: /Trace Context/i }));
+
+    expect(screen.getByText(SESSION_EXTERNAL_ID)).toBeInTheDocument();
+    expect(screen.getByText(SESSION_ID)).toBeInTheDocument();
   });
 });

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -272,7 +272,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
       <header className="border-b bg-white px-6 py-4">
         <div className="flex items-center gap-4">
           <Link to={returnTo} className="text-gray-500 hover:text-gray-700">
-            ← Traces
+            {returnTo.startsWith('/sessions/') ? '← Session' : '← Traces'}
           </Link>
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-3">
@@ -461,7 +461,9 @@ function getReturnToDestination(state: unknown): string {
   }
 
   const { returnTo } = state;
-  return returnTo === '/traces' || returnTo.startsWith('/traces?')
+  return returnTo === '/traces' ||
+    returnTo.startsWith('/traces?') ||
+    returnTo.startsWith('/sessions/')
     ? returnTo
     : '/traces';
 }
@@ -566,13 +568,18 @@ function TraceContextSection({
               copyButtonLabel="Copy external trace ID"
             />
             <TraceContextField
-              label="Session UUID"
+              label="Session"
               value={trace.session_id ? (
                 <Link
                   to={`/sessions/${trace.session_id}`}
-                  className="font-mono text-xs text-blue-600 hover:text-blue-800"
+                  className="inline-flex flex-col text-left text-blue-600 hover:text-blue-800"
                 >
-                  {trace.session_id}
+                  <span className="text-sm font-medium text-gray-900">
+                    {trace.session_external_id ?? trace.session_id}
+                  </span>
+                  <span className="font-mono text-xs text-gray-500">
+                    {trace.session_id}
+                  </span>
                 </Link>
               ) : (
                 renderContextText(undefined)

--- a/web/src/pages/TracesPage.test.tsx
+++ b/web/src/pages/TracesPage.test.tsx
@@ -282,7 +282,7 @@ describe('TracesPage', () => {
       `?limit=20&offset=20&session_id=${SESSION_ID}&q=checkout&has_errors=true`
     );
 
-    expect(screen.getByText(SESSION_ID)).toBeInTheDocument();
+    expect(screen.getAllByText(SESSION_ID).length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole('button', { name: 'Clear Search filter' }));
     await waitForListFetch(`?limit=20&session_id=${SESSION_ID}&has_errors=true`);
@@ -536,5 +536,53 @@ describe('TracesPage', () => {
     expect(
       screen.queryByRole('button', { name: 'Clear Search filter' })
     ).not.toBeInTheDocument();
+  });
+
+  it('toggles started sorting and resets offset when the page size changes', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: (url) =>
+          jsonResponse({
+            traces: url.searchParams.get('offset') === '20' ? [TRACE_TWO] : [TRACE_ONE],
+            total: 60,
+          }),
+      })
+    );
+
+    const { router } = renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Started' }));
+    await waitForListFetch('?limit=20&sort_by=started_at&sort_dir=asc');
+
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    await waitForListFetch('?limit=20&offset=20&sort_by=started_at&sort_dir=asc');
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Rows per page' }), '50');
+    await waitForListFetch('?limit=50&sort_by=started_at&sort_dir=asc');
+    await waitFor(() => {
+      expect(router.state.location.search).toBe('?limit=50&sort_by=started_at&sort_dir=asc');
+    });
+  });
+
+  it('disables the started sort header while search is active', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes(['/traces?q=checkout']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    expect(screen.queryByRole('button', { name: 'Started' })).not.toBeInTheDocument();
+    expect(screen.getByText('Started')).toBeInTheDocument();
+  });
+
+  it('renders session external ID first on trace rows', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    expect(screen.getByText('conv-checkout-123')).toBeInTheDocument();
+    expect(screen.getByText(SESSION_ID)).toBeInTheDocument();
   });
 });

--- a/web/src/pages/TracesPage.tsx
+++ b/web/src/pages/TracesPage.tsx
@@ -3,9 +3,11 @@ import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { fetchTraces, type Trace } from '../api/client';
 import { PaginationControls } from '../components/PaginationControls';
+import { SortableHeader } from '../components/SortableHeader';
 import { StatusBadge } from '../components/StatusBadge';
 import { useRequireApiKey } from '../hooks/useRequireApiKey';
 import { useTracesSearchParams } from '../hooks/useTracesSearchParams';
+import { DEFAULT_PAGE_SIZE, getLastValidOffset } from '../utils/pagination';
 import {
   buildCanonicalQueryString,
   deriveActiveChips,
@@ -21,7 +23,6 @@ import {
   formatTokens,
 } from '../utils/format';
 
-const PAGE_SIZE = 20;
 const DEBOUNCE_MS = 300;
 
 function normalizeTrimmedDraft(value: string): string {
@@ -201,10 +202,8 @@ function TracesContent() {
   const dateRangeError = getDateRangeError(startDate, endDate);
   const activeChips = deriveActiveChips(filters);
   const hasActiveFilters = activeChips.length > 0;
-  const queryParams = {
-    ...filters,
-    limit: PAGE_SIZE,
-  };
+  const isSearchActive = Boolean(filters.q);
+  const queryParams = { ...filters };
   const canonicalQueryString = buildCanonicalQueryString(queryParams);
   const tracesQuery = useQuery({
     queryKey: ['traces', canonicalQueryString],
@@ -222,11 +221,28 @@ function TracesContent() {
       return;
     }
 
-    const lastValidOffset = Math.floor((total - 1) / PAGE_SIZE) * PAGE_SIZE;
+    const lastValidOffset = getLastValidOffset(total, filters.limit ?? DEFAULT_PAGE_SIZE);
     if (lastValidOffset !== filters.offset) {
       setFilters({ offset: lastValidOffset }, 'replace');
     }
-  }, [filters.offset, setFilters, total, traces.length]);
+  }, [filters.limit, filters.offset, setFilters, total, traces.length]);
+
+  const handleStartedSortToggle = useCallback(() => {
+    if (isSearchActive) {
+      return;
+    }
+
+    setFilters(
+      {
+        sort_by: 'started_at',
+        sort_dir:
+          filters.sort_by === 'started_at' && filters.sort_dir === 'asc'
+            ? 'desc'
+            : 'asc',
+      },
+      'push'
+    );
+  }, [filters.sort_by, filters.sort_dir, isSearchActive, setFilters]);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -522,7 +538,13 @@ function TracesContent() {
                       Cost
                     </th>
                     <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
-                      Started
+                      <SortableHeader
+                        label="Started"
+                        isActive={filters.sort_by === 'started_at'}
+                        isAscending={filters.sort_dir === 'asc'}
+                        isDisabled={isSearchActive}
+                        onClick={handleStartedSortToggle}
+                      />
                     </th>
                   </tr>
                 </thead>
@@ -539,9 +561,12 @@ function TracesContent() {
             </div>
             <PaginationControls
               offset={filters.offset}
-              pageSize={PAGE_SIZE}
+              pageSize={filters.limit ?? DEFAULT_PAGE_SIZE}
               total={total}
+              currentItemCount={traces.length}
               onOffsetChange={(offset) => setFilters({ offset }, 'push')}
+              onPageSizeChange={(limit) => setFilters({ limit }, 'push')}
+              onRepairOffset={(offset) => setFilters({ offset }, 'replace')}
             />
           </>
         )}
@@ -580,9 +605,12 @@ function TraceRow({ trace, returnTo }: TraceRowProps) {
           {trace.session_id && (
             <Link
               to={`/sessions/${trace.session_id}`}
-              className="mt-1 inline-flex text-xs text-gray-500 transition hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="mt-1 inline-flex flex-col text-left text-xs transition hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
             >
-              Session {trace.session_id.slice(0, 8)}...
+              <span className="font-medium text-gray-600">
+                {trace.session_external_id ?? trace.session_id}
+              </span>
+              <span className="font-mono text-gray-400">{trace.session_id}</span>
             </Link>
           )}
         </div>

--- a/web/src/pages/testUtils.tsx
+++ b/web/src/pages/testUtils.tsx
@@ -3,8 +3,12 @@ import { render } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import {
+  OTHER_SESSION_EXTERNAL_ID,
   OTHER_SESSION_ID,
+  SESSION_EXTERNAL_ID,
   SESSION_ID,
+  SESSION_ONE,
+  SESSION_TWO,
   TRACE_DETAIL,
   TRACE_ONE,
   TRACE_THREE,
@@ -15,10 +19,16 @@ import {
   resetTestEntityCounter,
 } from '../test/traceFixtures';
 import { TraceDetailPage } from './TraceDetailPage';
+import { SessionDetailPage } from './SessionDetailPage';
+import { SessionsPage } from './SessionsPage';
 import { TracesPage } from './TracesPage';
 export {
+  OTHER_SESSION_EXTERNAL_ID,
   OTHER_SESSION_ID,
+  SESSION_EXTERNAL_ID,
   SESSION_ID,
+  SESSION_ONE,
+  SESSION_TWO,
   TRACE_DETAIL,
   TRACE_ONE,
   TRACE_THREE,
@@ -45,11 +55,15 @@ export function jsonResponse(data: unknown, status = 200): Response {
 export function buildFetchHandler({
   list,
   detail,
+  sessionsList,
+  sessionDetail,
   spans,
   timeline,
 }: {
   list?: JsonHandler;
   detail?: JsonHandler;
+  sessionsList?: JsonHandler;
+  sessionDetail?: JsonHandler;
   spans?: JsonHandler;
   timeline?: JsonHandler;
 } = {}) {
@@ -83,6 +97,31 @@ export function buildFetchHandler({
 
     if (/^\/api\/traces\/[^/]+$/.test(url.pathname)) {
       return detail?.(url) ?? jsonResponse(TRACE_DETAIL);
+    }
+
+    if (url.pathname === '/api/sessions') {
+      return (
+        sessionsList?.(url) ??
+        jsonResponse({
+          sessions: [SESSION_ONE, SESSION_TWO],
+          total: 2,
+        })
+      );
+    }
+
+    if (/^\/api\/sessions\/[^/]+$/.test(url.pathname)) {
+      if (sessionDetail) {
+        return sessionDetail(url);
+      }
+
+      const sessionId = url.pathname.split('/').at(-1);
+      if (sessionId === SESSION_ID) {
+        return jsonResponse(SESSION_ONE);
+      }
+      if (sessionId === OTHER_SESSION_ID) {
+        return jsonResponse(SESSION_TWO);
+      }
+      return jsonResponse({ code: 'not_found', message: 'Resource not found' }, 404);
     }
 
     throw new Error(`Unhandled request: ${url.pathname}${url.search}`);
@@ -129,6 +168,8 @@ export function renderTraceRoutes(
     [
       { path: '/traces', element: <TracesPage /> },
       { path: '/traces/:id', element: <TraceDetailPage /> },
+      { path: '/sessions', element: <SessionsPage /> },
+      { path: '/sessions/:id', element: <SessionDetailPage /> },
     ],
     {
       initialEntries,

--- a/web/src/test/traceFixtures.ts
+++ b/web/src/test/traceFixtures.ts
@@ -1,11 +1,32 @@
-import type { Span, TimelineEvent, Trace, TraceDetail } from '../api/client';
+import type { Session, Span, TimelineEvent, Trace, TraceDetail } from '../api/client';
 
 export const SESSION_ID = '123e4567-e89b-12d3-a456-426614174000';
 export const OTHER_SESSION_ID = '123e4567-e89b-12d3-a456-426614174001';
+export const SESSION_EXTERNAL_ID = 'conv-checkout-123';
+export const OTHER_SESSION_EXTERNAL_ID = 'conv-latency-456';
+
+export const SESSION_ONE: Session = {
+  id: SESSION_ID,
+  external_id: SESSION_EXTERNAL_ID,
+  name: 'Checkout Session',
+  user_id: 'user-123',
+  trace_count: 2,
+  created_at: '2026-03-14T09:00:00.000Z',
+};
+
+export const SESSION_TWO: Session = {
+  id: OTHER_SESSION_ID,
+  external_id: OTHER_SESSION_EXTERNAL_ID,
+  name: 'Latency Session',
+  user_id: 'user-456',
+  trace_count: 1,
+  created_at: '2026-03-14T10:00:00.000Z',
+};
 
 export const TRACE_ONE: Trace = {
   id: 'trace-checkout',
   session_id: SESSION_ID,
+  session_external_id: SESSION_EXTERNAL_ID,
   name: 'Checkout Trace',
   status: 'FAILED',
   started_at: '2026-03-14T10:00:00.000Z',
@@ -19,6 +40,7 @@ export const TRACE_ONE: Trace = {
 export const TRACE_TWO: Trace = {
   id: 'trace-latency',
   session_id: OTHER_SESSION_ID,
+  session_external_id: OTHER_SESSION_EXTERNAL_ID,
   name: 'Latency Trace',
   status: 'RUNNING',
   started_at: '2026-03-14T11:00:00.000Z',
@@ -31,6 +53,7 @@ export const TRACE_TWO: Trace = {
 export const TRACE_THREE: Trace = {
   id: 'trace-alpha',
   session_id: SESSION_ID,
+  session_external_id: SESSION_EXTERNAL_ID,
   name: 'Alpha Trace',
   status: 'COMPLETED',
   started_at: '2026-03-14T09:00:00.000Z',
@@ -46,6 +69,7 @@ export const TRACE_ZETA: Trace = {
   id: 'trace-zeta',
   name: 'Zeta Trace',
   session_id: OTHER_SESSION_ID,
+  session_external_id: OTHER_SESSION_EXTERNAL_ID,
   error_count: 1,
 };
 

--- a/web/src/utils/pagination.ts
+++ b/web/src/utils/pagination.ts
@@ -1,0 +1,33 @@
+export const PAGE_SIZE_OPTIONS = [20, 50, 100] as const;
+export const DEFAULT_PAGE_SIZE = PAGE_SIZE_OPTIONS[0];
+
+export function normalizeUiPageSize(
+  value: number | string | undefined,
+  fallback: number = DEFAULT_PAGE_SIZE
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  let normalized: number = fallback;
+  for (const option of PAGE_SIZE_OPTIONS) {
+    if (parsed >= option) {
+      normalized = option;
+    }
+  }
+
+  return normalized;
+}
+
+export function getLastValidOffset(total: number, pageSize: number): number {
+  if (total <= 0) {
+    return 0;
+  }
+
+  return Math.floor((total - 1) / pageSize) * pageSize;
+}

--- a/web/src/utils/sessionsSearchParams.ts
+++ b/web/src/utils/sessionsSearchParams.ts
@@ -1,0 +1,165 @@
+import { DEFAULT_PAGE_SIZE, normalizeUiPageSize } from './pagination';
+
+export type SessionSortBy = 'created_at' | 'trace_count';
+export type SortDirection = 'asc' | 'desc';
+
+export interface FetchSessionsParams {
+  limit?: number;
+  offset?: number;
+  q?: string;
+  user_id?: string;
+  sort_by?: SessionSortBy;
+  sort_dir?: SortDirection;
+}
+
+export interface SessionsSearchState {
+  limit: number;
+  offset: number;
+  q?: string;
+  user_id?: string;
+  sort_by?: SessionSortBy;
+  sort_dir?: SortDirection;
+}
+
+type NormalizedSessionsParams = FetchSessionsParams & {
+  offset: number;
+};
+
+type NormalizableSessionsParams = {
+  [Key in keyof FetchSessionsParams]?: FetchSessionsParams[Key] | string;
+} & {
+  offset?: number | string;
+};
+
+const CANONICAL_PARAM_ORDER: Array<keyof FetchSessionsParams> = [
+  'limit',
+  'offset',
+  'q',
+  'user_id',
+  'sort_by',
+  'sort_dir',
+];
+
+function normalizeOptionalText(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeNonNegativeInteger(value: number | string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function normalizeSessionSortBy(value: string | null | undefined): SessionSortBy | undefined {
+  return value === 'created_at' || value === 'trace_count' ? value : undefined;
+}
+
+function normalizeSortDirection(
+  value: string | null | undefined
+): SortDirection | undefined {
+  return value === 'asc' || value === 'desc' ? value : undefined;
+}
+
+function normalizeSessionsParams(
+  params: NormalizableSessionsParams
+): NormalizedSessionsParams {
+  return {
+    limit:
+      params.limit === undefined
+        ? undefined
+        : normalizeUiPageSize(params.limit),
+    offset: normalizeNonNegativeInteger(params.offset) ?? 0,
+    q: normalizeOptionalText(params.q),
+    user_id: normalizeOptionalText(params.user_id),
+    sort_by: normalizeSessionSortBy(params.sort_by),
+    sort_dir: normalizeSortDirection(params.sort_dir),
+  };
+}
+
+function toQueryEntries(
+  params: NormalizedSessionsParams,
+  options: { includeDefaultLimit: boolean }
+): Array<[keyof FetchSessionsParams, string]> {
+  const entries: Array<[keyof FetchSessionsParams, string]> = [];
+
+  if (
+    params.limit !== undefined &&
+    (options.includeDefaultLimit || params.limit !== DEFAULT_PAGE_SIZE)
+  ) {
+    entries.push(['limit', String(params.limit)]);
+  }
+  if (params.offset > 0) {
+    entries.push(['offset', String(params.offset)]);
+  }
+  if (params.q) {
+    entries.push(['q', params.q]);
+  }
+  if (params.user_id) {
+    entries.push(['user_id', params.user_id]);
+  }
+  if (params.sort_by) {
+    entries.push(['sort_by', params.sort_by]);
+  }
+  if (params.sort_dir) {
+    entries.push(['sort_dir', params.sort_dir]);
+  }
+
+  return entries.sort(
+    ([left], [right]) =>
+      CANONICAL_PARAM_ORDER.indexOf(left) - CANONICAL_PARAM_ORDER.indexOf(right)
+  );
+}
+
+export function parseSessionsParams(searchParams: URLSearchParams): SessionsSearchState {
+  const normalized = normalizeSessionsParams({
+    limit: searchParams.get('limit') ?? undefined,
+    offset: searchParams.get('offset') ?? undefined,
+    q: searchParams.get('q') ?? undefined,
+    user_id: searchParams.get('user_id') ?? undefined,
+    sort_by: searchParams.get('sort_by') ?? undefined,
+    sort_dir: searchParams.get('sort_dir') ?? undefined,
+  });
+
+  return {
+    limit: normalized.limit ?? DEFAULT_PAGE_SIZE,
+    offset: normalized.offset,
+    q: normalized.q,
+    user_id: normalized.user_id,
+    sort_by: normalized.sort_by,
+    sort_dir: normalized.sort_dir,
+  };
+}
+
+export function serializeSessionsParams(state: SessionsSearchState): URLSearchParams {
+  const normalized = normalizeSessionsParams(state);
+  const params = new URLSearchParams();
+
+  toQueryEntries(normalized, { includeDefaultLimit: false }).forEach(([key, value]) => {
+    params.set(key, value);
+  });
+
+  return params;
+}
+
+export function buildSessionsQueryString(
+  params: FetchSessionsParams | SessionsSearchState
+): string {
+  const normalized = normalizeSessionsParams(params);
+  const query = new URLSearchParams();
+
+  toQueryEntries(normalized, { includeDefaultLimit: normalized.limit !== undefined }).forEach(
+    ([key, value]) => {
+      query.set(key, value);
+    }
+  );
+
+  return query.toString();
+}

--- a/web/src/utils/tracesSearchParams.test.ts
+++ b/web/src/utils/tracesSearchParams.test.ts
@@ -26,7 +26,8 @@ describe('tracesSearchParams', () => {
 
     const parsed = parseTracesParams(params);
 
-    expect(parsed).toEqual({
+    expect(parsed).toMatchObject({
+      limit: 20,
       offset: 20,
       q: 'checkout flow',
       status: 'failed',
@@ -67,7 +68,7 @@ describe('tracesSearchParams', () => {
       })
     );
 
-    expect(parsed).toEqual({ offset: 0 });
+    expect(parsed).toMatchObject({ limit: 20, offset: 0 });
     expect(deriveActiveChips(parsed)).toEqual([]);
   });
 
@@ -124,7 +125,8 @@ describe('tracesSearchParams', () => {
       },
     ]);
 
-    expect(clearChip(state, 'q')).toEqual({
+    expect(clearChip(state, 'q')).toMatchObject({
+      limit: 20,
       offset: 0,
       has_errors: true,
       session_id: '123e4567-e89b-12d3-a456-426614174000',
@@ -157,7 +159,7 @@ describe('tracesSearchParams', () => {
     );
 
     expect(first).toBe(
-      'offset=20&session_id=123e4567-e89b-12d3-a456-426614174000&q=flow&status=failed&has_errors=true'
+      'limit=20&offset=20&session_id=123e4567-e89b-12d3-a456-426614174000&q=flow&status=failed&has_errors=true'
     );
     expect(second).toBe(first);
   });

--- a/web/src/utils/tracesSearchParams.ts
+++ b/web/src/utils/tracesSearchParams.ts
@@ -1,10 +1,16 @@
+import { DEFAULT_PAGE_SIZE, normalizeUiPageSize } from './pagination';
+
 export type TraceStatusFilter = 'running' | 'completed' | 'failed';
+export type TraceSortBy = 'started_at';
+export type SortDirection = 'asc' | 'desc';
 
 export interface FetchTracesParams {
   limit?: number;
   offset?: number;
   session_id?: string;
   q?: string;
+  sort_by?: TraceSortBy;
+  sort_dir?: SortDirection;
   status?: TraceStatusFilter;
   start_time_from?: string;
   start_time_to?: string;
@@ -14,9 +20,12 @@ export interface FetchTracesParams {
 }
 
 export interface TracesFilterState {
+  limit: number;
   offset: number;
   session_id?: string;
   q?: string;
+  sort_by?: TraceSortBy;
+  sort_dir?: SortDirection;
   status?: TraceStatusFilter;
   start_time_from?: string;
   start_time_to?: string;
@@ -55,6 +64,8 @@ const CANONICAL_PARAM_ORDER: Array<keyof FetchTracesParams> = [
   'offset',
   'session_id',
   'q',
+  'sort_by',
+  'sort_dir',
   'status',
   'start_time_from',
   'start_time_to',
@@ -78,6 +89,20 @@ function normalizeStatus(value: string | null | undefined): TraceStatusFilter | 
   return VALID_STATUSES.has(normalized as TraceStatusFilter)
     ? (normalized as TraceStatusFilter)
     : undefined;
+}
+
+function normalizeTraceSortBy(value: string | null | undefined): TraceSortBy | undefined {
+  return value?.trim() === 'started_at' ? 'started_at' : undefined;
+}
+
+function normalizeSortDirection(
+  value: string | null | undefined
+): SortDirection | undefined {
+  if (value === 'asc' || value === 'desc') {
+    return value;
+  }
+
+  return undefined;
 }
 
 function normalizeUUID(value: string | null | undefined): string | undefined {
@@ -133,10 +158,15 @@ function normalizeTracesParams(
   params: NormalizableTracesParams
 ): NormalizedTracesParams {
   return {
-    limit: normalizePositiveInteger(params.limit),
+    limit:
+      params.limit === undefined
+        ? undefined
+        : normalizeUiPageSize(params.limit),
     offset: normalizeNonNegativeInteger(params.offset) ?? 0,
     session_id: normalizeUUID(params.session_id),
     q: normalizeOptionalText(params.q),
+    sort_by: normalizeTraceSortBy(params.sort_by),
+    sort_dir: normalizeSortDirection(params.sort_dir),
     status: normalizeStatus(params.status),
     start_time_from: normalizeISODateTime(params.start_time_from),
     start_time_to: normalizeISODateTime(params.start_time_to),
@@ -147,11 +177,15 @@ function normalizeTracesParams(
 }
 
 function toQueryEntries(
-  params: NormalizedTracesParams
+  params: NormalizedTracesParams,
+  options: { includeDefaultLimit: boolean }
 ): Array<[keyof FetchTracesParams, string]> {
   const entries: Array<[keyof FetchTracesParams, string]> = [];
 
-  if (params.limit !== undefined) {
+  if (
+    params.limit !== undefined &&
+    (options.includeDefaultLimit || params.limit !== DEFAULT_PAGE_SIZE)
+  ) {
     entries.push(['limit', String(params.limit)]);
   }
   if (params.offset > 0) {
@@ -162,6 +196,12 @@ function toQueryEntries(
   }
   if (params.q) {
     entries.push(['q', params.q]);
+  }
+  if (params.sort_by) {
+    entries.push(['sort_by', params.sort_by]);
+  }
+  if (params.sort_dir) {
+    entries.push(['sort_dir', params.sort_dir]);
   }
   if (params.status) {
     entries.push(['status', params.status]);
@@ -216,9 +256,12 @@ function parseLocalDate(date: string): Date | null {
 
 export function parseTracesParams(searchParams: URLSearchParams): TracesFilterState {
   const normalized = normalizeTracesParams({
+    limit: searchParams.get('limit') ?? undefined,
     offset: searchParams.get('offset') ?? undefined,
     session_id: searchParams.get('session_id') ?? undefined,
     q: searchParams.get('q') ?? undefined,
+    sort_by: searchParams.get('sort_by') ?? undefined,
+    sort_dir: searchParams.get('sort_dir') ?? undefined,
     status: searchParams.get('status') ?? undefined,
     start_time_from: searchParams.get('start_time_from') ?? undefined,
     start_time_to: searchParams.get('start_time_to') ?? undefined,
@@ -228,9 +271,12 @@ export function parseTracesParams(searchParams: URLSearchParams): TracesFilterSt
   });
 
   return {
+    limit: normalized.limit ?? DEFAULT_PAGE_SIZE,
     offset: normalized.offset,
     session_id: normalized.session_id,
     q: normalized.q,
+    sort_by: normalized.sort_by,
+    sort_dir: normalized.sort_dir,
     status: normalized.status,
     start_time_from: normalized.start_time_from,
     start_time_to: normalized.start_time_to,
@@ -244,7 +290,7 @@ export function serializeTracesParams(state: TracesFilterState): URLSearchParams
   const normalized = normalizeTracesParams(state);
   const params = new URLSearchParams();
 
-  toQueryEntries(normalized).forEach(([key, value]) => {
+  toQueryEntries(normalized, { includeDefaultLimit: false }).forEach(([key, value]) => {
     params.set(key, value);
   });
 
@@ -257,7 +303,7 @@ export function buildCanonicalQueryString(
   const normalized = normalizeTracesParams(params);
   const query = new URLSearchParams();
 
-  toQueryEntries(normalized).forEach(([key, value]) => {
+  toQueryEntries(normalized, { includeDefaultLimit: normalized.limit !== undefined }).forEach(([key, value]) => {
     query.set(key, value);
   });
 


### PR DESCRIPTION
## Summary
- add session filtering, sorting, and external-first identity across the API and UI
- add shared pagination and URL-driven table state for traces, sessions, and session detail
- stabilize trace pagination ordering and update OpenSpec artifacts for Phase 10

## Testing
- make generate
- pnpm --filter web build
- pnpm --filter web test
- go test ./internal/store/... ./internal/api/...
- /bin/zsh -lc "TEST_DATABASE_URL='postgres://continua:continua@localhost:5432/continua_test?sslmode=disable' GOCACHE=/tmp/continua-go-build make test-go"
- openspec validate add-session-scale-ux --strict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sorting capabilities to traces (by start time) and sessions (by creation time or trace count)
  * Added search and filtering for sessions by name, external ID, or user ID
  * Sessions now display external identifiers alongside internal IDs for better clarity
  * Enhanced pagination controls with page size selection, First/Last buttons, and automatic offset correction

* **Improvements**
  * Session external IDs now appear in trace listings and details
  * Improved URL-based state management for filters, sorting, and pagination persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->