### PR TITLE
Implement phase 11 debugger semantics polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,20 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 9
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
 
       - name: Install sqlc
         run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.27.0

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ generate: ## Generate ALL code (contracts, sqlc, API types)
 	fi
 	@echo "==> Generating Python SDK types..."
 	@if [ -f contracts/openapi/openapi.bundle.yaml ]; then \
-		cd sdks/python && uv run python scripts/generate_types.py 2>/dev/null || true; \
+		cd sdks/python && uv run --with datamodel-code-generator python scripts/generate_types.py; \
 	fi
 	@echo "✅ All code generated"
 

--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -36,12 +36,14 @@ const (
 
 // Defines values for IngestEventType.
 const (
-	IngestEventTypeCustom    IngestEventType = "custom"
-	IngestEventTypeError     IngestEventType = "error"
-	IngestEventTypeException IngestEventType = "exception"
-	IngestEventTypeLog       IngestEventType = "log"
-	IngestEventTypeMessage   IngestEventType = "message"
-	IngestEventTypeMetric    IngestEventType = "metric"
+	IngestEventTypeCustom      IngestEventType = "custom"
+	IngestEventTypeDecision    IngestEventType = "decision"
+	IngestEventTypeError       IngestEventType = "error"
+	IngestEventTypeException   IngestEventType = "exception"
+	IngestEventTypeLog         IngestEventType = "log"
+	IngestEventTypeMessage     IngestEventType = "message"
+	IngestEventTypeMetric      IngestEventType = "metric"
+	IngestEventTypeStateChange IngestEventType = "state_change"
 )
 
 // Defines values for IngestResponseStatus.
@@ -120,6 +122,7 @@ const (
 // Defines values for TimelineEventType.
 const (
 	TimelineEventTypeCustom        TimelineEventType = "custom"
+	TimelineEventTypeDecision      TimelineEventType = "decision"
 	TimelineEventTypeError         TimelineEventType = "error"
 	TimelineEventTypeException     TimelineEventType = "exception"
 	TimelineEventTypeLog           TimelineEventType = "log"
@@ -128,6 +131,7 @@ const (
 	TimelineEventTypeSpanCompleted TimelineEventType = "span_completed"
 	TimelineEventTypeSpanFailed    TimelineEventType = "span_failed"
 	TimelineEventTypeSpanStarted   TimelineEventType = "span_started"
+	TimelineEventTypeStateChange   TimelineEventType = "state_change"
 )
 
 // Defines values for TimelineResponseTraceStatus.
@@ -214,11 +218,13 @@ type IngestEventInput struct {
 	EventType *IngestEventType `json:"event_type,omitempty"`
 
 	// IdempotencyKey Optional key for event-level deduplication
-	IdempotencyKey *string                 `json:"idempotency_key,omitempty"`
-	Level          *IngestEventLevel       `json:"level,omitempty"`
-	Message        *string                 `json:"message,omitempty"`
-	Payload        *map[string]interface{} `json:"payload,omitempty"`
-	Sequence       *int32                  `json:"sequence,omitempty"`
+	IdempotencyKey *string           `json:"idempotency_key,omitempty"`
+	Level          *IngestEventLevel `json:"level,omitempty"`
+	Message        *string           `json:"message,omitempty"`
+
+	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+	Payload  *map[string]interface{} `json:"payload,omitempty"`
+	Sequence *int32                  `json:"sequence,omitempty"`
 
 	// SpanId External span identifier
 	SpanId string `json:"span_id"`

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -342,7 +342,7 @@ export interface components {
             depth?: number;
         };
         /** @enum {string} */
-        IngestEventType: "log" | "error" | "exception" | "message" | "metric" | "custom";
+        IngestEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision";
         /** @enum {string} */
         IngestEventLevel: "debug" | "info" | "warning" | "error";
         IngestEventInput: {
@@ -359,12 +359,14 @@ export interface components {
             /** Format: int32 */
             sequence?: number;
             message?: string;
+            /** @description Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+             *      */
             payload?: Record<string, never>;
             /** @description Optional key for event-level deduplication */
             idempotency_key?: string;
         };
         /** @enum {string} */
-        TimelineEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "span_started" | "span_completed" | "span_failed";
+        TimelineEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision" | "span_started" | "span_completed" | "span_failed";
         /** @enum {string} */
         TimelineEventSource: "explicit" | "synthetic";
         /** @enum {string} */

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -785,6 +785,8 @@ components:
         - message
         - metric
         - custom
+        - state_change
+        - decision
     IngestEventLevel:
       type: string
       enum:
@@ -822,6 +824,8 @@ components:
           type: string
         payload:
           type: object
+          description: |
+            Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
         idempotency_key:
           type: string
           description: Optional key for event-level deduplication
@@ -834,6 +838,8 @@ components:
         - message
         - metric
         - custom
+        - state_change
+        - decision
         - span_started
         - span_completed
         - span_failed

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -729,7 +729,7 @@ components:
 
     IngestEventType:
       type: string
-      enum: [log, error, exception, message, metric, custom]
+      enum: [log, error, exception, message, metric, custom, state_change, decision]
 
     IngestEventLevel:
       type: string
@@ -763,6 +763,10 @@ components:
           type: string
         payload:
           type: object
+          description: >
+            Free-form event payload. Semantic debugger conventions apply for some event types:
+            `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`;
+            `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
         idempotency_key:
           type: string
           description: Optional key for event-level deduplication
@@ -770,7 +774,19 @@ components:
     TimelineEventType:
       type: string
       enum:
-        [log, error, exception, message, metric, custom, span_started, span_completed, span_failed]
+        [
+          log,
+          error,
+          exception,
+          message,
+          metric,
+          custom,
+          state_change,
+          decision,
+          span_started,
+          span_completed,
+          span_failed,
+        ]
 
     TimelineEventSource:
       type: string

--- a/docs/event-conventions.md
+++ b/docs/event-conventions.md
@@ -1,0 +1,107 @@
+# Event Conventions
+
+Continua events are debugger-facing observability signals.
+
+These are debugger semantics, not replay primitives.
+
+Use them to explain what happened during trace execution, not to model checkpoints, resumability, or durable workflow state machines.
+
+## Choosing an Event Type
+
+- Use `state_change` when an observable piece of state changes and you want the debugger to show the transition directly.
+- Use `decision` when the system chooses between alternatives and the debugger should show the branch point and rationale.
+- Use `custom` only when no existing semantic type fits or the payload is domain-specific and purely ad hoc.
+- Use `message` for lightweight narrative milestones.
+- Use `log`, `error`, and `exception` for operational logging and failures.
+- Use `metric` for structured numeric measurements.
+
+## Explicit Event Types
+
+| Event type | When to use it | Expected payload fields | Default level |
+| --- | --- | --- | --- |
+| `log` | Operational log line tied to a span | Any optional structured payload | `info` |
+| `error` | Explicit failure signal without exception details | Any optional structured payload | `error` |
+| `exception` | Captured exception with structured exception metadata | Common fields: `exception_type`, `exception_message`, `traceback` | `error` |
+| `message` | Lightweight narrative milestone or human-readable note | Optional | `info` |
+| `metric` | Numeric measurement attached to a span | `metric_name`, `metric_value`, optional `metric_unit` | `info` |
+| `custom` | Domain-specific event that does not fit another semantic type | Any optional structured payload | `info` |
+| `state_change` | Observable state transition that should render in the State view | `key`, optional `namespace`, optional `old_value`, optional `new_value` | `info` |
+| `decision` | Branch point or choice with a selected outcome | `question`, `chosen`, optional `alternatives`, optional `reasoning` | `info` |
+
+## Payload Guidance
+
+### `state_change`
+
+Use `state_change` for state that helps explain execution flow in the debugger.
+
+Recommended payload shape:
+
+```json
+{
+  "key": "status",
+  "namespace": "order",
+  "old_value": "pending",
+  "new_value": "approved"
+}
+```
+
+- `key` should be the field name within the namespace, not a whole sentence.
+- `namespace` groups related keys in the State tab. Omit it for general state.
+- `old_value` and `new_value` may be scalars, arrays, or objects.
+
+Use `state_change` instead of `custom` when you want the debugger to show a before/after transition rather than a raw JSON blob.
+
+Python SDK example:
+
+```python
+with span("validate_order") as s:
+    s.state_change(
+        "status",
+        "pending",
+        "approved",
+        namespace="order",
+        message="Order approved after validation",
+    )
+```
+
+### `decision`
+
+Use `decision` when the system evaluates options and selects one.
+
+Recommended payload shape:
+
+```json
+{
+  "question": "Which model should handle the request?",
+  "chosen": "gpt-4.1",
+  "alternatives": ["gpt-4o-mini", "gpt-4.1"],
+  "reasoning": "Escalated for higher quality on refund requests"
+}
+```
+
+- `question` should describe the branch point as a question or decision prompt.
+- `chosen` should be the final selected option or outcome.
+- `alternatives` should contain meaningful rejected options when available.
+- `reasoning` should explain why the choice was made, not restate the choice.
+
+Use `decision` instead of `custom` when the key debugging question is "why did the system choose this path?"
+
+Python SDK example:
+
+```python
+with span("route_request") as s:
+    s.decision(
+        "Which model should handle the request?",
+        "gpt-4.1",
+        alternatives=["gpt-4o-mini", "gpt-4.1"],
+        reasoning="Escalated for higher quality on refund requests",
+        message="Escalated to a higher-capability model",
+    )
+```
+
+## Quick Heuristics
+
+- If you want the debugger to show `old → new`, emit `state_change`.
+- If you want the debugger to show `question → chosen`, emit `decision`.
+- If you only need a human-readable sentence, emit `message`.
+- If you need a free-form payload with no special UI, emit `custom`.

--- a/internal/api/mapper.go
+++ b/internal/api/mapper.go
@@ -362,6 +362,10 @@ func mapExplicitTimelineEventType(eventType string) TimelineEventType {
 		return TimelineEventTypeMessage
 	case "metric":
 		return TimelineEventTypeMetric
+	case "state_change":
+		return TimelineEventTypeStateChange
+	case "decision":
+		return TimelineEventTypeDecision
 	default:
 		return TimelineEventTypeCustom
 	}

--- a/internal/api/mapper_timeline_test.go
+++ b/internal/api/mapper_timeline_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+)
+
+func TestExplicitTimelineEventToAPI_PreservesSemanticEventTypes(t *testing.T) {
+	now := time.Now().UTC()
+
+	testCases := []struct {
+		name      string
+		eventType string
+		expected  TimelineEventType
+	}{
+		{
+			name:      "state_change",
+			eventType: "state_change",
+			expected:  TimelineEventTypeStateChange,
+		},
+		{
+			name:      "decision",
+			eventType: "decision",
+			expected:  TimelineEventTypeDecision,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			event := platform.SpanEvent{
+				ID:               uuid.New(),
+				TraceID:          uuid.New(),
+				SpanID:           "span-1",
+				EventType:        tc.eventType,
+				ServerIngestedAt: now,
+			}
+
+			apiEvent := explicitTimelineEventToAPI(&event, nil)
+
+			assert.Equal(t, tc.expected, apiEvent.EventType)
+		})
+	}
+}

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -36,12 +36,14 @@ const (
 
 // Defines values for IngestEventType.
 const (
-	IngestEventTypeCustom    IngestEventType = "custom"
-	IngestEventTypeError     IngestEventType = "error"
-	IngestEventTypeException IngestEventType = "exception"
-	IngestEventTypeLog       IngestEventType = "log"
-	IngestEventTypeMessage   IngestEventType = "message"
-	IngestEventTypeMetric    IngestEventType = "metric"
+	IngestEventTypeCustom      IngestEventType = "custom"
+	IngestEventTypeDecision    IngestEventType = "decision"
+	IngestEventTypeError       IngestEventType = "error"
+	IngestEventTypeException   IngestEventType = "exception"
+	IngestEventTypeLog         IngestEventType = "log"
+	IngestEventTypeMessage     IngestEventType = "message"
+	IngestEventTypeMetric      IngestEventType = "metric"
+	IngestEventTypeStateChange IngestEventType = "state_change"
 )
 
 // Defines values for IngestResponseStatus.
@@ -120,6 +122,7 @@ const (
 // Defines values for TimelineEventType.
 const (
 	TimelineEventTypeCustom        TimelineEventType = "custom"
+	TimelineEventTypeDecision      TimelineEventType = "decision"
 	TimelineEventTypeError         TimelineEventType = "error"
 	TimelineEventTypeException     TimelineEventType = "exception"
 	TimelineEventTypeLog           TimelineEventType = "log"
@@ -128,6 +131,7 @@ const (
 	TimelineEventTypeSpanCompleted TimelineEventType = "span_completed"
 	TimelineEventTypeSpanFailed    TimelineEventType = "span_failed"
 	TimelineEventTypeSpanStarted   TimelineEventType = "span_started"
+	TimelineEventTypeStateChange   TimelineEventType = "state_change"
 )
 
 // Defines values for TimelineResponseTraceStatus.
@@ -214,11 +218,13 @@ type IngestEventInput struct {
 	EventType *IngestEventType `json:"event_type,omitempty"`
 
 	// IdempotencyKey Optional key for event-level deduplication
-	IdempotencyKey *string                 `json:"idempotency_key,omitempty"`
-	Level          *IngestEventLevel       `json:"level,omitempty"`
-	Message        *string                 `json:"message,omitempty"`
-	Payload        *map[string]interface{} `json:"payload,omitempty"`
-	Sequence       *int32                  `json:"sequence,omitempty"`
+	IdempotencyKey *string           `json:"idempotency_key,omitempty"`
+	Level          *IngestEventLevel `json:"level,omitempty"`
+	Message        *string           `json:"message,omitempty"`
+
+	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+	Payload  *map[string]interface{} `json:"payload,omitempty"`
+	Sequence *int32                  `json:"sequence,omitempty"`
 
 	// SpanId External span identifier
 	SpanId string `json:"span_id"`

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1,7 +1,9 @@
 package ingest_test
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"testing"
 	"time"
 
@@ -130,6 +132,157 @@ func TestIngest_RejectsSyntheticTimelineEventTypes(t *testing.T) {
 	var vErr *ingest.ValidationError
 	require.ErrorAs(t, err, &vErr)
 	assert.Contains(t, vErr.Errors, "event[0] invalid event_type: span_started")
+}
+
+func TestIngest_AcceptsSemanticEventTypes(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	svc := newTestService(s)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	traceID := "trace-" + uuid.NewString()[:8]
+	start := time.Now().UTC()
+	stateChangeType := "state_change"
+	decisionType := "decision"
+
+	resp, err := svc.Ingest(ctx, projectID, &ingest.IngestRequest{
+		BatchKey: "batch-" + uuid.NewString()[:8],
+		Traces: []ingest.TraceInput{
+			{
+				TraceID:   traceID,
+				Name:      testutil.StrPtr("semantic trace"),
+				StartTime: &start,
+			},
+		},
+		Spans: []ingest.SpanInput{
+			{
+				TraceID:   traceID,
+				SpanID:    "span-1",
+				Name:      "semantic span",
+				StartTime: start,
+			},
+		},
+		Events: []ingest.EventInput{
+			{
+				TraceID:   traceID,
+				SpanID:    "span-1",
+				EventType: &stateChangeType,
+				Payload: map[string]any{
+					"key":       "status",
+					"old_value": "pending",
+					"new_value": "running",
+				},
+			},
+			{
+				TraceID:   traceID,
+				SpanID:    "span-1",
+				EventType: &decisionType,
+				Payload: map[string]any{
+					"question": "route request?",
+					"chosen":   "fast-path",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(2), resp.EventCount)
+
+	trace, err := q.GetTraceByExternalID(ctx, platform.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   traceID,
+	})
+	require.NoError(t, err)
+
+	events, err := q.ListSpanEventsByTrace(ctx, trace.ID)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	assert.ElementsMatch(
+		t,
+		[]string{stateChangeType, decisionType},
+		[]string{events[0].EventType, events[1].EventType},
+	)
+}
+
+func TestIngest_WarnsForMissingSemanticEventFieldsButStillAccepts(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	svc := newTestService(s)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	traceID := "trace-" + uuid.NewString()[:8]
+	start := time.Now().UTC()
+	stateChangeType := "state_change"
+	decisionType := "decision"
+
+	var logBuffer bytes.Buffer
+	originalWriter := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&logBuffer)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(originalWriter)
+		log.SetFlags(originalFlags)
+	})
+
+	resp, err := svc.Ingest(ctx, projectID, &ingest.IngestRequest{
+		BatchKey: "batch-" + uuid.NewString()[:8],
+		Traces: []ingest.TraceInput{
+			{
+				TraceID:   traceID,
+				Name:      testutil.StrPtr("warning trace"),
+				StartTime: &start,
+			},
+		},
+		Spans: []ingest.SpanInput{
+			{
+				TraceID:   traceID,
+				SpanID:    "span-1",
+				Name:      "warning span",
+				StartTime: start,
+			},
+		},
+		Events: []ingest.EventInput{
+			{
+				TraceID:   traceID,
+				SpanID:    "span-1",
+				EventType: &stateChangeType,
+				Payload: map[string]any{
+					"old_value": "pending",
+					"new_value": "running",
+				},
+			},
+			{
+				TraceID:   traceID,
+				SpanID:    "span-1",
+				EventType: &decisionType,
+				Payload: map[string]any{
+					"question": "route request?",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(2), resp.EventCount)
+
+	trace, err := q.GetTraceByExternalID(ctx, platform.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   traceID,
+	})
+	require.NoError(t, err)
+
+	events, err := q.ListSpanEventsByTrace(ctx, trace.ID)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+
+	logOutput := logBuffer.String()
+	assert.Contains(t, logOutput, "[WARN] ingest state_change event missing semantic payload field 'key'")
+	assert.Contains(t, logOutput, "[WARN] ingest decision event missing semantic payload fields")
 }
 
 func TestIngest_RejectsInvalidEventLevel(t *testing.T) {

--- a/internal/ingest/processor.go
+++ b/internal/ingest/processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/google/uuid"
@@ -204,6 +205,8 @@ func (p *Processor) validateBatch(req *IngestRequest) []string {
 		if event.Level != nil && !isValidIngestEventLevel(*event.Level) {
 			errs = append(errs, fmt.Sprintf("event[%d] invalid level: %s", i, *event.Level))
 		}
+
+		warnForMissingSemanticPayloadFields(event)
 	}
 
 	return errs
@@ -211,11 +214,52 @@ func (p *Processor) validateBatch(req *IngestRequest) []string {
 
 func isValidIngestEventType(eventType string) bool {
 	switch eventType {
-	case "log", "error", "exception", "message", "metric", "custom":
+	case "log", "error", "exception", "message", "metric", "custom", "state_change", "decision":
 		return true
 	default:
 		return false
 	}
+}
+
+func warnForMissingSemanticPayloadFields(event *EventInput) {
+	eventType := defaultString(event.EventType, "log")
+
+	switch eventType {
+	case "state_change":
+		if !hasSemanticStringField(event.Payload, "key") {
+			log.Printf(
+				"[WARN] ingest state_change event missing semantic payload field 'key' for trace %s span %s",
+				event.TraceID,
+				event.SpanID,
+			)
+		}
+	case "decision":
+		missingQuestion := !hasSemanticStringField(event.Payload, "question")
+		missingChosen := !hasSemanticStringField(event.Payload, "chosen")
+		if missingQuestion || missingChosen {
+			log.Printf(
+				"[WARN] ingest decision event missing semantic payload fields for trace %s span %s (question=%t chosen=%t)",
+				event.TraceID,
+				event.SpanID,
+				missingQuestion,
+				missingChosen,
+			)
+		}
+	}
+}
+
+func hasSemanticStringField(payload map[string]any, field string) bool {
+	if payload == nil {
+		return false
+	}
+
+	value, ok := payload[field]
+	if !ok {
+		return false
+	}
+
+	text, ok := value.(string)
+	return ok && text != ""
 }
 
 func isValidIngestEventLevel(level string) bool {

--- a/openspec/changes/add-debugger-semantics-polish/design.md
+++ b/openspec/changes/add-debugger-semantics-polish/design.md
@@ -1,0 +1,84 @@
+# Design: Debugger Semantics & Final Polish
+
+## Overview
+Phase 11 spans backend contract changes, SDK updates, and significant frontend work across six capabilities. This document captures cross-cutting architectural decisions.
+
+## Dependency Structure
+
+```
+Track A: Event Taxonomy (contract + backend + SDK + frontend types)
+  ↓
+Track B: State Diff UI (depends on A's new event types)
+
+Tracks C–F are independent of each other, parallelizable after A:
+  Track C: Event Convention Docs
+  Track D: Settings UI + 401 Recovery
+  Track E: Command Palette
+  Track F: Dark Mode / Theming
+```
+
+Track A is foundational — it modifies the OpenAPI contract, which triggers `make generate` and cascades to backend, SDK, and frontend types. Track B depends on A because `StateDiffViewer` and the "Decisions" section require the new `state_change` and `decision` event types to exist in the type system.
+
+## Key Architectural Decisions
+
+### 1. Payload Validation: Accept-and-Warn
+
+**Decision**: Accept `state_change`/`decision` events even when semantic payload fields are missing. Log warnings server-side via `log.Printf("[WARN] ...")`.
+
+**Why**: Rejecting events for missing optional payload fields would break the established ingest contract where payload is always optional. The existing pattern (processor.go) accepts any valid event type and stores whatever payload is provided. Validation strictness belongs in the SDK (which will populate fields correctly) and in the UI (which degrades gracefully).
+
+**Trade-off**: Garbage-in is possible. Mitigated by: (a) SDK helpers enforce correct payload shape; (b) UI falls back to generic rendering; (c) `docs/event-conventions.md` documents expected schemas.
+
+### 2. Mapper Explicit Mapping (A3)
+
+**Decision**: Mapper must explicitly map `state_change` → `TimelineEventTypeStateChange` and `decision` → `TimelineEventTypeDecision`.
+
+**Why**: The current `mapExplicitTimelineEventType` in `mapper.go:353` has a `default: return TimelineEventTypeCustom` fallback. Without explicit cases, new event types silently degrade to `custom` and the frontend never sees them. This was identified as a critical gap — without A3, Tracks A6 and B are broken.
+
+### 3. Theming: Tailwind dark: Classes Primary
+
+**Decision**: Use Tailwind `darkMode: 'class'` as the primary mechanism. CSS custom properties in `globals.css` only for contexts where Tailwind classes cannot reach (inline styles on waterfall bars, resizable panel separators).
+
+**Why**: The codebase is 100% Tailwind utility classes today. Introducing a parallel CSS variable system for everything would create maintenance burden. CSS vars are limited to the two known inline-style contexts: waterfall bar colors (computed widths/colors in JSX) and panel separator styling.
+
+**FOUC prevention**: A synchronous `<script>` in `index.html` reads localStorage before React hydrates and sets the `dark` class on `<html>`. This runs before any paint.
+
+### 4. Settings: No ApiKeyPrompt Refactor
+
+**Decision**: `SettingsPage` uses `getApiKey`/`setApiKey`/`clearApiKey` directly. The existing `ApiKeyPrompt` component (used for first-run) is not refactored or reused.
+
+**Why**: `ApiKeyPrompt` has first-run-specific UX (welcome copy, redirect logic). Reusing it in Settings would require conditional rendering that adds complexity for no UX gain. A simple form with clear/update is cleaner.
+
+### 5. 401 Recovery: Page-Level Banners
+
+**Decision**: 401 errors show a page-level auth-error banner with "Invalid or missing API key" and a "Go to Settings" link. No toast system.
+
+**Why**: The existing error rendering paths on `TracesPage`, `SessionsPage`, `SessionDetailPage`, and `TraceDetailPage` already render full-page error states. Adding a 401-specific variant is consistent. A toast system would be a new pattern with no other current use case — over-engineering for a single error type.
+
+**Implementation note**: The existing `ApiError` class already has a `status` field, so 401 detection can use `error instanceof ApiError && error.status === 401` directly. A dedicated `isAuthError` helper is optional — use it if the check becomes repetitive across pages, but the spec does not require a specific abstraction. Each page's existing error render path adds a 401 check before the generic error fallback.
+
+### 6. SpanDetail Events Threading (B4)
+
+**Decision**: Thread timeline events to `SpanDetail` via a new `events` prop on `SpanDetailProps`.
+
+**Why**: `SpanDetail` currently has no access to events — it only receives the `Span` object. To render a "Decisions" section filtered to the selected span, it needs the event list. The parent (`TraceDetailPage` workspace) already has timeline events loaded; passing them down is the simplest path.
+
+**Filter**: `SpanDetail` filters to `event.span_id === span.span_id && event.event_type === 'decision'` and skips entries where `question` or `chosen` is missing from the payload.
+
+### 7. Command Palette Scope
+
+**Decision**: Minimal command set — navigate to Traces/Sessions/Settings, toggle theme. No fuzzy search over traces/spans/sessions.
+
+**Why**: Phase 11 is about shell polish, not a power-user search engine. Data-aware search (find a trace by name) requires API integration and is a separate feature. The palette establishes the UI pattern and keyboard shortcut; commands can be extended later.
+
+## Preservation Concerns
+
+These existing behaviors must not regress:
+- Filtered back-navigation and `?span=` deep-link selection
+- Failure-first auto-selection of primary failed span
+- Timeline polling and stale trace detection
+- Payload inspection with search, expand/collapse, copy
+- Resizable 3-panel workspace layout
+- Mobile tab-switcher fallback
+- Sessions URL-driven search/filter/sort
+- Trace/session pagination and `returnTo` navigation

--- a/openspec/changes/add-debugger-semantics-polish/proposal.md
+++ b/openspec/changes/add-debugger-semantics-polish/proposal.md
@@ -1,0 +1,30 @@
+# Change: Add Debugger Semantics & Final Polish
+
+## Why
+The debugger has traces, sessions, span trees, waterfall, timeline, payload inspection, failure-first UX, and session-scale browsing (Phases 1–10). Before replay begins, two gaps remain: (1) the event taxonomy lacks structured state/decision semantics — state changes and decision points are stored as opaque `custom` events, preventing meaningful rendering; (2) the debugger shell lacks polish expected of a daily-use tool — no dark mode, no keyboard-driven navigation, no settings management, and no 401 error recovery.
+
+Phase 11 closes these gaps with six capabilities: formal event taxonomy, state diff UI, event convention documentation, settings management, command palette, and dark mode.
+
+## What Changes
+- **Event taxonomy**: `state_change` and `decision` added to both `IngestEventType` and `TimelineEventType` OpenAPI enums. Ingest processor accepts them unconditionally; missing semantic fields (`key` for state_change, `question`/`chosen` for decision) produce server-log warnings via `log.Printf` but never reject the event. Mapper explicitly maps both types to prevent degradation to `custom`. Python SDK gains `span.state_change()` and `span.decision()` helpers. Frontend TypeScript types updated. Timeline renders full semantic UI when payload fields are present, degrades to generic event row using `message` when they are absent.
+- **State diff UI**: New `StateDiffViewer` component grouped by namespace with scalar inline and objects via existing `JsonViewer`. New `extractStateChanges` utility filters to events where `payload.key` exists. "State" tab added to `InspectorTabs` (badge count only when > 0). `SpanDetail` gains an `events` prop and renders a "Decisions" section filtered to the selected span. `WorkspaceShell` mobile tabs gain a 5th "State" tab.
+- **Event conventions**: New `docs/event-conventions.md` documenting type table, payload schemas, SDK examples. Explicit scope guard: "debugger semantics, not replay primitives." Python SDK docstrings enhanced with usage examples.
+- **Settings UI**: New `SettingsPage` using existing `getApiKey`/`setApiKey`/`clearApiKey` helpers. Route and nav link added. 401 error recovery: pages detect 401 via the existing `ApiError.status` field and render auth-error banners with "Go to Settings" link. No toast system — uses existing banner pattern.
+- **Command palette**: New `CommandPalette` component with search, arrow-key navigation, Enter/Escape. Commands: navigate to Traces/Sessions/Settings, toggle theme. Wired to `Cmd+K`/`Ctrl+K` globally. Discoverability hint in Navigation.
+- **Dark mode**: Tailwind `darkMode: 'class'` enabled. CSS custom properties in `globals.css` only for non-Tailwind contexts (waterfall inline styles, panel separators). Pre-hydration theme script prevents FOUC. `useTheme` hook with `system | light | dark` persisted to localStorage. Theme toggle in Navigation and Settings. `dark:` variants applied to all shell and workspace components.
+
+## Scope Boundary
+- No replay, checkpoints, resumability
+- No server-side settings CRUD or project-admin settings
+- No API-key rotation
+- No orphan-event surfacing (deferred — build only if users report confusion)
+- No changes to ingest response shape or `ProcessedBatch` return path
+
+## Impact
+- Affected specs: `event-taxonomy`, `state-diff-ui`, `event-conventions`, `settings-ui`, `command-palette`, `dark-mode`
+- Affected code:
+  - Backend: `contracts/openapi/openapi.yaml`, `internal/ingest/processor.go`, `internal/api/mapper.go`
+  - Python SDK: `sdks/python/src/continua/span.py`
+  - Frontend: `web/src/api/client.ts`, `web/src/utils/timeline.ts`, `web/src/components/Timeline.tsx`, `web/src/components/InspectorTabs.tsx`, `web/src/components/SpanDetail.tsx`, `web/src/pages/TraceDetailPage.tsx`, `web/src/components/WorkspaceShell.tsx`, `web/src/App.tsx`, `web/src/components/Navigation.tsx`, `web/tailwind.config.js`, `web/src/styles/globals.css`, all page and workspace components (dark variants)
+  - New files: `web/src/components/StateDiffViewer.tsx`, `web/src/utils/stateChanges.ts`, `web/src/components/CommandPalette.tsx`, `web/src/pages/SettingsPage.tsx`, `web/src/hooks/useTheme.ts`, `docs/event-conventions.md`
+- No new runtime dependencies

--- a/openspec/changes/add-debugger-semantics-polish/specs/command-palette/spec.md
+++ b/openspec/changes/add-debugger-semantics-polish/specs/command-palette/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Command Palette Component
+A `CommandPalette` component SHALL provide a searchable, keyboard-navigable command list. It SHALL support arrow-key navigation, Enter to execute, and Escape to dismiss. The initial command set SHALL include: navigate to Traces, navigate to Sessions, navigate to Settings, and toggle theme.
+
+#### Scenario: Open and search
+- **WHEN** the command palette is open and the user types "tra"
+- **THEN** the "Go to Traces" command is shown as a filtered match
+
+#### Scenario: Arrow key navigation
+- **WHEN** the user presses the down arrow key
+- **THEN** the selection moves to the next command in the filtered list
+
+#### Scenario: Execute command with Enter
+- **WHEN** the user presses Enter with "Go to Traces" selected
+- **THEN** the application navigates to `/traces`
+- **AND** the palette closes
+
+#### Scenario: Dismiss with Escape
+- **WHEN** the user presses Escape
+- **THEN** the palette closes without executing any command
+
+### Requirement: Global Keyboard Shortcut
+The command palette SHALL be toggled with `Cmd+K` (macOS) or `Ctrl+K` (other platforms). The shortcut SHALL be registered globally. A discoverability hint (`⌘K` or `Ctrl+K`) SHALL be visible in the navigation bar. The shortcut SHALL NOT activate when a text input, textarea, or contenteditable element has focus.
+
+#### Scenario: Open palette with Cmd+K
+- **WHEN** the user presses `Cmd+K` on macOS
+- **THEN** the command palette opens
+
+#### Scenario: Close palette with Cmd+K when open
+- **WHEN** the command palette is open and the user presses `Cmd+K`
+- **THEN** the palette closes
+
+#### Scenario: Keyboard hint visible in navigation
+- **WHEN** the navigation bar is rendered
+- **THEN** a `⌘K` (macOS) or `Ctrl+K` hint is visible
+
+#### Scenario: Shortcut does not hijack focused text inputs
+- **WHEN** the user presses `Cmd+K` / `Ctrl+K` while a text input, textarea, or contenteditable element has focus
+- **THEN** the command palette does NOT open
+- **AND** the default browser/input behavior is preserved

--- a/openspec/changes/add-debugger-semantics-polish/specs/dark-mode/spec.md
+++ b/openspec/changes/add-debugger-semantics-polish/specs/dark-mode/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Tailwind Dark Mode Configuration
+Tailwind SHALL be configured with `darkMode: 'class'` in `tailwind.config.js`. CSS custom properties SHALL be defined in `globals.css` only for non-Tailwind contexts: waterfall bar inline styles and resizable panel separator styling. A synchronous pre-hydration script in `index.html` SHALL read the theme preference from localStorage and apply the `dark` class to `<html>` before React renders, preventing FOUC.
+
+#### Scenario: Dark mode class activation
+- **WHEN** the `dark` class is present on the `<html>` element
+- **THEN** all `dark:` Tailwind variants are active
+
+#### Scenario: No FOUC on page load
+- **WHEN** a user with dark mode preference loads the page
+- **THEN** the dark theme is applied before any visible content renders
+
+#### Scenario: CSS custom properties for inline styles
+- **WHEN** the waterfall component renders bars with inline styles
+- **THEN** it reads colors from CSS custom properties that change with the dark class
+
+### Requirement: useTheme Hook
+A `useTheme` hook SHALL manage theme state with three modes: `system`, `light`, `dark`. The selected mode SHALL be persisted to localStorage. When `system` is selected, the hook SHALL follow the OS preference via `prefers-color-scheme` media query. The hook SHALL apply or remove the `dark` class on `<html>`.
+
+#### Scenario: System theme follows OS
+- **WHEN** the user selects "system" theme and the OS is in dark mode
+- **THEN** the `dark` class is applied to `<html>`
+
+#### Scenario: Explicit dark mode
+- **WHEN** the user selects "dark" theme
+- **THEN** the `dark` class is applied regardless of OS preference
+- **AND** the preference is persisted to localStorage
+
+#### Scenario: Switch to light mode
+- **WHEN** the user selects "light" theme
+- **THEN** the `dark` class is removed from `<html>`
+- **AND** the preference is persisted to localStorage
+
+### Requirement: Theme Toggle UI
+A theme toggle SHALL be present in the `Navigation` component and mirrored on the `SettingsPage`. The toggle SHALL cycle through or select between system, light, and dark modes.
+
+#### Scenario: Toggle theme from navigation
+- **WHEN** the user clicks the theme toggle in the navigation bar
+- **THEN** the theme changes and the UI updates immediately
+
+#### Scenario: Theme setting on settings page
+- **WHEN** the user visits the Settings page
+- **THEN** they see the current theme selection and can change it
+
+### Requirement: Dark Variants on Shell Components
+All shell components SHALL have `dark:` Tailwind variants applied: `Navigation`, page layouts, cards, tables, inputs, `StatusBadge`, and any shared UI primitives. Colors SHALL use appropriate dark palette values (darker backgrounds, lighter text, adjusted borders).
+
+#### Scenario: Navigation in dark mode
+- **WHEN** dark mode is active
+- **THEN** the Navigation component uses dark background and light text colors
+
+#### Scenario: Tables in dark mode
+- **WHEN** dark mode is active
+- **THEN** table rows, headers, and borders use dark-appropriate colors
+
+### Requirement: Dark Variants on Workspace Components
+All workspace components SHALL have `dark:` Tailwind variants: `SpanTree`, `SpanDetail`, `Timeline`, `Waterfall`, `PayloadInspector`, `InspectorTabs`, `TreeRail`, and `StateDiffViewer`. Interactive states (hover, focus, selected) SHALL have appropriate dark variants.
+
+#### Scenario: SpanTree in dark mode
+- **WHEN** dark mode is active
+- **THEN** tree nodes, selection highlights, and connecting lines use dark-appropriate colors
+
+#### Scenario: PayloadInspector in dark mode
+- **WHEN** dark mode is active
+- **THEN** the payload tree viewer, search input, match highlighting, expand/collapse controls, and copy buttons adapt to dark-safe colors

--- a/openspec/changes/add-debugger-semantics-polish/specs/event-conventions/spec.md
+++ b/openspec/changes/add-debugger-semantics-polish/specs/event-conventions/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Event Convention Documentation
+A `docs/event-conventions.md` document SHALL provide usage-oriented guidance for all supported event types. The document SHALL include a reference table of all 8 explicit event types with expected payload fields and default levels, but its primary focus SHALL be guiding developers on when to use each event type — especially when to emit `state_change` vs `decision` vs `custom`. SDK usage examples SHALL demonstrate real-world patterns. The document SHALL explicitly state: "These are debugger semantics, not replay primitives."
+
+#### Scenario: Usage guidance for event type selection
+- **WHEN** a developer reads `docs/event-conventions.md`
+- **THEN** they understand when to use `state_change` (observable state transitions), `decision` (branch points with reasoning), and `custom` (everything else)
+
+#### Scenario: SDK usage examples
+- **WHEN** a developer reads the state_change section
+- **THEN** they find Python SDK examples showing `span.state_change()` in a realistic context
+
+#### Scenario: Scope guard present
+- **WHEN** a developer reads the document
+- **THEN** they find a clear statement that these are debugger/observability semantics and not replay or state-machine primitives
+
+### Requirement: Python SDK Docstring Enhancement
+The Python SDK `Span` class methods for `state_change()` and `decision()` SHALL include docstrings with parameter descriptions, return type, and usage examples.
+
+#### Scenario: state_change docstring
+- **WHEN** a developer inspects `span.state_change` via help() or IDE
+- **THEN** they see parameter descriptions for `key`, `old_value`, `new_value`, `namespace`, and `message`
+
+#### Scenario: decision docstring
+- **WHEN** a developer inspects `span.decision` via help() or IDE
+- **THEN** they see parameter descriptions for `question`, `chosen`, `alternatives`, `reasoning`, and `message`

--- a/openspec/changes/add-debugger-semantics-polish/specs/event-taxonomy/spec.md
+++ b/openspec/changes/add-debugger-semantics-polish/specs/event-taxonomy/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### Requirement: Ingest Event Type Enum Extension
+The `IngestEventType` OpenAPI enum SHALL include `state_change` and `decision` in addition to the existing values (`log`, `error`, `exception`, `message`, `metric`, `custom`). The `TimelineEventType` enum SHALL include the same two new values alongside existing explicit and synthetic types.
+
+#### Scenario: Ingest a state_change event
+- **WHEN** a client sends `POST /v1/ingest` with an event having `event_type: "state_change"`
+- **THEN** the event is accepted and stored
+- **AND** the event appears in timeline responses with `event_type: "state_change"`
+
+#### Scenario: Ingest a decision event
+- **WHEN** a client sends `POST /v1/ingest` with an event having `event_type: "decision"`
+- **THEN** the event is accepted and stored
+- **AND** the event appears in timeline responses with `event_type: "decision"`
+
+### Requirement: Processor Warning for Missing Semantic Fields
+The ingest processor SHALL accept `state_change` and `decision` events regardless of payload content. When a `state_change` event payload is missing the `key` field, the processor SHALL log a warning via `log.Printf("[WARN] ...")`. When a `decision` event payload is missing `question` or `chosen`, the processor SHALL log a warning. The processor SHALL NOT reject the event and SHALL NOT modify the ingest response shape or `ProcessedBatch` return path.
+
+#### Scenario: state_change with complete payload
+- **WHEN** a `state_change` event is ingested with payload containing `key`, `old_value`, and `new_value`
+- **THEN** the event is accepted without warnings
+
+#### Scenario: state_change with missing key field
+- **WHEN** a `state_change` event is ingested with payload missing the `key` field
+- **THEN** the event is accepted
+- **AND** a `log.Printf("[WARN] ...")` warning is logged server-side
+
+#### Scenario: decision with missing question
+- **WHEN** a `decision` event is ingested with payload missing the `question` field
+- **THEN** the event is accepted
+- **AND** a `log.Printf("[WARN] ...")` warning is logged server-side
+
+### Requirement: Timeline Event Type Preservation
+When `state_change` or `decision` events are stored in the database and retrieved for timeline responses, the API SHALL return them with their original event types (`state_change`, `decision`). They SHALL NOT be degraded to `custom` or any other fallback type.
+
+#### Scenario: state_change preserved in timeline response
+- **WHEN** a `state_change` event is ingested and later retrieved via the timeline API
+- **THEN** the response contains `event_type: "state_change"`, not `"custom"`
+
+#### Scenario: decision preserved in timeline response
+- **WHEN** a `decision` event is ingested and later retrieved via the timeline API
+- **THEN** the response contains `event_type: "decision"`, not `"custom"`
+
+## ADDED Requirements
+
+### Requirement: Python SDK State Change Helper
+The Python SDK `Span` class SHALL provide a `state_change(key, old_value, new_value, namespace=None, message=None)` method that records an event with `event_type: "state_change"` and a payload containing `key`, `old_value`, `new_value`, and optionally `namespace`.
+
+#### Scenario: Record a state change via SDK
+- **WHEN** a user calls `span.state_change("user.status", "active", "suspended")`
+- **THEN** an event is recorded with `event_type: "state_change"`, `level: "info"`, and payload `{"key": "user.status", "old_value": "active", "new_value": "suspended"}`
+
+#### Scenario: Record a namespaced state change
+- **WHEN** a user calls `span.state_change("status", "active", "suspended", namespace="user")`
+- **THEN** the payload includes `{"key": "status", "namespace": "user", "old_value": "active", "new_value": "suspended"}`
+
+### Requirement: Python SDK Decision Helper
+The Python SDK `Span` class SHALL provide a `decision(question, chosen, alternatives=None, reasoning=None, message=None)` method that records an event with `event_type: "decision"` and a payload containing `question`, `chosen`, and optionally `alternatives` and `reasoning`.
+
+#### Scenario: Record a decision via SDK
+- **WHEN** a user calls `span.decision("Which model to use?", "gpt-4")`
+- **THEN** an event is recorded with `event_type: "decision"`, `level: "info"`, and payload `{"question": "Which model to use?", "chosen": "gpt-4"}`
+
+#### Scenario: Record a decision with alternatives
+- **WHEN** a user calls `span.decision("Which model?", "gpt-4", alternatives=["gpt-3.5", "claude-3"], reasoning="Higher accuracy needed")`
+- **THEN** the payload includes `{"question": "Which model?", "chosen": "gpt-4", "alternatives": ["gpt-3.5", "claude-3"], "reasoning": "Higher accuracy needed"}`
+
+### Requirement: Frontend Event Type Updates
+The frontend timeline event type definitions SHALL include `"state_change"` and `"decision"` as valid event types. Timeline event summary logic SHALL return meaningful summaries for both new types.
+
+#### Scenario: Summarize a state_change event with payload
+- **WHEN** a state_change event has payload `{"key": "user.status", "old_value": "active", "new_value": "suspended"}`
+- **THEN** `summarizeTimelineEvent` returns a summary like `"user.status: active → suspended"`
+
+#### Scenario: Summarize a decision event with payload
+- **WHEN** a decision event has payload `{"question": "Which model?", "chosen": "gpt-4"}`
+- **THEN** `summarizeTimelineEvent` returns a summary like `"Which model? → gpt-4"`
+
+#### Scenario: Summarize event with missing semantic fields
+- **WHEN** a state_change or decision event is missing required payload fields
+- **AND** the event has a `message` field
+- **THEN** `summarizeTimelineEvent` returns the `message` value
+
+### Requirement: Timeline Rendering for New Event Types
+The `Timeline` component SHALL render `state_change` events with inline old→new value display when `payload.key` is present, and degrade to generic event row using `message` when `key` is absent. The component SHALL render `decision` events with question and chosen value display when `payload.question` and `payload.chosen` are present, and degrade to generic event row using `message` when either is absent.
+
+#### Scenario: Render state_change with full payload
+- **WHEN** a timeline contains a `state_change` event with `payload.key`, `payload.old_value`, `payload.new_value`
+- **THEN** the Timeline renders an inline display showing the key and old→new transition
+
+#### Scenario: Render state_change with missing key
+- **WHEN** a timeline contains a `state_change` event without `payload.key`
+- **THEN** the Timeline renders the event as a generic event row using the `message` field
+
+#### Scenario: Render decision with full payload
+- **WHEN** a timeline contains a `decision` event with `payload.question` and `payload.chosen`
+- **THEN** the Timeline renders the question and chosen value
+
+#### Scenario: Render decision with missing question
+- **WHEN** a timeline contains a `decision` event without `payload.question`
+- **THEN** the Timeline renders the event as a generic event row using the `message` field

--- a/openspec/changes/add-debugger-semantics-polish/specs/settings-ui/spec.md
+++ b/openspec/changes/add-debugger-semantics-polish/specs/settings-ui/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Settings Page
+A settings page at `/settings` SHALL allow users to view, update, and clear their API key. The page SHALL show the current key (masked) when set, provide an input to enter a new key, and a button to clear the key.
+
+#### Scenario: View current API key
+- **WHEN** a user navigates to `/settings` with an API key already set
+- **THEN** the page shows the masked current key (e.g., "sk-...xxxx")
+
+#### Scenario: Update API key
+- **WHEN** a user enters a new API key and submits
+- **THEN** `setApiKey` is called with the new value
+- **AND** the page reflects the updated key
+
+#### Scenario: Clear API key
+- **WHEN** a user clicks the clear button
+- **THEN** `clearApiKey` is called
+- **AND** the page shows that no key is set
+
+### Requirement: Settings Route and Navigation Link
+The application SHALL include a `/settings` route accessible from the main navigation. The navigation bar SHALL include a "Settings" link.
+
+#### Scenario: Navigate to settings via nav
+- **WHEN** a user clicks "Settings" in the navigation
+- **THEN** they are routed to `/settings`
+- **AND** the Settings page renders
+
+### Requirement: 401 Error Recovery
+All pages that make authenticated API requests SHALL detect HTTP 401 responses and render a page-level auth-error banner with "Invalid or missing API key" and a "Go to Settings" link, instead of the generic error state. Non-401 errors SHALL continue to render using the existing generic error pattern. No toast system SHALL be introduced.
+
+#### Scenario: 401 on a data page
+- **WHEN** any authenticated API request returns a 401 response
+- **THEN** the page renders an auth-error banner instead of the generic error state
+- **AND** the banner includes a "Go to Settings" link
+
+#### Scenario: Non-401 errors render normally
+- **WHEN** the API returns a 500 response
+- **THEN** the existing generic error rendering is used (no auth-error banner)

--- a/openspec/changes/add-debugger-semantics-polish/specs/state-diff-ui/spec.md
+++ b/openspec/changes/add-debugger-semantics-polish/specs/state-diff-ui/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: State Change Viewer
+A state change viewer SHALL display emitted `state_change` events grouped by namespace. This is a structured viewer over explicitly emitted events, not a deep-diff engine or snapshot comparison system. Scalar values SHALL be displayed inline (key: old → new). Object/array values SHALL be rendered using the existing JSON tree viewer. Events where `payload.key` is missing SHALL be excluded before rendering.
+
+#### Scenario: Render grouped state changes
+- **WHEN** the StateDiffViewer receives state change events with namespaces "user" and "config"
+- **THEN** changes are grouped under their namespace headings
+- **AND** scalar values show inline old→new transitions
+
+#### Scenario: Render object value changes
+- **WHEN** a state change has object values for `old_value` or `new_value`
+- **THEN** the values are rendered using `JsonViewer`
+
+#### Scenario: Handle events with missing key
+- **WHEN** state change extraction receives events where some lack `payload.key`
+- **THEN** those events are excluded from the output
+- **AND** only events with `payload.key` present are shown in the viewer
+
+### Requirement: State Change Extraction
+A utility SHALL filter timeline events to only `state_change` type events where `payload.key` exists, and return them structured for the state change viewer.
+
+#### Scenario: Filter to state_change events with key
+- **WHEN** given a mixed list of timeline events
+- **THEN** the utility returns only events with `event_type === "state_change"` and `payload.key` defined
+
+#### Scenario: Empty result for no matching events
+- **WHEN** given timeline events with no `state_change` events
+- **THEN** the utility returns an empty array
+
+### Requirement: State Tab in InspectorTabs
+`InspectorTabs` SHALL support a third "State" tab displaying the `StateDiffViewer`. The tab SHALL show a badge count of state change events only when the count is greater than zero. When the count is zero, no badge or "(0)" SHALL be displayed.
+
+#### Scenario: State tab with changes
+- **WHEN** the trace has 3 state_change events with valid keys
+- **THEN** the State tab label shows a badge with "3"
+
+#### Scenario: State tab with no changes
+- **WHEN** the trace has no state_change events
+- **THEN** the State tab label shows "State" with no badge
+
+### Requirement: Span Decisions Section
+The span detail view SHALL render a "Decisions" section showing `decision` events associated with the currently selected span. Decision events where `payload.question` or `payload.chosen` is missing SHALL be skipped.
+
+#### Scenario: Show decisions for selected span
+- **WHEN** a span is selected that has 2 decision events with valid question and chosen fields
+- **THEN** SpanDetail renders a "Decisions" section with both entries
+
+#### Scenario: Skip decisions with missing fields
+- **WHEN** a decision event for the selected span is missing `payload.chosen`
+- **THEN** that decision is not rendered in the Decisions section
+
+#### Scenario: No decisions section when empty
+- **WHEN** the selected span has no valid decision events
+- **THEN** the Decisions section is not rendered
+
+### Requirement: Mobile State Tab
+The mobile workspace tab set SHALL include a 5th "State" tab alongside the existing Details, Waterfall, Tree, and Timeline tabs.
+
+#### Scenario: State tab in mobile layout
+- **WHEN** the debugger is viewed on a mobile viewport
+- **THEN** the tab bar includes a "State" tab
+- **AND** tapping it shows the StateDiffViewer content

--- a/openspec/changes/add-debugger-semantics-polish/tasks.md
+++ b/openspec/changes/add-debugger-semantics-polish/tasks.md
@@ -1,0 +1,82 @@
+## 1. Contract and codegen — Track A foundation
+
+- [x] 1.1 Add `state_change` and `decision` to `IngestEventType` enum in `contracts/openapi/openapi.yaml`
+- [x] 1.2 Add `state_change` and `decision` to `TimelineEventType` enum in `contracts/openapi/openapi.yaml`
+- [x] 1.3 Run `make generate` and verify generated Go server, TypeScript, and Python SDK types (including `sdks/python/src/continua/types.py` event enums) all include new enum values
+
+## 2. Backend event type handling — Track A
+
+- [x] 2.1 Update `internal/ingest/processor.go` to accept `state_change` and `decision` event types. Add `log.Printf("[WARN] ...")` when `state_change` payload is missing `key` or `decision` payload is missing `question`/`chosen`. No changes to `ProcessedBatch` or response shape
+- [x] 2.2 Add explicit `"state_change"` and `"decision"` cases to `mapExplicitTimelineEventType` in `internal/api/mapper.go` (prevents degradation to `TimelineEventTypeCustom`)
+- [x] 2.3 Add Go tests: ingest processor accepts new event types, warnings fire for missing semantic fields, mapper maps correctly (not degraded to custom)
+
+## 3. Python SDK helpers — Tracks A, C
+
+- [x] 3.1 Add `span.state_change(key, old_value, new_value, namespace=None, message=None)` method to `sdks/python/src/continua/span.py`
+- [x] 3.2 Add `span.decision(question, chosen, alternatives=None, reasoning=None, message=None)` method to `sdks/python/src/continua/span.py`
+- [x] 3.3 Add docstrings with parameter descriptions and usage examples to both new methods
+- [x] 3.4 Add Python SDK tests for `state_change()` and `decision()` helpers
+- [x] 3.5 Run `cd sdks/python && uv run pytest` to verify all SDK tests pass
+
+## 4. Frontend type updates — Track A
+
+- [x] 4.1 Add `"state_change"` and `"decision"` to `TimelineEvent.event_type` union in `web/src/api/client.ts`
+- [x] 4.2 Add `state_change` and `decision` cases to `summarizeTimelineEvent` in `web/src/utils/timeline.ts`. state_change: show `key: old → new` when payload fields present, fallback to `message`. decision: show `question → chosen` when payload fields present, fallback to `message`
+- [x] 4.3 Update Timeline component rendering for new event types with fallback to generic event row when semantic fields are missing
+
+## 5. State diff UI — Track B (depends on Track A)
+
+- [x] 5.1 Create `web/src/utils/stateChanges.ts` with `extractStateChanges` utility that filters to `state_change` events where `payload.key` exists
+- [x] 5.2 Create `web/src/components/StateDiffViewer.tsx` — grouped by namespace, scalar inline old→new, objects via `JsonViewer`
+- [x] 5.3 Extend `InspectorTabs` to support a third "State" tab. Show badge count only when > 0 (no "(0)" noise). Update `InspectorTabId` type to include `"state"`
+- [x] 5.4 Add `events?: TimelineEvent[]` prop to `SpanDetailProps` in `web/src/components/SpanDetail.tsx`. Render "Decisions" section filtered to selected span. Skip decision events where `payload.question` or `payload.chosen` is missing
+- [x] 5.5 Thread timeline events from `TraceDetailPage` workspace to `SpanDetail` via the new `events` prop
+- [x] 5.6 Update `WorkspaceShell` mobile tabs to include "State" as 5th tab. Update `MobileWorkspaceTabId` type
+- [x] 5.7 Add Vitest tests for `extractStateChanges` utility and StateDiffViewer rendering
+- [x] 5.8 Add integration-level Vitest tests for TraceDetailPage workspace with State tab and SpanDetail decisions section, and mobile workspace State tab parity
+
+## 6. Event convention documentation — Track C
+
+- [x] 6.1 Create `docs/event-conventions.md` with type table (all 8 explicit event types), payload schemas, SDK examples, and "debugger semantics, not replay primitives" scope guard
+
+## 7. Settings UI and 401 recovery — Track D
+
+- [x] 7.1 Create `web/src/pages/SettingsPage.tsx` using existing `getApiKey`/`setApiKey`/`clearApiKey` helpers. Show masked current key, input for new key, clear button
+- [x] 7.2 Add `/settings` route to `App.tsx` within `PageWithNav`. Add "Settings" link to `Navigation`
+- [x] 7.3 Update error rendering in `TracesPage`, `SessionsPage`, `SessionDetailPage`, `TraceDetailPage` to detect 401 via existing `ApiError.status` and render auth-error banner with "Go to Settings" link. Extract a shared helper only if the detection pattern becomes repetitive
+- [x] 7.4 Add Vitest tests for 401 banner rendering and SettingsPage key management
+
+## 8. Command palette — Track E
+
+- [x] 8.1 Create `web/src/components/CommandPalette.tsx` with search input, filtered command list, arrow-key navigation, Enter to execute, Escape to dismiss. Commands: navigate Traces/Sessions/Settings, toggle theme
+- [x] 8.2 Wire `CommandPalette` globally with `Cmd+K` / `Ctrl+K` shortcut. Guard against activation when text inputs, textareas, or contenteditable elements have focus. Add `⌘K` / `Ctrl+K` discoverability hint to `Navigation`
+- [x] 8.3 Add Vitest tests for CommandPalette search filtering, keyboard navigation, command execution, and shortcut suppression when text inputs/textareas/contenteditable elements have focus
+
+## 9. Dark mode and theming — Track F
+
+- [x] 9.1 Enable `darkMode: 'class'` in `web/tailwind.config.js`
+- [x] 9.2 Add CSS custom properties in `web/src/styles/globals.css` for non-Tailwind contexts (waterfall bar colors, panel separator colors) that change with `.dark` class
+- [x] 9.3 Add pre-hydration theme script to `web/index.html` that reads localStorage and sets `dark` class on `<html>` before React renders
+- [x] 9.4 Create `web/src/hooks/useTheme.ts` hook with `system | light | dark` modes, localStorage persistence, and OS preference detection via `prefers-color-scheme`
+- [x] 9.5 Add theme toggle to `Navigation` component. Mirror theme selection on `SettingsPage`
+- [x] 9.6 Apply `dark:` variants to shell components: `Navigation`, page layouts, cards, tables, inputs, `StatusBadge`
+- [x] 9.7 Apply `dark:` variants to workspace components: `SpanTree`, `SpanDetail`, `Timeline`, `Waterfall`, `PayloadInspector`, `InspectorTabs`, `TreeRail`, `StateDiffViewer`
+- [x] 9.8 Add Vitest test for `useTheme` hook (mode cycling, localStorage persistence)
+
+## 10. Integration verification
+
+- [x] 10.1 Run `make generate` — clean with no drift
+- [x] 10.2 Run `go test ./internal/ingest/... -v` — new event types accepted, warnings fire
+- [x] 10.3 Run `go test ./internal/api/... -v` — mapper tests pass
+- [x] 10.4 Run `cd sdks/python && uv run pytest` — SDK tests pass
+- [x] 10.5 Run `pnpm --filter web test` — all frontend tests pass
+
+## Parallelism Notes
+
+- Tasks 1–2 (contract + backend) are sequential and foundational
+- Task 3 (Python SDK) can run after task 1 (needs contract types)
+- Task 4 (frontend types) can run after task 1.3 (needs generated TS types)
+- Tasks 5 (state diff UI) depends on task 4 (needs frontend event types)
+- Tasks 6–9 (docs, settings, palette, dark mode) are independent of each other, can run in parallel after task 1.3
+- Task 7.4 (401 banners) and 9.6–9.7 (dark variants) touch overlapping files — coordinate if parallelized
+- Task 10 is final integration verification

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -17,7 +17,7 @@ if [ -f contracts/generated/go/server_gen.go ]; then
 fi
 
 if [ -f contracts/openapi/openapi.bundle.yaml ]; then
-    cd sdks/python && uv run python scripts/generate_types.py && cd ../..
+    cd sdks/python && uv run --with datamodel-code-generator python scripts/generate_types.py && cd ../..
 fi
 
 echo "✅ All code generated"

--- a/sdks/python/scripts/generate_types.py
+++ b/sdks/python/scripts/generate_types.py
@@ -15,7 +15,9 @@ def main():
         sys.exit(1)
 
     cmd = [
-        "datamodel-codegen",
+        sys.executable,
+        "-m",
+        "datamodel_code_generator",
         "--input", str(openapi_path),
         "--output", str(output_path),
         "--input-file-type", "openapi",

--- a/sdks/python/src/continua/span.py
+++ b/sdks/python/src/continua/span.py
@@ -257,6 +257,97 @@ class SpanContext:
             payload=metric_payload,
         )
 
+    def state_change(
+        self,
+        key: str,
+        old_value: Any,
+        new_value: Any,
+        namespace: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        """Emit a structured state change event for this span.
+
+        Args:
+            key: State field name that changed.
+            old_value: Previous value before the transition.
+            new_value: New value after the transition.
+            namespace: Optional grouping namespace for related state keys.
+            message: Optional human-readable summary shown in generic timeline fallbacks.
+
+        Returns:
+            None.
+
+        Example:
+            with span("validate_order") as s:
+                s.state_change(
+                    "status",
+                    "pending",
+                    "approved",
+                    namespace="order",
+                    message="Order approved after validation",
+                )
+        """
+        payload: dict[str, Any] = {
+            "key": key,
+            "old_value": old_value,
+            "new_value": new_value,
+        }
+        if namespace is not None:
+            payload["namespace"] = namespace
+
+        self._record_event(
+            event_type="state_change",
+            level="info",
+            message=message,
+            payload=payload,
+        )
+
+    def decision(
+        self,
+        question: str,
+        chosen: Any,
+        alternatives: list[Any] | None = None,
+        reasoning: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        """Emit a structured decision event for this span.
+
+        Args:
+            question: The question or branch point being evaluated.
+            chosen: The selected answer, option, or branch outcome.
+            alternatives: Optional rejected options considered alongside the choice.
+            reasoning: Optional explanation for why the choice was made.
+            message: Optional human-readable summary shown in generic timeline fallbacks.
+
+        Returns:
+            None.
+
+        Example:
+            with span("route_request") as s:
+                s.decision(
+                    "Which model should handle the request?",
+                    "gpt-4.1",
+                    alternatives=["gpt-4o-mini", "gpt-4.1"],
+                    reasoning="Escalated for higher quality on refund requests",
+                    message="Escalated to a higher-capability model",
+                )
+        """
+        payload: dict[str, Any] = {
+            "question": question,
+            "chosen": chosen,
+        }
+        if alternatives is not None:
+            payload["alternatives"] = alternatives
+        if reasoning is not None:
+            payload["reasoning"] = reasoning
+
+        self._record_event(
+            event_type="decision",
+            level="info",
+            message=message,
+            payload=payload,
+        )
+
     def __enter__(self) -> SpanContext:
         """Enter the span context."""
         self._token = _current_span.set(self)

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -34,6 +34,7 @@ class Status(Enum):
 class Trace(BaseModel):
     id: UUID
     session_id: UUID | None = None
+    session_external_id: str | None = None
     name: str
     status: Status
     started_at: AwareDatetime
@@ -45,6 +46,18 @@ class Trace(BaseModel):
         None, description="Count of failed spans in this trace"
     )
     metadata: dict[str, Any] | None = None
+
+
+class TraceDetail(Trace):
+    trace_id: str | None = None
+    user_id: str | None = None
+    tags: list[str] | None = None
+    environment: str | None = None
+    release: str | None = None
+    input: Any | None = Field(None, description="Trace input payload (any valid JSON)")
+    output: Any | None = Field(
+        None, description="Trace output payload (any valid JSON)"
+    )
 
 
 class TraceList(BaseModel):
@@ -87,8 +100,16 @@ class Span(BaseModel):
     cost_usd: float | None = None
     latency_ms: int | None = None
     error_message: str | None = None
+    model: str | None = None
+    provider: str | None = None
     input: Any | None = Field(None, description="Span input payload (any valid JSON)")
+    input_truncated: bool | None = None
+    input_original_size_bytes: int | None = None
+    input_truncation_reason: str | None = None
     output: Any | None = Field(None, description="Span output payload (any valid JSON)")
+    output_truncated: bool | None = None
+    output_original_size_bytes: int | None = None
+    output_truncation_reason: str | None = None
     metadata: dict[str, Any] | None = None
 
 
@@ -203,6 +224,8 @@ class IngestEventType(Enum):
     message = "message"
     metric = "metric"
     custom = "custom"
+    state_change = "state_change"
+    decision = "decision"
 
 
 class IngestEventLevel(Enum):
@@ -220,7 +243,10 @@ class IngestEventInput(BaseModel):
     event_ts: AwareDatetime | None = None
     sequence: int | None = None
     message: str | None = None
-    payload: dict[str, Any] | None = None
+    payload: dict[str, Any] | None = Field(
+        None,
+        description="Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.\n",
+    )
     idempotency_key: str | None = Field(
         None, description="Optional key for event-level deduplication"
     )
@@ -233,6 +259,8 @@ class TimelineEventType(Enum):
     message = "message"
     metric = "metric"
     custom = "custom"
+    state_change = "state_change"
+    decision = "decision"
     span_started = "span_started"
     span_completed = "span_completed"
     span_failed = "span_failed"

--- a/sdks/python/tests/test_span.py
+++ b/sdks/python/tests/test_span.py
@@ -1,7 +1,24 @@
 """Tests for span context."""
 
+from continua.client import Continua
 from continua.span import SpanContext, get_current_span, span
 from continua.trace import TraceContext
+
+
+class StubClient:
+    def __init__(self) -> None:
+        self.traces: list[dict] = []
+        self.spans: list[dict] = []
+        self.events: list[dict] = []
+
+    def add_trace(self, trace: dict) -> None:
+        self.traces.append(trace)
+
+    def add_span(self, span: dict) -> None:
+        self.spans.append(span)
+
+    def add_event(self, event: dict) -> None:
+        self.events.append(event)
 
 
 def test_span_context_basic():
@@ -88,3 +105,73 @@ def test_span_helper_function():
             assert s.name == "test_span"
             assert s.kind == "tool"
             assert s.metadata == {"key": "value"}
+
+
+def test_state_change_helper_records_semantic_event():
+    """Test state_change helper payload construction."""
+    stub_client = StubClient()
+    previous_client = Continua._instance
+    Continua._instance = stub_client
+
+    try:
+        with TraceContext(name="test_trace"):
+            with span("stateful_span") as s:
+                s.state_change(
+                    "status",
+                    "pending",
+                    "approved",
+                    namespace="order",
+                    message="Order approved",
+                )
+    finally:
+        Continua._instance = previous_client
+
+    assert len(stub_client.events) == 1
+    assert stub_client.events[0] == {
+        "trace_id": stub_client.traces[0]["trace_id"],
+        "span_id": stub_client.spans[0]["span_id"],
+        "event_type": "state_change",
+        "level": "info",
+        "message": "Order approved",
+        "payload": {
+            "key": "status",
+            "old_value": "pending",
+            "new_value": "approved",
+            "namespace": "order",
+        },
+    }
+
+
+def test_decision_helper_records_semantic_event():
+    """Test decision helper payload construction."""
+    stub_client = StubClient()
+    previous_client = Continua._instance
+    Continua._instance = stub_client
+
+    try:
+        with TraceContext(name="test_trace"):
+            with span("decision_span") as s:
+                s.decision(
+                    "Which model?",
+                    "gpt-4.1",
+                    alternatives=["gpt-4o-mini", "gpt-4.1"],
+                    reasoning="Need better reasoning quality",
+                    message="Escalated to stronger model",
+                )
+    finally:
+        Continua._instance = previous_client
+
+    assert len(stub_client.events) == 1
+    assert stub_client.events[0] == {
+        "trace_id": stub_client.traces[0]["trace_id"],
+        "span_id": stub_client.spans[0]["span_id"],
+        "event_type": "decision",
+        "level": "info",
+        "message": "Escalated to stronger model",
+        "payload": {
+            "question": "Which model?",
+            "chosen": "gpt-4.1",
+            "alternatives": ["gpt-4o-mini", "gpt-4.1"],
+            "reasoning": "Need better reasoning quality",
+        },
+    }

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,28 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Continua</title>
+    <script>
+      (function () {
+        var storageKey = 'continua_theme_mode';
+        var storedMode = localStorage.getItem(storageKey);
+        var mode =
+          storedMode === 'light' || storedMode === 'dark' || storedMode === 'system'
+            ? storedMode
+            : 'system';
+        var shouldUseDark =
+          mode === 'dark' ||
+          (mode === 'system' &&
+            window.matchMedia &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (shouldUseDark) {
+          document.documentElement.classList.add('dark');
+          document.documentElement.dataset.theme = 'dark';
+          return;
+        }
+        document.documentElement.classList.remove('dark');
+        document.documentElement.dataset.theme = 'light';
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,21 +5,26 @@ import { TraceDetailPage } from './pages/TraceDetailPage';
 import { SessionsPage } from './pages/SessionsPage';
 import { SessionDetailPage } from './pages/SessionDetailPage';
 import { Navigation } from './components/Navigation';
+import { SettingsPage } from './pages/SettingsPage';
+import { ThemeProvider } from './hooks/useTheme';
 
 const queryClient = new QueryClient();
 
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/traces" element={<PageWithNav><TracesPage /></PageWithNav>} />
-          <Route path="/traces/:id" element={<PageWithNav><TraceDetailPage /></PageWithNav>} />
-          <Route path="/sessions" element={<PageWithNav><SessionsPage /></PageWithNav>} />
-          <Route path="/sessions/:id" element={<PageWithNav><SessionDetailPage /></PageWithNav>} />
-        </Routes>
-      </BrowserRouter>
+      <ThemeProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<PageWithNav><HomePage /></PageWithNav>} />
+            <Route path="/traces" element={<PageWithNav><TracesPage /></PageWithNav>} />
+            <Route path="/traces/:id" element={<PageWithNav><TraceDetailPage /></PageWithNav>} />
+            <Route path="/sessions" element={<PageWithNav><SessionsPage /></PageWithNav>} />
+            <Route path="/sessions/:id" element={<PageWithNav><SessionDetailPage /></PageWithNav>} />
+            <Route path="/settings" element={<PageWithNav><SettingsPage /></PageWithNav>} />
+          </Routes>
+        </BrowserRouter>
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }
@@ -35,15 +40,15 @@ function PageWithNav({ children }: { children: React.ReactNode }) {
 
 function HomePage() {
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center">
       <div className="text-center">
-        <h1 className="text-4xl font-bold text-gray-900">Continua</h1>
-        <p className="mt-2 text-gray-600">AI Agent Observability Platform</p>
+        <h1 className="text-4xl font-bold text-slate-900 dark:text-slate-100">Continua</h1>
+        <p className="mt-2 text-slate-600 dark:text-slate-400">AI Agent Observability Platform</p>
         <div className="mt-4 space-x-4">
-          <Link to="/traces" className="inline-block text-blue-600 hover:underline">
+          <Link to="/traces" className="inline-block text-blue-600 hover:underline dark:text-sky-400">
             View Traces
           </Link>
-          <Link to="/sessions" className="inline-block text-blue-600 hover:underline">
+          <Link to="/sessions" className="inline-block text-blue-600 hover:underline dark:text-sky-400">
             View Sessions
           </Link>
         </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,7 @@ import { SessionsPage } from './pages/SessionsPage';
 import { SessionDetailPage } from './pages/SessionDetailPage';
 import { Navigation } from './components/Navigation';
 import { SettingsPage } from './pages/SettingsPage';
-import { ThemeProvider } from './hooks/useTheme';
+import { ThemeProvider } from './hooks/ThemeProvider';
 
 const queryClient = new QueryClient();
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -56,6 +56,10 @@ export class ApiError extends Error {
   }
 }
 
+export function isAuthError(error: unknown): error is ApiError {
+  return error instanceof ApiError && error.status === 401;
+}
+
 /**
  * Fetch wrapper with API key authentication.
  */
@@ -178,6 +182,8 @@ export interface TimelineEvent {
     | 'message'
     | 'metric'
     | 'custom'
+    | 'state_change'
+    | 'decision'
     | 'span_started'
     | 'span_completed'
     | 'span_failed';

--- a/web/src/components/ApiKeyPrompt.tsx
+++ b/web/src/components/ApiKeyPrompt.tsx
@@ -23,10 +23,10 @@ export function ApiKeyPrompt({ onSubmit }: ApiKeyPromptProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="bg-white p-8 rounded-lg shadow-lg max-w-md w-full">
-        <h2 className="text-2xl font-bold text-gray-900 mb-4">API Key Required</h2>
-        <p className="text-gray-600 mb-6">
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center dark:bg-slate-950">
+      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-lg dark:bg-slate-900">
+        <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-slate-100">API Key Required</h2>
+        <p className="mb-6 text-slate-600 dark:text-slate-300">
           Enter your Continua API key to view traces.
         </p>
         <form onSubmit={handleSubmit}>
@@ -38,7 +38,7 @@ export function ApiKeyPrompt({ onSubmit }: ApiKeyPromptProps) {
               setError('');
             }}
             placeholder="ck_live_..."
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-900 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
           />
           {error && (
             <p className="mt-2 text-red-600 text-sm">{error}</p>

--- a/web/src/components/AuthErrorBanner.tsx
+++ b/web/src/components/AuthErrorBanner.tsx
@@ -1,0 +1,31 @@
+import { Link } from 'react-router-dom';
+
+interface AuthErrorBannerProps {
+  message?: string;
+}
+
+export function AuthErrorBanner({
+  message = 'Your API key is missing, expired, or invalid.',
+}: AuthErrorBannerProps) {
+  return (
+    <div
+      role="alert"
+      className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-amber-950 shadow-sm dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.16em] text-amber-800 dark:text-amber-200">
+            Authentication required
+          </p>
+          <p className="mt-1 text-sm">{message}</p>
+        </div>
+        <Link
+          to="/settings"
+          className="inline-flex items-center justify-center rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-medium text-amber-900 transition hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-300 dark:border-amber-400/40 dark:bg-slate-950 dark:text-amber-100 dark:hover:bg-slate-900"
+        >
+          Go to Settings
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/CommandPalette.test.tsx
+++ b/web/src/components/CommandPalette.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CommandPalette, type CommandPaletteCommand } from './CommandPalette';
+
+function renderCommandPalette(commands: CommandPaletteCommand[]) {
+  return render(<CommandPalette commands={commands} />);
+}
+
+const commands: CommandPaletteCommand[] = [
+  {
+    id: 'traces',
+    title: 'Go to Traces',
+    keywords: ['navigate', 'trace'],
+    action: vi.fn(),
+  },
+  {
+    id: 'sessions',
+    title: 'Go to Sessions',
+    keywords: ['navigate', 'session'],
+    action: vi.fn(),
+  },
+  {
+    id: 'theme',
+    title: 'Toggle Theme',
+    keywords: ['appearance', 'dark', 'light'],
+    action: vi.fn(),
+  },
+];
+
+describe('CommandPalette', () => {
+  it('filters commands as the search query changes', async () => {
+    const user = userEvent.setup();
+    renderCommandPalette(commands);
+
+    await user.click(screen.getByRole('button', { name: /Command Palette/i }));
+    await user.type(screen.getByRole('combobox', { name: 'Search commands' }), 'theme');
+
+    expect(screen.getByRole('option', { name: /Toggle Theme/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Go to Traces/ })).not.toBeInTheDocument();
+  });
+
+  it('supports arrow-key navigation and Enter to execute the active command', async () => {
+    const user = userEvent.setup();
+    const themeAction = commands[2].action as ReturnType<typeof vi.fn>;
+    renderCommandPalette(commands);
+
+    await user.click(screen.getByRole('button', { name: /Command Palette/i }));
+    const input = screen.getByRole('combobox', { name: 'Search commands' });
+
+    await user.type(input, 'toggle');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(themeAction).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('combobox', { name: 'Search commands' })).not.toBeInTheDocument();
+  });
+
+  it('opens from the global shortcut and suppresses activation inside text inputs, textareas, and contenteditable elements', () => {
+    render(
+      <div>
+        <input aria-label="Plain input" />
+        <textarea aria-label="Plain textarea" />
+        <div aria-label="Editable div" contentEditable />
+        <CommandPalette commands={commands} />
+      </div>
+    );
+
+    const textInput = screen.getByLabelText('Plain input');
+    textInput.focus();
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(screen.queryByRole('combobox', { name: 'Search commands' })).not.toBeInTheDocument();
+
+    const textArea = screen.getByLabelText('Plain textarea');
+    textArea.focus();
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(screen.queryByRole('combobox', { name: 'Search commands' })).not.toBeInTheDocument();
+
+    const editable = screen.getByLabelText('Editable div');
+    editable.focus();
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(screen.queryByRole('combobox', { name: 'Search commands' })).not.toBeInTheDocument();
+
+    editable.blur();
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(screen.getByRole('combobox', { name: 'Search commands' })).toBeInTheDocument();
+  });
+
+  it('closes from the global shortcut while open and dismisses on backdrop click', async () => {
+    const user = userEvent.setup();
+    renderCommandPalette(commands);
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(screen.getByRole('combobox', { name: 'Search commands' })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(screen.queryByRole('combobox', { name: 'Search commands' })).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(screen.getByRole('combobox', { name: 'Search commands' })).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('command-palette-backdrop'));
+    expect(screen.queryByRole('combobox', { name: 'Search commands' })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,0 +1,262 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+
+export interface CommandPaletteCommand {
+  id: string;
+  title: string;
+  keywords?: string[];
+  action: () => void;
+}
+
+interface CommandPaletteProps {
+  commands: CommandPaletteCommand[];
+}
+
+export function CommandPalette({ commands }: CommandPaletteProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const listboxId = useId();
+  const shortcutHint = getCommandPaletteShortcutHint();
+  const filteredCommands = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return commands;
+    }
+
+    return commands.filter((command) => {
+      const haystack = [
+        command.title,
+        ...(command.keywords ?? []),
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      return haystack.includes(normalizedQuery);
+    });
+  }, [commands, query]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        if (!isOpen && shouldSuppressShortcut(document.activeElement)) {
+          return;
+        }
+
+        event.preventDefault();
+        setIsOpen((open) => !open);
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setQuery('');
+    setActiveIndex(0);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    searchInputRef.current?.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (filteredCommands.length === 0) {
+      setActiveIndex(0);
+      return;
+    }
+
+    if (activeIndex >= filteredCommands.length) {
+      setActiveIndex(0);
+    }
+  }, [activeIndex, filteredCommands.length]);
+
+  const executeCommand = (command: CommandPaletteCommand) => {
+    command.action();
+    setIsOpen(false);
+  };
+
+  const handleSearchKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((current) =>
+        filteredCommands.length === 0 ? 0 : (current + 1) % filteredCommands.length
+      );
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((current) =>
+        filteredCommands.length === 0
+          ? 0
+          : (current - 1 + filteredCommands.length) % filteredCommands.length
+      );
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const command = filteredCommands[activeIndex];
+      if (command) {
+        executeCommand(command);
+      }
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+      >
+        <span>Command Palette</span>
+        <kbd className="rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] text-slate-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400">
+          {shortcutHint}
+        </kbd>
+      </button>
+
+      {isOpen ? (
+        <div
+          data-testid="command-palette-backdrop"
+          className="fixed inset-0 z-50 flex items-start justify-center bg-slate-950/45 px-4 py-20 backdrop-blur-sm"
+          onClick={() => setIsOpen(false)}
+        >
+          <div
+            className="w-full max-w-2xl overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl dark:border-slate-800 dark:bg-slate-900"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="border-b border-slate-200 px-4 py-4 dark:border-slate-800">
+              <label className="sr-only" htmlFor="command-palette-search">
+                Search commands
+              </label>
+              <input
+                id="command-palette-search"
+                ref={searchInputRef}
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={handleSearchKeyDown}
+                placeholder="Search commands"
+                role="combobox"
+                aria-expanded="true"
+                aria-controls={listboxId}
+                aria-activedescendant={
+                  filteredCommands[activeIndex]
+                    ? `command-option-${filteredCommands[activeIndex].id}`
+                    : undefined
+                }
+                className="w-full rounded-xl border border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+              />
+            </div>
+
+            <div className="max-h-[24rem] overflow-y-auto p-2">
+              {filteredCommands.length === 0 ? (
+                <div className="px-4 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
+                  No commands match your search.
+                </div>
+              ) : (
+                <ul id={listboxId} role="listbox" className="space-y-1">
+                  {filteredCommands.map((command, index) => {
+                    const isActive = index === activeIndex;
+
+                    return (
+                      <li key={command.id}>
+                        <button
+                          id={`command-option-${command.id}`}
+                          type="button"
+                          role="option"
+                          aria-selected={isActive}
+                          className={`flex w-full items-center justify-between rounded-xl px-4 py-3 text-left text-sm transition ${
+                            isActive
+                              ? 'bg-blue-600 text-white'
+                              : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800'
+                          }`}
+                          onMouseEnter={() => setActiveIndex(index)}
+                          onClick={() => executeCommand(command)}
+                        >
+                          <span className="font-medium">{command.title}</span>
+                          <span
+                            className={`text-xs ${
+                              isActive
+                                ? 'text-blue-100'
+                                : 'text-slate-400 dark:text-slate-500'
+                            }`}
+                          >
+                            Enter
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function getCommandPaletteShortcutHint() {
+  return isMacLikePlatform() ? '⌘K' : 'Ctrl+K';
+}
+
+function isMacLikePlatform() {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  return /(mac|iphone|ipad)/i.test(navigator.platform);
+}
+
+function shouldSuppressShortcut(activeElement: Element | null) {
+  if (!activeElement) {
+    return false;
+  }
+
+  if (activeElement instanceof HTMLTextAreaElement) {
+    return true;
+  }
+
+  if (activeElement instanceof HTMLInputElement) {
+    return true;
+  }
+
+  if (activeElement instanceof HTMLElement && activeElement.isContentEditable) {
+    return true;
+  }
+
+  return Boolean(activeElement.closest('[contenteditable="true"]'));
+}

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -72,7 +72,7 @@ export function CopyButton({
     <button
       {...buttonProps}
       type={type}
-      className={`inline-flex items-center justify-center rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60 ${className}`.trim()}
+      className={`inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800 ${className}`.trim()}
       data-copy-status={status}
       onClick={handleClick}
     >

--- a/web/src/components/ExecutionWaterfall.tsx
+++ b/web/src/components/ExecutionWaterfall.tsx
@@ -23,7 +23,7 @@ interface ExecutionWaterfallProps {
 
 const MIN_BAR_WIDTH_REM = 0.875;
 const WATERFALL_ROW_HEIGHT = 68;
-const TICK_LINE_COLOR = 'rgba(209, 213, 219, 0.7)';
+const TICK_LINE_COLOR = 'var(--continua-waterfall-tick-color)';
 
 export function ExecutionWaterfall({
   events,
@@ -90,29 +90,29 @@ export function ExecutionWaterfall({
 
   if (rows.length === 0 || !window) {
     return (
-      <section className="flex h-full items-center justify-center rounded-2xl border border-gray-200 bg-white shadow-sm">
-        <div className="text-sm text-gray-500">No spans available for execution timing.</div>
+      <section className="flex h-full items-center justify-center rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="text-sm text-slate-500 dark:text-slate-400">No spans available for execution timing.</div>
       </section>
     );
   }
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-      <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
-        <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-gray-600">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">
           Execution Waterfall
         </h2>
-        <p className="mt-1 text-sm text-gray-500">
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
           Timing bars follow the visible tree order and selection state.
         </p>
       </div>
 
-      <div className="grid grid-cols-[minmax(0,13rem)_minmax(0,1fr)] border-b border-gray-200 bg-white">
-        <div className="border-r border-gray-200 px-4 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
+      <div className="grid grid-cols-[minmax(0,13rem)_minmax(0,1fr)] border-b border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+        <div className="border-r border-slate-200 px-4 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:border-slate-800 dark:text-slate-400">
           Visible spans
         </div>
         <div className="relative px-4 py-3">
-          <div className="relative flex h-full items-start justify-between gap-2 text-[11px] font-medium uppercase tracking-[0.16em] text-gray-500">
+          <div className="relative flex h-full items-start justify-between gap-2 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
             {ticks.map((tick) => (
               <span
                 key={tick.leftPercent}
@@ -132,7 +132,7 @@ export function ExecutionWaterfall({
         onScroll={onScroll}
       >
         <div
-          className="divide-y divide-gray-100"
+          className="divide-y divide-slate-100 dark:divide-slate-800"
           style={{
             paddingBottom: `${paddingBottom}px`,
             paddingTop: `${paddingTop}px`,
@@ -157,18 +157,20 @@ export function ExecutionWaterfall({
               >
                 <button
                   type="button"
-                  className={`min-w-0 border-r border-gray-200 px-4 py-3 text-left transition ${
-                    isSelected ? 'bg-blue-50' : 'bg-white hover:bg-gray-50'
+                  className={`min-w-0 border-r border-slate-200 px-4 py-3 text-left transition dark:border-slate-800 ${
+                    isSelected
+                      ? 'bg-blue-50 dark:bg-sky-500/10'
+                      : 'bg-white hover:bg-slate-50 dark:bg-slate-900 dark:hover:bg-slate-800/60'
                   }`}
                   onClick={() => onSelectSpanAndShowDetails(row.span.span_id)}
                 >
                   <div
-                    className="truncate text-sm font-medium text-gray-900"
+                    className="truncate text-sm font-medium text-slate-900 dark:text-slate-100"
                     style={{ paddingLeft: `${row.depth * 12}px` }}
                   >
                     {row.span.name}
                   </div>
-                  <div className="mt-1 text-xs text-gray-500">
+                  <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                     {row.span.status} · {formatDuration(row.span.latency_ms)}
                   </div>
                 </button>
@@ -187,19 +189,25 @@ export function ExecutionWaterfall({
                   >
                     <button
                       type="button"
-                      className={`absolute top-1/2 flex h-6 -translate-y-1/2 items-center rounded-full border px-2 text-xs font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
-                        bar.isRunning
-                          ? 'border-blue-300 bg-blue-100 text-blue-800'
-                          : row.span.status === 'FAILED'
-                            ? 'border-red-300 bg-red-100 text-red-800'
-                            : isSelected
-                              ? 'border-blue-300 bg-blue-200 text-blue-900'
-                              : 'border-emerald-200 bg-emerald-100 text-emerald-800'
-                      }`}
+                      className={`absolute top-1/2 flex h-6 -translate-y-1/2 items-center rounded-full border px-2 text-xs font-medium text-slate-900 transition focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-slate-50`}
                       style={{
                         left: `${bar.leftPercent}%`,
                         width: `${Math.max(bar.widthPercent, 0.35)}%`,
                         minWidth: `${MIN_BAR_WIDTH_REM}rem`,
+                        backgroundColor: bar.isRunning
+                          ? 'var(--continua-waterfall-running-bg)'
+                          : row.span.status === 'FAILED'
+                            ? 'var(--continua-waterfall-failed-bg)'
+                            : isSelected
+                              ? 'var(--continua-waterfall-success-selected-bg)'
+                              : 'var(--continua-waterfall-success-bg)',
+                        borderColor: bar.isRunning
+                          ? 'var(--continua-waterfall-running-border)'
+                          : row.span.status === 'FAILED'
+                            ? 'var(--continua-waterfall-failed-border)'
+                            : isSelected
+                              ? 'var(--continua-waterfall-success-selected-border)'
+                              : 'var(--continua-waterfall-success-border)',
                       }}
                       aria-label={`Select waterfall span ${row.span.name}`}
                       title={`${row.span.name} • ${row.span.status} • ${formatDuration(
@@ -209,7 +217,10 @@ export function ExecutionWaterfall({
                     >
                       <span className="truncate">{row.span.kind}</span>
                       {bar.isRunning ? (
-                        <span className="ml-1 h-2 w-2 shrink-0 rounded-full bg-blue-600" />
+                        <span
+                          className="ml-1 h-2 w-2 shrink-0 rounded-full"
+                          style={{ backgroundColor: 'var(--continua-waterfall-running-dot)' }}
+                        />
                       ) : null}
                     </button>
                   </div>

--- a/web/src/components/FailureSummary.tsx
+++ b/web/src/components/FailureSummary.tsx
@@ -14,8 +14,8 @@ export function FailureSummary({
   const primaryFailedSpan = summary.primaryFailedSpan;
 
   return (
-    <section className="overflow-hidden rounded-xl border border-red-200 bg-white shadow-sm">
-      <div className="border-b border-red-200 bg-red-50 px-4 py-3">
+    <section className="overflow-hidden rounded-xl border border-red-200 bg-white shadow-sm dark:border-red-500/40 dark:bg-slate-900">
+      <div className="border-b border-red-200 bg-red-50 px-4 py-3 dark:border-red-500/30 dark:bg-red-500/10">
         <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-red-700">
           Failure Summary
         </h2>
@@ -30,18 +30,18 @@ export function FailureSummary({
             <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
               <div className="min-w-0">
                 <div className="flex flex-wrap items-center gap-2">
-                  <h3 className="text-base font-semibold text-gray-900">
+                  <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
                     {primaryFailedSpan.name}
                   </h3>
-                  <span className="rounded-full bg-gray-900 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white">
+                  <span className="rounded-full bg-slate-900 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white dark:bg-slate-100 dark:text-slate-950">
                     {primaryFailedSpan.kind}
                   </span>
                 </div>
 
                 {summary.errorPreview ? (
-                  <p className="mt-2 text-sm text-gray-700">{summary.errorPreview}</p>
+                  <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">{summary.errorPreview}</p>
                 ) : (
-                  <p className="mt-2 text-sm text-gray-500">
+                  <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
                     No inline error preview was available for the primary failed span.
                   </p>
                 )}
@@ -73,7 +73,7 @@ export function FailureSummary({
             </div>
 
             <div>
-              <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-500">
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
                 Failure path
               </div>
               <SpanBreadcrumb
@@ -84,7 +84,7 @@ export function FailureSummary({
           </>
         ) : (
           <>
-            <p className="text-sm text-gray-700">
+            <p className="text-sm text-slate-700 dark:text-slate-200">
               This trace is marked as failed, but no failed span could be identified
               from the current span data.
             </p>
@@ -107,11 +107,11 @@ export function FailureSummary({
 
 function SummaryStat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-500">
+    <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/70">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
         {label}
       </div>
-      <div className="mt-2 text-sm font-medium text-gray-900">{value}</div>
+      <div className="mt-2 text-sm font-medium text-slate-900 dark:text-slate-100">{value}</div>
     </div>
   );
 }

--- a/web/src/components/InspectorTabs.test.tsx
+++ b/web/src/components/InspectorTabs.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { InspectorTabs } from './InspectorTabs';
+
+describe('InspectorTabs', () => {
+  it('shows the state badge only when the count is greater than zero', () => {
+    const { rerender } = render(
+      <InspectorTabs
+        details={<div>Details</div>}
+        timeline={<div>Timeline</div>}
+        state={<div>State</div>}
+        stateCount={0}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'State' })).toHaveTextContent(/^State$/);
+
+    rerender(
+      <InspectorTabs
+        details={<div>Details</div>}
+        timeline={<div>Timeline</div>}
+        state={<div>State</div>}
+        stateCount={3}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'State' })).toHaveTextContent('3');
+  });
+});

--- a/web/src/components/InspectorTabs.tsx
+++ b/web/src/components/InspectorTabs.tsx
@@ -5,17 +5,21 @@ import {
   type ReactNode,
 } from 'react';
 
-export type InspectorTabId = 'details' | 'timeline';
+export type InspectorTabId = 'details' | 'timeline' | 'state';
 
 interface InspectorTabsProps {
   details: ReactNode;
   timeline: ReactNode;
+  state: ReactNode;
+  stateCount: number;
   switchToDetailsRef?: MutableRefObject<(() => void) | null>;
 }
 
 export function InspectorTabs({
   details,
   timeline,
+  state,
+  stateCount,
   switchToDetailsRef,
 }: InspectorTabsProps) {
   const [activeTab, setActiveTab] = useState<InspectorTabId>('details');
@@ -36,8 +40,8 @@ export function InspectorTabs({
   }, [switchToDetailsRef]);
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-      <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
         <div className="flex items-center gap-2">
           <InspectorTabButton
             active={activeTab === 'details'}
@@ -48,6 +52,12 @@ export function InspectorTabs({
             active={activeTab === 'timeline'}
             label="Timeline"
             onClick={() => setActiveTab('timeline')}
+          />
+          <InspectorTabButton
+            active={activeTab === 'state'}
+            label="State"
+            badgeCount={stateCount}
+            onClick={() => setActiveTab('state')}
           />
         </div>
       </div>
@@ -65,6 +75,12 @@ export function InspectorTabs({
         >
           {timeline}
         </div>
+        <div
+          className="h-full"
+          style={{ display: activeTab === 'state' ? 'block' : 'none' }}
+        >
+          {state}
+        </div>
       </div>
     </section>
   );
@@ -73,24 +89,39 @@ export function InspectorTabs({
 function InspectorTabButton({
   active,
   label,
+  badgeCount,
   onClick,
 }: {
   active: boolean;
   label: string;
+  badgeCount?: number;
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
+      aria-label={label}
       className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
         active
-          ? 'bg-gray-900 text-white'
-          : 'bg-white text-gray-600 ring-1 ring-gray-200 hover:bg-gray-100'
+          ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+          : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800'
       }`}
       aria-pressed={active}
       onClick={onClick}
     >
-      {label}
+      <span>{label}</span>
+      {badgeCount && badgeCount > 0 ? (
+        <span
+          aria-hidden="true"
+          className={`ml-2 rounded-full px-2 py-0.5 text-xs font-semibold ${
+            active
+              ? 'bg-white/20 text-white dark:bg-slate-200/30 dark:text-slate-950'
+              : 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+          }`}
+        >
+          {badgeCount}
+        </span>
+      ) : null}
     </button>
   );
 }

--- a/web/src/components/Navigation.tsx
+++ b/web/src/components/Navigation.tsx
@@ -1,8 +1,11 @@
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { CommandPalette } from './CommandPalette';
+import { useTheme } from '../hooks/useTheme';
 
 const navItems = [
   { path: '/traces', label: 'Traces' },
   { path: '/sessions', label: 'Sessions' },
+  { path: '/settings', label: 'Settings' },
 ];
 
 /**
@@ -10,29 +13,57 @@ const navItems = [
  */
 export function Navigation() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { resolvedTheme, toggleTheme } = useTheme();
+  const commands = [
+    {
+      id: 'go-traces',
+      title: 'Go to Traces',
+      keywords: ['navigate', 'traces', 'home'],
+      action: () => navigate('/traces'),
+    },
+    {
+      id: 'go-sessions',
+      title: 'Go to Sessions',
+      keywords: ['navigate', 'sessions'],
+      action: () => navigate('/sessions'),
+    },
+    {
+      id: 'go-settings',
+      title: 'Go to Settings',
+      keywords: ['navigate', 'settings', 'api key', 'theme'],
+      action: () => navigate('/settings'),
+    },
+    {
+      id: 'toggle-theme',
+      title: 'Toggle Theme',
+      keywords: ['theme', 'dark', 'light', 'appearance'],
+      action: () => toggleTheme(),
+    },
+  ];
 
   return (
-    <nav className="bg-white border-b border-gray-200">
+    <nav className="border-b border-slate-200 bg-white/95 backdrop-blur dark:border-slate-800 dark:bg-slate-950/95">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between h-16">
-          <div className="flex">
+        <div className="flex min-h-16 flex-col gap-3 py-3 lg:h-16 lg:flex-row lg:items-center lg:justify-between lg:py-0">
+          <div className="flex min-w-0 items-center">
             <Link
               to="/"
-              className="flex items-center text-xl font-bold text-gray-900"
+              className="flex items-center text-xl font-bold text-slate-900 dark:text-slate-100"
             >
               Continua
             </Link>
-            <div className="ml-10 flex items-center space-x-4">
+            <div className="ml-6 flex flex-wrap items-center gap-2 lg:ml-10 lg:gap-4">
               {navItems.map((item) => {
                 const isActive = location.pathname.startsWith(item.path);
                 return (
                   <Link
                     key={item.path}
                     to={item.path}
-                    className={`px-3 py-2 rounded-md text-sm font-medium ${
+                    className={`rounded-md px-3 py-2 text-sm font-medium transition ${
                       isActive
-                        ? 'bg-gray-100 text-gray-900'
-                        : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
+                        ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+                        : 'text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-900 dark:hover:text-slate-100'
                     }`}
                   >
                     {item.label}
@@ -40,6 +71,21 @@ export function Navigation() {
                 );
               })}
             </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+              aria-label="Toggle theme"
+            >
+              <span>Theme</span>
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-slate-800 dark:text-slate-300">
+                {resolvedTheme}
+              </span>
+            </button>
+            <CommandPalette commands={commands} />
           </div>
         </div>
       </div>

--- a/web/src/components/PaginationControls.tsx
+++ b/web/src/components/PaginationControls.tsx
@@ -19,7 +19,7 @@ interface PaginationControlsProps {
 function buttonClassName(enabled: boolean): string {
   return enabled
     ? 'rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200'
-    : 'cursor-not-allowed rounded-lg bg-gray-200 px-3 py-2 text-sm font-medium text-gray-400';
+    : 'cursor-not-allowed rounded-lg bg-slate-200 px-3 py-2 text-sm font-medium text-slate-400 dark:bg-slate-800 dark:text-slate-500';
 }
 
 export function PaginationControls({
@@ -54,7 +54,7 @@ export function PaginationControls({
   }, [currentItemCount, lastValidOffset, offset, onRepairOffset]);
 
   return (
-    <div className="mt-4 flex flex-col gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm md:flex-row md:items-center md:justify-between">
+    <div className="mt-4 flex flex-col gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-slate-800 dark:bg-slate-900 md:flex-row md:items-center md:justify-between">
       <div className="flex flex-wrap items-center gap-2">
         <button
           type="button"
@@ -94,7 +94,7 @@ export function PaginationControls({
         </button>
       </div>
 
-      <div className="flex flex-col gap-2 text-sm text-gray-600 md:items-end">
+      <div className="flex flex-col gap-2 text-sm text-slate-600 dark:text-slate-300 md:items-end">
         <span>
           Showing {showingFrom}-{showingTo} of {total}
         </span>
@@ -106,7 +106,7 @@ export function PaginationControls({
               aria-label="Rows per page"
               value={pageSize}
               onChange={(event) => onPageSizeChange(Number(event.target.value) || DEFAULT_PAGE_SIZE)}
-              className="rounded-lg border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
             >
               {pageSizeOptions.map((option) => (
                 <option key={option} value={option}>

--- a/web/src/components/PayloadInspector.tsx
+++ b/web/src/components/PayloadInspector.tsx
@@ -171,8 +171,8 @@ export function PayloadInspector({
 
   if (tree === null) {
     return (
-      <div
-        className={`rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500 ${className}`.trim()}
+        <div
+        className={`rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-950/70 dark:text-slate-400 ${className}`.trim()}
       >
         No data
       </div>
@@ -187,9 +187,9 @@ export function PayloadInspector({
 
   return (
     <section
-      className={`flex min-h-0 flex-col rounded-lg border border-gray-200 bg-white ${className}`.trim()}
+      className={`flex min-h-0 flex-col rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900 ${className}`.trim()}
     >
-      <div className="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-gray-50 p-3">
+      <div className="flex flex-wrap items-center gap-2 border-b border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/70">
         <label className="sr-only" htmlFor={searchInputId}>
           Search payload
         </label>
@@ -200,11 +200,11 @@ export function PayloadInspector({
           onChange={(event) => setSearchQuery(event.target.value)}
           placeholder="Search payload"
           aria-label="Search payload"
-          className="min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          className="min-w-0 flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
         />
         <button
           type="button"
-          className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
           disabled={matchCount === 0}
           onClick={() =>
             setActiveMatchIndex((index) =>
@@ -216,7 +216,7 @@ export function PayloadInspector({
         </button>
         <button
           type="button"
-          className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
           disabled={matchCount === 0}
           onClick={() =>
             setActiveMatchIndex((index) =>
@@ -228,7 +228,7 @@ export function PayloadInspector({
         </button>
         <button
           type="button"
-          className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
           title={
             expandAllDisabled
               ? 'Expand all is disabled for payloads with more than 5,000 nodes.'
@@ -241,7 +241,7 @@ export function PayloadInspector({
         </button>
         <button
           type="button"
-          className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
           onClick={handleCollapseAll}
         >
           Collapse all
@@ -252,11 +252,11 @@ export function PayloadInspector({
           idleLabel="Copy full JSON"
           successLabel="Copied JSON"
         />
-        <span className="ml-auto text-xs text-gray-500">{matchSummary}</span>
+        <span className="ml-auto text-xs text-slate-500 dark:text-slate-400">{matchSummary}</span>
       </div>
 
       <div className="min-h-0 overflow-auto p-3">
-        <div className="font-mono text-xs leading-6 text-gray-800">
+        <div className="font-mono text-xs leading-6 text-slate-800 dark:text-slate-200">
           <PayloadNodeRow
             node={tree}
             activeMatchId={activeMatch?.id ?? null}
@@ -304,13 +304,13 @@ function PayloadNodeRow({
           <button
             type="button"
             aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${describeNode(node)}`}
-            className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-slate-500 dark:hover:bg-slate-800 dark:hover:text-slate-200"
             onClick={() => onToggleExpanded(node.path)}
           >
             {isExpanded ? '-' : '+'}
           </button>
         ) : (
-          <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-gray-300">
+          <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-slate-300 dark:text-slate-600">
             -
           </span>
         )}
@@ -321,14 +321,14 @@ function PayloadNodeRow({
               <>
                 <HighlightableText
                   activeMatchId={activeMatchId}
-                  className="break-all text-blue-700"
+                  className="break-all text-blue-700 dark:text-sky-300"
                   isMatch={keyMatch}
                   matchId={keyMatchId}
                   registerMatchElement={registerMatchElement}
                 >
                   {String(node.key)}
                 </HighlightableText>
-                <span className="text-gray-400">:</span>
+                <span className="text-slate-400 dark:text-slate-500">:</span>
               </>
             )}
 
@@ -339,8 +339,8 @@ function PayloadNodeRow({
                 activeMatchId={activeMatchId}
                 className={
                   typeof node.value === 'string'
-                    ? 'max-h-36 overflow-auto whitespace-pre-wrap break-words text-emerald-700'
-                    : 'break-all text-gray-800'
+                    ? 'max-h-36 overflow-auto whitespace-pre-wrap break-words text-emerald-700 dark:text-emerald-300'
+                    : 'break-all text-slate-800 dark:text-slate-100'
                 }
                 isMatch={valueMatch}
                 matchId={valueMatchId}
@@ -395,8 +395,8 @@ function CollectionSummary({ node }: { node: TreeNode }) {
 
   return (
     <span className="inline-flex flex-wrap items-center gap-2">
-      <span className="text-gray-500">{node.type === 'object' ? '{}' : '[]'}</span>
-      <span className="rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-600">
+      <span className="text-slate-500 dark:text-slate-400">{node.type === 'object' ? '{}' : '[]'}</span>
+      <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-300">
         {describeCollection(node)}
       </span>
     </span>
@@ -426,8 +426,8 @@ function HighlightableText({
       className={`${className} ${
         isMatch
           ? activeMatchId === matchId
-            ? 'rounded bg-amber-200 px-1'
-            : 'rounded bg-yellow-100 px-1'
+            ? 'rounded bg-amber-200 px-1 dark:bg-amber-400/40'
+            : 'rounded bg-yellow-100 px-1 dark:bg-yellow-400/20'
           : ''
       }`.trim()}
       data-match-state={

--- a/web/src/components/SortableHeader.tsx
+++ b/web/src/components/SortableHeader.tsx
@@ -25,7 +25,7 @@ export function SortableHeader({
 
   if (isDisabled) {
     return (
-      <span className="inline-flex items-center gap-1 text-gray-300">
+      <span className="inline-flex items-center gap-1 text-slate-300 dark:text-slate-600">
         <span>{label}</span>
         <span aria-hidden="true">{indicator}</span>
       </span>
@@ -36,7 +36,7 @@ export function SortableHeader({
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1 text-gray-500 transition hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+      className="inline-flex items-center gap-1 text-slate-500 transition hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-slate-400 dark:hover:text-slate-200"
     >
       <span>{label}</span>
       <span aria-hidden="true">{indicator}</span>

--- a/web/src/components/SpanBreadcrumb.tsx
+++ b/web/src/components/SpanBreadcrumb.tsx
@@ -24,7 +24,7 @@ export function SpanBreadcrumb({
       aria-label={ariaLabel}
       className={`overflow-x-auto ${className}`.trim()}
     >
-      <ol className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-gray-500">
+      <ol className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
         {path.map((segment, index) => {
           const isCurrent = index === lastIndex;
           const isInteractive = !isCurrent && Boolean(onSelectSpan);
@@ -34,7 +34,7 @@ export function SpanBreadcrumb({
               {isInteractive ? (
                 <button
                   type="button"
-                  className="truncate rounded-full border border-gray-200 bg-white px-2.5 py-1 font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="truncate rounded-full border border-slate-200 bg-white px-2.5 py-1 font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
                   aria-label={`Select ancestor span ${segment.name}`}
                   onClick={() => onSelectSpan?.(segment.spanId)}
                 >
@@ -44,8 +44,8 @@ export function SpanBreadcrumb({
                 <span
                   className={`truncate rounded-full px-2.5 py-1 ${
                     isCurrent
-                      ? 'bg-gray-900 text-white'
-                      : 'bg-gray-100 font-medium text-gray-700'
+                      ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+                      : 'bg-slate-100 font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200'
                   }`}
                   aria-current={isCurrent ? 'page' : undefined}
                 >

--- a/web/src/components/SpanDetail.test.tsx
+++ b/web/src/components/SpanDetail.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import type { Span } from '../api/client';
+import type { Span, TimelineEvent } from '../api/client';
 import { SpanDetail } from './SpanDetail';
 
 function createSpan(overrides: Partial<Span> = {}): Span {
@@ -123,5 +123,50 @@ describe('SpanDetail parent navigation', () => {
     await user.keyboard('{Enter}');
 
     expect(onSelectSpan).toHaveBeenCalledWith('root');
+  });
+
+  it('renders valid decision events and skips incomplete ones', () => {
+    const span = createSpan({ span_id: 'decision-span', name: 'Decision span' });
+    const events: TimelineEvent[] = [
+      {
+        id: 'decision-valid',
+        trace_id: 'trace-1',
+        span_id: 'decision-span',
+        event_type: 'decision',
+        timestamp: '2026-03-14T10:00:00.000Z',
+        source: 'explicit',
+        payload: {
+          question: 'Which model?',
+          chosen: 'gpt-4.1',
+          reasoning: 'Need higher accuracy',
+        },
+      },
+      {
+        id: 'decision-invalid',
+        trace_id: 'trace-1',
+        span_id: 'decision-span',
+        event_type: 'decision',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        source: 'explicit',
+        payload: {
+          question: 'Should be hidden',
+        },
+      },
+    ];
+
+    render(
+      <SpanDetail
+        span={span}
+        breadcrumbPath={[{ spanId: 'decision-span', name: 'Decision span' }]}
+        onSelectSpan={vi.fn()}
+        spanIndex={new Map([['decision-span', span]])}
+        events={events}
+      />
+    );
+
+    expect(screen.getByText('Decisions')).toBeInTheDocument();
+    expect(screen.getByText('Which model?')).toBeInTheDocument();
+    expect(screen.getByText('gpt-4.1')).toBeInTheDocument();
+    expect(screen.queryByText('Should be hidden')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { Span } from '../api/client';
+import { Span, TimelineEvent } from '../api/client';
 import { CopyButton } from './CopyButton';
 import { StatusBadge } from './StatusBadge';
 import { JsonViewer } from './JsonViewer';
@@ -10,6 +10,10 @@ import {
   formatTokens,
 } from '../utils/format';
 import type { BreadcrumbSegment } from '../utils/failureAnalysis';
+import {
+  formatInlineSemanticValue,
+  getDecisionDetails,
+} from '../utils/eventSemantics';
 import { SpanBreadcrumb } from './SpanBreadcrumb';
 import { TruncationBanner } from './TruncationBanner';
 
@@ -18,6 +22,7 @@ interface SpanDetailProps {
   breadcrumbPath: BreadcrumbSegment[];
   onSelectSpan: (spanId: string) => void;
   spanIndex: ReadonlyMap<string, Span>;
+  events?: TimelineEvent[];
 }
 
 /**
@@ -28,10 +33,11 @@ export function SpanDetail({
   breadcrumbPath,
   onSelectSpan,
   spanIndex,
+  events = [],
 }: SpanDetailProps) {
   if (!span) {
     return (
-      <div className="h-full flex items-center justify-center text-gray-500">
+      <div className="h-full flex items-center justify-center text-slate-500 dark:text-slate-400">
         Select a span to view details
       </div>
     );
@@ -44,6 +50,14 @@ export function SpanDetail({
   const parentSpan = span.parent_span_id
     ? spanIndex.get(span.parent_span_id) ?? null
     : null;
+  const decisions = events.flatMap((event) => {
+    if (event.span_id !== span.span_id) {
+      return [];
+    }
+
+    const decision = getDecisionDetails(event);
+    return decision ? [{ event, ...decision }] : [];
+  });
 
   return (
     <div className="h-full overflow-y-auto p-4">
@@ -54,9 +68,9 @@ export function SpanDetail({
           onSelectSpan={onSelectSpan}
           className="mb-3"
         />
-        <h2 className="text-lg font-semibold text-gray-900">{span.name}</h2>
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{span.name}</h2>
         <div className="flex items-center gap-2 mt-1">
-          <span className="text-sm text-gray-500">{span.kind}</span>
+          <span className="text-sm text-slate-500 dark:text-slate-400">{span.kind}</span>
           <StatusBadge status={span.status} />
         </div>
       </div>
@@ -71,14 +85,14 @@ export function SpanDetail({
       {/* Token breakdown */}
       {(span.tokens_in || span.tokens_out) && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-gray-700 mb-2">Token Breakdown</h3>
-          <div className="bg-gray-50 rounded p-3 text-sm">
+          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Token Breakdown</h3>
+          <div className="rounded bg-slate-50 p-3 text-sm dark:bg-slate-950/70">
             <div className="flex justify-between">
-              <span className="text-gray-600">Input tokens:</span>
+              <span className="text-slate-600 dark:text-slate-300">Input tokens:</span>
               <span className="font-mono">{span.tokens_in ?? 0}</span>
             </div>
             <div className="flex justify-between mt-1">
-              <span className="text-gray-600">Output tokens:</span>
+              <span className="text-slate-600 dark:text-slate-300">Output tokens:</span>
               <span className="font-mono">{span.tokens_out ?? 0}</span>
             </div>
           </div>
@@ -98,8 +112,8 @@ export function SpanDetail({
       {/* LLM context */}
       {showLLMContext && (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-gray-700">LLM Context</h3>
-          <div className="rounded bg-gray-50 p-3 text-sm">
+          <h3 className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">LLM Context</h3>
+          <div className="rounded bg-slate-50 p-3 text-sm dark:bg-slate-950/70">
             <DetailRow label="Model" value={span.model} />
             <DetailRow label="Provider" value={span.provider} className="mt-1" />
           </div>
@@ -109,7 +123,7 @@ export function SpanDetail({
       {/* Input */}
       {span.input !== undefined && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-gray-700 mb-2">Input</h3>
+          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Input</h3>
           <TruncationBanner
             title="Input payload"
             truncated={span.input_truncated}
@@ -123,7 +137,7 @@ export function SpanDetail({
       {/* Output */}
       {span.output !== undefined && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-gray-700 mb-2">Output</h3>
+          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Output</h3>
           <TruncationBanner
             title="Output payload"
             truncated={span.output_truncated}
@@ -137,15 +151,54 @@ export function SpanDetail({
       {/* Metadata */}
       {span.metadata && Object.keys(span.metadata).length > 0 && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-gray-700 mb-2">Metadata</h3>
+          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Metadata</h3>
           <JsonViewer data={span.metadata} />
+        </div>
+      )}
+
+      {decisions.length > 0 && (
+        <div className="mb-6">
+          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Decisions</h3>
+          <div className="space-y-3">
+            {decisions.map((decision) => (
+              <div
+                key={decision.event.id}
+                className="rounded border border-blue-100 bg-blue-50/70 p-3 dark:border-sky-500/30 dark:bg-sky-500/10"
+              >
+                <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  {decision.question}
+                </div>
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                  <span>Chosen</span>
+                  <DecisionValuePill tone="accent">
+                    {formatInlineSemanticValue(decision.chosen)}
+                  </DecisionValuePill>
+                </div>
+                {decision.reasoning ? (
+                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{decision.reasoning}</p>
+                ) : null}
+                {decision.alternatives && decision.alternatives.length > 0 ? (
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Alternatives</span>
+                    {decision.alternatives.map((alternative, index) => (
+                      <DecisionValuePill
+                        key={`${decision.event.id}-alternative-${index}`}
+                      >
+                        {formatInlineSemanticValue(alternative)}
+                      </DecisionValuePill>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
         </div>
       )}
 
       {/* IDs */}
       <div className="mb-6">
-        <h3 className="text-sm font-medium text-gray-700 mb-2">Identifiers</h3>
-        <div className="bg-gray-50 rounded p-3 text-sm">
+          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Identifiers</h3>
+          <div className="rounded bg-slate-50 p-3 text-sm dark:bg-slate-950/70">
           <DetailRow label="Span UUID" value={span.id} mono />
           <DetailRow
             label="Span ID"
@@ -168,7 +221,7 @@ export function SpanDetail({
                   <button
                     type="button"
                     aria-label={`Select parent span ${span.parent_span_id}`}
-                    className="rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
                     onClick={() => onSelectSpan(parentSpan.span_id)}
                   >
                     {span.parent_span_id}
@@ -192,8 +245,8 @@ export function SpanDetail({
 
       {/* Timestamps */}
       <div>
-        <h3 className="text-sm font-medium text-gray-700 mb-2">Timestamps</h3>
-        <div className="bg-gray-50 rounded p-3 text-sm">
+        <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Timestamps</h3>
+        <div className="rounded bg-slate-50 p-3 text-sm dark:bg-slate-950/70">
           <DetailRow
             label="Started"
             value={formatTimestamp(span.started_at)}
@@ -220,10 +273,30 @@ interface MetricCardProps {
 
 function MetricCard({ label, value }: MetricCardProps) {
   return (
-    <div className="bg-gray-50 rounded p-3 text-center">
-      <div className="text-xl font-semibold text-gray-900">{value}</div>
-      <div className="text-xs text-gray-500 mt-1">{label}</div>
+    <div className="rounded p-3 text-center bg-slate-50 dark:bg-slate-950/70">
+      <div className="text-xl font-semibold text-slate-900 dark:text-slate-100">{value}</div>
+      <div className="text-xs text-slate-500 mt-1 dark:text-slate-400">{label}</div>
     </div>
+  );
+}
+
+function DecisionValuePill({
+  children,
+  tone = 'neutral',
+}: {
+  children: string;
+  tone?: 'neutral' | 'accent';
+}) {
+  return (
+    <span
+      className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+        tone === 'accent'
+          ? 'border-blue-200 bg-white text-blue-800 dark:border-sky-500/40 dark:bg-slate-950 dark:text-sky-200'
+          : 'border-slate-200 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200'
+      }`}
+    >
+      {children}
+    </span>
   );
 }
 
@@ -246,7 +319,7 @@ function DetailRow({
 
   return (
     <div className={`flex justify-between gap-4 ${className}`.trim()}>
-      <span className="text-gray-600">{label}:</span>
+      <span className="text-slate-600 dark:text-slate-300">{label}:</span>
       {hasValue ? (
         <span className="flex min-w-0 items-center justify-end gap-2">
           <span className={mono ? 'font-mono text-xs text-right' : 'text-right'}>
@@ -255,7 +328,7 @@ function DetailRow({
           {action}
         </span>
       ) : (
-        <span className="text-gray-400">-</span>
+        <span className="text-slate-400 dark:text-slate-500">-</span>
       )}
     </div>
   );

--- a/web/src/components/SpanTree.tsx
+++ b/web/src/components/SpanTree.tsx
@@ -19,11 +19,11 @@ interface SpanTreeProps {
 }
 
 const kindColors: Record<string, string> = {
-  LLM: 'bg-purple-100 text-purple-800',
-  TOOL: 'bg-yellow-100 text-yellow-800',
-  CHAIN: 'bg-blue-100 text-blue-800',
-  AGENT: 'bg-green-100 text-green-800',
-  CUSTOM: 'bg-gray-100 text-gray-800',
+  LLM: 'bg-purple-100 text-purple-800 dark:bg-purple-500/15 dark:text-purple-200',
+  TOOL: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-500/15 dark:text-yellow-200',
+  CHAIN: 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-200',
+  AGENT: 'bg-green-100 text-green-800 dark:bg-green-500/15 dark:text-green-200',
+  CUSTOM: 'bg-gray-100 text-gray-800 dark:bg-slate-800 dark:text-slate-200',
 };
 
 export function SpanTree({
@@ -54,7 +54,7 @@ export function SpanTree({
 
   if (rows.length === 0) {
     return (
-      <div className="p-4 text-center text-gray-500">
+      <div className="p-4 text-center text-slate-500 dark:text-slate-400">
         No spans found for this trace.
       </div>
     );
@@ -75,12 +75,12 @@ export function SpanTree({
         const shouldDim = matchedSpanIds !== null && !isMatch;
 
         const rowClasses = isSelected
-          ? 'border-blue-200 bg-blue-50 shadow-sm ring-1 ring-blue-200'
+          ? 'border-blue-200 bg-blue-50 shadow-sm ring-1 ring-blue-200 dark:border-sky-500/50 dark:bg-sky-500/10 dark:ring-sky-500/40'
           : isOnPrimaryPath
-            ? 'border-amber-300 bg-amber-50'
+            ? 'border-amber-300 bg-amber-50 dark:border-amber-500/40 dark:bg-amber-500/10'
             : isFailed
-              ? 'border-red-200 bg-red-50/80'
-              : 'border-transparent bg-white hover:bg-gray-50';
+              ? 'border-red-200 bg-red-50/80 dark:border-red-500/40 dark:bg-red-500/10'
+              : 'border-transparent bg-white hover:bg-slate-50 dark:bg-slate-900 dark:hover:bg-slate-800/70';
 
         return (
           <div
@@ -103,7 +103,7 @@ export function SpanTree({
               {hasChildren ? (
                 <button
                   type="button"
-                  className="mt-3 flex h-6 w-6 shrink-0 items-center justify-center rounded text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="mt-3 flex h-6 w-6 shrink-0 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-slate-500 dark:hover:bg-slate-800 dark:hover:text-slate-200"
                   aria-label={`${isExpanded ? 'Collapse' : 'Expand'} span ${span.name}`}
                   onClick={() => onToggleExpand(span.span_id)}
                 >
@@ -111,7 +111,7 @@ export function SpanTree({
                 </button>
               ) : (
                 <span
-                  className="mt-3 flex h-6 w-6 shrink-0 items-center justify-center text-gray-300"
+                  className="mt-3 flex h-6 w-6 shrink-0 items-center justify-center text-slate-300 dark:text-slate-600"
                   aria-hidden="true"
                 >
                   ·
@@ -138,37 +138,37 @@ export function SpanTree({
                     <span
                       className={`truncate text-sm font-medium ${
                         isMatch
-                          ? 'rounded bg-amber-100 px-1 text-amber-950'
-                          : 'text-gray-900'
+                          ? 'rounded bg-amber-100 px-1 text-amber-950 dark:bg-amber-500/20 dark:text-amber-100'
+                          : 'text-slate-900 dark:text-slate-100'
                       }`}
                     >
                       {span.name}
                     </span>
                     {isSelected ? (
-                      <span className="rounded-full border border-blue-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-blue-700">
+                      <span className="rounded-full border border-blue-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-blue-700 dark:border-sky-500/40 dark:bg-slate-950 dark:text-sky-300">
                         Selected
                       </span>
                     ) : null}
                     {isOnPrimaryPath ? (
-                      <span className="rounded-full border border-amber-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700">
+                      <span className="rounded-full border border-amber-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700 dark:border-amber-500/40 dark:bg-slate-950 dark:text-amber-200">
                         Failure path
                       </span>
                     ) : null}
                     {isFailed ? (
-                      <span className="rounded-full border border-red-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-red-700">
+                      <span className="rounded-full border border-red-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-red-700 dark:border-red-500/40 dark:bg-slate-950 dark:text-red-200">
                         Failed
                       </span>
                     ) : null}
                   </div>
 
                   {errorPreview ? (
-                    <p className="mt-2 text-sm text-red-700 line-clamp-2">
+                    <p className="mt-2 text-sm text-red-700 line-clamp-2 dark:text-red-200">
                       {errorPreview}
                     </p>
                   ) : null}
 
                   {showMetrics ? (
-                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
                       <span>{formatTokens((span.tokens_in ?? 0) + (span.tokens_out ?? 0))} tokens</span>
                       <span>{formatCost(span.cost_usd)}</span>
                     </div>
@@ -176,7 +176,7 @@ export function SpanTree({
 
                   <div
                     id={rowStateId}
-                    className="mt-2 flex flex-wrap items-center gap-2 text-xs text-gray-500"
+                    className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400"
                   >
                     <StatusBadge status={span.status} />
                     <span>{formatDuration(span.latency_ms)}</span>

--- a/web/src/components/StateDiffViewer.test.tsx
+++ b/web/src/components/StateDiffViewer.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { createTimelineEvent } from '../test/traceFixtures';
+import { extractStateChanges } from '../utils/stateChanges';
+import { StateDiffViewer } from './StateDiffViewer';
+
+describe('StateDiffViewer', () => {
+  it('groups changes by namespace and renders scalar/object values appropriately', () => {
+    const changes = extractStateChanges([
+      createTimelineEvent({
+        id: 'scalar-change',
+        event_type: 'state_change',
+        span_name: 'Checkout span',
+        payload: {
+          key: 'status',
+          namespace: 'order',
+          old_value: 'pending',
+          new_value: 'approved',
+        },
+      }),
+      createTimelineEvent({
+        id: 'object-change',
+        event_type: 'state_change',
+        span_name: 'Config span',
+        payload: {
+          key: 'flags',
+          namespace: 'config',
+          old_value: { tier: 'standard' },
+          new_value: { tier: 'priority' },
+        },
+      }),
+    ]);
+
+    render(<StateDiffViewer changes={changes} />);
+
+    expect(screen.getByText('order')).toBeInTheDocument();
+    expect(screen.getByText('config')).toBeInTheDocument();
+    expect(screen.getByText('status')).toBeInTheDocument();
+    expect(screen.getByText('pending')).toBeInTheDocument();
+    expect(screen.getByText('approved')).toBeInTheDocument();
+    expect(screen.getAllByText('tier').length).toBeGreaterThan(0);
+    expect(screen.getByText('Old value')).toBeInTheDocument();
+    expect(screen.getByText('New value')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when no changes are present', () => {
+    render(<StateDiffViewer changes={[]} />);
+
+    expect(
+      screen.getByText('No structured state changes recorded for this trace.')
+    ).toBeInTheDocument();
+  });
+
+  it('uses the fallback namespace label for unscoped changes', () => {
+    const changes = extractStateChanges([
+      createTimelineEvent({
+        id: 'general-change',
+        event_type: 'state_change',
+        payload: {
+          key: 'phase',
+          new_value: 'running',
+        },
+      }),
+    ]);
+
+    render(<StateDiffViewer changes={changes} />);
+
+    expect(screen.getByText('General')).toBeInTheDocument();
+    expect(screen.getByText('phase')).toBeInTheDocument();
+    expect(screen.getByText('running')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/StateDiffViewer.tsx
+++ b/web/src/components/StateDiffViewer.tsx
@@ -1,0 +1,147 @@
+import { JsonViewer } from './JsonViewer';
+import {
+  formatInlineSemanticValue,
+  isStructuredSemanticValue,
+} from '../utils/eventSemantics';
+import type { ExtractedStateChange } from '../utils/stateChanges';
+
+interface StateDiffViewerProps {
+  changes: ExtractedStateChange[];
+}
+
+const FALLBACK_NAMESPACE_LABEL = 'General';
+
+export function StateDiffViewer({ changes }: StateDiffViewerProps) {
+  const groups = groupStateChanges(changes);
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">
+          State
+        </h2>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Structured state transitions grouped by namespace.
+        </p>
+      </div>
+
+      {changes.length === 0 ? (
+        <div className="px-4 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
+          No structured state changes recorded for this trace.
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-4">
+          {groups.map(([namespace, namespaceChanges]) => (
+            <div key={namespace}>
+              <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                {namespace}
+              </h3>
+              <div className="mt-3 space-y-3">
+                {namespaceChanges.map((change) => (
+                  <StateChangeCard key={change.event.id} change={change} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StateChangeCard({ change }: { change: ExtractedStateChange }) {
+  const usesStructuredView =
+    isStructuredSemanticValue(change.oldValue) ||
+    isStructuredSemanticValue(change.newValue);
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50/60 p-4 dark:border-slate-800 dark:bg-slate-950/70">
+      <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">{change.key}</div>
+      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+        {change.event.span_name ?? change.event.span_id ?? 'Trace'}
+        {' · '}
+        {formatStateChangeTime(change.event.timestamp)}
+      </div>
+
+      {usesStructuredView ? (
+        <div className="mt-4 grid gap-4 lg:grid-cols-2">
+          <StructuredValuePanel label="Old value" value={change.oldValue} />
+          <StructuredValuePanel label="New value" value={change.newValue} />
+        </div>
+      ) : (
+        <div className="mt-4 flex flex-wrap items-center gap-2 text-sm font-medium text-slate-900 dark:text-slate-100">
+          <InlineValuePill>{formatInlineSemanticValue(change.oldValue)}</InlineValuePill>
+          <span className="text-slate-400 dark:text-slate-500">→</span>
+          <InlineValuePill tone="accent">
+            {formatInlineSemanticValue(change.newValue)}
+          </InlineValuePill>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StructuredValuePanel({
+  label,
+  value,
+}: {
+  label: string;
+  value: unknown;
+}) {
+  return (
+    <div>
+      <div className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+        {label}
+      </div>
+      {isStructuredSemanticValue(value) ? (
+        <JsonViewer data={value} className="max-h-64 overflow-y-auto" />
+      ) : (
+        <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200">
+          {formatInlineSemanticValue(value)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InlineValuePill({
+  children,
+  tone = 'neutral',
+}: {
+  children: string;
+  tone?: 'neutral' | 'accent';
+}) {
+  return (
+    <span
+      className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+        tone === 'accent'
+          ? 'border-blue-200 bg-blue-100 text-blue-800 dark:border-sky-500/40 dark:bg-sky-500/15 dark:text-sky-200'
+          : 'border-slate-200 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200'
+      }`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function groupStateChanges(changes: ExtractedStateChange[]) {
+  const grouped = new Map<string, ExtractedStateChange[]>();
+
+  for (const change of changes) {
+    const namespace = change.namespace ?? FALLBACK_NAMESPACE_LABEL;
+    const current = grouped.get(namespace) ?? [];
+    current.push(change);
+    grouped.set(namespace, current);
+  }
+
+  return Array.from(grouped.entries());
+}
+
+function formatStateChangeTime(timestamp: string) {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -7,11 +7,11 @@ interface StatusBadgeProps {
  */
 export function StatusBadge({ status }: StatusBadgeProps) {
   const colors = {
-    RUNNING: 'bg-blue-100 text-blue-800',
-    STARTED: 'bg-blue-100 text-blue-800',
-    COMPLETED: 'bg-green-100 text-green-800',
-    FAILED: 'bg-red-100 text-red-800',
-    SCHEDULED: 'bg-gray-100 text-gray-800',
+    RUNNING: 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-200',
+    STARTED: 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-200',
+    COMPLETED: 'bg-green-100 text-green-800 dark:bg-emerald-500/15 dark:text-emerald-200',
+    FAILED: 'bg-red-100 text-red-800 dark:bg-red-500/15 dark:text-red-200',
+    SCHEDULED: 'bg-gray-100 text-gray-800 dark:bg-slate-800 dark:text-slate-200',
   };
 
   return (

--- a/web/src/components/Timeline.test.tsx
+++ b/web/src/components/Timeline.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createTimelineEvent } from '../test/traceFixtures';
+import { Timeline } from './Timeline';
+
+describe('Timeline semantic event rendering', () => {
+  it('renders state_change rows with inline old/new values', () => {
+    render(
+      <Timeline
+        events={[
+          createTimelineEvent({
+            event_type: 'state_change',
+            payload: {
+              key: 'status',
+              old_value: 'pending',
+              new_value: 'approved',
+            },
+          }),
+        ]}
+        traceStatus="COMPLETED"
+        isLive={false}
+        onSelectSpan={vi.fn()}
+        spanIndex={new Map()}
+      />
+    );
+
+    expect(screen.getByText('status')).toBeInTheDocument();
+    expect(screen.getByText('pending')).toBeInTheDocument();
+    expect(screen.getByText('approved')).toBeInTheDocument();
+  });
+
+  it('falls back to the message when semantic fields are missing', () => {
+    render(
+      <Timeline
+        events={[
+          createTimelineEvent({
+            event_type: 'decision',
+            message: 'Generic fallback',
+            payload: {
+              chosen: 'gpt-4.1',
+            },
+          }),
+        ]}
+        traceStatus="COMPLETED"
+        isLive={false}
+        onSelectSpan={vi.fn()}
+        spanIndex={new Map()}
+      />
+    );
+
+    expect(screen.getByText('Generic fallback')).toBeInTheDocument();
+  });
+
+  it('renders decision alternatives inline when they are present', () => {
+    render(
+      <Timeline
+        events={[
+          createTimelineEvent({
+            event_type: 'decision',
+            payload: {
+              question: 'Which model?',
+              chosen: 'gpt-4.1',
+              alternatives: ['gpt-4o-mini', 'claude-3-haiku'],
+            },
+          }),
+        ]}
+        traceStatus="COMPLETED"
+        isLive={false}
+        onSelectSpan={vi.fn()}
+        spanIndex={new Map()}
+      />
+    );
+
+    expect(screen.getByText('Which model?')).toBeInTheDocument();
+    expect(screen.getByText('Alternatives')).toBeInTheDocument();
+    expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument();
+    expect(screen.getByText('claude-3-haiku')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -2,6 +2,11 @@ import { useState } from 'react';
 import { Span, TimelineEvent, TimelineTraceStatus } from '../api/client';
 import { JsonViewer } from './JsonViewer';
 import {
+  formatInlineSemanticValue,
+  getDecisionDetails,
+  getStateChangeDetails,
+} from '../utils/eventSemantics';
+import {
   isTimelineErrorEvent,
   summarizeTimelineEvent,
 } from '../utils/timeline';
@@ -36,13 +41,13 @@ export function Timeline({
     : events;
 
   return (
-    <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3">
+    <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
         <div>
-          <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-gray-600">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">
             Timeline
           </h2>
-          <p className="mt-1 text-sm text-gray-500">
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
             Chronological trace events with lifecycle markers and payload inspection.
           </p>
         </div>
@@ -52,7 +57,7 @@ export function Timeline({
             className={`rounded-full border px-3 py-1 text-xs font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
               showErrorsOnly
                 ? 'border-red-200 bg-red-50 text-red-700'
-                : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-100'
+                : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800'
             }`}
             aria-label="Show error events only"
             aria-pressed={showErrorsOnly}
@@ -60,14 +65,14 @@ export function Timeline({
           >
             Errors only
           </button>
-          <div className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600">
+          <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
             <span
               className={`h-2.5 w-2.5 rounded-full ${
                 isLive
                   ? 'animate-pulse bg-emerald-500'
                   : traceStatus === 'FAILED'
                     ? 'bg-red-500'
-                    : 'bg-gray-400'
+                    : 'bg-slate-400 dark:bg-slate-500'
               }`}
             />
             <span>{timelineStatusLabel(traceStatus, isLive)}</span>
@@ -76,19 +81,19 @@ export function Timeline({
       </div>
 
       {isLoading && events.length === 0 ? (
-        <div className="px-4 py-12 text-center text-sm text-gray-500">
+        <div className="px-4 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
           Loading timeline...
         </div>
       ) : error && events.length === 0 ? (
         <div className="px-4 py-12 text-center text-sm text-red-600">{error}</div>
       ) : visibleEvents.length === 0 ? (
-        <div className="px-4 py-12 text-center text-sm text-gray-500">
+        <div className="px-4 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
           {showErrorsOnly
             ? 'No error events for this trace.'
             : 'No timeline events recorded for this trace yet.'}
         </div>
       ) : (
-        <div className="divide-y divide-gray-100">
+        <div className="divide-y divide-slate-100 dark:divide-slate-800">
           {visibleEvents.map((event) => (
             <TimelineRow
               key={event.id}
@@ -121,20 +126,22 @@ function TimelineRow({
   const hasDetails = Boolean(event.message || event.payload);
   const hasNavigableSpan = Boolean(event.span_id && spanIndex.has(event.span_id));
   const isError = isTimelineErrorEvent(event);
+  const stateChange = getStateChangeDetails(event);
+  const decision = getDecisionDetails(event);
   const rowAccent = isError
-    ? 'border-red-200 bg-red-50/70'
+    ? 'border-red-200 bg-red-50/70 dark:border-red-500/40 dark:bg-red-500/10'
     : event.source === 'synthetic'
-      ? 'border-amber-200 bg-amber-50/70'
-      : 'border-gray-200 bg-white';
+      ? 'border-amber-200 bg-amber-50/70 dark:border-amber-500/40 dark:bg-amber-500/10'
+      : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900';
 
   return (
     <div className="p-4">
       <div className={`rounded-2xl border ${rowAccent} p-4 transition-colors`}>
         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex min-w-0 gap-4">
-            <div className="min-w-28 rounded-xl bg-gray-900 px-3 py-2 text-xs font-medium uppercase tracking-[0.18em] text-white">
+            <div className="min-w-28 rounded-xl bg-slate-900 px-3 py-2 text-xs font-medium uppercase tracking-[0.18em] text-white dark:bg-slate-100 dark:text-slate-950">
               <div>{formatTimelineTime(event.timestamp)}</div>
-              <div className="mt-1 text-[10px] tracking-[0.25em] text-gray-300">
+              <div className="mt-1 text-[10px] tracking-[0.25em] text-slate-300 dark:text-slate-600">
                 {event.source}
               </div>
             </div>
@@ -147,25 +154,31 @@ function TimelineRow({
                       ? 'bg-red-100 text-red-700'
                       : event.source === 'synthetic'
                         ? 'bg-amber-100 text-amber-700'
-                        : 'bg-blue-100 text-blue-700'
+                        : 'bg-blue-100 text-blue-700 dark:bg-sky-500/15 dark:text-sky-200'
                   }`}
                 >
                   {formatEventType(event.event_type)}
                 </span>
                 {event.level && (
-                  <span className="rounded-full border border-gray-200 bg-white px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-gray-600">
+                  <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-600 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-300">
                     {event.level}
                   </span>
                 )}
               </div>
 
-              <p className="mt-3 text-sm font-medium leading-6 text-gray-900">
-                {summarizeTimelineEvent(event)}
-              </p>
+              {stateChange ? (
+                <StateChangePreview stateChange={stateChange} />
+              ) : decision ? (
+                <DecisionPreview decision={decision} />
+              ) : (
+                <p className="mt-3 text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
+                  {summarizeTimelineEvent(event)}
+                </p>
+              )}
 
               {(event.span_name || event.span_id) && (
-                <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-gray-500">
-                  <span className="uppercase tracking-[0.18em] text-gray-400">
+                <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                  <span className="uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
                     span
                   </span>
                   {hasNavigableSpan && event.span_id ? (
@@ -173,15 +186,15 @@ function TimelineRow({
                       type="button"
                       className={`rounded-full px-3 py-1 font-medium transition ${
                         isSelectedSpan
-                          ? 'bg-gray-900 text-white'
-                          : 'bg-white text-gray-700 ring-1 ring-gray-200 hover:bg-gray-100'
+                          ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+                          : 'bg-white text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-950 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-800'
                       }`}
                       onClick={() => onSelectSpan(event.span_id!)}
                     >
                       {event.span_name ?? event.span_id}
                     </button>
                   ) : (
-                    <span className="rounded-full bg-white px-3 py-1 font-mono text-gray-600 ring-1 ring-gray-200">
+                    <span className="rounded-full bg-white px-3 py-1 font-mono text-slate-600 ring-1 ring-slate-200 dark:bg-slate-950 dark:text-slate-300 dark:ring-slate-700">
                       {event.span_name ?? event.span_id}
                     </span>
                   )}
@@ -193,7 +206,7 @@ function TimelineRow({
           {hasDetails && (
             <button
               type="button"
-              className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:bg-gray-100"
+              className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-800"
               onClick={() => setIsExpanded((expanded) => !expanded)}
             >
               {isExpanded ? 'Hide details' : 'Show details'}
@@ -202,20 +215,20 @@ function TimelineRow({
         </div>
 
         {isExpanded && hasDetails && (
-          <div className="mt-4 space-y-3 border-t border-gray-200 pt-4">
+          <div className="mt-4 space-y-3 border-t border-slate-200 pt-4 dark:border-slate-700">
             {event.message && (
               <div>
-                <div className="mb-1 text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
+                <div className="mb-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
                   Message
                 </div>
-                <div className="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700">
+                <div className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200">
                   {event.message}
                 </div>
               </div>
             )}
             {event.payload && (
               <div>
-                <div className="mb-1 text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
+                <div className="mb-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
                   Payload
                 </div>
                 <JsonViewer data={event.payload} className="max-h-80 overflow-y-auto" />
@@ -225,6 +238,82 @@ function TimelineRow({
         )}
       </div>
     </div>
+  );
+}
+
+function StateChangePreview({
+  stateChange,
+}: {
+  stateChange: NonNullable<ReturnType<typeof getStateChangeDetails>>;
+}) {
+  return (
+    <div className="mt-3 space-y-2">
+      {stateChange.namespace ? (
+        <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+          {stateChange.namespace}
+        </div>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-2 text-sm font-medium text-slate-900 dark:text-slate-100">
+        <span>{stateChange.key}</span>
+        <SemanticValuePill>
+          {formatInlineSemanticValue(stateChange.oldValue)}
+        </SemanticValuePill>
+        <span className="text-slate-400 dark:text-slate-500">→</span>
+        <SemanticValuePill tone="accent">
+          {formatInlineSemanticValue(stateChange.newValue)}
+        </SemanticValuePill>
+      </div>
+    </div>
+  );
+}
+
+function DecisionPreview({
+  decision,
+}: {
+  decision: NonNullable<ReturnType<typeof getDecisionDetails>>;
+}) {
+  return (
+    <div className="mt-3 space-y-2">
+      <p className="text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
+        {decision.question}
+      </p>
+      <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+        <span>Chosen</span>
+        <SemanticValuePill tone="accent">
+          {formatInlineSemanticValue(decision.chosen)}
+        </SemanticValuePill>
+      </div>
+      {decision.alternatives && decision.alternatives.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+          <span>Alternatives</span>
+          {decision.alternatives.map((alternative, index) => (
+            <SemanticValuePill key={`${index}-${formatInlineSemanticValue(alternative)}`}>
+              {formatInlineSemanticValue(alternative)}
+            </SemanticValuePill>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SemanticValuePill({
+  children,
+  tone = 'neutral',
+}: {
+  children: string;
+  tone?: 'neutral' | 'accent';
+}) {
+  return (
+    <span
+      className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+        tone === 'accent'
+          ? 'border-blue-200 bg-blue-100 text-blue-800 dark:border-sky-500/40 dark:bg-sky-500/15 dark:text-sky-200'
+          : 'border-slate-200 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200'
+      }`}
+    >
+      {children}
+    </span>
   );
 }
 

--- a/web/src/components/TreeRail.tsx
+++ b/web/src/components/TreeRail.tsx
@@ -110,14 +110,14 @@ export function TreeRail({
   ]);
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-      <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
         <div className="flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-gray-600">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">
               Spans ({spans.length})
             </h2>
-            <p className="mt-1 text-sm text-gray-500">
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Search, expand, and inspect the visible span hierarchy.
             </p>
           </div>
@@ -131,21 +131,21 @@ export function TreeRail({
               value={searchQueryInput}
               onChange={(event) => setSearchQueryInput(event.target.value)}
               placeholder="Search name, kind, span ID, status, model, provider, errors"
-              className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-blue-300 focus:ring-2 focus:ring-blue-100"
+              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-300 focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
             />
           </label>
 
           <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              className="rounded-full bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-gray-200 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="rounded-full bg-white px-3 py-1.5 text-sm font-medium text-slate-600 ring-1 ring-slate-200 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800"
               onClick={handleExpandAll}
             >
               Expand all
             </button>
             <button
               type="button"
-              className="rounded-full bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-gray-200 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="rounded-full bg-white px-3 py-1.5 text-sm font-medium text-slate-600 ring-1 ring-slate-200 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800"
               onClick={handleCollapseAll}
             >
               Collapse all
@@ -154,8 +154,8 @@ export function TreeRail({
               type="button"
               className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
                 showMetrics
-                  ? 'bg-gray-900 text-white'
-                  : 'bg-white text-gray-600 ring-1 ring-gray-200 hover:bg-gray-100'
+                  ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+                  : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800'
               }`}
               aria-pressed={showMetrics}
               onClick={() => setShowMetrics((current) => !current)}
@@ -163,7 +163,7 @@ export function TreeRail({
               Show metrics
             </button>
             {matchedSpanIds !== null ? (
-              <span className="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">
+              <span className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                 {matchedSpanIds.size} match{matchedSpanIds.size === 1 ? '' : 'es'}
               </span>
             ) : null}

--- a/web/src/components/TruncationBanner.tsx
+++ b/web/src/components/TruncationBanner.tsx
@@ -25,13 +25,13 @@ export function TruncationBanner({
   ].filter((detail): detail is string => detail !== null);
 
   return (
-    <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-800">
+    <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-800 dark:text-amber-200">
         Payload truncated
       </div>
       <p className="mt-1">{title} was truncated before storage.</p>
       {details.length > 0 && (
-        <p className="mt-1 text-xs text-amber-800">{details.join(' | ')}</p>
+        <p className="mt-1 text-xs text-amber-800 dark:text-amber-200">{details.join(' | ')}</p>
       )}
     </div>
   );

--- a/web/src/components/WorkspaceShell.tsx
+++ b/web/src/components/WorkspaceShell.tsx
@@ -5,7 +5,8 @@ export type MobileWorkspaceTabId =
   | 'details'
   | 'waterfall'
   | 'tree'
-  | 'timeline';
+  | 'timeline'
+  | 'state';
 
 interface WorkspaceShellProps {
   isDesktop: boolean;
@@ -14,6 +15,7 @@ interface WorkspaceShellProps {
   inspector: ReactNode;
   mobileDetails: ReactNode;
   mobileTimeline: ReactNode;
+  mobileState: ReactNode;
   activeMobileTab: MobileWorkspaceTabId;
   onMobileTabChange: (tab: MobileWorkspaceTabId) => void;
 }
@@ -23,6 +25,7 @@ const MOBILE_TABS: Array<{ id: MobileWorkspaceTabId; label: string }> = [
   { id: 'waterfall', label: 'Waterfall' },
   { id: 'tree', label: 'Tree' },
   { id: 'timeline', label: 'Timeline' },
+  { id: 'state', label: 'State' },
 ];
 const USE_STATIC_DESKTOP_LAYOUT =
   typeof navigator !== 'undefined' && /\bjsdom\b/i.test(navigator.userAgent);
@@ -34,6 +37,7 @@ export function WorkspaceShell({
   inspector,
   mobileDetails,
   mobileTimeline,
+  mobileState,
   activeMobileTab,
   onMobileTabChange,
 }: WorkspaceShellProps) {
@@ -74,8 +78,8 @@ export function WorkspaceShell({
   }
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-      <div className="border-b border-gray-200 bg-gray-50 px-3 py-3">
+    <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="border-b border-slate-200 bg-slate-50 px-3 py-3 dark:border-slate-800 dark:bg-slate-950/70">
         <div className="flex flex-wrap items-center gap-2">
           {MOBILE_TABS.map((tab) => (
             <button
@@ -83,8 +87,8 @@ export function WorkspaceShell({
               type="button"
               className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
                 activeMobileTab === tab.id
-                  ? 'bg-gray-900 text-white'
-                  : 'bg-white text-gray-600 ring-1 ring-gray-200 hover:bg-gray-100'
+                  ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+                  : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800'
               }`}
               aria-pressed={activeMobileTab === tab.id}
               onClick={() => onMobileTabChange(tab.id)}
@@ -120,6 +124,12 @@ export function WorkspaceShell({
         >
           {mobileTimeline}
         </div>
+        <div
+          className="h-full"
+          style={{ display: activeMobileTab === 'state' ? 'block' : 'none' }}
+        >
+          {mobileState}
+        </div>
       </div>
     </section>
   );
@@ -133,9 +143,10 @@ function ResizeHandle({ horizontal = false }: { horizontal?: boolean }) {
       }`}
     >
       <div
-        className={`rounded-full bg-gray-200 transition group-hover:bg-gray-300 ${
+        className={`rounded-full transition group-hover:opacity-90 ${
           horizontal ? 'h-1 w-10' : 'h-10 w-1'
         }`}
+        style={{ backgroundColor: 'var(--continua-panel-separator)' }}
       />
     </Separator>
   );

--- a/web/src/hooks/ThemeProvider.tsx
+++ b/web/src/hooks/ThemeProvider.tsx
@@ -1,26 +1,12 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from 'react';
+  THEME_STORAGE_KEY,
+  ThemeContext,
+  type ResolvedTheme,
+  type ThemeMode,
+} from './themeContext';
 
-export type ThemeMode = 'system' | 'light' | 'dark';
-export type ResolvedTheme = 'light' | 'dark';
-
-export const THEME_STORAGE_KEY = 'continua_theme_mode';
 const SYSTEM_THEME_QUERY = '(prefers-color-scheme: dark)';
-
-interface ThemeContextValue {
-  mode: ThemeMode;
-  resolvedTheme: ResolvedTheme;
-  setMode: (mode: ThemeMode) => void;
-  toggleTheme: () => void;
-}
-
-const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [mode, setMode] = useState<ThemeMode>(() => readStoredThemeMode());
@@ -74,15 +60,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
-}
-
-export function useTheme(): ThemeContextValue {
-  const context = useContext(ThemeContext);
-  if (!context) {
-    throw new Error('useTheme must be used within a ThemeProvider');
-  }
-
-  return context;
 }
 
 function readStoredThemeMode(): ThemeMode {

--- a/web/src/hooks/themeContext.ts
+++ b/web/src/hooks/themeContext.ts
@@ -1,0 +1,15 @@
+import { createContext } from 'react';
+
+export type ThemeMode = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'continua_theme_mode';
+
+export interface ThemeContextValue {
+  mode: ThemeMode;
+  resolvedTheme: ResolvedTheme;
+  setMode: (mode: ThemeMode) => void;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null);

--- a/web/src/hooks/useTheme.test.tsx
+++ b/web/src/hooks/useTheme.test.tsx
@@ -1,0 +1,51 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { setMatchMediaMatches } from '../test/matchMedia';
+import { THEME_STORAGE_KEY, ThemeProvider, useTheme } from './useTheme';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    delete document.documentElement.dataset.theme;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    delete document.documentElement.dataset.theme;
+  });
+
+  it('starts in system mode, follows the OS preference, persists explicit mode changes, and toggles the resolved theme', () => {
+    setMatchMediaMatches(true);
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    expect(result.current.mode).toBe('system');
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('system');
+
+    act(() => {
+      result.current.setMode('light');
+    });
+
+    expect(result.current.mode).toBe('light');
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.mode).toBe('dark');
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/web/src/hooks/useTheme.test.tsx
+++ b/web/src/hooks/useTheme.test.tsx
@@ -1,7 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { setMatchMediaMatches } from '../test/matchMedia';
-import { THEME_STORAGE_KEY, ThemeProvider, useTheme } from './useTheme';
+import { ThemeProvider } from './ThemeProvider';
+import { THEME_STORAGE_KEY, useTheme } from './useTheme';
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return <ThemeProvider>{children}</ThemeProvider>;

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { ThemeContext, type ThemeContextValue } from './themeContext';
+
+export { THEME_STORAGE_KEY, type ResolvedTheme, type ThemeMode } from './themeContext';
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+}

--- a/web/src/hooks/useTheme.tsx
+++ b/web/src/hooks/useTheme.tsx
@@ -1,0 +1,115 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type ThemeMode = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'continua_theme_mode';
+const SYSTEM_THEME_QUERY = '(prefers-color-scheme: dark)';
+
+interface ThemeContextValue {
+  mode: ThemeMode;
+  resolvedTheme: ResolvedTheme;
+  setMode: (mode: ThemeMode) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<ThemeMode>(() => readStoredThemeMode());
+  const [systemPrefersDark, setSystemPrefersDark] = useState(() =>
+    getSystemPrefersDark()
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(SYSTEM_THEME_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemPrefersDark(event.matches);
+    };
+
+    setSystemPrefersDark(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  const resolvedTheme = resolveTheme(mode, systemPrefersDark);
+
+  useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEY, mode);
+  }, [mode]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle('dark', resolvedTheme === 'dark');
+    root.dataset.theme = resolvedTheme;
+  }, [resolvedTheme]);
+
+  const value = useMemo(
+    () => ({
+      mode,
+      resolvedTheme,
+      setMode,
+      toggleTheme: () => {
+        setMode((currentMode) => {
+          const currentResolvedTheme = resolveTheme(currentMode, systemPrefersDark);
+          return currentResolvedTheme === 'dark' ? 'light' : 'dark';
+        });
+      },
+    }),
+    [mode, resolvedTheme, systemPrefersDark]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+}
+
+function readStoredThemeMode(): ThemeMode {
+  if (typeof window === 'undefined') {
+    return 'system';
+  }
+
+  const storedMode = localStorage.getItem(THEME_STORAGE_KEY);
+  return isThemeMode(storedMode) ? storedMode : 'system';
+}
+
+function getSystemPrefersDark(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia(SYSTEM_THEME_QUERY).matches;
+}
+
+function resolveTheme(mode: ThemeMode, systemPrefersDark: boolean): ResolvedTheme {
+  if (mode === 'system') {
+    return systemPrefersDark ? 'dark' : 'light';
+  }
+
+  return mode;
+}
+
+function isThemeMode(value: string | null): value is ThemeMode {
+  return value === 'system' || value === 'light' || value === 'dark';
+}

--- a/web/src/pages/SessionDetailPage.test.tsx
+++ b/web/src/pages/SessionDetailPage.test.tsx
@@ -51,6 +51,22 @@ describe('SessionDetailPage', () => {
     await waitForSessionTraceFetch(`?limit=20&session_id=${SESSION_ID}`);
   });
 
+  it('shows the auth recovery banner when the session request returns 401', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        sessionDetail: () => jsonResponse({ message: 'Invalid or missing API key' }, 401),
+      })
+    );
+
+    renderTraceRoutes([`/sessions/${SESSION_ID}`]);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid or missing API key');
+    expect(screen.getByRole('link', { name: 'Go to Settings' })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+  });
+
   it('rehydrates URL state, toggles sorting, and updates page size', async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(

--- a/web/src/pages/SessionDetailPage.tsx
+++ b/web/src/pages/SessionDetailPage.tsx
@@ -1,11 +1,12 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect } from 'react';
 import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { AuthErrorBanner } from '../components/AuthErrorBanner';
 import { CopyButton } from '../components/CopyButton';
 import { PaginationControls } from '../components/PaginationControls';
 import { SortableHeader } from '../components/SortableHeader';
 import { StatusBadge } from '../components/StatusBadge';
-import { fetchSession, fetchTraces, type Trace } from '../api/client';
+import { fetchSession, fetchTraces, isAuthError, type Trace } from '../api/client';
 import { useRequireApiKey } from '../hooks/useRequireApiKey';
 import { DEFAULT_PAGE_SIZE, getLastValidOffset } from '../utils/pagination';
 import { buildCanonicalQueryString, parseTracesParams, serializeTracesParams } from '../utils/tracesSearchParams';
@@ -97,6 +98,10 @@ function getSessionsReturnToDestination(state: unknown): string {
     : '/sessions';
 }
 
+function queryErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
 export function SessionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { hasApiKey, prompt } = useRequireApiKey();
@@ -107,7 +112,7 @@ export function SessionDetailPage() {
 
   if (!id) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center dark:bg-slate-950">
         <div className="text-red-600">Session ID is required</div>
       </div>
     );
@@ -169,20 +174,23 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
 
   if (sessionQuery.isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-gray-500">Loading session...</div>
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center dark:bg-slate-950">
+        <div className="text-slate-500 dark:text-slate-400">Loading session...</div>
       </div>
     );
   }
 
   if (sessionQuery.error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-red-600">
-          Error loading session:{' '}
-          {sessionQuery.error instanceof Error
-            ? sessionQuery.error.message
-            : 'Unknown error'}
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+          {isAuthError(sessionQuery.error) ? (
+            <AuthErrorBanner message={queryErrorMessage(sessionQuery.error)} />
+          ) : (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+              Error loading session: {queryErrorMessage(sessionQuery.error)}
+            </div>
+          )}
         </div>
       </div>
     );
@@ -190,8 +198,8 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
 
   if (!sessionQuery.data) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-gray-500">Session not found</div>
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center dark:bg-slate-950">
+        <div className="text-slate-500 dark:text-slate-400">Session not found</div>
       </div>
     );
   }
@@ -199,20 +207,20 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
   const session = sessionQuery.data;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <Link
           to={returnTo}
-          className="text-blue-600 hover:text-blue-800 text-sm mb-4 inline-block"
+          className="mb-4 inline-block text-sm text-blue-600 hover:text-blue-800 dark:text-sky-400 dark:hover:text-sky-300"
         >
           &larr; Back to Sessions
         </Link>
 
-        <section className="mb-6 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <section className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
               <div className="flex flex-wrap items-center gap-3">
-                <h1 className="text-2xl font-bold text-gray-900">{session.external_id}</h1>
+                <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{session.external_id}</h1>
                 <CopyButton
                   aria-label="Copy session external ID"
                   value={session.external_id}
@@ -221,7 +229,7 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
                 />
               </div>
               <div className="mt-2 flex flex-wrap items-center gap-3">
-                <span className="font-mono text-sm text-gray-500">{session.id}</span>
+                <span className="font-mono text-sm text-slate-500 dark:text-slate-400">{session.id}</span>
                 <CopyButton
                   aria-label="Copy session UUID"
                   value={session.id}
@@ -230,28 +238,28 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
                 />
               </div>
               {session.name ? (
-                <p className="mt-3 text-sm text-gray-600">{session.name}</p>
+                <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{session.name}</p>
               ) : null}
             </div>
 
             <dl className="grid gap-4 sm:grid-cols-3">
               <div>
-                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">
+                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                   User ID
                 </dt>
-                <dd className="mt-1 text-sm text-gray-900">{session.user_id || '-'}</dd>
+                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">{session.user_id || '-'}</dd>
               </div>
               <div>
-                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">
+                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                   Trace Count
                 </dt>
-                <dd className="mt-1 text-sm text-gray-900">{session.trace_count ?? 0}</dd>
+                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">{session.trace_count ?? 0}</dd>
               </div>
               <div>
-                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">
+                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                   Created
                 </dt>
-                <dd className="mt-1 text-sm text-gray-900">
+                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
                   {formatRelativeTime(session.created_at)}
                 </dd>
               </div>
@@ -261,61 +269,64 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
 
         <div className="mb-4 flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900">Traces</h2>
-            <p className="mt-1 text-sm text-gray-500">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Traces</h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Sort by started time and preserve table state in the URL.
             </p>
           </div>
-          <div className="text-sm text-gray-500">
+          <div className="text-sm text-slate-500 dark:text-slate-400">
             <span>{total} traces</span>
             {tracesQuery.isFetching && !tracesQuery.isPending && (
-              <span className="ml-2 text-blue-600">Updating...</span>
+              <span className="ml-2 text-blue-600 dark:text-sky-400">Updating...</span>
             )}
           </div>
         </div>
 
         {tracesQuery.error && (
-          <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700">
-            Error loading traces:{' '}
-            {tracesQuery.error instanceof Error
-              ? tracesQuery.error.message
-              : 'Unknown error'}
-          </div>
+          isAuthError(tracesQuery.error) ? (
+            <div className="mb-4">
+              <AuthErrorBanner message={queryErrorMessage(tracesQuery.error)} />
+            </div>
+          ) : (
+            <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+              Error loading traces: {queryErrorMessage(tracesQuery.error)}
+            </div>
+          )
         )}
 
         {tracesQuery.isPending && !tracesQuery.data ? (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-gray-500 shadow-sm">
+          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
             Loading traces...
           </div>
         ) : traces.length === 0 ? (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-900">No traces in this session</h2>
-            <p className="mt-2 text-sm text-gray-500">
+          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No traces in this session</h2>
+            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
               Traces will appear here as they are ingested for this session.
             </p>
           </div>
         ) : (
           <>
-            <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+                <thead className="bg-slate-50 dark:bg-slate-950/70">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Name
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Status
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Duration
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Tokens
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Cost
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       <SortableHeader
                         label="Started"
                         isActive={filters.sort_by === 'started_at'}
@@ -325,7 +336,7 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
                     </th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200 bg-white">
+                <tbody className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-900">
                   {traces.map((trace) => (
                     <SessionTraceRow
                       key={trace.id}
@@ -364,12 +375,12 @@ function SessionTraceRow({
   const totalTokens = (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
 
   return (
-    <tr className="transition hover:bg-gray-50">
+    <tr className="transition hover:bg-slate-50 dark:hover:bg-slate-800/60">
       <td className="px-6 py-4 align-top">
         <Link
           to={`/traces/${trace.id}`}
           state={{ returnTo }}
-          className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-sky-400 dark:hover:text-sky-300"
         >
           {trace.name}
         </Link>
@@ -377,16 +388,16 @@ function SessionTraceRow({
       <td className="px-6 py-4 whitespace-nowrap align-top">
         <StatusBadge status={trace.status} />
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
         {formatDuration(duration)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
         {formatTokens(totalTokens)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
         {formatCost(trace.total_cost_usd)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 align-top">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-500 align-top dark:text-slate-400">
         {formatRelativeTime(trace.started_at)}
       </td>
     </tr>

--- a/web/src/pages/SessionsPage.test.tsx
+++ b/web/src/pages/SessionsPage.test.tsx
@@ -60,6 +60,22 @@ describe('SessionsPage', () => {
     expect(screen.getByRole('combobox', { name: 'Rows per page' })).toHaveDisplayValue('50');
   });
 
+  it('shows the auth recovery banner when the sessions request returns 401', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        sessionsList: () => jsonResponse({ message: 'Invalid or missing API key' }, 401),
+      })
+    );
+
+    renderTraceRoutes(['/sessions']);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid or missing API key');
+    expect(screen.getByRole('link', { name: 'Go to Settings' })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+  });
+
   it('normalizes malformed params in the URL', async () => {
     fetchMock.mockImplementation(buildFetchHandler());
 

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -1,7 +1,8 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { fetchSessions, type Session } from '../api/client';
+import { fetchSessions, isAuthError, type Session } from '../api/client';
+import { AuthErrorBanner } from '../components/AuthErrorBanner';
 import { PaginationControls } from '../components/PaginationControls';
 import { SortableHeader } from '../components/SortableHeader';
 import { useRequireApiKey } from '../hooks/useRequireApiKey';
@@ -138,29 +139,29 @@ function SessionsContent() {
   }, [filters.limit, filters.offset, sessions.length, setFilters, total]);
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">Sessions</h1>
-            <p className="mt-1 text-sm text-gray-500">
+            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Sessions</h1>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Search sessions by external ID, filter by user, and sort for scale.
             </p>
           </div>
-          <div className="text-sm text-gray-500">
+          <div className="text-sm text-slate-500 dark:text-slate-400">
             <span>{total} total</span>
             {sessionsQuery.isFetching && !sessionsQuery.isPending && (
-              <span className="ml-2 text-blue-600">Updating...</span>
+              <span className="ml-2 text-blue-600 dark:text-sky-400">Updating...</span>
             )}
           </div>
         </div>
 
-        <section className="mb-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <section className="mb-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
           <div className="grid gap-4 md:grid-cols-2">
             <div>
               <label
                 htmlFor="session-search"
-                className="mb-1 block text-sm font-medium text-gray-700"
+                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
               >
                 Search
               </label>
@@ -170,14 +171,14 @@ function SessionsContent() {
                 value={searchDraft}
                 onChange={(event) => setSearchDraft(event.target.value)}
                 placeholder="Search external ID or name"
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
               />
             </div>
 
             <div>
               <label
                 htmlFor="session-user-id"
-                className="mb-1 block text-sm font-medium text-gray-700"
+                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
               >
                 User ID
               </label>
@@ -187,7 +188,7 @@ function SessionsContent() {
                 value={userIdDraft}
                 onChange={(event) => setUserIdDraft(event.target.value)}
                 placeholder="Filter by exact user"
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
               />
             </div>
           </div>
@@ -197,7 +198,7 @@ function SessionsContent() {
               <button
                 type="button"
                 onClick={clearAll}
-                className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:border-gray-400 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900 dark:hover:text-slate-100"
               >
                 Clear filters
               </button>
@@ -206,24 +207,36 @@ function SessionsContent() {
         </section>
 
         {sessionsQuery.error && (
-          <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700">
-            Error loading sessions:{' '}
-            {sessionsQuery.error instanceof Error
-              ? sessionsQuery.error.message
-              : 'Unknown error'}
-          </div>
+          isAuthError(sessionsQuery.error) ? (
+            <div className="mb-4">
+              <AuthErrorBanner
+                message={
+                  sessionsQuery.error instanceof Error
+                    ? sessionsQuery.error.message
+                    : 'Invalid or missing API key'
+                }
+              />
+            </div>
+          ) : (
+            <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+              Error loading sessions:{' '}
+              {sessionsQuery.error instanceof Error
+                ? sessionsQuery.error.message
+                : 'Unknown error'}
+            </div>
+          )
         )}
 
         {sessionsQuery.isPending && !sessionsQuery.data ? (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-gray-500 shadow-sm">
+          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
             Loading sessions...
           </div>
         ) : sessions.length === 0 ? (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-900">
+          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               {hasFilters ? 'No matching sessions' : 'No sessions yet'}
             </h2>
-            <p className="mt-2 text-sm text-gray-500">
+            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
               {hasFilters
                 ? 'Try broadening the filters or clearing them.'
                 : 'Sessions are created when traces include a session identifier.'}
@@ -231,20 +244,20 @@ function SessionsContent() {
           </div>
         ) : (
           <>
-            <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+                <thead className="bg-slate-50 dark:bg-slate-950/70">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Session
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Name
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       User ID
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       <SortableHeader
                         label="Traces"
                         isActive={filters.sort_by === 'trace_count'}
@@ -253,7 +266,7 @@ function SessionsContent() {
                         onClick={handleTraceCountSortToggle}
                       />
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       <SortableHeader
                         label="Created"
                         isActive={filters.sort_by === 'created_at'}
@@ -264,7 +277,7 @@ function SessionsContent() {
                     </th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200 bg-white">
+                <tbody className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-900">
                   {sessions.map((session) => (
                     <SessionRow
                       key={session.id}
@@ -300,29 +313,29 @@ function SessionRow({
   returnTo: string;
 }) {
   return (
-    <tr className="transition hover:bg-gray-50">
+    <tr className="transition hover:bg-slate-50 dark:hover:bg-slate-800/60">
       <td className="px-6 py-4 align-top">
         <div className="min-w-[14rem]">
           <Link
             to={`/sessions/${session.id}`}
             state={{ returnTo }}
-            className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-sky-400 dark:hover:text-sky-300"
           >
             {session.external_id}
           </Link>
-          <div className="mt-1 font-mono text-xs text-gray-400">{session.id}</div>
+          <div className="mt-1 font-mono text-xs text-slate-400 dark:text-slate-500">{session.id}</div>
         </div>
       </td>
-      <td className="px-6 py-4 text-sm text-gray-900 align-top">
+      <td className="px-6 py-4 text-sm text-slate-900 align-top dark:text-slate-100">
         {session.name || '-'}
       </td>
-      <td className="px-6 py-4 text-sm text-gray-500 align-top">
+      <td className="px-6 py-4 text-sm text-slate-500 align-top dark:text-slate-400">
         {session.user_id || '-'}
       </td>
-      <td className="px-6 py-4 text-sm text-gray-900 align-top">
+      <td className="px-6 py-4 text-sm text-slate-900 align-top dark:text-slate-100">
         {session.trace_count ?? 0}
       </td>
-      <td className="px-6 py-4 text-sm text-gray-500 align-top">
+      <td className="px-6 py-4 text-sm text-slate-500 align-top dark:text-slate-400">
         {formatRelativeTime(session.created_at)}
       </td>
     </tr>

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,38 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearApiKey, getApiKey, setApiKey } from '../api/client';
+import { renderTraceRoutes } from './testUtils';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  clearApiKey();
+  localStorage.clear();
+});
+
+describe('SettingsPage', () => {
+  it('shows the masked current key, saves a new key, and clears it', async () => {
+    const user = userEvent.setup();
+    setApiKey('ck_live_existing_key_1234');
+
+    renderTraceRoutes(['/settings']);
+
+    expect(await screen.findByText('ck_l••••••1234')).toBeInTheDocument();
+
+    const input = screen.getByLabelText('New API key');
+    await user.type(input, 'ck_live_updated_key_9876');
+    await user.click(screen.getByRole('button', { name: 'Save key' }));
+
+    expect(getApiKey()).toBe('ck_live_updated_key_9876');
+    expect(await screen.findByText('API key saved.')).toBeInTheDocument();
+    expect(screen.getByText('ck_l••••••9876')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear key' }));
+    expect(getApiKey()).toBeNull();
+    expect(await screen.findByText('API key cleared.')).toBeInTheDocument();
+    expect(screen.getByText('Not configured')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react';
+import { clearApiKey, getApiKey, setApiKey } from '../api/client';
+import { useTheme, type ThemeMode } from '../hooks/useTheme';
+
+export function SettingsPage() {
+  const { mode, resolvedTheme, setMode } = useTheme();
+  const [draftKey, setDraftKey] = useState('');
+  const [storedKey, setStoredKey] = useState<string | null>(() => getApiKey());
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!statusMessage) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setStatusMessage(null);
+    }, 2500);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [statusMessage]);
+
+  const handleSave = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const nextKey = draftKey.trim();
+    if (!nextKey) {
+      setStatusMessage('Enter an API key before saving.');
+      return;
+    }
+
+    setApiKey(nextKey);
+    setStoredKey(nextKey);
+    setDraftKey('');
+    setStatusMessage('API key saved.');
+  };
+
+  const handleClear = () => {
+    clearApiKey();
+    setStoredKey(null);
+    setDraftKey('');
+    setStatusMessage('API key cleared.');
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+            Settings
+          </h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Manage the debugger API key and local UI preferences for this browser.
+          </p>
+        </div>
+
+        <div className="grid gap-6">
+          <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <div className="mb-4">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                API Key
+              </h2>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                The key is stored locally and sent as `X-API-Key` on API requests.
+              </p>
+            </div>
+
+            <dl className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/60">
+              <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                Current key
+              </dt>
+              <dd className="mt-2 font-mono text-sm text-slate-900 dark:text-slate-100">
+                {storedKey ? maskApiKey(storedKey) : 'Not configured'}
+              </dd>
+            </dl>
+
+            <form className="mt-4 space-y-4" onSubmit={handleSave}>
+              <div>
+                <label
+                  htmlFor="settings-api-key"
+                  className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                >
+                  New API key
+                </label>
+                <input
+                  id="settings-api-key"
+                  type="password"
+                  value={draftKey}
+                  onChange={(event) => setDraftKey(event.target.value)}
+                  placeholder="ck_live_..."
+                  className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+                />
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="submit"
+                  className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                >
+                  Save key
+                </button>
+                <button
+                  type="button"
+                  onClick={handleClear}
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900"
+                >
+                  Clear key
+                </button>
+                {statusMessage ? (
+                  <span className="text-sm text-slate-500 dark:text-slate-400">
+                    {statusMessage}
+                  </span>
+                ) : null}
+              </div>
+            </form>
+          </section>
+
+          <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <div className="mb-4">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                Theme
+              </h2>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Current rendering: {resolvedTheme}. System mode follows the OS preference.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              {(['system', 'light', 'dark'] as ThemeMode[]).map((themeMode) => {
+                const isActive = themeMode === mode;
+
+                return (
+                  <button
+                    key={themeMode}
+                    type="button"
+                    aria-pressed={isActive}
+                    onClick={() => setMode(themeMode)}
+                    className={`rounded-full px-4 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
+                      isActive
+                        ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+                        : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900'
+                    }`}
+                  >
+                    {formatThemeMode(themeMode)}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function maskApiKey(key: string) {
+  if (key.length <= 8) {
+    return `${key.slice(0, 2)}••••${key.slice(-2)}`;
+  }
+
+  return `${key.slice(0, 4)}••••••${key.slice(-4)}`;
+}
+
+function formatThemeMode(mode: ThemeMode) {
+  return mode.charAt(0).toUpperCase() + mode.slice(1);
+}

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -77,6 +77,43 @@ describe('TraceDetailPage', () => {
     );
   });
 
+  it('shows the auth recovery banner when the trace request returns 401', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse({ message: 'Invalid or missing API key' }, 401),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid or missing API key');
+    expect(screen.getByRole('link', { name: 'Go to Settings' })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+  });
+
+  it('shows the auth recovery banner when the timeline request returns 401', async () => {
+    const rootSpan = createSpan({ span_id: 'timeline-auth-root', name: 'Timeline auth root' });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse({ ...TRACE_DETAIL, status: 'COMPLETED', error_count: 0 }),
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () => jsonResponse({ message: 'Invalid or missing API key' }, 401),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid or missing API key');
+    expect(screen.getByRole('link', { name: 'Go to Settings' })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+    expect(screen.getByRole('heading', { name: 'Execution Waterfall' })).toBeInTheDocument();
+  });
+
   it('renders the non-desktop stacked layout with Details active by default', async () => {
     setMatchMediaMatches(false);
     const rootSpan = createSpan({ span_id: 'mobile-root', name: 'Mobile root' });
@@ -107,6 +144,105 @@ describe('TraceDetailPage', () => {
       'aria-expanded',
       'false'
     );
+  });
+
+  it('renders the state tab with a badge and shows span decisions in details', async () => {
+    const statefulSpan = createSpan({
+      span_id: 'decision-span',
+      name: 'Decision span',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse({ ...TRACE_DETAIL, status: 'COMPLETED', error_count: 0 }),
+        spans: () => jsonResponse({ spans: [statefulSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'state-change',
+                span_id: 'decision-span',
+                span_name: 'Decision span',
+                event_type: 'state_change',
+                payload: {
+                  key: 'status',
+                  namespace: 'order',
+                  old_value: 'pending',
+                  new_value: 'approved',
+                },
+              }),
+              createTimelineEvent({
+                id: 'decision-event',
+                span_id: 'decision-span',
+                span_name: 'Decision span',
+                event_type: 'decision',
+                payload: {
+                  question: 'Which model?',
+                  chosen: 'gpt-4.1',
+                  reasoning: 'Need higher accuracy',
+                },
+              }),
+            ],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}?span=decision-span`]);
+
+    const decisionsHeading = await screen.findByText('Decisions');
+    expect(
+      within(decisionsHeading.parentElement!).getByText('Which model?')
+    ).toBeInTheDocument();
+
+    const stateTab = screen.getByRole('button', { name: 'State' });
+    expect(stateTab).toHaveTextContent('1');
+
+    await userEvent.setup().click(stateTab);
+    expect((await screen.findAllByText('status')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('pending').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('approved').length).toBeGreaterThan(0);
+  });
+
+  it('keeps the state tab available in the mobile workspace', async () => {
+    setMatchMediaMatches(false);
+    const mobileSpan = createSpan({ span_id: 'mobile-state', name: 'Mobile state span' });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse({ ...TRACE_DETAIL, status: 'COMPLETED', error_count: 0 }),
+        spans: () => jsonResponse({ spans: [mobileSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'mobile-state-change',
+                span_id: 'mobile-state',
+                span_name: 'Mobile state span',
+                event_type: 'state_change',
+                payload: {
+                  key: 'phase',
+                  old_value: 'queued',
+                  new_value: 'running',
+                },
+              }),
+            ],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}?span=mobile-state`]);
+
+    const stateTab = await screen.findByRole('button', { name: 'State' });
+    expect(stateTab).toBeInTheDocument();
+
+    await userEvent.setup().click(stateTab);
+    expect((await screen.findAllByText('phase')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('queued').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('running').length).toBeGreaterThan(0);
   });
 
   it('shows and hides inline tree metrics from the tree-rail toggle', async () => {

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -14,16 +14,19 @@ import { useQuery } from '@tanstack/react-query';
 import {
   fetchSpans,
   fetchTrace,
+  isAuthError,
   type Span,
   type TimelineEvent,
   type TraceDetail,
 } from '../api/client';
+import { AuthErrorBanner } from '../components/AuthErrorBanner';
 import { CopyButton } from '../components/CopyButton';
 import { ExecutionWaterfall } from '../components/ExecutionWaterfall';
 import { FailureSummary } from '../components/FailureSummary';
 import { InspectorTabs } from '../components/InspectorTabs';
 import { JsonViewer } from '../components/JsonViewer';
 import { SpanDetail } from '../components/SpanDetail';
+import { StateDiffViewer } from '../components/StateDiffViewer';
 import { StatusBadge } from '../components/StatusBadge';
 import { TreeRail } from '../components/TreeRail';
 import { Timeline } from '../components/Timeline';
@@ -51,6 +54,7 @@ import {
   evaluateStaleTraceSignal,
   type StaleTraceSignal,
 } from '../utils/failureAnalysis';
+import { extractStateChanges } from '../utils/stateChanges';
 import { serializeSpanParam } from '../utils/traceDetailSearchParams';
 import {
   buildSpanTree,
@@ -68,6 +72,10 @@ const EMPTY_STALE_TRACE_SIGNAL: StaleTraceSignal = {
 };
 const DESKTOP_MEDIA_QUERY = '(min-width: 1024px)';
 
+function queryErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
 export function TraceDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { hasApiKey, prompt } = useRequireApiKey();
@@ -78,7 +86,7 @@ export function TraceDetailPage() {
 
   if (!id) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
         <div className="text-red-600">Trace ID is required</div>
       </div>
     );
@@ -115,11 +123,16 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
   const timeline = useTraceTimeline(traceId);
   const trace = traceQuery.data ?? null;
   const spans = spansQuery.data?.spans ?? EMPTY_SPANS;
+  const timelineAuthError = isAuthError(timeline.rawError);
   const timelineStatus = trace ? timeline.traceStatus ?? trace.status : timeline.traceStatus;
   const duration = trace ? calculateDuration(trace.started_at, trace.ended_at) : null;
   const totalTokens = trace
     ? (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0)
     : 0;
+  const stateChanges = useMemo(
+    () => extractStateChanges(timeline.events),
+    [timeline.events]
+  );
   const returnTo = getReturnToDestination(location.state);
   const spanIndex = useMemo(() => buildSpanIndex(spans), [spans]);
   const failureAnalysis = useMemo(
@@ -194,20 +207,23 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
 
   if (traceQuery.isLoading || spansQuery.isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <div className="text-gray-500">Loading trace...</div>
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
+        <div className="text-slate-500 dark:text-slate-400">Loading trace...</div>
       </div>
     );
   }
 
   if (traceQuery.error) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <div className="text-red-600">
-          Error loading trace:{' '}
-          {traceQuery.error instanceof Error
-            ? traceQuery.error.message
-            : 'Unknown error'}
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+          {isAuthError(traceQuery.error) ? (
+            <AuthErrorBanner message={queryErrorMessage(traceQuery.error)} />
+          ) : (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+              Error loading trace: {queryErrorMessage(traceQuery.error)}
+            </div>
+          )}
         </div>
       </div>
     );
@@ -215,12 +231,15 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
 
   if (spansQuery.error) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <div className="text-red-600">
-          Error loading spans:{' '}
-          {spansQuery.error instanceof Error
-            ? spansQuery.error.message
-            : 'Unknown error'}
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+          {isAuthError(spansQuery.error) ? (
+            <AuthErrorBanner message={queryErrorMessage(spansQuery.error)} />
+          ) : (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+              Error loading spans: {queryErrorMessage(spansQuery.error)}
+            </div>
+          )}
         </div>
       </div>
     );
@@ -228,7 +247,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
 
   if (!trace) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
         <div className="text-red-600">Trace not found</div>
       </div>
     );
@@ -243,6 +262,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
       selectedBreadcrumbPath={selectedBreadcrumbPath}
       selectedSpan={selectedSpan}
       spanIndex={spanIndex}
+      events={timeline.events}
       traceContext={isDesktop ? null : (
         <TraceContextSection
           buildCopyTraceUrl={buildCopyTraceUrl}
@@ -260,33 +280,34 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
       traceStatus={timelineStatus}
       isLive={timeline.isLive}
       isLoading={timeline.isLoading}
-      error={timeline.error}
+      error={timelineAuthError ? null : timeline.error}
       selectedSpanId={selectedSpanExternalId}
       onSelectSpan={handleSelectSpanAndShowDetails}
       spanIndex={spanIndex}
     />
   );
+  const stateContent = <StateDiffViewer changes={stateChanges} />;
 
   return (
-    <div className="flex min-h-screen flex-col bg-gray-50">
-      <header className="border-b bg-white px-6 py-4">
+    <div className="flex min-h-screen flex-col bg-slate-50 dark:bg-slate-950">
+      <header className="border-b border-slate-200 bg-white px-6 py-4 dark:border-slate-800 dark:bg-slate-900">
         <div className="flex items-center gap-4">
-          <Link to={returnTo} className="text-gray-500 hover:text-gray-700">
+          <Link to={returnTo} className="text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200">
             {returnTo.startsWith('/sessions/') ? '← Session' : '← Traces'}
           </Link>
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-3">
-              <h1 className="truncate text-xl font-semibold text-gray-900">
+              <h1 className="truncate text-xl font-semibold text-slate-900 dark:text-slate-100">
                 {trace.name}
               </h1>
               <StatusBadge status={timelineStatus ?? trace.status} />
             </div>
-            <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-gray-500">
+            <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-slate-500 dark:text-slate-400">
               <span>{formatDuration(duration)}</span>
               <span>{formatTokens(totalTokens)} tokens</span>
               <span>{formatCost(trace.total_cost_usd)}</span>
               {trace.error_count && trace.error_count > 0 ? (
-                <span className="text-red-600">{trace.error_count} errors</span>
+                <span className="text-red-600 dark:text-red-300">{trace.error_count} errors</span>
               ) : null}
             </div>
           </div>
@@ -295,6 +316,10 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
 
       <div className="min-h-0 flex-1 overflow-hidden p-4">
         <div className="mx-auto flex h-full max-w-[96rem] flex-col gap-4">
+          {timelineAuthError ? (
+            <AuthErrorBanner message={queryErrorMessage(timeline.rawError)} />
+          ) : null}
+
           {isDesktop ? (
             <TraceContextSection
               buildCopyTraceUrl={buildCopyTraceUrl}
@@ -327,6 +352,8 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
             spanIndex={spanIndex}
             spanTree={spanTree}
             spans={spans}
+            stateChangeCount={stateChanges.length}
+            stateContent={stateContent}
             timelineContent={timelineContent}
             traceEndedAt={trace.ended_at}
             traceStartedAt={trace.started_at}
@@ -360,6 +387,8 @@ interface TraceWorkspaceProps {
   spanIndex: ReadonlyMap<string, Span>;
   spanTree: SpanTreeNode[];
   spans: Span[];
+  stateChangeCount: number;
+  stateContent: ReactNode;
   timelineContent: ReactNode;
   traceEndedAt?: string;
   traceStartedAt?: string;
@@ -388,6 +417,8 @@ function TraceWorkspace({
   spanIndex,
   spanTree,
   spans,
+  stateChangeCount,
+  stateContent,
   timelineContent,
   traceEndedAt,
   traceStartedAt,
@@ -439,11 +470,14 @@ function TraceWorkspace({
         <InspectorTabs
           details={detailsContent}
           timeline={timelineContent}
+          state={stateContent}
+          stateCount={stateChangeCount}
           switchToDetailsRef={inspectorSwitchToDetailsRef}
         />
       }
       mobileDetails={detailsContent}
       mobileTimeline={timelineContent}
+      mobileState={stateContent}
       activeMobileTab={activeMobileTab}
       onMobileTabChange={onMobileTabChange}
     />
@@ -476,6 +510,7 @@ function TraceDetailsSurface({
   selectedBreadcrumbPath,
   selectedSpan,
   spanIndex,
+  events,
   traceContext,
 }: {
   staleTraceSignal: StaleTraceSignal;
@@ -485,10 +520,11 @@ function TraceDetailsSurface({
   selectedBreadcrumbPath: ReturnType<typeof buildBreadcrumbPath>;
   selectedSpan: Span | null;
   spanIndex: ReadonlyMap<string, Span>;
+  events: TimelineEvent[];
   traceContext: ReactNode;
 }) {
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-gray-50 p-4">
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-slate-50 p-4 dark:bg-slate-950">
       <div className="space-y-4">
         {traceContext}
 
@@ -503,12 +539,13 @@ function TraceDetailsSurface({
           <StaleTraceSignalPanel staleTraceSignal={staleTraceSignal} />
         ) : null}
 
-        <div className="min-h-[22rem] overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+        <div className="min-h-[22rem] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
           <SpanDetail
             span={selectedSpan}
             breadcrumbPath={selectedBreadcrumbPath}
             onSelectSpan={onSelectSpan}
             spanIndex={spanIndex}
+            events={events}
           />
         </div>
       </div>
@@ -528,18 +565,18 @@ function TraceContextSection({
   trace: TraceDetail;
 }) {
   return (
-    <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3">
+    <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
         <button
           type="button"
           className="flex items-center gap-3 text-left"
           aria-expanded={open}
           onClick={onToggle}
         >
-          <span className="text-sm font-semibold uppercase tracking-[0.2em] text-gray-600">
+          <span className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">
             Trace Context
           </span>
-          <span className="rounded-full bg-white px-2 py-1 text-xs font-medium text-gray-500 ring-1 ring-gray-200">
+          <span className="rounded-full bg-white px-2 py-1 text-xs font-medium text-slate-500 ring-1 ring-slate-200 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700">
             {open ? 'Hide' : 'Show'}
           </span>
         </button>
@@ -572,12 +609,12 @@ function TraceContextSection({
               value={trace.session_id ? (
                 <Link
                   to={`/sessions/${trace.session_id}`}
-                  className="inline-flex flex-col text-left text-blue-600 hover:text-blue-800"
+                  className="inline-flex flex-col text-left text-blue-600 hover:text-blue-800 dark:text-sky-400 dark:hover:text-sky-300"
                 >
-                  <span className="text-sm font-medium text-gray-900">
+                  <span className="text-sm font-medium text-slate-900 dark:text-slate-100">
                     {trace.session_external_id ?? trace.session_id}
                   </span>
-                  <span className="font-mono text-xs text-gray-500">
+                  <span className="font-mono text-xs text-slate-500 dark:text-slate-400">
                     {trace.session_id}
                   </span>
                 </Link>
@@ -607,7 +644,7 @@ function TraceContextSection({
                   {trace.tags.map((tag) => (
                     <span
                       key={tag}
-                      className="rounded-full border border-gray-200 bg-white px-3 py-1 font-mono text-xs text-gray-700"
+                      className="rounded-full border border-slate-200 bg-white px-3 py-1 font-mono text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
                     >
                       {tag}
                     </span>
@@ -649,12 +686,12 @@ function TraceContextField({
   copyButtonLabel?: string;
 }) {
   return (
-    <div className={`rounded-lg border border-gray-200 bg-gray-50 p-4 ${className}`.trim()}>
-      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-500">
+    <div className={`rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/70 ${className}`.trim()}>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
         {label}
       </div>
       <div className="mt-2 flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1 text-sm text-gray-900">{value}</div>
+        <div className="min-w-0 flex-1 text-sm text-slate-900 dark:text-slate-100">{value}</div>
         {copyValue && copyButtonLabel ? (
           <CopyButton
             aria-label={copyButtonLabel}
@@ -669,9 +706,9 @@ function TraceContextField({
 
 function TracePayloadPanel({ title, data }: { title: string; data: unknown }) {
   return (
-    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
-      <h3 className="mb-2 text-sm font-medium text-gray-700">{title}</h3>
-      <JsonViewer data={data} className="max-h-80 overflow-y-auto bg-white" />
+    <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/70">
+      <h3 className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">{title}</h3>
+      <JsonViewer data={data} className="max-h-80 overflow-y-auto bg-white dark:bg-slate-900" />
     </div>
   );
 }
@@ -702,11 +739,17 @@ function StaleTraceSignalPanel({
 
 function renderContextText(value: string | undefined, monospace = false) {
   if (value === undefined) {
-    return <span className="text-sm text-gray-400">-</span>;
+    return <span className="text-sm text-slate-400 dark:text-slate-500">-</span>;
   }
 
   return (
-    <span className={monospace ? 'font-mono text-xs text-gray-900' : 'text-sm text-gray-900'}>
+    <span
+      className={
+        monospace
+          ? 'font-mono text-xs text-slate-900 dark:text-slate-100'
+          : 'text-sm text-slate-900 dark:text-slate-100'
+      }
+    >
       {value}
     </span>
   );

--- a/web/src/pages/TracesPage.test.tsx
+++ b/web/src/pages/TracesPage.test.tsx
@@ -78,6 +78,22 @@ describe('TracesPage', () => {
     expect(screen.queryByRole('button', { name: 'Clear all' })).not.toBeInTheDocument();
   });
 
+  it('shows the auth recovery banner when the traces request returns 401', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: () => jsonResponse({ message: 'Invalid or missing API key' }, 401),
+      })
+    );
+
+    renderTraceRoutes(['/traces']);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid or missing API key');
+    expect(screen.getByRole('link', { name: 'Go to Settings' })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+  });
+
   it('pre-populates controls from a deep link and issues the filtered request', async () => {
     const start = localDateToISOStart('2026-03-10');
     const end = localDateToISOEnd('2026-03-12');

--- a/web/src/pages/TracesPage.tsx
+++ b/web/src/pages/TracesPage.tsx
@@ -1,7 +1,8 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { fetchTraces, type Trace } from '../api/client';
+import { fetchTraces, isAuthError, type Trace } from '../api/client';
+import { AuthErrorBanner } from '../components/AuthErrorBanner';
 import { PaginationControls } from '../components/PaginationControls';
 import { SortableHeader } from '../components/SortableHeader';
 import { StatusBadge } from '../components/StatusBadge';
@@ -245,29 +246,29 @@ function TracesContent() {
   }, [filters.sort_by, filters.sort_dir, isSearchActive, setFilters]);
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">Traces</h1>
-            <p className="mt-1 text-sm text-gray-500">
+            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Traces</h1>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Find traces by name, owner, time window, or error signals.
             </p>
           </div>
-          <div className="text-sm text-gray-500">
+          <div className="text-sm text-slate-500 dark:text-slate-400">
             <span>{total} total</span>
             {tracesQuery.isFetching && !tracesQuery.isPending && (
-              <span className="ml-2 text-blue-600">Updating...</span>
+              <span className="ml-2 text-blue-600 dark:text-sky-400">Updating...</span>
             )}
           </div>
         </div>
 
-        <section className="mb-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <section className="mb-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
             <div className="xl:col-span-2">
               <label
                 htmlFor="trace-search"
-                className="mb-1 block text-sm font-medium text-gray-700"
+                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
               >
                 Search
               </label>
@@ -283,9 +284,9 @@ function TracesContent() {
                 }
                 aria-describedby="trace-search-hint"
                 placeholder="Search traces"
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
               />
-              <p id="trace-search-hint" className="mt-1 text-xs text-gray-500">
+              <p id="trace-search-hint" className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                 Search names, user IDs, and matching span names.
               </p>
             </div>
@@ -293,7 +294,7 @@ function TracesContent() {
             <div>
               <label
                 htmlFor="trace-status"
-                className="mb-1 block text-sm font-medium text-gray-700"
+                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
               >
                 Status
               </label>
@@ -310,7 +311,7 @@ function TracesContent() {
                     'push'
                   )
                 }
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
               >
                 <option value="">All statuses</option>
                 <option value="running">Running</option>
@@ -322,7 +323,7 @@ function TracesContent() {
             <div>
               <label
                 htmlFor="trace-start-date"
-                className="mb-1 block text-sm font-medium text-gray-700"
+                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
               >
                 Start Date
               </label>
@@ -340,14 +341,14 @@ function TracesContent() {
                     'push'
                   )
                 }
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
               />
             </div>
 
             <div>
               <label
                 htmlFor="trace-end-date"
-                className="mb-1 block text-sm font-medium text-gray-700"
+                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
               >
                 End Date
               </label>
@@ -365,7 +366,7 @@ function TracesContent() {
                     'push'
                   )
                 }
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
               />
             </div>
 
@@ -395,7 +396,7 @@ function TracesContent() {
               <div>
                 <label
                   htmlFor="trace-min-duration"
-                  className="mb-1 block text-sm font-medium text-gray-700"
+                  className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
                 >
                   Min Duration (ms)
                 </label>
@@ -412,11 +413,11 @@ function TracesContent() {
                     handleEnterCommit(event, commitMinDuration, minDurationDraft)
                   }
                   placeholder="e.g. 1500"
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
                 />
               </div>
 
-              <label className="flex items-end gap-2 text-sm font-medium text-gray-700 xl:pt-0">
+              <label className="flex items-end gap-2 text-sm font-medium text-slate-700 xl:pt-0 dark:text-slate-200">
                 <input
                   type="checkbox"
                   checked={Boolean(filters.has_errors)}
@@ -429,7 +430,7 @@ function TracesContent() {
                     )
                   }
                   aria-label="Only show traces with errors"
-                  className="mt-0 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-200"
+                  className="mt-0 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950"
                 />
                 <span>Has errors</span>
               </label>
@@ -442,12 +443,12 @@ function TracesContent() {
         </section>
 
         {hasActiveFilters && (
-          <div className="mb-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="mb-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
             <div className="flex flex-wrap items-center gap-2">
               {activeChips.map((chip) => (
                 <span
                   key={chip.key}
-                  className="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-sm text-gray-700"
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200"
                 >
                   <span className="font-medium">{chip.label}:</span>
                   <span>{chip.value}</span>
@@ -455,7 +456,7 @@ function TracesContent() {
                     type="button"
                     onClick={() => clearChip(chip.key)}
                     aria-label={`Clear ${chip.label} filter`}
-                    className="rounded-full p-0.5 text-gray-500 transition hover:bg-gray-200 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    className="rounded-full p-0.5 text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
                   >
                     ×
                   </button>
@@ -464,7 +465,7 @@ function TracesContent() {
               <button
                 type="button"
                 onClick={clearAll}
-                className="ml-auto rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:border-gray-400 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="ml-auto rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900 dark:hover:text-slate-100"
               >
                 Clear all
               </button>
@@ -473,71 +474,77 @@ function TracesContent() {
         )}
 
         {tracesQuery.error && (
-          <div className="mb-4 flex flex-col gap-3 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <p className="font-semibold">Could not load traces</p>
-              <p className="text-sm">{getErrorMessage(tracesQuery.error)}</p>
+          isAuthError(tracesQuery.error) ? (
+            <div className="mb-4">
+              <AuthErrorBanner message={getErrorMessage(tracesQuery.error)} />
             </div>
-            <button
-              type="button"
-              onClick={() => void tracesQuery.refetch()}
-              className="rounded-lg bg-red-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-200"
-            >
-              Retry
-            </button>
-          </div>
+          ) : (
+            <div className="mb-4 flex flex-col gap-3 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-semibold">Could not load traces</p>
+                <p className="text-sm">{getErrorMessage(tracesQuery.error)}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => void tracesQuery.refetch()}
+                className="rounded-lg bg-red-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-200"
+              >
+                Retry
+              </button>
+            </div>
+          )
         )}
 
         {dateRangeError ? (
-          <div className="rounded-xl border border-dashed border-red-200 bg-white p-8 text-center text-sm text-gray-600 shadow-sm">
+          <div className="rounded-xl border border-dashed border-red-200 bg-white p-8 text-center text-sm text-slate-600 shadow-sm dark:border-red-500/40 dark:bg-slate-900 dark:text-slate-300">
             Fix the date range to load traces.
           </div>
         ) : tracesQuery.isPending && !tracesQuery.data ? (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-gray-500 shadow-sm">
+          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
             Loading traces...
           </div>
         ) : tracesQuery.error && !tracesQuery.data ? (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-gray-600 shadow-sm">
+          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-600 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
             Retry the request or adjust your filters to continue.
           </div>
         ) : traces.length === 0 ? (
           hasActiveFilters ? (
-            <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900">No matching traces</h2>
-              <p className="mt-2 text-sm text-gray-500">
+            <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No matching traces</h2>
+              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
                 Try broadening the filters or clearing them entirely.
               </p>
             </div>
           ) : (
-            <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900">No traces yet</h2>
-              <p className="mt-2 text-sm text-gray-500">
+            <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No traces yet</h2>
+              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
                 Start sending traces from your application to see them here.
               </p>
             </div>
           )
         ) : (
           <>
-            <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+                <thead className="bg-slate-50 dark:bg-slate-950/70">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Name
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Status
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Duration
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Tokens
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       Cost
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
                       <SortableHeader
                         label="Started"
                         isActive={filters.sort_by === 'started_at'}
@@ -548,7 +555,7 @@ function TracesContent() {
                     </th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200 bg-white">
+                <tbody className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-900">
                   {traces.map((trace) => (
                     <TraceRow
                       key={trace.id}
@@ -585,19 +592,19 @@ function TraceRow({ trace, returnTo }: TraceRowProps) {
   const totalTokens = (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
 
   return (
-    <tr className="transition hover:bg-gray-50">
+    <tr className="transition hover:bg-slate-50 dark:hover:bg-slate-800/60">
       <td className="px-6 py-4 align-top">
         <div className="min-w-[16rem]">
           <div className="flex flex-wrap items-center gap-2">
             <Link
               to={`/traces/${trace.id}`}
               state={{ returnTo }}
-              className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-sky-400 dark:hover:text-sky-300"
             >
               {trace.name}
             </Link>
             {trace.error_count && trace.error_count > 0 && (
-              <span className="inline-flex rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">
+              <span className="inline-flex rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-500/15 dark:text-red-200">
                 {trace.error_count} error{trace.error_count === 1 ? '' : 's'}
               </span>
             )}
@@ -605,12 +612,12 @@ function TraceRow({ trace, returnTo }: TraceRowProps) {
           {trace.session_id && (
             <Link
               to={`/sessions/${trace.session_id}`}
-              className="mt-1 inline-flex flex-col text-left text-xs transition hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              className="mt-1 inline-flex flex-col text-left text-xs transition hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:hover:text-sky-300"
             >
-              <span className="font-medium text-gray-600">
+              <span className="font-medium text-slate-600 dark:text-slate-300">
                 {trace.session_external_id ?? trace.session_id}
               </span>
-              <span className="font-mono text-gray-400">{trace.session_id}</span>
+              <span className="font-mono text-slate-400 dark:text-slate-500">{trace.session_id}</span>
             </Link>
           )}
         </div>
@@ -618,16 +625,16 @@ function TraceRow({ trace, returnTo }: TraceRowProps) {
       <td className="px-6 py-4 whitespace-nowrap align-top">
         <StatusBadge status={trace.status} />
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
         {formatDuration(duration)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
         {formatTokens(totalTokens)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 align-top">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
         {formatCost(trace.total_cost_usd)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 align-top">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-500 align-top dark:text-slate-400">
         {formatRelativeTime(trace.started_at)}
       </td>
     </tr>

--- a/web/src/pages/testUtils.tsx
+++ b/web/src/pages/testUtils.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
-import { ThemeProvider } from '../hooks/useTheme';
+import { ThemeProvider } from '../hooks/ThemeProvider';
 import {
   OTHER_SESSION_EXTERNAL_ID,
   OTHER_SESSION_ID,

--- a/web/src/pages/testUtils.tsx
+++ b/web/src/pages/testUtils.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
+import { ThemeProvider } from '../hooks/useTheme';
 import {
   OTHER_SESSION_EXTERNAL_ID,
   OTHER_SESSION_ID,
@@ -21,6 +22,7 @@ import {
 import { TraceDetailPage } from './TraceDetailPage';
 import { SessionDetailPage } from './SessionDetailPage';
 import { SessionsPage } from './SessionsPage';
+import { SettingsPage } from './SettingsPage';
 import { TracesPage } from './TracesPage';
 export {
   OTHER_SESSION_EXTERNAL_ID,
@@ -170,6 +172,7 @@ export function renderTraceRoutes(
       { path: '/traces/:id', element: <TraceDetailPage /> },
       { path: '/sessions', element: <SessionsPage /> },
       { path: '/sessions/:id', element: <SessionDetailPage /> },
+      { path: '/settings', element: <SettingsPage /> },
     ],
     {
       initialEntries,
@@ -179,7 +182,9 @@ export function renderTraceRoutes(
 
   const view = render(
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <ThemeProvider>
+        <RouterProvider router={router} />
+      </ThemeProvider>
     </QueryClientProvider>
   );
 

--- a/web/src/pages/useTraceTimeline.ts
+++ b/web/src/pages/useTraceTimeline.ts
@@ -97,18 +97,21 @@ export function useTraceTimeline(traceId: string) {
     setNeedsTerminalRefresh(false);
   }, [timelineTerminalRefreshQuery.data]);
 
+  const rawError = selectTimelineError(
+    timelineSnapshot,
+    timelineBootstrapQuery.error,
+    timelinePollQuery.error,
+    timelineTerminalRefreshQuery.error
+  );
+
   return {
     events: timelineSnapshot?.events ?? [],
     traceStatus: timelineSnapshot?.traceStatus ?? null,
     hasSnapshot: timelineSnapshot !== null,
     isLive: pollingEnabled,
     isLoading: !timelineSnapshot && timelineBootstrapQuery.isLoading,
-    error: resolveTimelineError(
-      timelineSnapshot,
-      timelineBootstrapQuery.error,
-      timelinePollQuery.error,
-      timelineTerminalRefreshQuery.error
-    ),
+    rawError,
+    error: queryErrorMessage(rawError),
   };
 }
 
@@ -144,17 +147,17 @@ async function fetchFullTimelineSnapshot(traceId: string): Promise<TimelineSnaps
   };
 }
 
-function resolveTimelineError(
+function selectTimelineError(
   timelineSnapshot: TimelineSnapshot | null,
   bootstrapError: unknown,
   pollError: unknown,
   terminalRefreshError: unknown
-): string | null {
+): unknown {
   if (!timelineSnapshot) {
-    return queryErrorMessage(bootstrapError ?? terminalRefreshError);
+    return bootstrapError ?? terminalRefreshError;
   }
 
-  return queryErrorMessage(pollError ?? terminalRefreshError);
+  return pollError ?? terminalRefreshError;
 }
 
 function queryErrorMessage(error: unknown): string | null {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1,3 +1,45 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+    --continua-panel-separator: rgba(203, 213, 225, 0.95);
+    --continua-waterfall-failed-bg: #fee2e2;
+    --continua-waterfall-failed-border: #fca5a5;
+    --continua-waterfall-running-bg: #dbeafe;
+    --continua-waterfall-running-border: #93c5fd;
+    --continua-waterfall-running-dot: #2563eb;
+    --continua-waterfall-success-bg: #dcfce7;
+    --continua-waterfall-success-border: #86efac;
+    --continua-waterfall-success-selected-bg: #bfdbfe;
+    --continua-waterfall-success-selected-border: #60a5fa;
+    --continua-waterfall-tick-color: rgba(148, 163, 184, 0.3);
+  }
+
+  html.dark {
+    color-scheme: dark;
+    --continua-panel-separator: rgba(51, 65, 85, 0.95);
+    --continua-waterfall-failed-bg: rgba(127, 29, 29, 0.5);
+    --continua-waterfall-failed-border: rgba(248, 113, 113, 0.55);
+    --continua-waterfall-running-bg: rgba(30, 64, 175, 0.45);
+    --continua-waterfall-running-border: rgba(96, 165, 250, 0.65);
+    --continua-waterfall-running-dot: #93c5fd;
+    --continua-waterfall-success-bg: rgba(6, 95, 70, 0.5);
+    --continua-waterfall-success-border: rgba(52, 211, 153, 0.6);
+    --continua-waterfall-success-selected-bg: rgba(37, 99, 235, 0.6);
+    --continua-waterfall-success-selected-border: rgba(125, 211, 252, 0.7);
+    --continua-waterfall-tick-color: rgba(71, 85, 105, 0.45);
+  }
+
+  html,
+  body,
+  #root {
+    min-height: 100%;
+  }
+
+  body {
+    @apply bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100;
+  }
+}

--- a/web/src/utils/eventSemantics.ts
+++ b/web/src/utils/eventSemantics.ts
@@ -1,0 +1,86 @@
+import type { TimelineEvent } from '../api/client';
+
+export interface StateChangeDetails {
+  key: string;
+  namespace?: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+export interface DecisionDetails {
+  question: string;
+  chosen: unknown;
+  alternatives?: unknown[];
+  reasoning?: string;
+}
+
+export function getStateChangeDetails(
+  event: TimelineEvent
+): StateChangeDetails | null {
+  if (event.event_type !== 'state_change' || !event.payload) {
+    return null;
+  }
+
+  const key = getNonEmptyString(event.payload, 'key');
+  if (!key) {
+    return null;
+  }
+
+  return {
+    key,
+    namespace: getNonEmptyString(event.payload, 'namespace') ?? undefined,
+    oldValue: event.payload.old_value,
+    newValue: event.payload.new_value,
+  };
+}
+
+export function getDecisionDetails(event: TimelineEvent): DecisionDetails | null {
+  if (event.event_type !== 'decision' || !event.payload) {
+    return null;
+  }
+
+  const question = getNonEmptyString(event.payload, 'question');
+  const hasChosen = Object.prototype.hasOwnProperty.call(event.payload, 'chosen');
+  if (!question || !hasChosen) {
+    return null;
+  }
+
+  return {
+    question,
+    chosen: event.payload.chosen,
+    alternatives: Array.isArray(event.payload.alternatives)
+      ? event.payload.alternatives
+      : undefined,
+    reasoning: getNonEmptyString(event.payload, 'reasoning') ?? undefined,
+  };
+}
+
+export function formatInlineSemanticValue(value: unknown): string {
+  if (value === undefined) {
+    return 'unset';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value) ?? 'unserializable';
+  } catch {
+    return 'unserializable';
+  }
+}
+
+export function isStructuredSemanticValue(value: unknown): boolean {
+  return typeof value === 'object' && value !== null;
+}
+
+function getNonEmptyString(
+  payload: Record<string, unknown>,
+  key: string
+): string | null {
+  const value = payload[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}

--- a/web/src/utils/stateChanges.test.ts
+++ b/web/src/utils/stateChanges.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { createTimelineEvent } from '../test/traceFixtures';
+import { extractStateChanges } from './stateChanges';
+
+describe('extractStateChanges', () => {
+  it('filters to state_change events with payload.key', () => {
+    const changes = extractStateChanges([
+      createTimelineEvent({
+        id: 'state-valid',
+        event_type: 'state_change',
+        payload: {
+          key: 'status',
+          namespace: 'order',
+          old_value: 'pending',
+          new_value: 'approved',
+        },
+      }),
+      createTimelineEvent({
+        id: 'state-missing-key',
+        event_type: 'state_change',
+        payload: {
+          old_value: 'pending',
+          new_value: 'approved',
+        },
+      }),
+      createTimelineEvent({
+        id: 'decision',
+        event_type: 'decision',
+        payload: {
+          question: 'Which model?',
+          chosen: 'gpt-4.1',
+        },
+      }),
+    ]);
+
+    expect(changes).toEqual([
+      {
+        event: expect.objectContaining({ id: 'state-valid' }),
+        key: 'status',
+        namespace: 'order',
+        oldValue: 'pending',
+        newValue: 'approved',
+      },
+    ]);
+  });
+
+  it('returns an empty array when no valid state changes exist', () => {
+    expect(
+      extractStateChanges([
+        createTimelineEvent({ event_type: 'message', message: 'hello' }),
+      ])
+    ).toEqual([]);
+  });
+
+  it('preserves interleaved namespaces and missing optional values', () => {
+    const changes = extractStateChanges([
+      createTimelineEvent({
+        id: 'general-change',
+        event_type: 'state_change',
+        payload: {
+          key: 'phase',
+          new_value: 'running',
+        },
+      }),
+      createTimelineEvent({
+        id: 'order-change',
+        event_type: 'state_change',
+        payload: {
+          key: 'status',
+          namespace: 'order',
+          old_value: 'pending',
+          new_value: 'approved',
+        },
+      }),
+      createTimelineEvent({
+        id: 'network-change',
+        event_type: 'state_change',
+        payload: {
+          key: 'retry_count',
+          namespace: 'network',
+          new_value: 2,
+        },
+      }),
+    ]);
+
+    expect(changes).toEqual([
+      {
+        event: expect.objectContaining({ id: 'general-change' }),
+        key: 'phase',
+        namespace: undefined,
+        oldValue: undefined,
+        newValue: 'running',
+      },
+      {
+        event: expect.objectContaining({ id: 'order-change' }),
+        key: 'status',
+        namespace: 'order',
+        oldValue: 'pending',
+        newValue: 'approved',
+      },
+      {
+        event: expect.objectContaining({ id: 'network-change' }),
+        key: 'retry_count',
+        namespace: 'network',
+        oldValue: undefined,
+        newValue: 2,
+      },
+    ]);
+  });
+});

--- a/web/src/utils/stateChanges.ts
+++ b/web/src/utils/stateChanges.ts
@@ -1,0 +1,31 @@
+import type { TimelineEvent } from '../api/client';
+import { getStateChangeDetails } from './eventSemantics';
+
+export interface ExtractedStateChange {
+  event: TimelineEvent;
+  key: string;
+  namespace?: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+export function extractStateChanges(
+  events: TimelineEvent[]
+): ExtractedStateChange[] {
+  return events.flatMap((event) => {
+    const details = getStateChangeDetails(event);
+    if (!details) {
+      return [];
+    }
+
+    return [
+      {
+        event,
+        key: details.key,
+        namespace: details.namespace,
+        oldValue: details.oldValue,
+        newValue: details.newValue,
+      },
+    ];
+  });
+}

--- a/web/src/utils/timeline.test.ts
+++ b/web/src/utils/timeline.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { createTimelineEvent } from '../test/traceFixtures';
+import { summarizeTimelineEvent } from './timeline';
+
+describe('summarizeTimelineEvent', () => {
+  it('summarizes state changes from semantic payload fields', () => {
+    const event = createTimelineEvent({
+      event_type: 'state_change',
+      message: 'fallback message',
+      payload: {
+        key: 'status',
+        old_value: 'pending',
+        new_value: 'approved',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('status: pending → approved');
+  });
+
+  it('summarizes decisions from semantic payload fields', () => {
+    const event = createTimelineEvent({
+      event_type: 'decision',
+      message: 'fallback message',
+      payload: {
+        question: 'Which model?',
+        chosen: 'gpt-4.1',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('Which model? → gpt-4.1');
+  });
+
+  it('falls back to the message when semantic fields are missing', () => {
+    const stateEvent = createTimelineEvent({
+      event_type: 'state_change',
+      message: 'state fallback',
+      payload: {
+        old_value: 'pending',
+        new_value: 'approved',
+      },
+    });
+    const decisionEvent = createTimelineEvent({
+      event_type: 'decision',
+      message: 'decision fallback',
+      payload: {
+        question: 'Which model?',
+      },
+    });
+
+    expect(summarizeTimelineEvent(stateEvent)).toBe('state fallback');
+    expect(summarizeTimelineEvent(decisionEvent)).toBe('decision fallback');
+  });
+});

--- a/web/src/utils/timeline.ts
+++ b/web/src/utils/timeline.ts
@@ -1,4 +1,9 @@
 import { TimelineEvent } from '../api/client';
+import {
+  formatInlineSemanticValue,
+  getDecisionDetails,
+  getStateChangeDetails,
+} from './eventSemantics';
 
 /**
  * Merge timeline pages and polling updates without duplicating already-rendered events.
@@ -56,11 +61,23 @@ export function isTimelineErrorEvent(event: TimelineEvent): boolean {
 }
 
 export function summarizeTimelineEvent(event: TimelineEvent): string {
-  if (event.message) {
-    return event.message;
-  }
-
   switch (event.event_type) {
+    case 'state_change': {
+      const details = getStateChangeDetails(event);
+      if (details) {
+        return `${details.key}: ${formatInlineSemanticValue(
+          details.oldValue
+        )} → ${formatInlineSemanticValue(details.newValue)}`;
+      }
+      return event.message ?? 'state change';
+    }
+    case 'decision': {
+      const details = getDecisionDetails(event);
+      if (details) {
+        return `${details.question} → ${formatInlineSemanticValue(details.chosen)}`;
+      }
+      return event.message ?? 'decision';
+    }
     case 'span_started':
       return `${event.span_name ?? event.span_id ?? 'Span'} started`;
     case 'span_completed':
@@ -70,6 +87,9 @@ export function summarizeTimelineEvent(event: TimelineEvent): string {
     case 'metric':
       return formatMetricSummary(event);
     default:
+      if (event.message) {
+        return event.message;
+      }
       return event.event_type.replace(/_/g, ' ');
   }
 }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- add Phase 11 debugger semantics across contract, backend mapper/ingest validation, and Python SDK helpers
- add frontend state diff, decision rendering, settings/auth recovery, command palette, and dark mode polish
- add OpenSpec artifacts, docs, and focused test coverage for the new debugger semantics flows

## Verification
- make generate
- go test ./internal/ingest/... -v
- go test ./internal/api/... -v
- cd sdks/python && uv run pytest
- pnpm --filter web type-check
- pnpm --filter web test
- openspec validate add-debugger-semantics-polish --strict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic event types "state_change" and "decision" with inline previews (old → new, question → chosen) and a Decisions section in span details
  * New State tab with a State Diff viewer grouping changes by namespace
  * Settings page for API key management and theme selection; persistent system-aware dark mode
  * Global command palette (Cmd/Ctrl+K) and page-level auth-recovery banners with "Go to Settings"
  * Python SDK helpers to emit state_change and decision events; ingest accepts them with server-side warnings when fields are missing

* **Documentation**
  * New event conventions guide describing event types, payload shapes, and UI behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->