### PR TITLE
Add Python SDK effect and wait emission

### DIFF
--- a/docs/event-conventions.md
+++ b/docs/event-conventions.md
@@ -10,10 +10,12 @@ Use them to explain what happened during trace execution, not to model checkpoin
 
 - Use `state_change` when an observable piece of state changes and you want the debugger to show the transition directly.
 - Use `decision` when the system chooses between alternatives and the debugger should show the branch point and rationale.
-- Use `custom` only when no existing semantic type fits or the payload is domain-specific and purely ad hoc.
+- Use `effect` when the span performs an external action or model invocation that matters for debugging.
+- Use `wait` when progress is blocked on a human, external dependency, timer, or similar resolution outside the current span's direct control.
 - Use `message` for lightweight narrative milestones.
 - Use `log`, `error`, and `exception` for operational logging and failures.
 - Use `metric` for structured numeric measurements.
+- Use `custom` only when no existing semantic type fits or the payload is domain-specific and purely ad hoc.
 
 ## Explicit Event Types
 
@@ -27,6 +29,10 @@ Use them to explain what happened during trace execution, not to model checkpoin
 | `custom` | Domain-specific event that does not fit another semantic type | Any optional structured payload | `info` |
 | `state_change` | Observable state transition that should render in the State view | `key`, optional `namespace`, optional `old_value`, optional `new_value` | `info` |
 | `decision` | Branch point or choice with a selected outcome | `question`, `chosen`, optional `alternatives`, optional `reasoning` | `info` |
+| `effect` | External side effect, tool call, or model invocation worth surfacing in the debugger | `effect_kind`, `has_external_side_effect`, optional `effect_id`, optional `idempotent`, optional `idempotency_key` | `info` |
+| `wait` | Blocked or deferred progress that depends on later resolution | `wait_kind`, `phase`, optional `wait_id`, optional `resolution` | `info` |
+
+`message` and `custom` remain supported event types in this phase, but the Python SDK does not add dedicated `span.message()` or `span.custom()` helpers yet.
 
 ## Payload Guidance
 
@@ -99,9 +105,102 @@ with span("route_request") as s:
     )
 ```
 
+### `effect`
+
+Use `effect` when a span performs work whose observable consequence matters outside the current call stack: model calls, tool invocations, outbound API calls, writes to external systems, or similarly meaningful side effects.
+
+Recommended payload shape:
+
+```json
+{
+  "effect_kind": "api_call",
+  "has_external_side_effect": true,
+  "effect_id": "effect_123",
+  "idempotent": false
+}
+```
+
+- `effect_kind` is a descriptive category. Common values include `model_call`, `tool_call`, `api_call`, and `custom`.
+- `has_external_side_effect` should be `false` for read-only or observational effects and `true` when the action can mutate external state.
+- `effect_id` is optional. When omitted, the server may derive it.
+- `idempotent` and `idempotency_key` are effect semantics in the payload, not ingest-level deduplication keys.
+
+Implicit Python SDK examples:
+
+```python
+with span("draft_reply", kind="llm") as s:
+    s.set_llm_response(
+        model="gpt-4.1-mini",
+        messages=[{"role": "user", "content": "Summarize this ticket"}],
+        response={"role": "assistant", "content": "Summary"},
+        tokens_in=120,
+        tokens_out=48,
+    )
+```
+
+```python
+with span("lookup_weather", kind="tool") as s:
+    s.set_tool_call(
+        "weather_api",
+        {"city": "Berlin"},
+        {"temperature_c": 18},
+        has_external_side_effect=False,
+    )
+```
+
+Explicit Python SDK example:
+
+```python
+with span("sync_billing") as s:
+    s.effect(
+        "api_call",
+        has_external_side_effect=True,
+        effect_id="billing-sync-42",
+        payload={"target": "billing"},
+    )
+```
+
+### `wait`
+
+Use `wait` when the interesting debugging fact is that execution paused pending some later resolution.
+
+Recommended payload shape:
+
+```json
+{
+  "wait_kind": "human_approval",
+  "phase": "entered",
+  "wait_id": "wait_123"
+}
+```
+
+- `wait_kind` is the category of dependency. Common values include `human_approval`, `external`, `timer`, and `custom`.
+- `phase` describes the lifecycle point. Common values include `entered` and `resolved`.
+- `resolution` is optional and useful when the wait is resolved with a meaningful outcome such as `approved`, `rejected`, or `elapsed`.
+- `wait_id` is optional. When omitted, the server may derive it.
+
+Python SDK examples:
+
+```python
+with span("review_order") as s:
+    s.wait("human_approval", phase="entered", payload={"reviewer": "ops"})
+```
+
+```python
+with span("review_order") as s:
+    s.wait(
+        "human_approval",
+        phase="resolved",
+        wait_id="approval-42",
+        resolution="approved",
+    )
+```
+
 ## Quick Heuristics
 
 - If you want the debugger to show `old → new`, emit `state_change`.
 - If you want the debugger to show `question → chosen`, emit `decision`.
+- If you want the debugger to show "this span called out to something important", emit `effect`.
+- If you want the debugger to show "this span had to wait", emit `wait`.
 - If you only need a human-readable sentence, emit `message`.
 - If you need a free-form payload with no special UI, emit `custom`.

--- a/openspec/changes/add-python-sdk-effect-wait-emission/design.md
+++ b/openspec/changes/add-python-sdk-effect-wait-emission/design.md
@@ -1,0 +1,76 @@
+## Context
+
+Phase 1 (`add-effect-wait-semantic-foundation`) established server-side acceptance and deterministic semantic ID derivation for `effect` and `wait` events. The derivation function reads `event_ts` and `sequence` from `EventInput` when present, falling back to payload hashing when absent.
+
+This phase adds the Python SDK surface: explicit helpers, implicit emission from existing setters, and per-span event metadata (`event_ts`, `sequence`) that improves derivation determinism and ordering fidelity.
+
+The SDK is the only system touched. No backend, frontend, migration, or TypeScript SDK changes are included.
+
+## Goals / Non-Goals
+
+- **Goals:**
+  - Emit `event_ts` and `sequence` on every explicit SDK event so server-side semantic ID derivation has stable inputs
+  - Provide `span.effect()` and `span.wait()` helpers with documented vocabulary and reserved-field merge
+  - Extend `set_llm_response()` and `set_tool_call()` with implicit, at-most-once effect emission
+  - Maintain full backward compatibility for existing SDK callers
+  - Thread-safe sequence assignment without serializing event construction or enqueue
+
+- **Non-Goals:**
+  - Client-side derivation of `effect_id` or `wait_id` (server derives these)
+  - Full SpanContext thread safety for general span mutation
+  - Context-manager API for wait enter/resolve lifecycle
+  - Dedicated `message()` or `custom()` helpers
+  - Backend, UI, or TypeScript SDK changes
+
+## Decisions
+
+### D1: Per-span monotonic sequence counter with int32 bound
+
+**Decision:** Use a single per-span counter initialized to 0, pre-incremented on each emission so the first event receives sequence 1. Shared across all event types emitted through `_record_event()`. Raise `OverflowError` at 2,147,483,647.
+
+**Alternatives considered:**
+- Per-event-type counters: rejected because server derivation uses a single `sequence` field and expects monotonic ordering across all events within a span.
+- Unbounded counter: rejected because `sequence` is stored as int32 server-side. Silent wrap would corrupt ordering and semantic ID derivation.
+- Saturate at max: rejected because saturation causes duplicate sequences, which corrupts semantic ID uniqueness.
+
+### D2: Narrow lock scope in _record_event()
+
+**Decision:** `_event_lock` protects only: (1) incrementing the sequence counter, (2) enforcing the int32 upper bound, (3) capturing the timestamp string. The lock is released before building the event dict and before calling `client.add_event()`.
+
+**Rationale:** The enqueue path (`BatchQueue.add_event`) already holds its own lock. Holding `_event_lock` through enqueue would serialize all event emission per span, which is unnecessary. Out-of-order enqueue is acceptable because the `sequence` and `event_ts` fields carry the ordering truth.
+
+**Trade-off:** Events may arrive at the batch queue out of sequence order. This is documented as intentional — the server uses `sequence` for ordering, not arrival order.
+
+### D3: Early returns before lock acquisition
+
+**Decision:** `_record_event()` checks `self.trace_id is None` and `_get_client_if_initialized() is None` before acquiring `_event_lock`. Disabled tracing does not consume sequence numbers or timestamps.
+
+**Rationale:** Consuming sequence numbers during no-op paths would create gaps that are confusing to debug and would shift deterministic derivation inputs when tracing is conditionally enabled.
+
+### D4: Implicit emission flags are independent per setter
+
+**Decision:** `_implicit_llm_effect_emitted` and `_implicit_tool_effect_emitted` are separate boolean flags. Each setter's implicit emission is at-most-once and independent of the other. Explicit `span.effect()` / `span.wait()` calls never read or write these flags.
+
+**Rationale:** A developer may call `set_llm_response()` and `set_tool_call()` on the same span (e.g., an LLM span that also invokes a tool). Each should produce its own implicit effect. The `emit_effect=False` parameter suppresses the implicit event without consuming the flag, so a subsequent call with the default `emit_effect=True` can still emit.
+
+### D5: Reserved-field merge — helper args win
+
+**Decision:** `effect()` and `wait()` start from a shallow copy of the caller's `payload` dict, then write helper-owned fields last. Helper-owned keys whose value is `None` are omitted; `False` is preserved.
+
+**Rationale:** Ensures the semantic structure of effect/wait payloads is always correct regardless of what the caller passes in `payload`. Shallow copy prevents mutation of the caller's dict. Omitting `None` keys keeps payloads clean while preserving semantically meaningful `False` values (e.g., `has_external_side_effect=False`).
+
+### D6: No runtime validation of kind/phase vocabulary, but reject empty strings
+
+**Decision:** The helpers accept any non-empty string for `kind` and `phase`. Empty strings raise `ValueError`. Preferred vocabularies (`model_call`, `tool_call`, `api_call`, `custom` for effects; `human_approval`, `external`, `timer`, `custom` for waits; `entered`, `resolved` for phases) are documented but not enforced.
+
+**Rationale:** Forward compatibility. New kinds and phases can be introduced without SDK updates. Runtime validation would force SDK releases for vocabulary expansion. Empty-string rejection is a minimal guard that prevents silent emission of semantically invalid events — a developer passing `""` is almost certainly a bug, not an intentional forward-compatible kind.
+
+## Risks / Trade-offs
+
+- **Out-of-order enqueue under concurrency:** Mitigated by `sequence` and `event_ts` carrying ordering truth. Documented as intentional.
+- **OverflowError on extreme sequence values:** Intentional fail-loud. A span emitting 2B+ events indicates a bug, not a legitimate workload.
+- **No client-side ID derivation:** Relies on Phase 1 server derivation. If the server is unavailable or buggy, IDs won't be derived. Acceptable for v1 — server is the single source of truth for semantic IDs.
+
+## Open Questions
+
+None — all QA feedback from the planning phase has been addressed in this design.

--- a/openspec/changes/add-python-sdk-effect-wait-emission/proposal.md
+++ b/openspec/changes/add-python-sdk-effect-wait-emission/proposal.md
@@ -1,0 +1,41 @@
+# Change: Add Python SDK Effect/Wait Emission
+
+## Why
+
+Phase 1 (`add-effect-wait-semantic-foundation`) added wire-level acceptance of `effect` and `wait` event types with deterministic semantic ID derivation on the server. The SDK internals already support emitting arbitrary event types through the private `_record_event()` method, but there is no public ergonomic API for `effect` or `wait`, no implicit emission from existing span setters, and no client-side `event_ts` or `sequence` metadata. Developers have no supported way to emit effect/wait events and cannot rely on ordering guarantees for semantic ID derivation.
+
+This phase adds the SDK-side ergonomics: explicit `span.effect()` and `span.wait()` helpers, implicit effect emission from `set_llm_response()` and `set_tool_call()`, and per-span monotonic sequencing with RFC 3339 timestamps on all explicit events. Together these make the Phase 1 backend foundation usable from Python without manual payload construction.
+
+## What Changes
+
+### SDK event metadata (cross-cutting)
+- `_record_event()` emits top-level `event_ts` (RFC 3339 UTC with Z suffix) and `sequence` (per-span monotonic int32) on every explicit event
+- Thread-safe sequence assignment via `_event_lock` scoped narrowly to counter increment + timestamp capture
+- Defensive OverflowError at int32 boundary (2,147,483,647)
+- Early returns (no trace_id, no client) execute before lock acquisition and do not consume sequence numbers
+
+### Implicit effect emission from existing helpers
+- `set_llm_response()` gains `emit_effect: bool = True` keyword-only parameter; emits one `effect` event with `effect_kind: "model_call"` at most once per span
+- `set_tool_call()` gains `has_external_side_effect: bool = True` and `emit_effect: bool = True` keyword-only parameters; emits one `effect` event with `effect_kind: "tool_call"` at most once per span
+- All new parameters are keyword-only; existing positional callers remain valid
+
+### New explicit helpers
+- `span.effect(kind, *, has_external_side_effect, ...)` — emits `event_type="effect"` with reserved-field merge semantics
+- `span.wait(kind, *, phase, ...)` — emits `event_type="wait"` with reserved-field merge semantics
+- No vocabulary validation beyond rejecting empty strings; preferred vocabularies are documented only
+
+### Documentation
+- Expand `docs/event-conventions.md` to cover all 10 explicit platform event types including effect and wait
+- Add examples for implicit and explicit emission patterns
+
+## Impact
+- Affected specs: `sdk-event-metadata` (new), `python-sdk-effect-wait` (new), `event-conventions` (modified — extends existing doc requirement from `add-debugger-semantics-polish`)
+- Affected code:
+  - `sdks/python/src/continua/span.py` — new helpers, extended setters, `_record_event()` metadata, lock, counter
+  - `sdks/python/tests/test_span.py` — new unit tests for effect/wait/implicit/sequencing/concurrency/empty-string
+  - `sdks/python/tests/test_errors.py` — updated existing setter/helper assertions (`set_llm_response`, `set_tool_call`, `log`, `error`, `exception`, `metric`) to verify event_ts/sequence fields
+  - `sdks/python/tests/test_integration.py` — new live-server integration tests (sync mode) for effect/wait timeline round-trip
+  - `docs/event-conventions.md` — expanded from 8 to 10 event types with implicit/explicit examples
+- No backend, migration, UI, TypeScript SDK, or engine changes
+- No OpenAPI or codegen changes
+- Backward-compatible: all new parameters are keyword-only additions

--- a/openspec/changes/add-python-sdk-effect-wait-emission/specs/event-conventions/spec.md
+++ b/openspec/changes/add-python-sdk-effect-wait-emission/specs/event-conventions/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Event Convention Documentation
+
+A `docs/event-conventions.md` document SHALL provide usage-oriented guidance for all supported event types. The document SHALL include a reference table of all 10 explicit event types (`log`, `error`, `exception`, `message`, `metric`, `custom`, `state_change`, `decision`, `effect`, `wait`) with expected payload fields and default levels. The document SHALL guide developers on when to use each event type — including when to use `effect` (external side effects and model calls) and `wait` (human approval, external dependencies, timers). SDK usage examples SHALL demonstrate real-world patterns including implicit effect emission via `set_llm_response()` and `set_tool_call()`, and explicit wait enter/resolve patterns via `span.wait()`. The document SHALL state that `message` and `custom` remain supported event types without dedicated Python helpers in this phase. The document SHALL explicitly state: "These are debugger semantics, not replay primitives."
+
+#### Scenario: Usage guidance for event type selection
+- **WHEN** a developer reads `docs/event-conventions.md`
+- **THEN** they understand when to use `state_change` (observable state transitions), `decision` (branch points with reasoning), `effect` (external side effects), `wait` (blocking on external resolution), and `custom` (everything else)
+
+#### Scenario: SDK usage examples
+- **WHEN** a developer reads the state_change section
+- **THEN** they find Python SDK examples showing `span.state_change()` in a realistic context
+
+#### Scenario: Scope guard present
+- **WHEN** a developer reads the document
+- **THEN** they find a clear statement that these are debugger/observability semantics and not replay or state-machine primitives
+
+#### Scenario: All 10 event types documented
+- **WHEN** a developer reads `docs/event-conventions.md`
+- **THEN** they find a reference entry for each of the 10 explicit event types with expected payload fields
+
+#### Scenario: Implicit effect examples present
+- **WHEN** a developer reads the effect section
+- **THEN** they find Python SDK examples showing implicit emission via `set_llm_response()` and `set_tool_call()`
+
+#### Scenario: Wait examples present
+- **WHEN** a developer reads the wait section
+- **THEN** they find Python SDK examples showing `span.wait()` with enter/resolve patterns
+
+#### Scenario: Undocumented helper types acknowledged
+- **WHEN** a developer reads the document
+- **THEN** they find a statement that `message` and `custom` event types are supported but have no dedicated Python SDK helper in this phase

--- a/openspec/changes/add-python-sdk-effect-wait-emission/specs/python-sdk-effect-wait/spec.md
+++ b/openspec/changes/add-python-sdk-effect-wait-emission/specs/python-sdk-effect-wait/spec.md
@@ -1,0 +1,257 @@
+## ADDED Requirements
+
+### Requirement: Explicit Effect Helper
+
+The Python SDK `SpanContext` class SHALL provide an `effect()` method with the following signature:
+
+```python
+def effect(
+    self,
+    kind: str,
+    *,
+    has_external_side_effect: bool,
+    effect_id: str | None = None,
+    idempotent: bool | None = None,
+    idempotency_key: str | None = None,
+    message: str | None = None,
+    payload: dict[str, Any] | None = None,
+    level: str = "info",
+) -> None
+```
+
+The method SHALL emit an event with `event_type="effect"` via `_record_event()`.
+
+The `idempotent` and `idempotency_key` parameters are payload-level semantic metadata for the effect, not event-level deduplication fields:
+- `idempotent` (bool): whether replaying or retrying this effect is safe in principle (e.g., a read-only API call is idempotent; sending an email is not).
+- `idempotency_key` (str): the concrete business key or operation identifier that makes retries safe (e.g., a payment transaction ID). Meaningful only when `idempotent` is `True`.
+
+Neither field SHALL be confused with the event-level `idempotency_key` in the ingest contract, which is a top-level batch deduplication mechanism. The helper writes both fields into the event payload dict only; it does not set any top-level event dedup key.
+
+The default message SHALL be `"Effect: <kind>"` with underscores in `kind` normalized to spaces (e.g., `"model_call"` becomes `"Effect: model call"`).
+
+The method SHALL NOT modify any span fields (name, model, input, output, metadata).
+
+#### Scenario: Basic effect emission
+- **WHEN** `span.effect("api_call", has_external_side_effect=True)` is called
+- **THEN** an event is emitted with `event_type="effect"`, `level="info"`, `message="Effect: api call"`, and payload containing `{"effect_kind": "api_call", "has_external_side_effect": True}`
+
+#### Scenario: Effect with caller-supplied payload
+- **WHEN** `span.effect("api_call", has_external_side_effect=True, payload={"url": "https://example.com"})` is called
+- **THEN** the payload SHALL contain `{"url": "https://example.com", "effect_kind": "api_call", "has_external_side_effect": True}`
+
+#### Scenario: Effect with custom message
+- **WHEN** `span.effect("api_call", has_external_side_effect=True, message="Called weather API")` is called
+- **THEN** the event message SHALL be `"Called weather API"`
+
+#### Scenario: Caller-supplied effect_id round-trips
+- **WHEN** `span.effect("api_call", has_external_side_effect=True, effect_id="my-effect-1")` is called
+- **THEN** the payload SHALL contain `"effect_id": "my-effect-1"`
+
+#### Scenario: Empty-string effect_id is treated as absent
+- **WHEN** `span.effect("api_call", has_external_side_effect=True, effect_id="")` is called
+- **THEN** the payload SHALL NOT contain the key `effect_id`
+- **AND** the server SHALL derive the `effect_id` as if the caller omitted it
+
+#### Scenario: None-valued optional fields are omitted from payload
+- **WHEN** `span.effect("api_call", has_external_side_effect=True)` is called without `effect_id`, `idempotent`, or `idempotency_key`
+- **THEN** the payload SHALL NOT contain keys `effect_id`, `idempotent`, or `idempotency_key`
+
+#### Scenario: Empty-string kind is rejected
+- **WHEN** `span.effect("", has_external_side_effect=True)` is called
+- **THEN** a `ValueError` SHALL be raised with a message indicating that `kind` must be a non-empty string
+
+#### Scenario: False-valued fields are preserved in payload
+- **WHEN** `span.effect("api_call", has_external_side_effect=False, idempotent=False)` is called
+- **THEN** the payload SHALL contain `"has_external_side_effect": False` and `"idempotent": False`
+
+---
+
+### Requirement: Explicit Wait Helper
+
+The Python SDK `SpanContext` class SHALL provide a `wait()` method with the following signature:
+
+```python
+def wait(
+    self,
+    kind: str,
+    *,
+    phase: str,
+    resolution: str | None = None,
+    wait_id: str | None = None,
+    message: str | None = None,
+    payload: dict[str, Any] | None = None,
+    level: str = "info",
+) -> None
+```
+
+The method SHALL emit an event with `event_type="wait"` via `_record_event()`.
+
+The default message SHALL be `"<Phase> wait: <kind>"` with underscores in both `phase` and `kind` normalized to spaces and `phase` capitalized (e.g., `phase="entered"`, `kind="human_approval"` becomes `"Entered wait: human approval"`).
+
+The method SHALL NOT modify any span fields (name, model, input, output, metadata).
+
+#### Scenario: Basic wait emission
+- **WHEN** `span.wait("human_approval", phase="entered")` is called
+- **THEN** an event is emitted with `event_type="wait"`, `level="info"`, `message="Entered wait: human approval"`, and payload containing `{"wait_kind": "human_approval", "phase": "entered"}`
+
+#### Scenario: Wait with resolution
+- **WHEN** `span.wait("human_approval", phase="resolved", resolution="approved")` is called
+- **THEN** the payload SHALL contain `{"wait_kind": "human_approval", "phase": "resolved", "resolution": "approved"}`
+- **AND** the message SHALL be `"Resolved wait: human approval"`
+
+#### Scenario: Wait with caller-supplied payload
+- **WHEN** `span.wait("external", phase="entered", payload={"service": "stripe"})` is called
+- **THEN** the payload SHALL contain `{"service": "stripe", "wait_kind": "external", "phase": "entered"}`
+
+#### Scenario: Caller-supplied wait_id round-trips
+- **WHEN** `span.wait("human_approval", phase="entered", wait_id="wait-abc")` is called
+- **THEN** the payload SHALL contain `"wait_id": "wait-abc"`
+
+#### Scenario: Empty-string wait_id is treated as absent
+- **WHEN** `span.wait("human_approval", phase="entered", wait_id="")` is called
+- **THEN** the payload SHALL NOT contain the key `wait_id`
+
+#### Scenario: None-valued optional fields omitted
+- **WHEN** `span.wait("timer", phase="entered")` is called without `resolution` or `wait_id`
+- **THEN** the payload SHALL NOT contain keys `resolution` or `wait_id`
+
+#### Scenario: Empty-string kind is rejected
+- **WHEN** `span.wait("", phase="entered")` is called
+- **THEN** a `ValueError` SHALL be raised with a message indicating that `kind` must be a non-empty string
+
+#### Scenario: Empty-string phase is rejected
+- **WHEN** `span.wait("human_approval", phase="")` is called
+- **THEN** a `ValueError` SHALL be raised with a message indicating that `phase` must be a non-empty string
+
+---
+
+### Requirement: Reserved-Field Merge Semantics
+
+The `effect()` and `wait()` helpers SHALL merge caller-supplied `payload` with helper-owned reserved fields using the following rule:
+
+1. Start from a shallow copy of the caller's `payload` dict (or empty dict if `None`)
+2. Write helper-owned fields last, so helper arguments always win over caller payload keys
+3. Omit helper-owned keys whose value is `None`; preserve `False`
+4. Treat empty-string (`""`) values for string ID fields (`effect_id`, `wait_id`, `idempotency_key`) as absent and omit them. This matches the server's behavior where empty-string `effect_id`/`wait_id` triggers derivation as if the field were absent, and avoids emitting semantically meaningless empty keys
+
+Effect helper-owned fields: `effect_kind`, `has_external_side_effect`, `effect_id`, `idempotent`, `idempotency_key`.
+
+Wait helper-owned fields: `wait_kind`, `phase`, `wait_id`, `resolution`.
+
+#### Scenario: Helper args override conflicting caller payload keys
+- **WHEN** `span.effect("api_call", has_external_side_effect=True, payload={"effect_kind": "wrong"})` is called
+- **THEN** the payload SHALL contain `"effect_kind": "api_call"` (helper wins)
+
+#### Scenario: Caller payload dict is not mutated
+- **WHEN** a caller passes `payload = {"key": "value"}` to `span.effect()`
+- **THEN** the original dict object SHALL NOT be modified after the call
+
+---
+
+### Requirement: Implicit LLM Effect Emission
+
+The `set_llm_response()` method SHALL accept an additional keyword-only parameter `emit_effect: bool = True`.
+
+When `emit_effect` is `True` and the implicit LLM effect has not already been emitted for this span, the method SHALL emit one event with:
+- `event_type="effect"`, `level="info"`
+- `message="Model call: <model>"` (using the `model` argument)
+- payload: `{"effect_kind": "model_call", "has_external_side_effect": False}`
+
+The implicit emission SHALL occur at most once per span, tracked by an `_implicit_llm_effect_emitted` flag.
+
+When `emit_effect` is `False`, the implicit event SHALL be suppressed and the flag SHALL NOT be consumed (a subsequent call with `emit_effect=True` can still emit).
+
+The method SHALL continue to perform all existing span mutations (model, input, output, tokens, provider, cost) exactly as before, regardless of `emit_effect`.
+
+#### Scenario: First set_llm_response emits implicit effect
+- **WHEN** `span.set_llm_response("gpt-4", messages, response, 100, 50)` is called for the first time on a span
+- **THEN** the span fields SHALL be set as before (model, input, output, tokens)
+- **AND** one event SHALL be emitted with `event_type="effect"` and `effect_kind="model_call"`
+
+#### Scenario: Repeated set_llm_response does not duplicate effect
+- **WHEN** `span.set_llm_response(...)` is called twice on the same span
+- **THEN** only one implicit effect event SHALL be emitted (from the first call)
+
+#### Scenario: emit_effect=False suppresses without consuming flag
+- **WHEN** `span.set_llm_response("gpt-4", m, r, 100, 50, emit_effect=False)` is called
+- **THEN** no implicit effect event SHALL be emitted
+- **AND** a subsequent call with `emit_effect=True` SHALL still emit the implicit effect
+
+#### Scenario: Existing callers remain valid
+- **WHEN** `span.set_llm_response("gpt-4", messages, response, 100, 50)` is called with only positional and existing keyword arguments
+- **THEN** the call SHALL succeed without errors (backward compatible)
+
+---
+
+### Requirement: Implicit Tool Effect Emission
+
+The `set_tool_call()` method SHALL accept two additional keyword-only parameters: `has_external_side_effect: bool = True` and `emit_effect: bool = True`.
+
+When `emit_effect` is `True` and the implicit tool effect has not already been emitted for this span, the method SHALL emit one event with:
+- `event_type="effect"`, `level="info"`
+- `message="Tool call: <tool_name>"` (using the `tool_name` argument)
+- payload: `{"effect_kind": "tool_call", "has_external_side_effect": <flag>}`
+
+The implicit emission SHALL occur at most once per span, tracked by an `_implicit_tool_effect_emitted` flag.
+
+When `emit_effect` is `False`, the implicit event SHALL be suppressed and the flag SHALL NOT be consumed.
+
+The method SHALL continue to perform all existing span mutations (name, input, output) exactly as before.
+
+#### Scenario: First set_tool_call emits implicit effect
+- **WHEN** `span.set_tool_call("search", {"q": "test"}, {"results": []})` is called for the first time on a span
+- **THEN** the span fields SHALL be set as before (name, input, output)
+- **AND** one event SHALL be emitted with `event_type="effect"`, `effect_kind="tool_call"`, and `has_external_side_effect=True`
+
+#### Scenario: Override has_external_side_effect
+- **WHEN** `span.set_tool_call("cache_lookup", args, result, has_external_side_effect=False)` is called
+- **THEN** the effect payload SHALL contain `"has_external_side_effect": False`
+
+#### Scenario: Repeated set_tool_call does not duplicate effect
+- **WHEN** `span.set_tool_call(...)` is called twice on the same span
+- **THEN** only one implicit effect event SHALL be emitted (from the first call)
+
+#### Scenario: emit_effect=False suppresses without consuming flag
+- **WHEN** `span.set_tool_call("search", args, result, emit_effect=False)` is called
+- **THEN** no implicit effect event SHALL be emitted
+- **AND** a subsequent call with `emit_effect=True` SHALL still emit the implicit effect
+
+#### Scenario: Existing callers remain valid
+- **WHEN** `span.set_tool_call("search", {"q": "test"}, {"results": []})` is called with the original 3 positional arguments
+- **THEN** the call SHALL succeed without errors (backward compatible)
+
+---
+
+### Requirement: Explicit Helpers Independent of Implicit Flags
+
+Explicit `span.effect()` and `span.wait()` calls SHALL NOT read, write, or be blocked by the implicit emission flags (`_implicit_llm_effect_emitted`, `_implicit_tool_effect_emitted`).
+
+#### Scenario: Explicit effect after implicit suppression
+- **WHEN** `span.set_llm_response("gpt-4", m, r, 100, 50, emit_effect=False)` is called
+- **AND** then `span.effect("model_call", has_external_side_effect=False)` is called
+- **THEN** the explicit effect event SHALL be emitted successfully
+
+#### Scenario: Explicit effect does not block later implicit emission
+- **WHEN** `span.effect("model_call", has_external_side_effect=False)` is called
+- **AND** then `span.set_llm_response("gpt-4", m, r, 100, 50)` is called for the first time
+- **THEN** both the explicit effect and the implicit effect SHALL be emitted (two events total)
+
+---
+
+### Requirement: Quiet No-Op When Tracing Is Inactive
+
+The `effect()`, `wait()`, and the implicit effect emission from `set_llm_response()` and `set_tool_call()` SHALL be quiet no-ops when tracing is inactive. This preserves the repo-wide SDK convention where helper calls silently skip when there is no active trace context or no initialized client.
+
+#### Scenario: effect() with no trace context
+- **WHEN** `span.effect("api_call", has_external_side_effect=True)` is called on a span with `trace_id = None`
+- **THEN** no event SHALL be emitted and no error SHALL be raised
+
+#### Scenario: wait() with no initialized client
+- **WHEN** `span.wait("human_approval", phase="entered")` is called and no client is initialized
+- **THEN** no event SHALL be emitted and no error SHALL be raised
+
+#### Scenario: Implicit effect with no trace context
+- **WHEN** `span.set_llm_response("gpt-4", m, r, 100, 50)` is called on a span with `trace_id = None`
+- **THEN** the span fields SHALL still be mutated as normal
+- **AND** no implicit effect event SHALL be emitted and no error SHALL be raised
+

--- a/openspec/changes/add-python-sdk-effect-wait-emission/specs/sdk-event-metadata/spec.md
+++ b/openspec/changes/add-python-sdk-effect-wait-emission/specs/sdk-event-metadata/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Per-Span Monotonic Sequence Counter
+
+The Python SDK `_record_event()` method SHALL assign a monotonically increasing `sequence` integer to every explicit event emitted through the method. The counter SHALL be per-span, starting at 1, and shared across all explicit event types (`log`, `error`, `exception`, `metric`, `state_change`, `decision`, `effect`, `wait`, `message`, `custom`).
+
+The `sequence` value SHALL be serialized as a top-level integer sibling of `trace_id`, `span_id`, `event_type`, `level`, `message`, and `payload` in the event dict passed to `client.add_event()`.
+
+#### Scenario: Sequential events receive increasing sequence values
+- **WHEN** a span emits three explicit events via `log()`, `metric()`, and `state_change()` in order
+- **THEN** the events SHALL have `sequence` values 1, 2, and 3 respectively
+
+#### Scenario: Sequence counter is per-span
+- **WHEN** two spans each emit two events
+- **THEN** each span's events SHALL have sequence values 1 and 2 independently
+
+#### Scenario: All explicit event types share one counter
+- **WHEN** a span emits a `log` event (sequence 1) then an `effect` event
+- **THEN** the `effect` event SHALL have sequence 2, not sequence 1
+
+---
+
+### Requirement: Int32 Overflow Guard
+
+The per-span sequence counter SHALL raise `OverflowError` if the next sequence value would exceed 2,147,483,647 (int32 maximum).
+
+This is intentional fail-loud behavior. Silent wrap or saturation would corrupt ordering semantics and semantic ID derivation inputs.
+
+#### Scenario: OverflowError at int32 boundary
+- **WHEN** the per-span sequence counter is at 2,147,483,647 and another event is emitted
+- **THEN** `_record_event()` SHALL raise `OverflowError`
+
+#### Scenario: Normal operation below boundary
+- **WHEN** the per-span sequence counter is at 2,147,483,646 and another event is emitted
+- **THEN** the event SHALL receive sequence 2,147,483,647 without error
+
+---
+
+### Requirement: RFC 3339 UTC Timestamp on Explicit Events
+
+The Python SDK `_record_event()` method SHALL include a top-level `event_ts` string on every explicit event. The timestamp SHALL be formatted as RFC 3339 UTC with `Z` suffix and microsecond precision (e.g., `2026-03-23T12:00:00.000000Z`).
+
+The `event_ts` SHALL be captured inside `_event_lock` alongside the sequence increment to ensure monotonic timestamp-sequence pairs under concurrent emission.
+
+#### Scenario: Event includes event_ts
+- **WHEN** any explicit event is emitted via `_record_event()`
+- **THEN** the event dict SHALL contain an `event_ts` key matching the pattern `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z`
+
+#### Scenario: Timestamp is UTC
+- **WHEN** an event is emitted
+- **THEN** `event_ts` SHALL end with `Z` (not `+00:00`)
+
+---
+
+### Requirement: Thread-Safe Sequence Assignment
+
+The Python SDK SHALL use a per-span `_event_lock` (threading.Lock) to protect sequence counter increment, int32 bound enforcement, and timestamp capture. The lock SHALL be released before building the event dict and before calling `client.add_event()`.
+
+#### Scenario: Concurrent event emission produces duplicate-free contiguous sequences
+- **WHEN** N threads each emit one event on the same span concurrently
+- **THEN** the N assigned sequence values SHALL form a duplicate-free contiguous set (e.g., {1, 2, ..., N})
+- **AND** ordering correctness SHALL be determined by sorting on `sequence` and `event_ts` after collection, not by observation order in the queue or test harness
+
+#### Scenario: Lock does not serialize enqueue
+- **WHEN** multiple threads emit events concurrently on the same span
+- **THEN** the events MAY arrive at the batch queue out of sequence order
+- **AND** this is acceptable because the `sequence` field carries ordering truth independent of enqueue order
+
+---
+
+### Requirement: Early Returns Do Not Consume Sequence Numbers
+
+The `_record_event()` method SHALL perform its existing early-return checks (`trace_id is None`, client not initialized) before acquiring `_event_lock`. Disabled tracing SHALL NOT increment the sequence counter or capture a timestamp.
+
+#### Scenario: No trace_id does not consume sequence
+- **WHEN** `_record_event()` is called on a span with `trace_id = None`
+- **THEN** the sequence counter SHALL NOT be incremented
+- **AND** no timestamp SHALL be captured
+
+#### Scenario: No client does not consume sequence
+- **WHEN** `_record_event()` is called and no client is initialized
+- **THEN** the sequence counter SHALL NOT be incremented

--- a/openspec/changes/add-python-sdk-effect-wait-emission/tasks.md
+++ b/openspec/changes/add-python-sdk-effect-wait-emission/tasks.md
@@ -1,0 +1,39 @@
+## 1. Event Metadata Foundation
+- [x] 1.1 Add `_event_seq` counter (int, initialized to 0, pre-incremented to 1 on first emission) and `_event_lock` (threading.Lock) to `SpanContext.__init__`
+- [x] 1.2 Update `_record_event()`: early returns before lock; acquire lock to pre-increment counter, enforce int32 bound, capture `event_ts`; release lock; add `sequence` and `event_ts` to event dict
+- [x] 1.3 Add unit tests: sequential events get increasing sequence starting at 1; per-span independence; OverflowError at int32 boundary; early-return path does not consume sequence
+- [x] 1.4 Add targeted concurrency test: spawn N threads each emitting one event on the same span, collect all sequence values, assert they form a duplicate-free contiguous set {1..N} (verify by sorting after collection, not by observation order)
+- [x] 1.5 Update existing event helper tests in `test_errors.py` (set_llm_response, set_tool_call, log, error, exception, metric) and `test_span.py` (state_change, decision) to assert `event_ts` exists and matches RFC 3339 UTC Z pattern, and `sequence` exists as expected integer
+
+## 2. Implicit Effect Emission from Existing Helpers
+- [x] 2.1 Add `_implicit_llm_effect_emitted` and `_implicit_tool_effect_emitted` flags to `SpanContext.__init__`
+- [x] 2.2 Extend `set_llm_response()` with `emit_effect: bool = True` keyword-only param; emit at-most-once effect event with `effect_kind: "model_call"`
+- [x] 2.3 Extend `set_tool_call()` with `has_external_side_effect: bool = True` and `emit_effect: bool = True` keyword-only params; emit at-most-once effect event with `effect_kind: "tool_call"`
+- [x] 2.4 Add unit tests: implicit LLM effect emission, deduplication, emit_effect=False suppression without flag consumption
+- [x] 2.5 Add unit tests: implicit tool effect emission, deduplication, has_external_side_effect override, emit_effect=False suppression
+
+## 3. Explicit Effect and Wait Helpers
+- [x] 3.1 Implement `span.effect()` with reserved-field merge, underscore normalization for default message, None-omission, empty-string omission for ID fields, and `ValueError` on empty `kind`
+- [x] 3.2 Implement `span.wait()` with reserved-field merge, underscore normalization for default message, None-omission, empty-string omission for `wait_id`, and `ValueError` on empty `kind` or `phase`
+- [x] 3.3 Add unit tests: effect event type, default message, caller payload merge, reserved-field precedence, caller dict not mutated, None omission, False preservation, empty-string effect_id omitted, empty kind raises ValueError, `idempotency_key` stays payload-only (not mapped to top-level event dedup field), empty-string `idempotency_key` is omitted from payload
+- [x] 3.4 Add unit tests: wait event type, default message with phase capitalization, resolution round-trip, caller payload merge, wait_id round-trip, empty-string wait_id omitted, empty kind/phase raises ValueError
+- [x] 3.5 Add unit tests: explicit helpers independent of implicit flags (effect after emit_effect=False, explicit does not block implicit)
+- [x] 3.6 Add unit tests: quiet no-op behavior — `span.effect()` and `span.wait()` emit nothing and raise no error when `trace_id` is `None` or no client is initialized; implicit effect from `set_llm_response()` and `set_tool_call()` likewise emits nothing (while still mutating span fields) when tracing is inactive
+
+## 4. Documentation
+- [x] 4.1 Expand `docs/event-conventions.md` to cover all 10 explicit event types including effect and wait, with expected payload fields and default levels
+- [x] 4.2 Add Python SDK examples in `docs/event-conventions.md` for implicit model-call/tool-call effects via `set_llm_response()`/`set_tool_call()` and explicit wait enter/resolve patterns via `span.wait()`
+- [x] 4.3 State in `docs/event-conventions.md` that `message` and `custom` remain supported without dedicated helpers in this phase
+
+## 5. Integration Tests
+- [x] 5.1 Add live-server integration test in `sdks/python/tests/test_integration.py` using `ingest_mode="sync"`: emit LLM span with `set_llm_response()`, fetch timeline, assert effect event present with expected payload
+- [x] 5.2 Add live-server integration test using `ingest_mode="sync"`: emit tool span with `set_tool_call()`, fetch timeline, assert effect event present
+- [x] 5.3 Add live-server integration test using `ingest_mode="sync"`: emit explicit `span.wait()`, fetch timeline, assert wait event present with expected fields
+- [x] 5.4 Assert server-derived `effect_id`/`wait_id` appear when omitted by SDK; caller-provided IDs round-trip unchanged
+- [x] 5.5 Assert timeline ordering: span_started < explicit effect/wait < span_completed for each span
+- [x] 5.6 Assert event metadata round-trip from live server: fetched timeline events for effect/wait SHALL contain non-null `timestamp` (mapped from `event_ts` via `mapper.go`) parseable as RFC 3339 `date-time`, and integer `sequence` values preserving SDK-assigned ordering. Do not assert the SDK's original microsecond Z format verbatim — the server may normalize the timestamp representation
+
+## 6. Final Verification
+- [x] 6.1 Run full SDK unit test suite: `cd sdks/python && uv run pytest`
+- [x] 6.2 Run integration tests against live server with `ingest_mode="sync"`: `cd sdks/python && uv run pytest tests/test_integration.py -v`
+- [x] 6.3 Confirm no backend, UI, migration, or TypeScript SDK changes were introduced

--- a/sdks/python/src/continua/span.py
+++ b/sdks/python/src/continua/span.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import traceback
 import uuid
 from contextvars import ContextVar
@@ -17,6 +18,7 @@ _current_span: ContextVar[SpanContext | None] = ContextVar(
 )
 
 SpanKind = Literal["llm", "tool", "agent", "chain", "retrieval", "embedding", "generation", "default"]
+_MAX_EVENT_SEQUENCE = 2_147_483_647
 
 
 def get_current_span() -> SpanContext | None:
@@ -76,6 +78,10 @@ class SpanContext:
         self._completion_tokens: int | None = None
         self._total_tokens: int | None = None
         self._total_cost: float | None = None
+        self._event_seq = 0
+        self._event_lock = threading.Lock()
+        self._implicit_llm_effect_emitted = False
+        self._implicit_tool_effect_emitted = False
 
         self._token: Any = None
 
@@ -136,6 +142,7 @@ class SpanContext:
         *,
         provider: str | None = None,
         cost: float | None = None,
+        emit_effect: bool = True,
     ) -> None:
         """Set LLM call details on this span.
 
@@ -147,6 +154,8 @@ class SpanContext:
             tokens_out: Number of output/completion tokens
             provider: Optional provider name (e.g., "openai", "anthropic")
             cost: Optional cost in USD
+            emit_effect: Emit an implicit effect event the first time this
+                helper is used on the span
         """
         self._model = model
         self._provider = provider
@@ -158,12 +167,22 @@ class SpanContext:
             self._total_tokens = (tokens_in or 0) + (tokens_out or 0)
         if cost is not None:
             self._total_cost = cost
+        if emit_effect:
+            self._emit_implicit_effect(
+                flag_name="_implicit_llm_effect_emitted",
+                effect_kind="model_call",
+                has_external_side_effect=False,
+                message=f"Model call: {model}",
+            )
 
     def set_tool_call(
         self,
         tool_name: str,
         arguments: Any,
         result: Any,
+        *,
+        has_external_side_effect: bool = True,
+        emit_effect: bool = True,
     ) -> None:
         """Set tool call details on this span.
 
@@ -171,10 +190,21 @@ class SpanContext:
             tool_name: Name of the tool being called
             arguments: The tool arguments/input
             result: The tool execution result
+            has_external_side_effect: Whether the tool can mutate external
+                state
+            emit_effect: Emit an implicit effect event the first time this
+                helper is used on the span
         """
         self.name = tool_name  # Override span name with tool name
         self._input = arguments
         self._output = result
+        if emit_effect:
+            self._emit_implicit_effect(
+                flag_name="_implicit_tool_effect_emitted",
+                effect_kind="tool_call",
+                has_external_side_effect=has_external_side_effect,
+                message=f"Tool call: {tool_name}",
+            )
 
     def log(
         self,
@@ -348,6 +378,72 @@ class SpanContext:
             payload=payload,
         )
 
+    def effect(
+        self,
+        kind: str,
+        *,
+        has_external_side_effect: bool,
+        effect_id: str | None = None,
+        idempotent: bool | None = None,
+        idempotency_key: str | None = None,
+        message: str | None = None,
+        payload: dict[str, Any] | None = None,
+        level: str = "info",
+    ) -> None:
+        """Emit a structured effect event for this span."""
+        self._require_non_empty_string("kind", kind)
+        effect_payload = self._merge_reserved_payload(
+            payload,
+            reserved_fields={
+                "effect_kind": kind,
+                "has_external_side_effect": has_external_side_effect,
+                "effect_id": effect_id,
+                "idempotent": idempotent,
+                "idempotency_key": idempotency_key,
+            },
+            empty_string_keys=frozenset({"effect_id", "idempotency_key"}),
+        )
+
+        self._record_event(
+            event_type="effect",
+            level=level,
+            message=message or f"Effect: {self._normalize_event_label(kind)}",
+            payload=effect_payload,
+        )
+
+    def wait(
+        self,
+        kind: str,
+        *,
+        phase: str,
+        resolution: str | None = None,
+        wait_id: str | None = None,
+        message: str | None = None,
+        payload: dict[str, Any] | None = None,
+        level: str = "info",
+    ) -> None:
+        """Emit a structured wait event for this span."""
+        self._require_non_empty_string("kind", kind)
+        self._require_non_empty_string("phase", phase)
+        wait_payload = self._merge_reserved_payload(
+            payload,
+            reserved_fields={
+                "wait_kind": kind,
+                "phase": phase,
+                "wait_id": wait_id,
+                "resolution": resolution,
+            },
+            empty_string_keys=frozenset({"wait_id"}),
+        )
+        phase_label = self._normalize_event_label(phase).capitalize()
+
+        self._record_event(
+            event_type="wait",
+            level=level,
+            message=message or f"{phase_label} wait: {self._normalize_event_label(kind)}",
+            payload=wait_payload,
+        )
+
     def __enter__(self) -> SpanContext:
         """Enter the span context."""
         self._token = _current_span.set(self)
@@ -434,26 +530,108 @@ class SpanContext:
         level: str,
         message: str | None = None,
         payload: dict[str, Any] | None = None,
-    ) -> None:
+    ) -> bool:
         """Queue a structured event for this span."""
         if self.trace_id is None:
-            return
+            return False
 
         client = _get_client_if_initialized()
         if client is None:
-            return
+            return False
+
+        with self._event_lock:
+            if self._event_seq >= _MAX_EVENT_SEQUENCE:
+                raise OverflowError(
+                    f"event sequence exceeds int32 maximum of {_MAX_EVENT_SEQUENCE}"
+                )
+            self._event_seq += 1
+            sequence = self._event_seq
+            event_ts = self._format_event_ts(datetime.now(timezone.utc))
 
         event_data: dict[str, Any] = {
             "trace_id": self.trace_id,
             "span_id": self.span_id,
             "event_type": event_type,
             "level": level,
+            "event_ts": event_ts,
+            "sequence": sequence,
         }
         if message is not None:
             event_data["message"] = message
         if payload is not None:
             event_data["payload"] = payload
         client.add_event(event_data)
+        return True
+
+    def _emit_implicit_effect(
+        self,
+        *,
+        flag_name: str,
+        effect_kind: str,
+        has_external_side_effect: bool,
+        message: str,
+    ) -> None:
+        """Emit an implicit effect event once per helper type per span."""
+        with self._event_lock:
+            if getattr(self, flag_name):
+                return
+            setattr(self, flag_name, True)
+
+        try:
+            emitted = self._record_event(
+                event_type="effect",
+                level="info",
+                message=message,
+                payload={
+                    "effect_kind": effect_kind,
+                    "has_external_side_effect": has_external_side_effect,
+                },
+            )
+        except Exception:
+            with self._event_lock:
+                setattr(self, flag_name, False)
+            raise
+
+        if emitted:
+            return
+
+        with self._event_lock:
+            setattr(self, flag_name, False)
+
+    @staticmethod
+    def _format_event_ts(value: datetime) -> str:
+        """Format datetimes as RFC 3339 UTC strings with microsecond precision."""
+        return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace(
+            "+00:00",
+            "Z",
+        )
+
+    @staticmethod
+    def _normalize_event_label(value: str) -> str:
+        """Normalize event labels for human-readable default messages."""
+        return value.replace("_", " ")
+
+    @staticmethod
+    def _require_non_empty_string(field_name: str, value: str) -> None:
+        """Reject empty semantic identifiers while allowing new vocabularies."""
+        if value == "":
+            raise ValueError(f"{field_name} must be a non-empty string")
+
+    @staticmethod
+    def _merge_reserved_payload(
+        payload: dict[str, Any] | None,
+        *,
+        reserved_fields: dict[str, Any],
+        empty_string_keys: frozenset[str],
+    ) -> dict[str, Any]:
+        """Copy caller payload and overlay helper-owned semantic fields."""
+        merged_payload = dict(payload or {})
+        for key, value in reserved_fields.items():
+            if value is None or (key in empty_string_keys and value == ""):
+                merged_payload.pop(key, None)
+                continue
+            merged_payload[key] = value
+        return merged_payload
 
 
 def span(

--- a/sdks/python/tests/__init__.py
+++ b/sdks/python/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Python SDK test helpers package."""

--- a/sdks/python/tests/support.py
+++ b/sdks/python/tests/support.py
@@ -1,0 +1,43 @@
+"""Shared assertions for Python SDK tests."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+EVENT_TS_PATTERN = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z"
+)
+RFC3339_TIMESTAMP_PATTERN = re.compile(
+    r"^(?P<head>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})"
+    r"(?:\.(?P<fraction>\d+))?"
+    r"(?P<offset>Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def assert_event_metadata(event: dict[str, Any], *, sequence: int) -> None:
+    """Assert common explicit-event metadata fields emitted by the SDK."""
+    assert event.get("sequence") == sequence
+    event_ts = event.get("event_ts")
+    assert isinstance(event_ts, str)
+    assert EVENT_TS_PATTERN.fullmatch(event_ts) is not None
+
+
+def parse_rfc3339_timestamp(value: str) -> datetime:
+    """Parse RFC 3339 timestamps with either Z or explicit UTC offsets."""
+    match = RFC3339_TIMESTAMP_PATTERN.fullmatch(value)
+    if match is None:
+        raise ValueError(f"Invalid RFC 3339 timestamp: {value}")
+
+    fraction = match.group("fraction")
+    normalized_fraction = ""
+    if fraction is not None:
+        normalized_fraction = f".{fraction[:6].ljust(6, '0')}"
+
+    offset = match.group("offset")
+    normalized_offset = "+00:00" if offset == "Z" else offset
+
+    return datetime.fromisoformat(
+        f"{match.group('head')}{normalized_fraction}{normalized_offset}"
+    )

--- a/sdks/python/tests/test_errors.py
+++ b/sdks/python/tests/test_errors.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from tests.support import assert_event_metadata
+
 
 class TestCustomExceptions:
     """Tests for custom exception types."""
@@ -439,6 +441,52 @@ class TestSpanHelperMethods:
             assert span_data.get("total_tokens") is None
             assert span_data.get("input") == [{"role": "user", "content": "Hello"}]
             assert span_data.get("output") == {"role": "assistant", "content": "Hi there!"}
+            assert len(client._batch._events) == 1
+            event = client._batch._events[0]
+            assert_event_metadata(event, sequence=1)
+            assert event.get("event_type") == "effect"
+            assert event.get("message") == "Model call: gpt-4"
+            assert event.get("payload") == {
+                "effect_kind": "model_call",
+                "has_external_side_effect": False,
+            }
+            client.shutdown()
+
+    def test_set_llm_response_sets_optional_provider_and_cost(self):
+        """Scenario: Set optional LLM provider and cost
+        WHEN span.set_llm_response(..., provider=..., cost=...) is called
+        THEN the span stores the provider and total cost alongside the other LLM fields
+        """
+        with patch("continua.client.httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+
+            from continua import Continua, trace
+            from continua.span import span
+
+            Continua._instance = None
+            client = Continua.init(api_key="test-key", endpoint="http://localhost:8080")
+
+            @trace()
+            def my_agent():
+                with span("llm_call", kind="llm") as s:
+                    s.set_llm_response(
+                        model="gpt-4",
+                        messages=[{"role": "user", "content": "Hello"}],
+                        response={"role": "assistant", "content": "Hi there!"},
+                        tokens_in=10,
+                        tokens_out=5,
+                        provider="openai",
+                        cost=0.42,
+                    )
+
+            my_agent()
+
+            assert len(client._batch._spans) >= 1
+            span_data = client._batch._spans[-1]
+            assert span_data.get("model") == "gpt-4"
+            assert span_data.get("provider") == "openai"
+            assert span_data.get("total_cost") == 0.42
             client.shutdown()
 
     def test_set_tool_call(self):
@@ -472,6 +520,56 @@ class TestSpanHelperMethods:
             assert span_data.get("name") == "get_weather"
             assert span_data.get("input") == {"city": "New York"}
             assert span_data.get("output") == {"temperature": 72, "conditions": "sunny"}
+            assert len(client._batch._events) == 1
+            event = client._batch._events[0]
+            assert_event_metadata(event, sequence=1)
+            assert event.get("event_type") == "effect"
+            assert event.get("message") == "Tool call: get_weather"
+            assert event.get("payload") == {
+                "effect_kind": "tool_call",
+                "has_external_side_effect": True,
+            }
+            client.shutdown()
+
+    def test_set_tool_call_preserves_three_positional_arg_compatibility(self):
+        """Scenario: Existing callers pass exactly three positional arguments
+        WHEN span.set_tool_call(tool_name, arguments, result) is called positionally
+        THEN the helper still updates the span and emits the default implicit effect
+        """
+        with patch("continua.client.httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+
+            from continua import Continua, trace
+            from continua.span import span
+
+            Continua._instance = None
+            client = Continua.init(api_key="test-key", endpoint="http://localhost:8080")
+
+            @trace()
+            def my_agent():
+                with span("tool_call", kind="tool") as s:
+                    s.set_tool_call(
+                        "get_weather",
+                        {"city": "New York"},
+                        {"temperature": 72, "conditions": "sunny"},
+                    )
+
+            my_agent()
+
+            assert len(client._batch._spans) >= 1
+            span_data = client._batch._spans[-1]
+            assert span_data.get("name") == "get_weather"
+            assert span_data.get("input") == {"city": "New York"}
+            assert span_data.get("output") == {"temperature": 72, "conditions": "sunny"}
+            assert len(client._batch._events) == 1
+            event = client._batch._events[0]
+            assert_event_metadata(event, sequence=1)
+            assert event.get("message") == "Tool call: get_weather"
+            assert event.get("payload") == {
+                "effect_kind": "tool_call",
+                "has_external_side_effect": True,
+            }
             client.shutdown()
 
     def test_log_message(self):
@@ -505,10 +603,12 @@ class TestSpanHelperMethods:
             assert len(client._batch._events) == 2
 
             event1 = client._batch._events[0]
+            assert_event_metadata(event1, sequence=1)
             assert event1.get("message") == "Processing started"
             assert event1.get("level") == "info"
 
             event2 = client._batch._events[1]
+            assert_event_metadata(event2, sequence=2)
             assert event2.get("message") == "Found items"
             assert event2.get("level") == "debug"
             assert event2.get("payload") == {"count": 42, "items": ["a", "b"]}
@@ -539,6 +639,7 @@ class TestSpanHelperMethods:
             assert len(client._batch._events) == 1
 
             event = client._batch._events[0]
+            assert_event_metadata(event, sequence=1)
             assert event.get("trace_id") is not None
             assert event.get("span_id") is not None
             assert event.get("event_type") == "error"
@@ -575,6 +676,7 @@ class TestSpanHelperMethods:
             assert len(client._batch._events) == 1
 
             event = client._batch._events[0]
+            assert_event_metadata(event, sequence=1)
             payload = event.get("payload")
             assert event.get("event_type") == "exception"
             assert event.get("level") == "error"
@@ -611,6 +713,7 @@ class TestSpanHelperMethods:
             assert len(client._batch._events) == 2
 
             first_metric = client._batch._events[0]
+            assert_event_metadata(first_metric, sequence=1)
             assert first_metric.get("event_type") == "metric"
             assert first_metric.get("level") == "info"
             assert first_metric.get("payload") == {
@@ -621,6 +724,7 @@ class TestSpanHelperMethods:
             }
 
             second_metric = client._batch._events[1]
+            assert_event_metadata(second_metric, sequence=2)
             assert second_metric.get("payload") == {
                 "metric_name": "retry_count",
                 "metric_value": 3,

--- a/sdks/python/tests/test_integration.py
+++ b/sdks/python/tests/test_integration.py
@@ -15,11 +15,15 @@ from __future__ import annotations
 import os
 import time
 import uuid
+from datetime import datetime, timezone
+from typing import Any
 
 import httpx
 import pytest
 
 from continua import Continua, span, trace
+from continua.trace import TraceContext
+from tests.support import parse_rfc3339_timestamp
 
 # Server configuration
 CONTINUA_ENDPOINT = os.environ.get("CONTINUA_ENDPOINT", "http://localhost:8081")
@@ -53,13 +57,79 @@ def reset_client():
             pass
         Continua._instance = None
     yield
-    # Cleanup after test
     if Continua._instance is not None:
         try:
             Continua._instance.shutdown()
         except Exception:
             pass
         Continua._instance = None
+
+
+def api_headers() -> dict[str, str]:
+    """Build auth headers for debugger API calls."""
+    return {"X-API-Key": CONTINUA_API_KEY}
+
+
+def wait_for_trace_record(trace_name: str, timeout: float = 5.0) -> dict[str, Any]:
+    """Poll the traces list until a trace with the requested name appears."""
+    deadline = time.monotonic() + timeout
+    params = {
+        "limit": 50,
+        "offset": 0,
+        "sort_by": "started_at",
+        "sort_dir": "desc",
+    }
+
+    while True:
+        response = httpx.get(
+            f"{CONTINUA_ENDPOINT}/api/traces",
+            params=params,
+            headers=api_headers(),
+            timeout=5.0,
+        )
+        response.raise_for_status()
+        for trace_record in response.json()["traces"]:
+            if trace_record["name"] == trace_name:
+                return trace_record
+
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"Timed out waiting for trace {trace_name!r}")
+
+        time.sleep(0.1)
+
+
+def fetch_timeline(trace_db_id: str) -> dict[str, Any]:
+    """Fetch the timeline for a trace using a single large page."""
+    response = httpx.get(
+        f"{CONTINUA_ENDPOINT}/api/traces/{trace_db_id}/events",
+        params={"limit": 100},
+        headers=api_headers(),
+        timeout=5.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def explicit_events_for_span(
+    timeline_events: list[dict[str, Any]],
+    span_id: str,
+    event_type: str,
+) -> list[dict[str, Any]]:
+    """Filter explicit timeline events for a specific span and type."""
+    return [
+        event
+        for event in timeline_events
+        if event.get("span_id") == span_id
+        and event["source"] == "explicit"
+        and event["event_type"] == event_type
+    ]
+
+
+def assert_timeline_sequence(event: dict[str, Any], expected_sequence: int) -> None:
+    """Assert timeline metadata round-trips from the SDK."""
+    assert event["sequence"] == expected_sequence
+    assert event["timestamp"] is not None
+    parse_rfc3339_timestamp(event["timestamp"])
 
 
 class TestIntegration:
@@ -108,7 +178,7 @@ class TestIntegration:
             flush_interval=0.1,
         )
 
-        @trace
+        @trace()
         def my_agent():
             with span("llm_call", kind="llm") as s:
                 s.set_model("gpt-4")
@@ -134,7 +204,7 @@ class TestIntegration:
             flush_interval=0.1,
         )
 
-        @trace
+        @trace()
         def nested_agent():
             with span("outer", kind="chain") as outer:
                 outer.set_input({"step": "outer"})
@@ -210,6 +280,7 @@ class TestIntegration:
         """Test direct HTTP call to ingest endpoint."""
         batch_key = f"integration-test-{uuid.uuid4()}"
         trace_id = f"direct-trace-{uuid.uuid4()}"
+        start_time = datetime.now(timezone.utc).isoformat()
 
         payload = {
             "batch_key": batch_key,
@@ -217,6 +288,7 @@ class TestIntegration:
                 "trace_id": trace_id,
                 "name": "direct_ingest_test",
                 "status": "completed",
+                "start_time": start_time,
             }],
             "spans": [{
                 "trace_id": trace_id,
@@ -224,6 +296,7 @@ class TestIntegration:
                 "name": "direct_span",
                 "type": "llm",
                 "status": "completed",
+                "start_time": start_time,
                 "prompt_tokens": 90,
                 "completion_tokens": 60,
                 "total_cost": 0.01,
@@ -306,3 +379,165 @@ class TestIntegration:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ok"
+
+    def test_sync_llm_effect_round_trip(self):
+        """Implicit LLM effect events round-trip through the timeline API."""
+        client = Continua.init(
+            api_key=CONTINUA_API_KEY,
+            endpoint=CONTINUA_ENDPOINT,
+            batch_size=100,
+            flush_interval=60.0,
+            ingest_mode="sync",
+        )
+        trace_name = f"sdk-llm-effect-{uuid.uuid4()}"
+
+        with TraceContext(name=trace_name):
+            with span("llm_effect", kind="llm") as effect_span:
+                effect_span.set_llm_response(
+                    model="gpt-4.1-mini",
+                    messages=[{"role": "user", "content": "Hello"}],
+                    response={"role": "assistant", "content": "Hi"},
+                    tokens_in=12,
+                    tokens_out=7,
+                )
+                span_id = effect_span.span_id
+
+        client.flush()
+        trace_record = wait_for_trace_record(trace_name)
+        timeline = fetch_timeline(trace_record["id"])
+        span_events = [
+            event for event in timeline["events"] if event.get("span_id") == span_id
+        ]
+
+        assert [event["event_type"] for event in span_events] == [
+            "span_started",
+            "effect",
+            "span_completed",
+        ]
+
+        effect_events = explicit_events_for_span(timeline["events"], span_id, "effect")
+        assert len(effect_events) == 1
+
+        effect_event = effect_events[0]
+        assert_timeline_sequence(effect_event, expected_sequence=1)
+        assert effect_event["payload"]["effect_kind"] == "model_call"
+        assert effect_event["payload"]["has_external_side_effect"] is False
+        assert effect_event["payload"]["effect_id"]
+        assert effect_event["message"] == "Model call: gpt-4.1-mini"
+
+    def test_sync_tool_effect_round_trip(self):
+        """Implicit tool effects round-trip with ordering preserved."""
+        client = Continua.init(
+            api_key=CONTINUA_API_KEY,
+            endpoint=CONTINUA_ENDPOINT,
+            batch_size=100,
+            flush_interval=60.0,
+            ingest_mode="sync",
+        )
+        trace_name = f"sdk-tool-effect-{uuid.uuid4()}"
+
+        with TraceContext(name=trace_name):
+            with span("tool_effect", kind="tool") as effect_span:
+                effect_span.set_tool_call(
+                    "get_weather",
+                    {"city": "New York"},
+                    {"temperature": 72, "conditions": "sunny"},
+                    has_external_side_effect=True,
+                )
+                span_id = effect_span.span_id
+
+        client.flush()
+        trace_record = wait_for_trace_record(trace_name)
+        timeline = fetch_timeline(trace_record["id"])
+        span_events = [
+            event for event in timeline["events"] if event.get("span_id") == span_id
+        ]
+
+        assert [event["event_type"] for event in span_events] == [
+            "span_started",
+            "effect",
+            "span_completed",
+        ]
+
+        effect_events = explicit_events_for_span(timeline["events"], span_id, "effect")
+        assert len(effect_events) == 1
+
+        effect_event = effect_events[0]
+        assert_timeline_sequence(effect_event, expected_sequence=1)
+        assert effect_event["payload"]["effect_kind"] == "tool_call"
+        assert effect_event["payload"]["has_external_side_effect"] is True
+        assert effect_event["payload"]["effect_id"]
+        assert effect_event["message"] == "Tool call: get_weather"
+
+    def test_sync_explicit_wait_and_effect_round_trip(self):
+        """Explicit wait/effect helpers should preserve IDs, ordering, and metadata."""
+        client = Continua.init(
+            api_key=CONTINUA_API_KEY,
+            endpoint=CONTINUA_ENDPOINT,
+            batch_size=100,
+            flush_interval=60.0,
+            ingest_mode="sync",
+        )
+        trace_name = f"sdk-wait-effect-{uuid.uuid4()}"
+        explicit_effect_id = f"effect-{uuid.uuid4()}"
+        explicit_wait_id = f"wait-{uuid.uuid4()}"
+
+        with TraceContext(name=trace_name):
+            with span("wait_effect", kind="default") as effect_span:
+                effect_span.wait("human_approval", phase="entered")
+                effect_span.wait(
+                    "timer",
+                    phase="resolved",
+                    resolution="elapsed",
+                    wait_id=explicit_wait_id,
+                )
+                effect_span.effect(
+                    "api_call",
+                    has_external_side_effect=True,
+                    effect_id=explicit_effect_id,
+                    payload={"target": "billing"},
+                )
+                span_id = effect_span.span_id
+
+        client.flush()
+        trace_record = wait_for_trace_record(trace_name)
+        timeline = fetch_timeline(trace_record["id"])
+        span_events = [
+            event for event in timeline["events"] if event.get("span_id") == span_id
+        ]
+
+        assert [event["event_type"] for event in span_events] == [
+            "span_started",
+            "wait",
+            "wait",
+            "effect",
+            "span_completed",
+        ]
+
+        wait_events = explicit_events_for_span(timeline["events"], span_id, "wait")
+        effect_events = explicit_events_for_span(timeline["events"], span_id, "effect")
+
+        assert len(wait_events) == 2
+        assert len(effect_events) == 1
+
+        entered_wait = next(
+            event for event in wait_events if event["payload"]["phase"] == "entered"
+        )
+        resolved_wait = next(
+            event for event in wait_events if event["payload"]["phase"] == "resolved"
+        )
+        effect_event = effect_events[0]
+
+        assert_timeline_sequence(entered_wait, expected_sequence=1)
+        assert_timeline_sequence(resolved_wait, expected_sequence=2)
+        assert_timeline_sequence(effect_event, expected_sequence=3)
+
+        assert entered_wait["payload"]["wait_kind"] == "human_approval"
+        assert entered_wait["payload"]["wait_id"]
+        assert resolved_wait["payload"]["wait_kind"] == "timer"
+        assert resolved_wait["payload"]["resolution"] == "elapsed"
+        assert resolved_wait["payload"]["wait_id"] == explicit_wait_id
+
+        assert effect_event["payload"]["effect_kind"] == "api_call"
+        assert effect_event["payload"]["effect_id"] == explicit_effect_id
+        assert effect_event["payload"]["target"] == "billing"

--- a/sdks/python/tests/test_span.py
+++ b/sdks/python/tests/test_span.py
@@ -1,24 +1,116 @@
-"""Tests for span context."""
+"""Tests for span context and semantic event helpers."""
+
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+import pytest
+
+from tests.support import assert_event_metadata
 
 from continua.client import Continua
-from continua.span import SpanContext, get_current_span, span
+from continua.span import (
+    SpanContext,
+    _MAX_EVENT_SEQUENCE,
+    get_current_span,
+    span,
+)
 from continua.trace import TraceContext
 
 
 class StubClient:
     def __init__(self) -> None:
+        self._lock = threading.Lock()
         self.traces: list[dict] = []
         self.spans: list[dict] = []
         self.events: list[dict] = []
 
     def add_trace(self, trace: dict) -> None:
-        self.traces.append(trace)
+        with self._lock:
+            self.traces.append(trace)
 
-    def add_span(self, span: dict) -> None:
-        self.spans.append(span)
+    def add_span(self, span_data: dict) -> None:
+        with self._lock:
+            self.spans.append(span_data)
 
     def add_event(self, event: dict) -> None:
-        self.events.append(event)
+        with self._lock:
+            self.events.append(event)
+
+
+class SlowStubClient(StubClient):
+    def __init__(self, *, delay_s: float = 0.01) -> None:
+        super().__init__()
+        self._delay_s = delay_s
+
+    def add_event(self, event: dict) -> None:
+        time.sleep(self._delay_s)
+        super().add_event(event)
+
+
+@contextmanager
+def use_stub_client(stub_client: StubClient) -> Iterator[None]:
+    previous_client = Continua._instance
+    Continua._instance = stub_client
+    try:
+        yield
+    finally:
+        Continua._instance = previous_client
+
+
+@contextmanager
+def without_client() -> Iterator[None]:
+    previous_client = Continua._instance
+    Continua._instance = None
+    try:
+        yield
+    finally:
+        Continua._instance = previous_client
+
+
+@contextmanager
+def traced_span(
+    stub_client: StubClient,
+    *,
+    trace_name: str = "test_trace",
+    span_name: str = "test_span",
+    kind: str = "default",
+) -> Iterator[SpanContext]:
+    with use_stub_client(stub_client):
+        with TraceContext(name=trace_name):
+            with span(span_name, kind=kind) as ctx:
+                yield ctx
+
+
+def run_concurrent_workers(
+    worker_count: int,
+    action: Callable[[int], None],
+) -> list[BaseException]:
+    barrier = threading.Barrier(worker_count)
+    failures: list[BaseException] = []
+    failures_lock = threading.Lock()
+
+    def worker(index: int) -> None:
+        try:
+            barrier.wait()
+            action(index)
+        except BaseException as exc:  # pragma: no cover - only for debugging failures
+            with failures_lock:
+                failures.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, args=(index,))
+        for index in range(worker_count)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    return failures
 
 
 def test_span_context_basic():
@@ -84,12 +176,8 @@ def test_set_tokens_total_only_raises():
     """Test total-only token usage is rejected."""
     with TraceContext(name="test_trace"):
         with span("llm_call", kind="llm") as s:
-            try:
+            with pytest.raises(ValueError):
                 s.set_tokens(total=150)
-                raised = False
-            except ValueError:
-                raised = True
-    assert raised is True
 
 
 def test_span_without_trace():
@@ -107,71 +195,507 @@ def test_span_helper_function():
             assert s.metadata == {"key": "value"}
 
 
+def test_explicit_events_receive_monotonic_sequence_and_timestamps():
+    """Explicit helpers share one per-span sequence and emit event metadata."""
+    stub_client = StubClient()
+
+    with traced_span(stub_client, span_name="eventful_span") as s:
+        s.log("started")
+        s.metric("latency_ms", 42.5, "ms")
+        s.state_change("status", "pending", "approved")
+
+    assert [event["event_type"] for event in stub_client.events] == [
+        "log",
+        "metric",
+        "state_change",
+    ]
+    for sequence, event in enumerate(stub_client.events, start=1):
+        assert_event_metadata(event, sequence=sequence)
+
+
+def test_sequence_counter_is_per_span():
+    """Each span maintains its own event sequence counter."""
+    stub_client = StubClient()
+
+    with use_stub_client(stub_client):
+        with TraceContext(name="test_trace"):
+            with span("first_span") as first:
+                first.log("one")
+                first.metric("count", 1)
+            with span("second_span") as second:
+                second.log("alpha")
+                second.decision("route?", "fast")
+
+    first_sequences = [
+        event["sequence"]
+        for event in stub_client.events
+        if event["span_id"] == first.span_id
+    ]
+    second_sequences = [
+        event["sequence"]
+        for event in stub_client.events
+        if event["span_id"] == second.span_id
+    ]
+
+    assert first_sequences == [1, 2]
+    assert second_sequences == [1, 2]
+
+
+def test_sequence_overflow_raises_at_int32_boundary():
+    """Sequence assignment fails loudly when the int32 boundary is exceeded."""
+    stub_client = StubClient()
+
+    with traced_span(stub_client, span_name="overflow_span") as s:
+        s._event_seq = _MAX_EVENT_SEQUENCE - 1
+
+        s.log("last allowed event")
+        assert_event_metadata(stub_client.events[0], sequence=_MAX_EVENT_SEQUENCE)
+
+        with pytest.raises(OverflowError, match="int32 maximum"):
+            s.log("overflow")
+
+
+def test_early_return_paths_do_not_consume_sequence_numbers():
+    """No trace or no client should not increment the per-span counter."""
+    orphan = SpanContext("orphan")
+    with without_client():
+        orphan.log("ignored")
+    assert orphan._event_seq == 0
+
+    stub_client = StubClient()
+    with use_stub_client(stub_client):
+        orphan.trace_id = "trace-1"
+        orphan.log("sent")
+
+    assert orphan._event_seq == 1
+    assert_event_metadata(stub_client.events[0], sequence=1)
+
+    late_client = SpanContext("late_client")
+    late_client.trace_id = "trace-2"
+    with without_client():
+        late_client.log("ignored without client")
+    assert late_client._event_seq == 0
+
+    with use_stub_client(stub_client):
+        late_client.log("sent after client init")
+
+    assert late_client._event_seq == 1
+    assert_event_metadata(stub_client.events[1], sequence=1)
+
+
+def test_concurrent_event_emission_produces_contiguous_sequences():
+    """Concurrent emission should assign duplicate-free contiguous sequences."""
+    stub_client = StubClient()
+    worker_count = 24
+
+    with traced_span(stub_client, span_name="parallel_span") as s:
+        failures = run_concurrent_workers(
+            worker_count,
+            lambda index: s.log(f"worker-{index}"),
+        )
+
+    assert failures == []
+    sequences = sorted(event["sequence"] for event in stub_client.events)
+    assert sequences == list(range(1, worker_count + 1))
+
+
 def test_state_change_helper_records_semantic_event():
     """Test state_change helper payload construction."""
     stub_client = StubClient()
-    previous_client = Continua._instance
-    Continua._instance = stub_client
 
-    try:
-        with TraceContext(name="test_trace"):
-            with span("stateful_span") as s:
-                s.state_change(
-                    "status",
-                    "pending",
-                    "approved",
-                    namespace="order",
-                    message="Order approved",
-                )
-    finally:
-        Continua._instance = previous_client
+    with traced_span(stub_client, span_name="stateful_span") as s:
+        s.state_change(
+            "status",
+            "pending",
+            "approved",
+            namespace="order",
+            message="Order approved",
+        )
 
     assert len(stub_client.events) == 1
-    assert stub_client.events[0] == {
-        "trace_id": stub_client.traces[0]["trace_id"],
-        "span_id": stub_client.spans[0]["span_id"],
-        "event_type": "state_change",
-        "level": "info",
-        "message": "Order approved",
-        "payload": {
-            "key": "status",
-            "old_value": "pending",
-            "new_value": "approved",
-            "namespace": "order",
-        },
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["trace_id"] == s.trace_id
+    assert event["span_id"] == s.span_id
+    assert event["event_type"] == "state_change"
+    assert event["level"] == "info"
+    assert event["message"] == "Order approved"
+    assert event["payload"] == {
+        "key": "status",
+        "old_value": "pending",
+        "new_value": "approved",
+        "namespace": "order",
     }
 
 
 def test_decision_helper_records_semantic_event():
     """Test decision helper payload construction."""
     stub_client = StubClient()
-    previous_client = Continua._instance
-    Continua._instance = stub_client
 
-    try:
-        with TraceContext(name="test_trace"):
-            with span("decision_span") as s:
-                s.decision(
-                    "Which model?",
-                    "gpt-4.1",
-                    alternatives=["gpt-4o-mini", "gpt-4.1"],
-                    reasoning="Need better reasoning quality",
-                    message="Escalated to stronger model",
-                )
-    finally:
-        Continua._instance = previous_client
+    with traced_span(stub_client, span_name="decision_span") as s:
+        s.decision(
+            "Which model?",
+            "gpt-4.1",
+            alternatives=["gpt-4o-mini", "gpt-4.1"],
+            reasoning="Need better reasoning quality",
+            message="Escalated to stronger model",
+        )
 
     assert len(stub_client.events) == 1
-    assert stub_client.events[0] == {
-        "trace_id": stub_client.traces[0]["trace_id"],
-        "span_id": stub_client.spans[0]["span_id"],
-        "event_type": "decision",
-        "level": "info",
-        "message": "Escalated to stronger model",
-        "payload": {
-            "question": "Which model?",
-            "chosen": "gpt-4.1",
-            "alternatives": ["gpt-4o-mini", "gpt-4.1"],
-            "reasoning": "Need better reasoning quality",
-        },
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["trace_id"] == s.trace_id
+    assert event["span_id"] == s.span_id
+    assert event["event_type"] == "decision"
+    assert event["level"] == "info"
+    assert event["message"] == "Escalated to stronger model"
+    assert event["payload"] == {
+        "question": "Which model?",
+        "chosen": "gpt-4.1",
+        "alternatives": ["gpt-4o-mini", "gpt-4.1"],
+        "reasoning": "Need better reasoning quality",
     }
+
+
+def test_effect_helper_records_reserved_merge_semantics():
+    """Effect helper should merge payloads without mutating caller input."""
+    stub_client = StubClient()
+    caller_payload = {
+        "url": "https://example.com",
+        "effect_kind": "wrong",
+        "has_external_side_effect": True,
+        "effect_id": "caller-effect",
+        "idempotent": True,
+        "idempotency_key": "caller-key",
+    }
+    original_payload = dict(caller_payload)
+
+    with traced_span(stub_client, span_name="effect_span") as s:
+        s.effect(
+            "api_call",
+            has_external_side_effect=False,
+            effect_id=None,
+            idempotent=False,
+            idempotency_key="operation-123",
+            payload=caller_payload,
+        )
+
+    assert caller_payload == original_payload
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["event_type"] == "effect"
+    assert event["level"] == "info"
+    assert event["message"] == "Effect: api call"
+    assert "idempotency_key" not in event
+    assert event["payload"] == {
+        "url": "https://example.com",
+        "effect_kind": "api_call",
+        "has_external_side_effect": False,
+        "idempotent": False,
+        "idempotency_key": "operation-123",
+    }
+
+
+def test_effect_helper_omits_empty_string_identifiers():
+    """Empty string effect identifiers should be treated as absent."""
+    stub_client = StubClient()
+
+    with traced_span(stub_client, span_name="effect_span") as s:
+        s.effect(
+            "api_call",
+            has_external_side_effect=True,
+            effect_id="",
+            idempotency_key="",
+        )
+
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["payload"] == {
+        "effect_kind": "api_call",
+        "has_external_side_effect": True,
+    }
+
+
+def test_effect_helper_rejects_empty_kind():
+    """Effect helper rejects empty effect kinds."""
+    with pytest.raises(ValueError, match="kind must be a non-empty string"):
+        SpanContext("effect_span").effect("", has_external_side_effect=True)
+
+
+def test_wait_helper_records_reserved_merge_semantics():
+    """Wait helper should merge payloads with helper-owned field precedence."""
+    stub_client = StubClient()
+    caller_payload = {
+        "service": "stripe",
+        "phase": "wrong",
+        "wait_kind": "wrong",
+        "wait_id": "caller-wait",
+        "resolution": "wrong",
+    }
+    original_payload = dict(caller_payload)
+
+    with traced_span(stub_client, span_name="wait_span") as s:
+        s.wait(
+            "human_approval",
+            phase="resolved",
+            resolution="approved",
+            wait_id="wait-abc",
+            payload=caller_payload,
+        )
+
+    assert caller_payload == original_payload
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["event_type"] == "wait"
+    assert event["level"] == "info"
+    assert event["message"] == "Resolved wait: human approval"
+    assert event["payload"] == {
+        "service": "stripe",
+        "wait_kind": "human_approval",
+        "phase": "resolved",
+        "wait_id": "wait-abc",
+        "resolution": "approved",
+    }
+
+
+def test_wait_helper_omits_empty_wait_id():
+    """Empty string wait identifiers should be treated as absent."""
+    stub_client = StubClient()
+
+    with traced_span(stub_client, span_name="wait_span") as s:
+        s.wait("timer", phase="entered", wait_id="")
+
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["message"] == "Entered wait: timer"
+    assert event["payload"] == {
+        "wait_kind": "timer",
+        "phase": "entered",
+    }
+
+
+def test_wait_helper_rejects_empty_kind_or_phase():
+    """Wait helper rejects empty semantic identifiers."""
+    span_context = SpanContext("wait_span")
+
+    with pytest.raises(ValueError, match="kind must be a non-empty string"):
+        span_context.wait("", phase="entered")
+    with pytest.raises(ValueError, match="phase must be a non-empty string"):
+        span_context.wait("human_approval", phase="")
+
+
+def test_set_llm_response_emits_one_implicit_effect():
+    """First set_llm_response call emits an implicit effect exactly once."""
+    stub_client = StubClient()
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with traced_span(stub_client, span_name="llm_span", kind="llm") as s:
+        s.set_llm_response("gpt-4", messages, {"content": "Hi"}, 10, 5)
+        s.set_llm_response("gpt-4", messages, {"content": "Still hi"}, 11, 6)
+
+    assert len(stub_client.events) == 1
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["event_type"] == "effect"
+    assert event["message"] == "Model call: gpt-4"
+    assert event["payload"] == {
+        "effect_kind": "model_call",
+        "has_external_side_effect": False,
+    }
+
+
+def test_set_llm_response_emit_effect_false_does_not_consume_flag():
+    """Suppressing implicit LLM emission should not block a later default call."""
+    stub_client = StubClient()
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with traced_span(stub_client, span_name="llm_span", kind="llm") as s:
+        s.set_llm_response(
+            "gpt-4",
+            messages,
+            {"content": "Hi"},
+            10,
+            5,
+            emit_effect=False,
+        )
+        s.set_llm_response("gpt-4", messages, {"content": "Hi again"}, 10, 5)
+
+    assert len(stub_client.events) == 1
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["message"] == "Model call: gpt-4"
+
+
+def test_concurrent_set_llm_response_emits_one_implicit_effect():
+    """Concurrent LLM setter calls should still emit a single implicit effect."""
+    stub_client = SlowStubClient()
+    worker_count = 8
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with traced_span(stub_client, span_name="llm_span", kind="llm") as s:
+        failures = run_concurrent_workers(
+            worker_count,
+            lambda index: s.set_llm_response(
+                "gpt-4",
+                messages,
+                {"content": f"Hi {index}"},
+                10,
+                5,
+            ),
+        )
+
+    assert failures == []
+    effect_events = [event for event in stub_client.events if event["event_type"] == "effect"]
+    assert len(effect_events) == 1
+    assert_event_metadata(effect_events[0], sequence=1)
+    assert effect_events[0]["message"] == "Model call: gpt-4"
+    assert effect_events[0]["payload"] == {
+        "effect_kind": "model_call",
+        "has_external_side_effect": False,
+    }
+
+
+def test_set_tool_call_emits_one_implicit_effect_with_override():
+    """Tool helper should emit a single implicit effect with override support."""
+    stub_client = StubClient()
+
+    with traced_span(stub_client, span_name="tool_span", kind="tool") as s:
+        s.set_tool_call(
+            "cache_lookup",
+            {"key": "weather"},
+            {"hit": True},
+            has_external_side_effect=False,
+        )
+        s.set_tool_call(
+            "cache_lookup",
+            {"key": "weather"},
+            {"hit": True},
+            has_external_side_effect=True,
+        )
+
+    assert len(stub_client.events) == 1
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["message"] == "Tool call: cache_lookup"
+    assert event["payload"] == {
+        "effect_kind": "tool_call",
+        "has_external_side_effect": False,
+    }
+
+
+def test_set_tool_call_emit_effect_false_does_not_consume_flag():
+    """Suppressing implicit tool emission should not block a later default call."""
+    stub_client = StubClient()
+
+    with traced_span(stub_client, span_name="tool_span", kind="tool") as s:
+        s.set_tool_call(
+            "search",
+            {"q": "test"},
+            {"results": []},
+            emit_effect=False,
+        )
+        s.set_tool_call(
+            "search",
+            {"q": "test"},
+            {"results": []},
+            has_external_side_effect=True,
+        )
+
+    assert len(stub_client.events) == 1
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["message"] == "Tool call: search"
+    assert event["payload"] == {
+        "effect_kind": "tool_call",
+        "has_external_side_effect": True,
+    }
+
+
+def test_concurrent_set_tool_call_emits_one_implicit_effect():
+    """Concurrent tool setter calls should still emit a single implicit effect."""
+    stub_client = SlowStubClient()
+    worker_count = 8
+
+    with traced_span(stub_client, span_name="tool_span", kind="tool") as s:
+        failures = run_concurrent_workers(
+            worker_count,
+            lambda index: s.set_tool_call(
+                "search",
+                {"q": f"test-{index}"},
+                {"results": []},
+            ),
+        )
+
+    assert failures == []
+    effect_events = [event for event in stub_client.events if event["event_type"] == "effect"]
+    assert len(effect_events) == 1
+    assert_event_metadata(effect_events[0], sequence=1)
+    assert effect_events[0]["message"] == "Tool call: search"
+    assert effect_events[0]["payload"] == {
+        "effect_kind": "tool_call",
+        "has_external_side_effect": True,
+    }
+
+
+def test_explicit_helpers_do_not_interfere_with_implicit_effect_flags():
+    """Explicit helpers should neither consume nor block implicit effect emission."""
+    stub_client = StubClient()
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with traced_span(stub_client, span_name="llm_span", kind="llm") as s:
+        s.set_llm_response(
+            "gpt-4",
+            messages,
+            {"content": "Hi"},
+            10,
+            5,
+            emit_effect=False,
+        )
+        s.effect("model_call", has_external_side_effect=False)
+        s.wait("external", phase="entered")
+        s.set_llm_response("gpt-4", messages, {"content": "Hi again"}, 10, 5)
+
+    assert [event["event_type"] for event in stub_client.events] == [
+        "effect",
+        "wait",
+        "effect",
+    ]
+    assert [event["message"] for event in stub_client.events] == [
+        "Effect: model call",
+        "Entered wait: external",
+        "Model call: gpt-4",
+    ]
+    for sequence, event in enumerate(stub_client.events, start=1):
+        assert_event_metadata(event, sequence=sequence)
+
+
+def test_effect_and_wait_are_quiet_no_ops_without_trace_context():
+    """Effect and wait helpers should do nothing when no trace is active."""
+    stub_client = StubClient()
+    orphan = SpanContext("orphan")
+
+    with use_stub_client(stub_client):
+        orphan.effect("api_call", has_external_side_effect=True)
+        orphan.wait("human_approval", phase="entered")
+
+    assert stub_client.events == []
+    assert orphan._event_seq == 0
+
+
+def test_effect_helpers_are_quiet_no_ops_without_initialized_client():
+    """Tracing helpers should stay quiet when no client is initialized."""
+    with without_client():
+        with TraceContext(name="inactive_trace"):
+            with span("inactive_span", kind="llm") as s:
+                s.set_llm_response("gpt-4", [{"role": "user", "content": "Hello"}], {"ok": True}, 3, 2)
+                s.set_tool_call("search", {"q": "test"}, {"results": []})
+                s.effect("api_call", has_external_side_effect=True)
+                s.wait("human_approval", phase="entered")
+
+    assert s._model == "gpt-4"
+    assert s.name == "search"
+    assert s._input == {"q": "test"}
+    assert s._output == {"results": []}
+    assert s._event_seq == 0
+    assert s._implicit_llm_effect_emitted is False
+    assert s._implicit_tool_effect_emitted is False


### PR DESCRIPTION
## Summary
- add Python SDK effect and wait event emission support plus explicit event metadata
- make implicit LLM/tool effect emission thread-safe and at-most-once per span
- add OpenSpec artifacts, docs updates, and regression coverage for SDK behavior

## Testing
- uv run --with-editable . --extra dev pytest
- openspec validate add-python-sdk-effect-wait-emission --strict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `span.effect()` and `span.wait()` methods for explicit semantic event emission with customizable metadata.
  * Enhanced `set_llm_response()` and `set_tool_call()` with automatic effect tracking via new keyword-only parameters.
  * Introduced per-span event sequencing and RFC 3339 timestamps for improved timeline ordering.

* **Documentation**
  * Updated event conventions guide with usage guidance and Python SDK examples for effect and wait events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->