### PR TITLE
Add effect/wait semantic event foundation

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -38,12 +38,14 @@ const (
 const (
 	IngestEventTypeCustom      IngestEventType = "custom"
 	IngestEventTypeDecision    IngestEventType = "decision"
+	IngestEventTypeEffect      IngestEventType = "effect"
 	IngestEventTypeError       IngestEventType = "error"
 	IngestEventTypeException   IngestEventType = "exception"
 	IngestEventTypeLog         IngestEventType = "log"
 	IngestEventTypeMessage     IngestEventType = "message"
 	IngestEventTypeMetric      IngestEventType = "metric"
 	IngestEventTypeStateChange IngestEventType = "state_change"
+	IngestEventTypeWait        IngestEventType = "wait"
 )
 
 // Defines values for IngestResponseStatus.
@@ -123,6 +125,7 @@ const (
 const (
 	TimelineEventTypeCustom        TimelineEventType = "custom"
 	TimelineEventTypeDecision      TimelineEventType = "decision"
+	TimelineEventTypeEffect        TimelineEventType = "effect"
 	TimelineEventTypeError         TimelineEventType = "error"
 	TimelineEventTypeException     TimelineEventType = "exception"
 	TimelineEventTypeLog           TimelineEventType = "log"
@@ -132,6 +135,7 @@ const (
 	TimelineEventTypeSpanFailed    TimelineEventType = "span_failed"
 	TimelineEventTypeSpanStarted   TimelineEventType = "span_started"
 	TimelineEventTypeStateChange   TimelineEventType = "state_change"
+	TimelineEventTypeWait          TimelineEventType = "wait"
 )
 
 // Defines values for TimelineResponseTraceStatus.
@@ -222,7 +226,7 @@ type IngestEventInput struct {
 	Level          *IngestEventLevel `json:"level,omitempty"`
 	Message        *string           `json:"message,omitempty"`
 
-	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
 	Payload  *map[string]interface{} `json:"payload,omitempty"`
 	Sequence *int32                  `json:"sequence,omitempty"`
 

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -342,7 +342,7 @@ export interface components {
             depth?: number;
         };
         /** @enum {string} */
-        IngestEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision";
+        IngestEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision" | "effect" | "wait";
         /** @enum {string} */
         IngestEventLevel: "debug" | "info" | "warning" | "error";
         IngestEventInput: {
@@ -359,14 +359,14 @@ export interface components {
             /** Format: int32 */
             sequence?: number;
             message?: string;
-            /** @description Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+            /** @description Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
              *      */
             payload?: Record<string, never>;
             /** @description Optional key for event-level deduplication */
             idempotency_key?: string;
         };
         /** @enum {string} */
-        TimelineEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision" | "span_started" | "span_completed" | "span_failed";
+        TimelineEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision" | "effect" | "wait" | "span_started" | "span_completed" | "span_failed";
         /** @enum {string} */
         TimelineEventSource: "explicit" | "synthetic";
         /** @enum {string} */

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -787,6 +787,8 @@ components:
         - custom
         - state_change
         - decision
+        - effect
+        - wait
     IngestEventLevel:
       type: string
       enum:
@@ -825,7 +827,7 @@ components:
         payload:
           type: object
           description: |
-            Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+            Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
         idempotency_key:
           type: string
           description: Optional key for event-level deduplication
@@ -840,6 +842,8 @@ components:
         - custom
         - state_change
         - decision
+        - effect
+        - wait
         - span_started
         - span_completed
         - span_failed

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -729,7 +729,7 @@ components:
 
     IngestEventType:
       type: string
-      enum: [log, error, exception, message, metric, custom, state_change, decision]
+      enum: [log, error, exception, message, metric, custom, state_change, decision, effect, wait]
 
     IngestEventLevel:
       type: string
@@ -765,6 +765,8 @@ components:
           type: object
           description: >
             Free-form event payload. Semantic debugger conventions apply for some event types:
+            `effect` may include reserved `effect_id`;
+            `wait` may include reserved `wait_id`;
             `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`;
             `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
         idempotency_key:
@@ -783,6 +785,8 @@ components:
           custom,
           state_change,
           decision,
+          effect,
+          wait,
           span_started,
           span_completed,
           span_failed,

--- a/internal/api/ingest_handlers_test.go
+++ b/internal/api/ingest_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -158,6 +159,44 @@ func TestIngest_SyncTrueOverridesAsyncHeader(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, traceID, trace.TraceID)
+}
+
+func TestIngest_SyncTrueAcceptsUnknownExplicitEventType(t *testing.T) {
+	server, _, q, projectID := newAsyncIngestServer(t)
+	traceID := "trace-" + uuid.NewString()[:8]
+	startTime := time.Now().UTC().Format(time.RFC3339Nano)
+	sync := true
+
+	rec := invokeIngest(
+		t,
+		server,
+		projectID,
+		`{
+			"batch_key":"batch-unknown-explicit",
+			"traces":[{"trace_id":"`+traceID+`","name":"unknown explicit trace"}],
+			"spans":[{"trace_id":"`+traceID+`","span_id":"span-1","name":"unknown explicit span","start_time":"`+startTime+`"}],
+			"events":[{"trace_id":"`+traceID+`","span_id":"span-1","event_type":"workflow_step","message":"planning"}]
+		}`,
+		IngestParams{Sync: &sync},
+		nil,
+	)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeJSONBody[IngestResponse](t, rec)
+	assert.Equal(t, IngestResponseStatusOk, resp.Status)
+	require.NotNil(t, resp.EventCount)
+	assert.Equal(t, int32(1), *resp.EventCount)
+
+	trace, err := q.GetTraceByExternalID(context.Background(), platform.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   traceID,
+	})
+	require.NoError(t, err)
+
+	events, err := q.ListSpanEventsByTrace(context.Background(), trace.ID)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "workflow_step", events[0].EventType)
 }
 
 func TestIngest_InvalidAsyncVersionReturnsBadRequest(t *testing.T) {

--- a/internal/api/mapper.go
+++ b/internal/api/mapper.go
@@ -11,6 +11,8 @@ import (
 	"github.com/continua-ai/continua/internal/store"
 )
 
+const originalEventTypePayloadKey = "__continua_original_event_type"
+
 // traceToAPI converts a database trace to an API trace.
 func traceToAPI(t *store.TraceRead) Trace {
 	trace := Trace{
@@ -216,8 +218,9 @@ func spanToAPI(sp *platform.Span) Span {
 
 // explicitTimelineEventToAPI converts an explicit span event row to a timeline event.
 func explicitTimelineEventToAPI(ev *platform.SpanEvent, spanName *string) TimelineEvent {
+	eventType, recognized := mapExplicitTimelineEventType(ev.EventType)
 	event := TimelineEvent{
-		EventType: mapExplicitTimelineEventType(ev.EventType),
+		EventType: eventType,
 		Id:        ev.ID.String(),
 		Source:    Explicit,
 		Timestamp: timelineEventDisplayTimestamp(ev.EventTs, ev.ServerIngestedAt),
@@ -240,6 +243,12 @@ func explicitTimelineEventToAPI(ev *platform.SpanEvent, spanName *string) Timeli
 		event.Message = ev.Message
 	}
 	if payload := parseJSONObject(ev.Payload); payload != nil {
+		if !recognized {
+			payload = cloneTimelinePayloadWithOriginalType(payload, ev.EventType)
+		}
+		event.Payload = &payload
+	} else if !recognized {
+		payload := cloneTimelinePayloadWithOriginalType(nil, ev.EventType)
 		event.Payload = &payload
 	}
 
@@ -350,25 +359,42 @@ func mapSpanStatus(status string) string {
 	}
 }
 
-func mapExplicitTimelineEventType(eventType string) TimelineEventType {
+func mapExplicitTimelineEventType(eventType string) (TimelineEventType, bool) {
 	switch eventType {
 	case "log":
-		return TimelineEventTypeLog
+		return TimelineEventTypeLog, true
 	case "error":
-		return TimelineEventTypeError
+		return TimelineEventTypeError, true
 	case "exception":
-		return TimelineEventTypeException
+		return TimelineEventTypeException, true
 	case "message":
-		return TimelineEventTypeMessage
+		return TimelineEventTypeMessage, true
 	case "metric":
-		return TimelineEventTypeMetric
+		return TimelineEventTypeMetric, true
+	case "custom":
+		return TimelineEventTypeCustom, true
 	case "state_change":
-		return TimelineEventTypeStateChange
+		return TimelineEventTypeStateChange, true
 	case "decision":
-		return TimelineEventTypeDecision
+		return TimelineEventTypeDecision, true
+	case "effect":
+		return TimelineEventTypeEffect, true
+	case "wait":
+		return TimelineEventTypeWait, true
 	default:
-		return TimelineEventTypeCustom
+		return TimelineEventTypeCustom, false
 	}
+}
+
+func cloneTimelinePayloadWithOriginalType(payload map[string]interface{}, originalType string) map[string]interface{} {
+	cloned := make(map[string]interface{}, len(payload)+1)
+	for key, value := range payload {
+		cloned[key] = value
+	}
+
+	// TODO: consider pooling or lower-allocation path if this becomes hot
+	cloned[originalEventTypePayloadKey] = originalType
+	return cloned
 }
 
 func mapTimelineEventLevel(level string) *TimelineEventLevel {

--- a/internal/api/mapper_timeline_test.go
+++ b/internal/api/mapper_timeline_test.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/continua-ai/continua/db/gen/go/platform"
 )
@@ -28,6 +30,16 @@ func TestExplicitTimelineEventToAPI_PreservesSemanticEventTypes(t *testing.T) {
 			eventType: "decision",
 			expected:  TimelineEventTypeDecision,
 		},
+		{
+			name:      "effect",
+			eventType: "effect",
+			expected:  TimelineEventTypeEffect,
+		},
+		{
+			name:      "wait",
+			eventType: "wait",
+			expected:  TimelineEventTypeWait,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -45,4 +57,69 @@ func TestExplicitTimelineEventToAPI_PreservesSemanticEventTypes(t *testing.T) {
 			assert.Equal(t, tc.expected, apiEvent.EventType)
 		})
 	}
+}
+
+func TestExplicitTimelineEventToAPI_DowngradesUnknownTypeWithOriginalTypeMetadata(t *testing.T) {
+	now := time.Now().UTC()
+	payloadBytes, err := json.Marshal(map[string]any{"key": "value"})
+	require.NoError(t, err)
+
+	event := platform.SpanEvent{
+		ID:               uuid.New(),
+		TraceID:          uuid.New(),
+		SpanID:           "span-1",
+		EventType:        "workflow_step",
+		Payload:          payloadBytes,
+		ServerIngestedAt: now,
+	}
+
+	apiEvent := explicitTimelineEventToAPI(&event, nil)
+
+	assert.Equal(t, TimelineEventTypeCustom, apiEvent.EventType)
+	require.NotNil(t, apiEvent.Payload)
+	assert.Equal(t, "value", (*apiEvent.Payload)["key"])
+	assert.Equal(t, "workflow_step", (*apiEvent.Payload)[originalEventTypePayloadKey])
+}
+
+func TestCloneTimelinePayloadWithOriginalType_DoesNotMutateInput(t *testing.T) {
+	original := map[string]any{"key": "value"}
+
+	cloned := cloneTimelinePayloadWithOriginalType(original, "workflow_step")
+
+	assert.Equal(t, map[string]any{"key": "value"}, original)
+	assert.Equal(t, "value", cloned["key"])
+	assert.Equal(t, "workflow_step", cloned[originalEventTypePayloadKey])
+}
+
+func TestCloneTimelinePayloadWithOriginalType_CreatesPayloadWhenAbsent(t *testing.T) {
+	cloned := cloneTimelinePayloadWithOriginalType(nil, "workflow_step")
+
+	assert.Equal(
+		t,
+		map[string]any{originalEventTypePayloadKey: "workflow_step"},
+		cloned,
+	)
+}
+
+func TestExplicitTimelineEventToAPI_DoesNotTagRecognizedCustomEvents(t *testing.T) {
+	now := time.Now().UTC()
+	payloadBytes, err := json.Marshal(map[string]any{"kind": "manual"})
+	require.NoError(t, err)
+
+	event := platform.SpanEvent{
+		ID:               uuid.New(),
+		TraceID:          uuid.New(),
+		SpanID:           "span-1",
+		EventType:        "custom",
+		Payload:          payloadBytes,
+		ServerIngestedAt: now,
+	}
+
+	apiEvent := explicitTimelineEventToAPI(&event, nil)
+
+	assert.Equal(t, TimelineEventTypeCustom, apiEvent.EventType)
+	require.NotNil(t, apiEvent.Payload)
+	assert.Equal(t, "manual", (*apiEvent.Payload)["kind"])
+	_, hasOriginalType := (*apiEvent.Payload)[originalEventTypePayloadKey]
+	assert.False(t, hasOriginalType)
 }

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -38,12 +38,14 @@ const (
 const (
 	IngestEventTypeCustom      IngestEventType = "custom"
 	IngestEventTypeDecision    IngestEventType = "decision"
+	IngestEventTypeEffect      IngestEventType = "effect"
 	IngestEventTypeError       IngestEventType = "error"
 	IngestEventTypeException   IngestEventType = "exception"
 	IngestEventTypeLog         IngestEventType = "log"
 	IngestEventTypeMessage     IngestEventType = "message"
 	IngestEventTypeMetric      IngestEventType = "metric"
 	IngestEventTypeStateChange IngestEventType = "state_change"
+	IngestEventTypeWait        IngestEventType = "wait"
 )
 
 // Defines values for IngestResponseStatus.
@@ -123,6 +125,7 @@ const (
 const (
 	TimelineEventTypeCustom        TimelineEventType = "custom"
 	TimelineEventTypeDecision      TimelineEventType = "decision"
+	TimelineEventTypeEffect        TimelineEventType = "effect"
 	TimelineEventTypeError         TimelineEventType = "error"
 	TimelineEventTypeException     TimelineEventType = "exception"
 	TimelineEventTypeLog           TimelineEventType = "log"
@@ -132,6 +135,7 @@ const (
 	TimelineEventTypeSpanFailed    TimelineEventType = "span_failed"
 	TimelineEventTypeSpanStarted   TimelineEventType = "span_started"
 	TimelineEventTypeStateChange   TimelineEventType = "state_change"
+	TimelineEventTypeWait          TimelineEventType = "wait"
 )
 
 // Defines values for TimelineResponseTraceStatus.
@@ -222,7 +226,7 @@ type IngestEventInput struct {
 	Level          *IngestEventLevel `json:"level,omitempty"`
 	Message        *string           `json:"message,omitempty"`
 
-	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
 	Payload  *map[string]interface{} `json:"payload,omitempty"`
 	Sequence *int32                  `json:"sequence,omitempty"`
 

--- a/internal/api/traces_handlers_test.go
+++ b/internal/api/traces_handlers_test.go
@@ -183,6 +183,114 @@ func TestGetTraceEvents_CursorPaginationDoesNotDuplicate(t *testing.T) {
 	assert.NotEqual(t, *tailCursor, *incrementalPoll.PollCursor)
 }
 
+func TestGetTraceEvents_PaginationHandlesMixedKnownAndUnknownEventTypes(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	base := time.Date(2026, 3, 7, 11, 30, 0, 0, time.UTC)
+	trace := createTimelineTrace(ctx, t, q, projectID, "running", base, nil)
+
+	createTimelineSpan(ctx, t, q, projectID, trace.ID, "alpha", "Alpha Span", "running", base.Add(time.Second), nil)
+	createTimelineSpan(ctx, t, q, projectID, trace.ID, "beta", "Beta Span", "completed", base.Add(2*time.Second), testutil.Ptr(base.Add(5*time.Second)))
+
+	insertTimelineEvent(
+		ctx, t, q, projectID, trace.ID, "alpha", "effect", "info",
+		base.Add(1500*time.Millisecond), testutil.Int32Ptr(1), "effect emitted", map[string]any{"target": "cache"},
+	)
+	insertTimelineEvent(
+		ctx, t, q, projectID, trace.ID, "alpha", "wait", "warning",
+		base.Add(2500*time.Millisecond), testutil.Int32Ptr(2), "waiting", map[string]any{"reason": "network"},
+	)
+	insertTimelineEvent(
+		ctx, t, q, projectID, trace.ID, "beta", "workflow_step", "info",
+		base.Add(3*time.Second), testutil.Int32Ptr(3), "workflow step", map[string]any{"phase": "plan"},
+	)
+
+	full := decodeJSONBody[TimelineResponse](t, invokeGetTraceEvents(
+		t, server, projectID, trace.ID, GetTraceEventsParams{Limit: testutil.IntPtr(100)},
+	))
+	require.Len(t, full.Events, 6)
+
+	seen := make(map[string]struct{}, len(full.Events))
+	var after *string
+	var tailCursor *string
+	foundDowngradedUnknown := false
+
+	for {
+		page := decodeJSONBody[TimelineResponse](t, invokeGetTraceEvents(
+			t, server, projectID, trace.ID, GetTraceEventsParams{
+				After: after,
+				Limit: testutil.IntPtr(2),
+			},
+		))
+
+		for _, event := range page.Events {
+			if _, exists := seen[event.Id]; exists {
+				t.Fatalf("duplicate event returned across pages: %s", event.Id)
+			}
+			seen[event.Id] = struct{}{}
+
+			if event.EventType == TimelineEventTypeCustom {
+				require.NotNil(t, event.Payload)
+				assert.Equal(t, "workflow_step", (*event.Payload)[originalEventTypePayloadKey])
+				foundDowngradedUnknown = true
+			}
+		}
+
+		require.NotNil(t, page.PollCursor)
+		tailCursor = page.PollCursor
+
+		if !page.HasMore {
+			break
+		}
+
+		require.NotNil(t, page.NextCursor)
+		after = page.NextCursor
+	}
+
+	assert.Len(t, seen, len(full.Events))
+	assert.True(t, foundDowngradedUnknown)
+	require.NotNil(t, tailCursor)
+
+	emptyPoll := decodeJSONBody[TimelineResponse](t, invokeGetTraceEvents(
+		t, server, projectID, trace.ID, GetTraceEventsParams{
+			After: tailCursor,
+			Limit: testutil.IntPtr(2),
+		},
+	))
+	assert.Empty(t, emptyPoll.Events)
+	assert.False(t, emptyPoll.HasMore)
+	require.NotNil(t, emptyPoll.PollCursor)
+	assert.Equal(t, *tailCursor, *emptyPoll.PollCursor)
+
+	lateEventID := insertTimelineEvent(
+		ctx, t, q, projectID, trace.ID, "beta", "workflow_step", "info",
+		base.Add(4*time.Second), testutil.Int32Ptr(4), "late workflow step", map[string]any{"phase": "ship"},
+	)
+
+	incrementalPoll := decodeJSONBody[TimelineResponse](t, invokeGetTraceEvents(
+		t, server, projectID, trace.ID, GetTraceEventsParams{
+			After: tailCursor,
+			Limit: testutil.IntPtr(2),
+		},
+	))
+	require.Len(t, incrementalPoll.Events, 1)
+	assert.Equal(t, lateEventID.String(), incrementalPoll.Events[0].Id)
+	assert.Equal(t, TimelineEventTypeCustom, incrementalPoll.Events[0].EventType)
+	require.NotNil(t, incrementalPoll.Events[0].Payload)
+	assert.Equal(
+		t,
+		"workflow_step",
+		(*incrementalPoll.Events[0].Payload)[originalEventTypePayloadKey],
+	)
+	require.NotNil(t, incrementalPoll.PollCursor)
+	assert.NotEqual(t, *tailCursor, *incrementalPoll.PollCursor)
+}
+
 func TestGetTraceEvents_InvalidCursorReturns400(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ctx := context.Background()

--- a/internal/ingest/processor.go
+++ b/internal/ingest/processor.go
@@ -213,12 +213,19 @@ func (p *Processor) validateBatch(req *IngestRequest) []string {
 }
 
 func isValidIngestEventType(eventType string) bool {
-	switch eventType {
-	case "log", "error", "exception", "message", "metric", "custom", "state_change", "decision":
-		return true
-	default:
+	if eventType == "" {
 		return false
 	}
+
+	_, blocked := syntheticTimelineOnlyEventTypes[eventType]
+	return !blocked
+}
+
+var syntheticTimelineOnlyEventTypes = map[string]struct{}{
+	// keep in sync with synthetic timeline event types in contracts/openapi/openapi.yaml and internal/api/timeline.go
+	"span_started":   {},
+	"span_completed": {},
+	"span_failed":    {},
 }
 
 func warnForMissingSemanticPayloadFields(event *EventInput) {
@@ -385,15 +392,6 @@ func (p *Processor) upsertSpan(ctx context.Context, tx *store.Tx, projectID, tra
 }
 
 func (p *Processor) insertEvent(ctx context.Context, tx *store.Tx, projectID, traceUUID uuid.UUID, input *EventInput) (bool, error) {
-	var payloadData []byte
-	var truncated bool
-	var origSize *int64
-	var truncReason *string
-
-	if input.Payload != nil {
-		payloadData, truncated, origSize, truncReason = processPayload(input.Payload, truncation.DefaultMaxBytes)
-	}
-
 	var eventTs pgtype.Timestamptz
 	if input.EventTs != nil {
 		eventTs = pgtype.Timestamptz{Time: *input.EventTs, Valid: true}
@@ -401,6 +399,7 @@ func (p *Processor) insertEvent(ctx context.Context, tx *store.Tx, projectID, tr
 
 	eventType := defaultString(input.EventType, "log")
 	level := defaultString(input.Level, "info")
+	payloadData, truncated, origSize, truncReason := processEventPayload(eventType, input, truncation.DefaultMaxBytes)
 
 	id, err := tx.InsertSpanEvent(ctx, &platform.InsertSpanEventParams{
 		ProjectID:         projectID,
@@ -432,13 +431,7 @@ func processPayload(data any, maxBytes int) (jsonData []byte, truncated bool, or
 		return nil, false, nil, nil
 	}
 
-	jsonBytes, err := json.Marshal(data)
-	if err != nil {
-		wrapped := map[string]string{"error": "failed to serialize", "type": "unknown"}
-		jsonBytes, _ = json.Marshal(wrapped)
-	}
-
-	jsonBytes, _ = truncation.EnsureJSON(jsonBytes)
+	jsonBytes := marshalPayloadData(data)
 
 	if maxBytes <= 0 {
 		maxBytes = truncation.DefaultMaxBytes
@@ -452,6 +445,17 @@ func processPayload(data any, maxBytes int) (jsonData []byte, truncated bool, or
 
 	reasonStr := string(result.Reason)
 	return result.Data, true, &result.OriginalSizeBytes, &reasonStr
+}
+
+func marshalPayloadData(data any) []byte {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		wrapped := map[string]string{"error": "failed to serialize", "type": "unknown"}
+		jsonBytes, _ = json.Marshal(wrapped)
+	}
+
+	jsonBytes, _ = truncation.EnsureJSON(jsonBytes)
+	return jsonBytes
 }
 
 // defaultString returns the value if non-nil, otherwise returns the default.

--- a/internal/ingest/semantic_events_test.go
+++ b/internal/ingest/semantic_events_test.go
@@ -1,0 +1,488 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+	"github.com/continua-ai/continua/pkg/truncation"
+)
+
+type semanticHarness struct {
+	ctx       context.Context
+	q         *platform.Queries
+	service   *Service
+	projectID uuid.UUID
+	traceID   string
+	spanID    string
+	startTime time.Time
+}
+
+func newSemanticHarness(t *testing.T) *semanticHarness {
+	t.Helper()
+
+	pool := testutil.TestDB(t)
+	s := store.New(pool)
+	ctx := context.Background()
+
+	return &semanticHarness{
+		ctx:       ctx,
+		q:         s.Queries(),
+		service:   NewService(s, nil, NewProcessor(s, nil), nil),
+		projectID: testutil.CreateTestProject(t, ctx, s.Queries()),
+		traceID:   testutil.UniqueID("semantic-trace"),
+		spanID:    testutil.UniqueID("semantic-span"),
+		startTime: time.Now().UTC().Truncate(time.Microsecond),
+	}
+}
+
+func (h *semanticHarness) ingestWithTraceAndSpan(t *testing.T, events ...EventInput) *IngestResponse {
+	t.Helper()
+
+	resp, err := h.service.Ingest(h.ctx, h.projectID, &IngestRequest{
+		BatchKey: testutil.UniqueID("batch"),
+		Traces: []TraceInput{
+			{
+				TraceID:   h.traceID,
+				Name:      testutil.StrPtr("semantic trace"),
+				StartTime: &h.startTime,
+			},
+		},
+		Spans: []SpanInput{
+			{
+				TraceID:   h.traceID,
+				SpanID:    h.spanID,
+				Name:      "semantic span",
+				StartTime: h.startTime,
+			},
+		},
+		Events: events,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	return resp
+}
+
+func (h *semanticHarness) createTraceOnly(t *testing.T) uuid.UUID {
+	t.Helper()
+
+	trace, err := h.q.UpsertTrace(h.ctx, platform.UpsertTraceParams{
+		ProjectID: h.projectID,
+		TraceID:   h.traceID,
+		Name:      testutil.StrPtr("semantic trace"),
+		StartTime: testutil.PgtypeTimestamptz(h.startTime),
+	})
+	require.NoError(t, err)
+
+	return trace.ID
+}
+
+func (h *semanticHarness) ingestEventsOnly(t *testing.T, events ...EventInput) *IngestResponse {
+	t.Helper()
+
+	resp, err := h.service.Ingest(h.ctx, h.projectID, &IngestRequest{
+		BatchKey: testutil.UniqueID("batch"),
+		Events:   events,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	return resp
+}
+
+func (h *semanticHarness) listEvents(t *testing.T) []platform.SpanEvent {
+	t.Helper()
+
+	trace, err := h.q.GetTraceByExternalID(h.ctx, platform.GetTraceByExternalIDParams{
+		ProjectID: h.projectID,
+		TraceID:   h.traceID,
+	})
+	require.NoError(t, err)
+
+	events, err := h.q.ListSpanEventsByTrace(h.ctx, trace.ID)
+	require.NoError(t, err)
+
+	return events
+}
+
+func decodeEventPayload(t *testing.T, event platform.SpanEvent) map[string]any {
+	t.Helper()
+
+	if len(event.Payload) == 0 {
+		return nil
+	}
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(event.Payload, &payload))
+	return payload
+}
+
+func payloadsByEventType(t *testing.T, events []platform.SpanEvent) map[string][]map[string]any {
+	t.Helper()
+
+	grouped := make(map[string][]map[string]any, len(events))
+	for i := range events {
+		grouped[events[i].EventType] = append(grouped[events[i].EventType], decodeEventPayload(t, events[i]))
+	}
+
+	return grouped
+}
+
+func TestDeriveSemanticID_DeterministicForEffect(t *testing.T) {
+	payload := map[string]any{
+		"target": "tool-output",
+		"nested": map[string]any{
+			"step": "summarize",
+		},
+	}
+
+	idOne := deriveSemanticID("effect", "trace-1", "span-1", nil, nil, "info", "effect emitted", payload)
+	idTwo := deriveSemanticID("effect", "trace-1", "span-1", nil, nil, "info", "effect emitted", payload)
+
+	require.Regexp(t, `^effect_[0-9a-f]{32}$`, idOne)
+	assert.Equal(t, idOne, idTwo)
+}
+
+func TestDeriveSemanticID_DeterministicForWait(t *testing.T) {
+	eventTS := time.Date(2026, 3, 7, 12, 0, 0, 123456000, time.UTC)
+
+	idOne := deriveSemanticID("wait", "trace-1", "span-1", testutil.Int32Ptr(7), &eventTS, "warning", "waiting", map[string]any{
+		"reason": "dependency",
+	})
+	idTwo := deriveSemanticID("wait", "trace-1", "span-1", testutil.Int32Ptr(7), &eventTS, "warning", "waiting", map[string]any{
+		"reason": "dependency",
+	})
+
+	require.Regexp(t, `^wait_[0-9a-f]{32}$`, idOne)
+	assert.Equal(t, idOne, idTwo)
+}
+
+func TestDeriveSemanticID_TreatsNilAndEmptyPayloadEqually(t *testing.T) {
+	nilPayloadID := deriveSemanticID("effect", "trace-1", "span-1", nil, nil, "info", "", nil)
+	emptyPayloadID := deriveSemanticID("effect", "trace-1", "span-1", nil, nil, "info", "", map[string]any{})
+
+	assert.Equal(t, nilPayloadID, emptyPayloadID)
+}
+
+func TestDeriveSemanticID_DistinguishesOmittedAndExplicitInfoLevels(t *testing.T) {
+	omittedLevelID := deriveSemanticID("effect", "trace-1", "span-1", nil, nil, "", "", map[string]any{
+		"target": "cache",
+	})
+	explicitInfoLevelID := deriveSemanticID("effect", "trace-1", "span-1", nil, nil, "info", "", map[string]any{
+		"target": "cache",
+	})
+
+	assert.NotEqual(t, omittedLevelID, explicitInfoLevelID)
+}
+
+func TestDeriveSemanticID_RecursivelySortsNestedPayloadObjects(t *testing.T) {
+	first := map[string]any{
+		"root": map[string]any{
+			"nested": map[string]any{
+				"b": "two",
+				"a": "one",
+			},
+			"list": []any{
+				map[string]any{"z": 1, "y": 2},
+			},
+		},
+	}
+	second := map[string]any{
+		"root": map[string]any{
+			"list": []any{
+				map[string]any{"y": 2, "z": 1},
+			},
+			"nested": map[string]any{
+				"a": "one",
+				"b": "two",
+			},
+		},
+	}
+
+	firstID := deriveSemanticID("effect", "trace-1", "span-1", nil, nil, "info", "", first)
+	secondID := deriveSemanticID("effect", "trace-1", "span-1", nil, nil, "info", "", second)
+
+	assert.Equal(t, firstID, secondID)
+}
+
+func TestIngest_AcceptsEffectAndWaitEventTypes(t *testing.T) {
+	h := newSemanticHarness(t)
+	effectType := "effect"
+	waitType := "wait"
+
+	resp := h.ingestWithTraceAndSpan(
+		t,
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &effectType,
+			Message:   testutil.StrPtr("effect event"),
+			Payload:   map[string]any{"target": "cache"},
+		},
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &waitType,
+			Message:   testutil.StrPtr("wait event"),
+			Payload:   map[string]any{"reason": "io"},
+		},
+	)
+
+	assert.Equal(t, int32(2), resp.EventCount)
+
+	events := h.listEvents(t)
+	require.Len(t, events, 2)
+	assert.ElementsMatch(t, []string{"effect", "wait"}, []string{events[0].EventType, events[1].EventType})
+}
+
+func TestIngest_PreservesProvidedSemanticIDs(t *testing.T) {
+	h := newSemanticHarness(t)
+	effectType := "effect"
+	waitType := "wait"
+
+	h.ingestWithTraceAndSpan(
+		t,
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &effectType,
+			Payload: map[string]any{
+				"effect_id": "effect_manual",
+				"target":    "db",
+			},
+		},
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &waitType,
+			Payload: map[string]any{
+				"wait_id": "wait_manual",
+				"reason":  "network",
+			},
+		},
+	)
+
+	events := h.listEvents(t)
+	require.Len(t, events, 2)
+	payloads := payloadsByEventType(t, events)
+
+	require.Len(t, payloads["effect"], 1)
+	require.Len(t, payloads["wait"], 1)
+	assert.Equal(t, "effect_manual", payloads["effect"][0]["effect_id"])
+	assert.Equal(t, "wait_manual", payloads["wait"][0]["wait_id"])
+}
+
+func TestIngest_DerivesSemanticIDsForEmptyAndNonStringReservedFields(t *testing.T) {
+	h := newSemanticHarness(t)
+	effectType := "effect"
+	waitType := "wait"
+
+	h.ingestWithTraceAndSpan(
+		t,
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &effectType,
+			Payload: map[string]any{
+				"effect_id": "",
+				"target":    "db",
+			},
+		},
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &waitType,
+			Payload: map[string]any{
+				"wait_id": 123,
+				"reason":  "dependency",
+			},
+		},
+	)
+
+	events := h.listEvents(t)
+	require.Len(t, events, 2)
+	payloads := payloadsByEventType(t, events)
+
+	require.Len(t, payloads["effect"], 1)
+	require.Len(t, payloads["wait"], 1)
+	require.Regexp(t, `^effect_[0-9a-f]{32}$`, payloads["effect"][0]["effect_id"])
+	require.Regexp(t, `^wait_[0-9a-f]{32}$`, payloads["wait"][0]["wait_id"])
+}
+
+func TestIngest_DerivesSemanticIDsWhenAbsent(t *testing.T) {
+	h := newSemanticHarness(t)
+	effectType := "effect"
+	waitType := "wait"
+
+	h.ingestWithTraceAndSpan(
+		t,
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &effectType,
+			Message:   testutil.StrPtr("effect event"),
+			Payload:   map[string]any{"target": "db"},
+		},
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &effectType,
+			Message:   testutil.StrPtr("effect event"),
+			Payload:   map[string]any{"target": "db"},
+		},
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &waitType,
+			Message:   testutil.StrPtr("wait event"),
+			Payload:   map[string]any{"reason": "dependency"},
+		},
+	)
+
+	events := h.listEvents(t)
+	require.Len(t, events, 3)
+	payloads := payloadsByEventType(t, events)
+
+	require.Len(t, payloads["effect"], 2)
+	require.Len(t, payloads["wait"], 1)
+	require.Regexp(t, `^effect_[0-9a-f]{32}$`, payloads["effect"][0]["effect_id"])
+	require.Regexp(t, `^wait_[0-9a-f]{32}$`, payloads["wait"][0]["wait_id"])
+	assert.Equal(t, payloads["effect"][0]["effect_id"], payloads["effect"][1]["effect_id"])
+}
+
+func TestIngest_DerivesSemanticIDBeforeTruncationAndPersistsIt(t *testing.T) {
+	h := newSemanticHarness(t)
+	effectType := "effect"
+	largePayload := map[string]any{
+		"blob": strings.Repeat("x", truncation.DefaultMaxBytes),
+		"meta": map[string]any{
+			"kind": "oversized",
+		},
+	}
+
+	expectedID := deriveSemanticID("effect", h.traceID, h.spanID, nil, nil, "", "", largePayload)
+
+	h.ingestWithTraceAndSpan(
+		t,
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &effectType,
+			Payload:   largePayload,
+		},
+	)
+
+	events := h.listEvents(t)
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].Truncated)
+	assert.True(t, *events[0].Truncated)
+	assert.LessOrEqual(t, len(events[0].Payload), truncation.DefaultMaxBytes)
+
+	payload := decodeEventPayload(t, events[0])
+	require.NotNil(t, payload)
+	assert.Equal(t, expectedID, payload["effect_id"])
+}
+
+func TestIngest_StoresOrphanWaitEvent(t *testing.T) {
+	h := newSemanticHarness(t)
+	waitType := "wait"
+
+	h.createTraceOnly(t)
+
+	resp := h.ingestEventsOnly(
+		t,
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    "missing-span",
+			EventType: &waitType,
+			Payload:   map[string]any{"reason": "dependency"},
+		},
+	)
+
+	assert.Equal(t, int32(1), resp.EventCount)
+
+	events := h.listEvents(t)
+	require.Len(t, events, 1)
+	assert.Equal(t, "wait", events[0].EventType)
+	assert.Equal(t, "missing-span", events[0].SpanID)
+}
+
+func TestIngest_AcceptsUnknownExplicitEventTypes(t *testing.T) {
+	h := newSemanticHarness(t)
+	workflowStepType := "workflow_step"
+
+	resp := h.ingestWithTraceAndSpan(
+		t,
+		EventInput{
+			TraceID:   h.traceID,
+			SpanID:    h.spanID,
+			EventType: &workflowStepType,
+			Payload:   map[string]any{"step": "plan"},
+		},
+	)
+
+	assert.Equal(t, int32(1), resp.EventCount)
+
+	events := h.listEvents(t)
+	require.Len(t, events, 1)
+	assert.Equal(t, workflowStepType, events[0].EventType)
+}
+
+func TestIngest_RejectsSyntheticTimelineOnlyEventTypes(t *testing.T) {
+	svc := NewService(nil, nil, NewProcessor(nil, nil), nil)
+
+	for _, eventType := range []string{"span_started", "span_completed", "span_failed"} {
+		t.Run(eventType, func(t *testing.T) {
+			resp, err := svc.Ingest(context.Background(), uuid.New(), &IngestRequest{
+				BatchKey: testutil.UniqueID("batch"),
+				Events: []EventInput{
+					{
+						TraceID:   "trace-1",
+						SpanID:    "span-1",
+						EventType: &eventType,
+					},
+				},
+			})
+
+			require.Nil(t, resp)
+			require.Error(t, err)
+
+			var validationErr *ValidationError
+			require.ErrorAs(t, err, &validationErr)
+			assert.Contains(t, validationErr.Errors, "event[0] invalid event_type: "+eventType)
+		})
+	}
+}
+
+func TestIngest_RejectsEmptyEventType(t *testing.T) {
+	svc := NewService(nil, nil, NewProcessor(nil, nil), nil)
+	emptyType := ""
+
+	resp, err := svc.Ingest(context.Background(), uuid.New(), &IngestRequest{
+		BatchKey: testutil.UniqueID("batch"),
+		Events: []EventInput{
+			{
+				TraceID:   "trace-1",
+				SpanID:    "span-1",
+				EventType: &emptyType,
+			},
+		},
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+
+	var validationErr *ValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Contains(t, validationErr.Errors, "event[0] invalid event_type: ")
+}

--- a/internal/ingest/semantic_ids.go
+++ b/internal/ingest/semantic_ids.go
@@ -1,0 +1,285 @@
+package ingest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/continua-ai/continua/pkg/truncation"
+)
+
+const (
+	semanticIDNamespace = "continua-semantic-id"
+	semanticIDVersion   = "v1"
+	semanticIDSeparator = "\x1f"
+)
+
+type semanticFallbackContent struct {
+	Level   string         `json:"level"`
+	Message string         `json:"message"`
+	Payload map[string]any `json:"payload"`
+}
+
+func deriveSemanticID(
+	kind string,
+	traceID string,
+	spanID string,
+	sequence *int32,
+	eventTS *time.Time,
+	level string,
+	message string,
+	payload map[string]any,
+) string {
+	parts := []string{
+		semanticIDNamespace,
+		semanticIDVersion,
+		kind,
+		traceID,
+		spanID,
+		formatSemanticSequence(sequence),
+		formatSemanticEventTS(eventTS),
+	}
+
+	if sequence == nil && eventTS == nil {
+		parts = append(parts, hashSemanticFallbackContent(level, message, payload))
+	}
+
+	return kind + "_" + hashSemanticString(strings.Join(parts, semanticIDSeparator))
+}
+
+func semanticPayloadIDKey(eventType string) string {
+	switch eventType {
+	case "effect":
+		return "effect_id"
+	case "wait":
+		return "wait_id"
+	default:
+		return ""
+	}
+}
+
+func semanticPayloadIDValue(eventType string, input *EventInput) string {
+	key := semanticPayloadIDKey(eventType)
+	if key == "" {
+		return ""
+	}
+
+	if value, ok := payloadStringField(input.Payload, key); ok {
+		return value
+	}
+
+	return deriveSemanticID(
+		eventType,
+		input.TraceID,
+		input.SpanID,
+		input.Sequence,
+		input.EventTs,
+		optionalString(input.Level),
+		defaultString(input.Message, ""),
+		input.Payload,
+	)
+}
+
+func processEventPayload(eventType string, input *EventInput, maxBytes int) (jsonData []byte, truncated bool, origSize *int64, reason *string) {
+	semanticKey := semanticPayloadIDKey(eventType)
+	if semanticKey == "" {
+		return processPayload(input.Payload, maxBytes)
+	}
+
+	semanticID := semanticPayloadIDValue(eventType, input)
+	basePayload := cloneJSONObject(input.Payload)
+	if basePayload == nil {
+		basePayload = map[string]any{}
+	}
+
+	fullPayload := cloneJSONObject(basePayload)
+	fullPayload[semanticKey] = semanticID
+
+	fullJSONBytes := marshalPayloadData(fullPayload)
+	if maxBytes <= 0 {
+		maxBytes = truncation.DefaultMaxBytes
+	}
+
+	if len(fullJSONBytes) <= maxBytes {
+		return fullJSONBytes, false, nil, nil
+	}
+
+	delete(basePayload, semanticKey)
+	truncatedBytes := truncatePayloadWithReservedString(basePayload, semanticKey, semanticID, maxBytes)
+	originalSize := int64(len(fullJSONBytes))
+	reasonStr := string(truncation.TruncateReasonSize)
+
+	return truncatedBytes, true, &originalSize, &reasonStr
+}
+
+func truncatePayloadWithReservedString(payload map[string]any, reservedKey, reservedValue string, maxBytes int) []byte {
+	baseJSONBytes := marshalPayloadData(payload)
+	if maxBytes <= 0 {
+		maxBytes = truncation.DefaultMaxBytes
+	}
+
+	baseBudget := maxBytes - reservedStringJSONBudget(reservedKey, reservedValue)
+	if baseBudget < 2 {
+		baseBudget = 2
+	}
+
+	for {
+		truncatedPayload := parsePayloadObject(truncation.TruncateWithLimit(baseJSONBytes, baseBudget).Data)
+		truncatedPayload[reservedKey] = reservedValue
+
+		finalJSONBytes := marshalPayloadData(truncatedPayload)
+		if len(finalJSONBytes) <= maxBytes || baseBudget <= 2 {
+			return finalJSONBytes
+		}
+
+		baseBudget--
+	}
+}
+
+func reservedStringJSONBudget(key, value string) int {
+	reservedOnlyJSON := marshalPayloadData(map[string]string{key: value})
+	if len(reservedOnlyJSON) == 0 {
+		return 0
+	}
+
+	return len(reservedOnlyJSON) - 1
+}
+
+func parsePayloadObject(data []byte) map[string]any {
+	if len(data) == 0 {
+		return map[string]any{}
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil || payload == nil {
+		return map[string]any{}
+	}
+
+	return payload
+}
+
+func payloadStringField(payload map[string]any, field string) (string, bool) {
+	if payload == nil {
+		return "", false
+	}
+
+	value, ok := payload[field]
+	if !ok {
+		return "", false
+	}
+
+	text, ok := value.(string)
+	return text, ok && text != ""
+}
+
+func cloneJSONObject(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+
+	cloned := make(map[string]any, len(payload))
+	for key, value := range payload {
+		cloned[key] = cloneJSONValue(value)
+	}
+
+	return cloned
+}
+
+func cloneJSONValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneJSONObject(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i := range typed {
+			cloned[i] = cloneJSONValue(typed[i])
+		}
+		return cloned
+	default:
+		return typed
+	}
+}
+
+func formatSemanticSequence(sequence *int32) string {
+	if sequence == nil {
+		return ""
+	}
+
+	return strconv.FormatInt(int64(*sequence), 10)
+}
+
+func formatSemanticEventTS(eventTS *time.Time) string {
+	if eventTS == nil {
+		return ""
+	}
+
+	return eventTS.UTC().Format(time.RFC3339Nano)
+}
+
+func optionalString(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
+}
+
+func hashSemanticFallbackContent(level, message string, payload map[string]any) string {
+	content := semanticFallbackContent{
+		Level:   level,
+		Message: message,
+		Payload: normalizeSemanticPayload(payload),
+	}
+
+	return hashSemanticBytes(marshalPayloadData(content))
+}
+
+func normalizeSemanticPayload(payload map[string]any) map[string]any {
+	if len(payload) == 0 {
+		return map[string]any{}
+	}
+
+	normalized := make(map[string]any, len(payload))
+	for key, value := range payload {
+		if key == "effect_id" || key == "wait_id" || strings.HasPrefix(key, "__continua_") {
+			continue
+		}
+		normalized[key] = normalizeSemanticValue(value)
+	}
+
+	return normalized
+}
+
+func normalizeSemanticValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		normalized := make(map[string]any, len(typed))
+		for key, nestedValue := range typed {
+			if strings.HasPrefix(key, "__continua_") {
+				continue
+			}
+			normalized[key] = normalizeSemanticValue(nestedValue)
+		}
+		return normalized
+	case []any:
+		normalized := make([]any, len(typed))
+		for i := range typed {
+			normalized[i] = normalizeSemanticValue(typed[i])
+		}
+		return normalized
+	default:
+		return typed
+	}
+}
+
+func hashSemanticString(value string) string {
+	return hashSemanticBytes([]byte(value))
+}
+
+func hashSemanticBytes(value []byte) string {
+	sum := sha256.Sum256(value)
+	return hex.EncodeToString(sum[:])[:32]
+}

--- a/openspec/changes/add-effect-wait-semantic-foundation/design.md
+++ b/openspec/changes/add-effect-wait-semantic-foundation/design.md
@@ -1,0 +1,129 @@
+## Context
+
+Continua's event taxonomy has 8 ingest types and 11 timeline types (adding 3 synthetic span lifecycle markers). Two of the ingest types—`state_change` and `decision`—are already first-class semantic types with SDK helpers (`span.state_change()`, `span.decision()`), documentation (`docs/event-conventions.md`), and frontend summarization (`web/src/utils/timeline.ts`). This change extends the semantic taxonomy with causal relationship types—`effect` and `wait`—and introduces a forward-compatible fallback so the server can accept future event types without requiring contract changes for every new type.
+
+**Scope**: This is a wire-level foundation phase. It adds contract enums, backend plumbing, and generated type support. SDK convenience helpers, documentation conventions, and frontend summarization/rendering for `effect`/`wait` are deferred to a follow-up phase.
+
+The change spans the OpenAPI contract, Go ingest validation, Go timeline mapping, and the web client's manual type union. It does not touch the database schema, River jobs, or the engine module.
+
+### Stakeholders
+- Backend: ingest validation, timeline mapping
+- Frontend: timeline event type rendering
+- SDK consumers: Python SDK (auto-generated types), TypeScript SDK (stub)
+
+## Goals / Non-Goals
+
+### Goals
+- Add `effect` and `wait` as accepted and preserved event types across the ingest → store → timeline read path (wire-level foundation, not product-level parity with `state_change`/`decision`)
+- Deterministic `effect_id` / `wait_id` derivation so causal links are stable without caller coordination
+- Accept unknown explicit event type strings server-side only for forward compatibility (generated SDK enums remain strict)
+- Downgrade unknown types to `custom` on timeline read with preserved original type in payload metadata
+
+### Non-Goals
+- No `engine/` runtime work
+- No richer `effect`/`wait` payload validation beyond reserved ID fields
+- No causal graph construction or linking logic (future phase)
+- No WebSocket or replay changes
+- No database migration
+- No SDK convenience helpers (like `span.effect()` / `span.wait()`) — deferred
+- No `docs/event-conventions.md` entries — deferred until SDK helpers exist
+- No frontend summarization or rendering for `effect`/`wait` — deferred
+
+## Decisions
+
+### D1: Platform-path only, no engine/ runtime work
+The `engine/` module is scaffolded and isolated. This change stays on the live platform path: contracts, ingest, API, and web.
+
+### D2: Track A and Track B are separate deliverables
+Track A (first-class `effect`/`wait`) and Track B (forward-compatible unknown fallback) are independently testable and reviewable. Track A can land without Track B, but Track B depends on Track A's enum additions being present.
+
+### D3: Server-side forward compatibility is intentional server-only permissiveness
+The OpenAPI enum remains strict (`effect`, `wait`, plus existing types). The server-side ingest validation is deliberately relaxed beyond the enum to accept unknown strings. This creates an intentional contract/runtime divergence:
+- **Generated SDK clients** (Python `types.py`, TS generated types) will only expose enum-defined types. Sending an unknown type via the SDK requires bypassing the typed API.
+- **Raw HTTP clients** can send any non-empty, non-synthetic event type string, and the server will persist it.
+- This divergence is acceptable because Track B targets forward compatibility for raw integrations and internal tooling, not SDK-driven workflows. The SDK enum is updated when a type graduates to first-class (as `effect`/`wait` do in Track A).
+
+### D4: Reserved metadata key is `__continua_original_event_type`
+When an unknown stored event type is downgraded to `custom` on timeline read, the original raw type is preserved in `payload.__continua_original_event_type`. The `__continua_` prefix is reserved for platform metadata. No new top-level response field is added.
+
+### D5: Deterministic semantic ID derivation is v1, internal, pure, and stateless
+
+#### Derivation trigger
+- Only when the event type is `effect` and `payload.effect_id` is missing/empty/non-string, or `wait` and `payload.wait_id` is missing/empty/non-string.
+- A non-empty caller-provided string ID is preserved unchanged.
+
+#### Tuple structure
+Positional-first to avoid JSON serialization-order ambiguity. Fields joined with `\x1f` (ASCII unit separator):
+
+| Position | Field | Value |
+|----------|-------|-------|
+| 0 | namespace | `continua-semantic-id` (literal) |
+| 1 | version | `v1` (literal) |
+| 2 | kind | `effect` or `wait` |
+| 3 | trace_id | external `trace_id` string |
+| 4 | span_id | external `span_id` string |
+| 5 | sequence | decimal string, or `""` if nil |
+| 6 | event_ts | RFC3339Nano UTC, or `""` if nil |
+| 7 | fallback hash | only present when both sequence and event_ts are absent |
+
+#### Fallback content hash
+When both `sequence` and `event_ts` are absent, a content hash is appended as field 7:
+- Remove `effect_id`, `wait_id`, and all `__continua_*` keys from payload
+- Treat nil and empty payload identically as `{}`
+- Canonicalize with a custom recursive normalizer:
+  - Maps/objects: sort keys at every nesting level
+  - Arrays: preserve original order
+  - Scalars: preserve value type
+  - Nil object values remain nil
+- Canonical fallback content: `level` (string or empty) + `message` (string or empty) + recursively normalized payload
+- SHA-256 the canonical content and take the first 32 lowercase hex chars
+
+#### Final digest
+- SHA-256 the `\x1f`-joined tuple bytes
+- Take the first 32 lowercase hex chars
+- Prefix with `effect_` or `wait_`
+- Result: `effect_<32hex>` or `wait_<32hex>`
+
+#### Properties
+- `sequence` is nullable `int32`, serialized as decimal string in the tuple
+- `TimelineEvent.id` remains the persisted row UUID; derived semantic IDs live only in payload
+- Stateless: identical inputs always produce identical outputs across instances
+
+### D6: Synthetic type blocklist coupling
+The blocklist of synthetic-only types (`span_started`, `span_completed`, `span_failed`) that are rejected at ingest is maintained as a single set/helper with a code comment noting its coupling to `contracts/openapi/openapi.yaml` and `internal/api/timeline.go`.
+
+### D7: Unknown-type downgrade clone strategy
+When downgrading an unknown type to `custom`:
+- If payload is absent, create a new map with only `__continua_original_event_type`
+- If payload exists, clone once and append the metadata key (do not mutate the parsed original)
+- Accept the per-event clone allocation cost in Phase 1; leave a TODO noting pooling can be considered later
+
+Note: the `default → TimelineEventTypeCustom` fallback already exists in `mapExplicitTimelineEventType` today. The new behavior in Track B is specifically the `__continua_original_event_type` metadata injection and the intentional server-side acceptance of unknown types at ingest.
+
+### D8: Semantic IDs are guaranteed to survive payload truncation
+Event payloads are truncated on write via `pkg/truncation.TruncateJSON` (default 64KB limit). The `truncateObject` function iterates Go maps with non-deterministic order, so simply injecting the semantic ID key before truncation does NOT guarantee survival — near-limit payloads could randomly drop it.
+
+The derivation and persistence steps must follow this order:
+
+1. **Derive** `effect_id` / `wait_id` from the pre-truncation payload (so the derivation input is deterministic and not affected by truncation heuristics)
+2. **Extract** the semantic ID key from the payload map (hold it aside)
+3. **Serialize** the payload (without the semantic ID key) to JSON bytes
+4. **Truncate** the serialized payload if it exceeds the size limit
+5. **Re-inject** the semantic ID key into the (possibly truncated) payload bytes
+
+Implementation: truncate the payload to `maxBytes - reservedKeySize` (where `reservedKeySize` accounts for the semantic ID key-value pair, ~50 bytes for `"effect_id":"effect_<32hex>"`), then re-inject the reserved key into the result. This avoids overshooting the intended size budget — a naive "truncate to full limit, then re-inject" approach would exceed `maxBytes`.
+
+This guarantees the spec's `SHALL be stored in payload` requirement is met regardless of payload size or truncation behavior.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Forward-compatible acceptance could let typos through silently | Only affects server-side; SDK enums remain strict. Monitoring/logging can flag unexpected types. |
+| Payload clone on downgrade adds allocation per unknown event | Acceptable in Phase 1; leave TODO for optimization if it becomes hot path |
+| Deterministic ID collisions if tuple fields are all empty | Fallback content hash ensures differentiation; truly identical events correctly share an ID |
+| Truncated payload reduces effective max size by ~50 bytes for semantic events | Negligible vs 64KB limit. Reserved headroom approach keeps truncation budget honest. |
+
+## Open Questions
+
+None — all decisions are locked for Phase 1.

--- a/openspec/changes/add-effect-wait-semantic-foundation/proposal.md
+++ b/openspec/changes/add-effect-wait-semantic-foundation/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add Effect/Wait Semantic Event Contract Foundation
+
+## Why
+
+Continua's event taxonomy already includes semantic types (`state_change`, `decision`) with SDK helpers, documentation, and frontend rendering. This change **extends the existing semantic taxonomy** with causal relationship types—`effect` and `wait`—that are central to agent debugging. Adding them as accepted ingest and timeline event types, with deterministic ID derivation, lays the wire-level foundation for future causal linking. A forward-compatible unknown-type fallback ensures the server-side ingest path can accept future event types without requiring contract changes for each new type.
+
+This is a **wire-level foundation** phase: it adds contract, backend plumbing, and generated type support. SDK convenience helpers (like `span.state_change()`), documentation conventions (like `docs/event-conventions.md`), and frontend summarization/rendering for `effect`/`wait` are deferred to a follow-up phase once there are consumers of the causal data.
+
+## What Changes
+
+### Track A: Accepted and preserved `effect` / `wait`
+- Add `effect` and `wait` to `IngestEventType` enum in OpenAPI
+- Add `effect` and `wait` to `TimelineEventType` enum in OpenAPI
+- Run `make generate` to propagate to Go, TypeScript, and Python artifacts
+- Update `web/src/api/client.ts` manual type union
+- Extend ingest validation to accept `effect` and `wait`
+- Extend timeline mapper to return stored `effect`/`wait` as recognized types (not downgraded to `custom`)
+- Implement deterministic `effect_id`/`wait_id` derivation when caller omits them
+
+### Track B: Forward-compatible unknown explicit-event fallback (server-only permissiveness)
+- Relax **server-side** ingest validation to accept unknown non-empty event type strings (generated SDK enums remain strict; this is intentional divergence for raw HTTP clients)
+- Explicitly reject synthetic-only types (`span_started`, `span_completed`, `span_failed`) at ingest
+- Preserve raw event type in `span_events.event_type` column (already TEXT, no migration needed)
+- On timeline read, downgrade unknown stored types to `custom` with `payload.__continua_original_event_type` metadata (note: the `default → custom` fallback already exists in `mapExplicitTimelineEventType`; the new behavior is injecting the `__continua_original_event_type` metadata key)
+
+## Impact
+- Affected specs: `event-taxonomy` (new capability spec)
+- Affected code:
+  - `contracts/openapi/openapi.yaml` — enum additions
+  - `internal/ingest/processor.go` — validation changes
+  - `internal/api/mapper.go` — timeline type mapping and downgrade logic
+  - `internal/api/timeline.go` — no structural change, but coupled via synthetic type blocklist
+  - `web/src/api/client.ts` — manual type union update
+- No database migration required (`event_type` is already `TEXT NOT NULL`)
+- No breaking changes to existing clients

--- a/openspec/changes/add-effect-wait-semantic-foundation/specs/event-taxonomy/spec.md
+++ b/openspec/changes/add-effect-wait-semantic-foundation/specs/event-taxonomy/spec.md
@@ -1,0 +1,168 @@
+## ADDED Requirements
+
+### Requirement: Accepted and Preserved Effect Event Type
+
+The system SHALL accept `effect` as a valid ingest event type, persist it, and return it as a recognized timeline event type.
+
+The system SHALL include `effect` in the `IngestEventType` and `TimelineEventType` OpenAPI enums.
+
+When an `effect` event is ingested, the system SHALL store the raw `effect` type in `span_events.event_type` and return it as `event_type: "effect"` on the timeline read path.
+
+_Note: This phase adds wire-level acceptance and preservation only. SDK helpers, documentation conventions, and frontend summarization for `effect` are deferred._
+
+#### Scenario: Ingest accepts effect event type
+- **WHEN** a client sends an ingest payload with `event_type: "effect"`
+- **THEN** the system SHALL accept the event without validation errors
+- **AND** the event SHALL be persisted with `event_type = "effect"` in `span_events`
+
+#### Scenario: Timeline returns effect as recognized type
+- **WHEN** a stored event has `event_type = "effect"`
+- **THEN** the timeline API SHALL return it with `event_type: "effect"` and `source: "explicit"`
+
+---
+
+### Requirement: Accepted and Preserved Wait Event Type
+
+The system SHALL accept `wait` as a valid ingest event type, persist it, and return it as a recognized timeline event type.
+
+The system SHALL include `wait` in the `IngestEventType` and `TimelineEventType` OpenAPI enums.
+
+When a `wait` event is ingested, the system SHALL store the raw `wait` type in `span_events.event_type` and return it as `event_type: "wait"` on the timeline read path.
+
+_Note: This phase adds wire-level acceptance and preservation only. SDK helpers, documentation conventions, and frontend summarization for `wait` are deferred._
+
+#### Scenario: Ingest accepts wait event type
+- **WHEN** a client sends an ingest payload with `event_type: "wait"`
+- **THEN** the system SHALL accept the event without validation errors
+- **AND** the event SHALL be persisted with `event_type = "wait"` in `span_events`
+
+#### Scenario: Timeline returns wait as recognized type
+- **WHEN** a stored event has `event_type = "wait"`
+- **THEN** the timeline API SHALL return it with `event_type: "wait"` and `source: "explicit"`
+
+#### Scenario: Orphan wait events are accepted (confirms existing behavior for new type)
+- **WHEN** a `wait` event references a `span_id` that has not yet been ingested
+- **THEN** the system SHALL store the event successfully
+- **AND** the timeline SHALL return the event without a synthesized `span_name`
+
+_Note: Orphan event acceptance is existing behavior (no FK on `span_id`). This scenario confirms the new `wait` type follows the same path._
+
+---
+
+### Requirement: Deterministic Semantic ID Derivation
+
+The system SHALL derive deterministic `effect_id` or `wait_id` values for `effect` and `wait` events when the caller does not provide one.
+
+The derivation SHALL be stateless: identical inputs SHALL always produce identical outputs across service instances and restarts.
+
+Derived IDs SHALL be stored in the event payload and SHALL NOT replace `TimelineEvent.id`, which remains the persisted row UUID.
+
+#### Scenario: Caller-provided effect_id is preserved
+- **WHEN** an `effect` event is ingested with a non-empty string `payload.effect_id`
+- **THEN** the system SHALL preserve the caller-provided `effect_id` unchanged
+
+#### Scenario: Caller-provided wait_id is preserved
+- **WHEN** a `wait` event is ingested with a non-empty string `payload.wait_id`
+- **THEN** the system SHALL preserve the caller-provided `wait_id` unchanged
+
+#### Scenario: Deterministic effect_id derived when absent
+- **WHEN** an `effect` event is ingested without `payload.effect_id` (or with empty/non-string value)
+- **THEN** the system SHALL derive a deterministic `effect_id` in the format `effect_<32hex>`
+- **AND** the derived ID SHALL be stored in `payload.effect_id`
+
+#### Scenario: Deterministic wait_id derived when absent
+- **WHEN** a `wait` event is ingested without `payload.wait_id` (or with empty/non-string value)
+- **THEN** the system SHALL derive a deterministic `wait_id` in the format `wait_<32hex>`
+- **AND** the derived ID SHALL be stored in `payload.wait_id`
+
+#### Scenario: Repeated derivation produces identical IDs
+- **WHEN** two `effect` events with identical `trace_id`, `span_id`, `sequence`, `event_ts`, `level`, `message`, and `payload` are processed
+- **THEN** the system SHALL derive the same `effect_id` for both
+
+#### Scenario: Derivation is stateless (pure function of inputs)
+- **WHEN** the same event inputs are processed by separate calls to the derivation function
+- **THEN** the derived semantic ID SHALL be identical
+
+_Note: This is tested as a unit property of the derivation helper, not as a distributed systems test. It validates no hidden state (counters, caches) affects output._
+
+#### Scenario: Nil and empty payload produce identical fallback IDs
+- **WHEN** an `effect` event has nil payload and another has empty `{}` payload
+- **AND** all other tuple fields are identical
+- **THEN** the system SHALL derive the same `effect_id` for both
+
+#### Scenario: Nested payload objects are recursively sorted for fallback hashing
+- **WHEN** two `effect` events have identical payload content but different JSON key ordering at nested levels
+- **AND** both lack `sequence` and `event_ts`
+- **THEN** the system SHALL derive the same `effect_id` for both
+
+#### Scenario: Semantic ID derivation uses pre-truncation payload and survives truncation
+- **WHEN** an `effect` event is ingested with a large payload that triggers truncation
+- **THEN** the `effect_id` SHALL be derived from the original pre-truncation payload content
+- **AND** the derived `effect_id` SHALL be present in the persisted (possibly truncated) payload
+- **AND** the semantic ID key SHALL NOT be lost due to truncation regardless of payload size
+
+---
+
+### Requirement: Forward-Compatible Unknown Event Type Acceptance
+
+The server-side ingest validation SHALL accept any non-empty explicit event type string, not only the types enumerated in the OpenAPI `IngestEventType` schema.
+
+The system SHALL explicitly reject event type strings that correspond to synthetic timeline-only types: `span_started`, `span_completed`, and `span_failed`.
+
+The synthetic-type blocklist SHALL be maintained in a single helper or set with a code comment noting its coupling to the OpenAPI contract and timeline code.
+
+The OpenAPI `IngestEventType` enum SHALL remain strict (not widened to free-form strings).
+
+#### Scenario: Known explicit types are accepted
+- **WHEN** a client sends an event with a known `event_type` such as `"log"`, `"effect"`, or `"custom"`
+- **THEN** the system SHALL accept the event
+
+#### Scenario: Unknown explicit types are accepted server-side
+- **WHEN** a client sends an event with `event_type: "workflow_step"` (not in the OpenAPI enum)
+- **THEN** the server SHALL accept and persist the event with `event_type = "workflow_step"` in `span_events`
+
+#### Scenario: Synthetic timeline types are rejected at ingest
+- **WHEN** a client sends an event with `event_type: "span_started"`
+- **THEN** the system SHALL reject the event with a validation error
+- **AND** the same rejection SHALL apply to `"span_completed"` and `"span_failed"`
+
+#### Scenario: Empty event type string is rejected
+- **WHEN** a client sends an event with `event_type: ""`
+- **THEN** the system SHALL reject the event with a validation error
+
+---
+
+### Requirement: Unknown Event Type Timeline Downgrade
+
+When the timeline read path encounters a stored event whose `event_type` is not a recognized `TimelineEventType`, the system SHALL downgrade it to `custom` and preserve the original type in payload metadata.
+
+_Note: The `default → custom` fallback already exists in `mapExplicitTimelineEventType`. The new behavior added here is the `__continua_original_event_type` metadata injection, which preserves the original type for consumers that need to distinguish downgraded events from intentional `custom` events._
+
+The reserved metadata key SHALL be `payload.__continua_original_event_type`.
+
+If the event has no existing payload, the system SHALL create a new payload object containing only the metadata key.
+
+If the event has an existing payload, the system SHALL clone the payload once and append the metadata key without mutating the parsed original map.
+
+#### Scenario: Unknown stored type downgrades to custom on timeline
+- **WHEN** a stored event has `event_type = "workflow_step"` (not a recognized timeline type)
+- **THEN** the timeline API SHALL return it with `event_type: "custom"`
+- **AND** `payload.__continua_original_event_type` SHALL be `"workflow_step"`
+
+#### Scenario: Downgrade with existing payload
+- **WHEN** a stored event has `event_type = "workflow_step"` and an existing payload `{"key": "value"}`
+- **THEN** the timeline API SHALL return `event_type: "custom"` with payload `{"key": "value", "__continua_original_event_type": "workflow_step"}`
+- **AND** the original parsed payload map SHALL NOT be mutated
+
+#### Scenario: Downgrade with absent payload
+- **WHEN** a stored event has `event_type = "workflow_step"` and no payload
+- **THEN** the timeline API SHALL return `event_type: "custom"` with payload `{"__continua_original_event_type": "workflow_step"}`
+
+#### Scenario: Genuine custom events are not tagged as downgraded
+- **WHEN** a stored event has `event_type = "custom"` (a recognized timeline type)
+- **THEN** the timeline API SHALL return it with `event_type: "custom"`
+- **AND** the payload SHALL NOT contain a `__continua_original_event_type` key
+
+#### Scenario: Pagination remains correct with mixed event types
+- **WHEN** a timeline contains `effect`, `wait`, known, and unknown-downgraded events
+- **THEN** cursor pagination and poll-cursor traversal SHALL remain duplicate-free

--- a/openspec/changes/add-effect-wait-semantic-foundation/tasks.md
+++ b/openspec/changes/add-effect-wait-semantic-foundation/tasks.md
@@ -1,0 +1,73 @@
+## Track A: Accepted and Preserved Effect / Wait Types
+
+### 1. Contract and generation
+- [x] 1.1 Add `effect` and `wait` to `IngestEventType` enum in `contracts/openapi/openapi.yaml`
+- [x] 1.2 Add `effect` and `wait` to `TimelineEventType` enum in `contracts/openapi/openapi.yaml`
+- [x] 1.3 Run `make generate` and verify Go, TypeScript, and Python artifacts include the new types
+- [x] 1.4 Update `web/src/api/client.ts` to add `'effect' | 'wait'` to the manual `TimelineEvent.event_type` union
+
+### 2. Write Track A tests first
+- [x] 2.1 Write ingest tests: `effect` accepted, `wait` accepted
+- [x] 2.2 Write ingest tests: caller-provided `effect_id` and `wait_id` preserved unchanged
+- [x] 2.3 Write ingest tests: deterministic `effect_id` derived when absent; repeated identical inputs produce the same ID
+- [x] 2.4 Write ingest tests: deterministic `wait_id` derived when absent
+- [x] 2.5 Write ingest tests: nil payload and `{}` produce identical fallback derivation
+- [x] 2.6 Write ingest tests: recursively sorted nested payload objects in fallback hashing
+- [x] 2.7 Write ingest tests: semantic ID derived from pre-truncation payload and survives truncation (near-limit payload with semantic ID key guaranteed present in persisted payload)
+- [x] 2.8 Write API/mapper tests: timeline returns `effect` as `effect`, `wait` as `wait`
+- [x] 2.9 Write ingest test: orphan `wait` event stored successfully _(confirms existing behavior for new type)_
+- [x] 2.10 Confirm all new tests fail (red phase)
+
+### 3. Implement Track A
+- [x] 3.1 Add `"effect"` and `"wait"` to `isValidIngestEventType` in `internal/ingest/processor.go`
+- [x] 3.2 Add `"effect"` → `TimelineEventTypeEffect` and `"wait"` → `TimelineEventTypeWait` cases in `mapExplicitTimelineEventType` in `internal/api/mapper.go`
+- [x] 3.3 Implement a pure, stateless `deriveSemanticID` helper with positional tuple, `\x1f` separator, SHA-256, and `effect_`/`wait_` prefix
+- [x] 3.4 Implement recursive payload canonicalization for fallback content hashing (sort map keys at every level, preserve array order, handle nil/empty equivalence)
+- [x] 3.5 Wire derivation into ingest processing: derive `effect_id`/`wait_id` when missing/empty/non-string, using pre-truncation payload as input
+- [x] 3.6 Guarantee semantic ID key survives truncation: extract before truncation, re-inject after (see design.md D8)
+- [x] 3.7 Ensure caller-provided non-empty string IDs are preserved unchanged
+
+### 4. Verify Track A tests pass
+- [x] 4.1 Run `go test ./internal/ingest/...` — all Track A tests pass
+- [x] 4.2 Run `go test ./internal/api/...` — all Track A tests pass
+- [x] 4.3 Run `pnpm --filter web test` — web type changes compile
+- [x] 4.4 Run `make lint` — no lint issues
+
+---
+
+## Track B: Forward-Compatible Unknown Explicit-Event Fallback
+
+_Depends on Track A being complete._
+
+### 5. Write Track B tests first
+- [x] 5.1 Write ingest tests: unknown explicit type strings (e.g. `"workflow_step"`) accepted and persisted
+- [x] 5.2 Write HTTP handler-level test: POST raw JSON with `event_type: "workflow_step"` through the actual ingest endpoint with sync mode forced, verify sync success response and persisted type _(validates the public server boundary, not just internal service)_
+- [x] 5.3 Write ingest tests: `span_started`, `span_completed`, `span_failed` explicitly rejected
+- [x] 5.4 Write ingest tests: empty string event type rejected
+- [x] 5.5 Write API/mapper tests: unknown stored type downgrades to `custom` with `__continua_original_event_type` _(note: `default → custom` fallback is existing; the metadata injection is the new behavior)_
+- [x] 5.6 Write API/mapper tests: downgrade works for events with and without existing payload; original parsed map is not mutated
+- [x] 5.7 Write API/mapper negative test: genuine stored `event_type = "custom"` round-trips as `custom` with NO `__continua_original_event_type` key in payload
+- [x] 5.8 Write API/mapper tests: pagination and poll-cursor traversal remain duplicate-free with mixed `effect`, `wait`, and downgraded unknown events
+- [x] 5.9 Confirm all new Track B tests fail (red phase)
+
+### 6. Implement Track B
+- [x] 6.1 Replace strict `isValidIngestEventType` with explicit blocklist + non-empty-string acceptance in `internal/ingest/processor.go`
+- [x] 6.2 Create synthetic-type blocklist set (`span_started`, `span_completed`, `span_failed`) with coupling comment: `// keep in sync with synthetic timeline event types in contracts/openapi/openapi.yaml and internal/api/timeline.go`
+- [x] 6.3 Reject empty string event types explicitly
+- [x] 6.4 In the timeline mapper, detect unknown stored types and downgrade to `TimelineEventTypeCustom` with `__continua_original_event_type` metadata injection
+- [x] 6.5 Clone payload if it exists; create new map if absent. Do not mutate the original parsed map
+- [x] 6.6 Add TODO comment near clone: `// TODO: consider pooling or lower-allocation path if this becomes hot`
+
+### 7. Verify Track B tests pass
+- [x] 7.1 Run `go test ./internal/ingest/...` — all Track B tests pass
+- [x] 7.2 Run `go test ./internal/api/...` — all Track B tests pass
+- [x] 7.3 Run `pnpm --filter web test` — still passing
+
+---
+
+## Final Validation
+- [x] 8.1 `make generate` passes
+- [x] 8.2 `go test ./internal/ingest/...` passes (all tests)
+- [x] 8.3 `go test ./internal/api/...` passes (all tests)
+- [x] 8.4 `pnpm --filter web test` passes
+- [x] 8.5 `make lint` passes

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -226,6 +226,8 @@ class IngestEventType(Enum):
     custom = "custom"
     state_change = "state_change"
     decision = "decision"
+    effect = "effect"
+    wait = "wait"
 
 
 class IngestEventLevel(Enum):
@@ -245,7 +247,7 @@ class IngestEventInput(BaseModel):
     message: str | None = None
     payload: dict[str, Any] | None = Field(
         None,
-        description="Free-form event payload. Semantic debugger conventions apply for some event types: `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.\n",
+        description="Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.\n",
     )
     idempotency_key: str | None = Field(
         None, description="Optional key for event-level deduplication"
@@ -261,6 +263,8 @@ class TimelineEventType(Enum):
     custom = "custom"
     state_change = "state_change"
     decision = "decision"
+    effect = "effect"
+    wait = "wait"
     span_started = "span_started"
     span_completed = "span_completed"
     span_failed = "span_failed"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -184,6 +184,8 @@ export interface TimelineEvent {
     | 'custom'
     | 'state_change'
     | 'decision'
+    | 'effect'
+    | 'wait'
     | 'span_started'
     | 'span_completed'
     | 'span_failed';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `effect` and `wait` as new event types for ingest and timeline operations.
  * Implemented automatic semantic ID generation for `effect` and `wait` events when IDs are not provided.
  * Added forward-compatible handling of unknown event types—gracefully downgraded to custom while preserving original type information.

* **Documentation**
  * Added design specifications and implementation guidance for new event taxonomy.

* **Tests**
  * Added comprehensive test coverage for semantic ID derivation and mixed event type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->