### PR TITLE
Add basic semantic timeline surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ tmp/
 
 # Claude Code session state (per-user, not shared)
 .claude/hooks/state/
+Study/
+continua

--- a/openspec/changes/add-basic-semantic-timeline-surfaces/design.md
+++ b/openspec/changes/add-basic-semantic-timeline-surfaces/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The timeline in `Timeline.tsx` currently renders `state_change` and `decision` events with dedicated preview components (`StateChangePreview`, `DecisionPreview`) extracted via helpers in `eventSemantics.ts`. All other explicit event types, including the newly accepted `effect` and `wait`, fall through to a generic text summary. This change adds extraction, preview rendering, and filtering for effect/wait events while preserving the existing rendering chain and component patterns.
+
+The Python SDK (`span.py`) is the payload source of truth. The verified payload keys are:
+- **effect**: `effect_kind` (string, required), `has_external_side_effect` (boolean, required), `effect_id` (string, optional), `idempotent` (boolean, optional), `idempotency_key` (string, optional)
+- **wait**: `wait_kind` (string, required), `phase` (string, required), `resolution` (string, optional), `wait_id` (string, optional)
+
+## Goals / Non-Goals
+
+- **Goals**: Surface effect/wait semantics in the timeline with the same fidelity as state_change/decision; let users filter the timeline to semantic or effect/wait events only
+- **Non-Goals**: Causal linking between effect_id/wait_id pairs, session-level aggregation, retry-safety classification, stuck-wait detection, cost surfaces, StateDiffViewer changes
+
+## Decisions
+
+### Extraction pattern: mirror existing eventSemantics.ts helpers
+- `getEffectDetails()` and `getWaitDetails()` follow the same guard-clause pattern as `getStateChangeDetails()` and `getDecisionDetails()`: check `event_type`, check `payload`, validate required fields, return typed object or `null`
+- **Why**: Consistency with established codebase pattern; zero new abstractions
+
+### Preview rendering: new components in Timeline.tsx
+- `EffectPreview` and `WaitPreview` are private components in `Timeline.tsx`, parallel to `StateChangePreview` and `DecisionPreview`
+- Rendering chain in `TimelineRow`: `stateChange ? <StateChangePreview> : decision ? <DecisionPreview> : effectDetails ? <EffectPreview> : waitDetails ? <WaitPreview> : <generic summary>`
+- **Why**: Keeps the rendering chain flat and readable; new event types slot in without restructuring
+
+### Effect preview: kind + mutating/read-only only
+- Primary display: kind label (e.g. `model_call`, `tool_call`, `api_call`) + mutating/read-only badge based on `has_external_side_effect`
+- Opaque identifiers (`effect_id`, `idempotency_key`) and the `idempotent` flag are accessible in the expanded payload panel, not surfaced as collapsed-row badges
+- **Why**: Users need to quickly see what kind of effect happened and whether it mutated external state; opaque IDs add visual noise in the collapsed row without aiding at-a-glance triage. Deeper causal linking is deferred
+
+### Wait preview: kind + phase + optional resolution
+- Primary display: kind label (e.g. `human_approval`, `external`, `timer`) + phase badge (`entered`, `resolved`)
+- Resolution shown as accent pill when present
+- `wait_id` is accessible in the expanded payload panel, not surfaced as a collapsed-row badge
+- **Why**: Phase is the key differentiator for wait events at a glance; resolution provides the outcome. Opaque IDs belong in the detail view
+
+### Segmented filter: custom radiogroup control
+- Three modes: `All` (default), `Semantic`, `Effects & waits`
+- Implemented as a `<div role="radiogroup">` with `<button role="radio">` children, supporting arrow-key navigation per WAI-ARIA radio group pattern
+- **Why**: Native `<select>` would break the visual consistency with the existing `Errors only` toggle; radiogroup semantics are the correct ARIA pattern for a mutually exclusive choice set
+- **Alternative considered**: Dropdown menu — rejected because three options don't warrant a popover; segmented control is more discoverable
+
+### Filter composition: intersection
+- When `Errors only` is active alongside a segmented filter, the filters compose by intersection: an event must match both the segmented filter AND be an error event
+- **Why**: Intersection is the intuitive mental model ("show me only errors among effects & waits")
+
+### Filter state: local, not URL-backed
+- Filter state lives in `Timeline` component state via `useState`
+- Persists across inspector tab switches (component stays mounted when switching Details/Timeline/State tabs in InspectorTabs)
+- Resets on trace navigation (component unmounts and remounts with new trace)
+- Not part of React Query cache keys
+- **Why**: Timeline filters are ephemeral exploration aids, not shareable navigation state; URL params are reserved for cross-page state like selected span
+
+### Empty-state messages: fixed strings
+- Six combinations of segmented filter × errors-only produce six distinct messages
+- Messages are statically defined, not template-generated
+- **Why**: Fixed strings are easier to test and localize; six cases don't warrant a template system
+
+## Risks / Trade-offs
+
+- **Rendering chain length**: Adding two more branches to the `TimelineRow` conditional increases cyclomatic complexity. Mitigation: each branch is a simple component call; the chain remains flat
+- **Filter discoverability**: Users may not notice the segmented control. Mitigation: positioned directly beside the existing `Errors only` toggle in the header bar
+- **Payload drift**: If the SDK adds new payload keys, the extractors will ignore them. Mitigation: extractors are additive; new keys can be surfaced in future phases without breaking existing rendering
+
+## Open Questions
+
+None — the scope is fully constrained by the SDK payload contract and the existing Timeline component patterns.

--- a/openspec/changes/add-basic-semantic-timeline-surfaces/proposal.md
+++ b/openspec/changes/add-basic-semantic-timeline-surfaces/proposal.md
@@ -1,0 +1,43 @@
+# Change: Add Basic Semantic Timeline Surfaces
+
+## Why
+
+Phase 1 (`add-effect-wait-semantic-foundation`) added wire-level acceptance of `effect` and `wait` event types with deterministic semantic ID derivation. Phase 2 (`add-python-sdk-effect-wait-emission`) added ergonomic `span.effect()` and `span.wait()` helpers to the Python SDK. However, the debugger frontend currently renders these events through the generic fallback branch — `event.message ?? event.event_type.replace(/_/g, ' ')` — losing the structured payload information that makes them useful for debugging. This phase adds dedicated extraction, preview rendering, and filtering for effect and wait events in the timeline, completing the vertical slice from SDK emission to visual surface.
+
+## What Changes
+
+### Effect and wait payload extraction (`eventSemantics.ts`)
+- Add `getEffectDetails()` extracting `effect_kind`, `has_external_side_effect`, `effect_id`, `idempotent`, and `idempotency_key` from event payloads
+- Add `getWaitDetails()` extracting `wait_kind`, `phase`, `resolution`, and `wait_id` from event payloads
+- Both return `null` when required fields are missing or malformed, preserving generic fallback rendering
+
+### Effect and wait summary text (`timeline.ts`)
+- Add `effect` and `wait` branches to `summarizeTimelineEvent()` using extracted payload details
+- Preserve existing generic fallback when semantic extraction fails
+
+### Effect and wait preview components (`Timeline.tsx`)
+- Add `EffectPreview` component parallel to `StateChangePreview` — shows kind and external/read-only distinction as the collapsed-row surface; opaque IDs (`effect_id`, `idempotency_key`) remain accessible via the expanded payload panel
+- Add `WaitPreview` component parallel to `DecisionPreview` — shows kind, phase, and resolution when present; `wait_id` remains accessible via the expanded payload panel
+- Wire into `TimelineRow` rendering chain after decision check, before generic fallback
+- Preserve all existing row behavior: expand/collapse, payload inspection, span navigation
+
+### Timeline segmented filter (`Timeline.tsx`)
+- Add a keyboard-accessible segmented control with `All`, `Semantic`, `Effects & waits` modes
+- `Semantic` filters to explicit events with `event_type` in `{state_change, decision, effect, wait}`
+- `Effects & waits` filters to explicit events with `event_type` in `{effect, wait}`
+- Composes with existing `Errors only` toggle by intersection
+- Filter state is local to `Timeline`, persists across inspector tab switches, resets on trace navigation
+- Six distinct empty-state messages for all filter combinations
+
+## Impact
+- Affected specs: `timeline-ui` (extended — adds effect/wait extraction, summary, and preview rendering), `error-timeline-filter` (extended — adds segmented filter, composition, lifecycle, polling, and empty-state requirements)
+- Affected code:
+  - `web/src/utils/eventSemantics.ts` — new extractors
+  - `web/src/utils/timeline.ts` — new summary branches
+  - `web/src/components/Timeline.tsx` — new preview components and segmented filter
+  - `web/src/utils/eventSemantics.test.ts` — new extractor tests
+  - `web/src/utils/timeline.test.ts` — extended summary tests
+  - `web/src/components/Timeline.test.tsx` — extended component and filter tests
+  - `web/src/pages/TraceDetailPage.test.tsx` — page-level integration tests for filter lifecycle
+- No backend, contract, store, migration, mapper, or engine changes
+- No changes to `StateDiffViewer`, `stateChanges.ts`, or session-level surfaces

--- a/openspec/changes/add-basic-semantic-timeline-surfaces/specs/error-timeline-filter/spec.md
+++ b/openspec/changes/add-basic-semantic-timeline-surfaces/specs/error-timeline-filter/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Timeline Segmented Filter Control
+
+The `Timeline` component SHALL provide a segmented control with three mutually exclusive modes: `All` (default), `Semantic`, and `Effects & waits`.
+
+The control SHALL be implemented as a `<div role="radiogroup">` containing `<button role="radio">` elements with appropriate `aria-checked` attributes and arrow-key navigation per WAI-ARIA radio group pattern.
+
+#### Scenario: Default state shows all events
+- **WHEN** the Timeline component mounts
+- **THEN** the segmented control is set to `All` and all events are visible (subject to `Errors only` toggle)
+
+#### Scenario: Semantic filter shows only semantic explicit events
+- **WHEN** the user selects `Semantic`
+- **THEN** only explicit events with `event_type` in `{state_change, decision, effect, wait}` are displayed
+- **AND** synthetic events (`span_started`, `span_completed`, `span_failed`) are hidden
+
+#### Scenario: Effects & waits filter shows only effect and wait events
+- **WHEN** the user selects `Effects & waits`
+- **THEN** only explicit events with `event_type` in `{effect, wait}` are displayed
+
+#### Scenario: Keyboard navigation within segmented control
+- **WHEN** the segmented control has focus and the user presses the right arrow key
+- **THEN** focus moves to the next option and that option becomes selected
+- **AND** pressing left arrow moves to the previous option
+
+### Requirement: Filter Composition with Errors Only
+
+The segmented filter SHALL compose with the existing `Errors only` toggle by intersection. When both filters are active, an event MUST satisfy both conditions to be displayed.
+
+#### Scenario: Semantic plus Errors only
+- **WHEN** the segmented control is set to `Semantic` and `Errors only` is active
+- **THEN** only events matching both conditions are shown: the intersection of the semantic predicate (explicit events with `event_type` in `{state_change, decision, effect, wait}`) and `isTimelineErrorEvent` (which includes `level === 'error'`), with synthetic rows still excluded by the semantic predicate
+
+#### Scenario: Effects & waits plus Errors only
+- **WHEN** the segmented control is set to `Effects & waits` and `Errors only` is active
+- **THEN** only effect or wait events that are also error events are shown
+
+#### Scenario: All plus Errors only
+- **WHEN** the segmented control is set to `All` and `Errors only` is active
+- **THEN** behavior is identical to the existing `Errors only` filter (all error events shown)
+
+### Requirement: Timeline Filter State Lifecycle
+
+Timeline filter state (both segmented control and errors-only) SHALL be local to the `Timeline` component instance. Filter state SHALL NOT be URL-backed and SHALL NOT be included in React Query cache keys.
+
+These lifecycle guarantees operate at the page level (via `TraceDetailPage` mount/unmount semantics), not just within the isolated `Timeline` component.
+
+#### Scenario: Filter state persists across inspector tab switches
+- **WHEN** the user sets the segmented control to `Semantic`, switches from the Timeline tab to the Details tab, and switches back to the Timeline tab
+- **THEN** the segmented control remains set to `Semantic`
+
+#### Scenario: Filter state resets on trace navigation
+- **WHEN** the user navigates from one trace to another (triggering a `TraceDetailPage` remount)
+- **THEN** the segmented control resets to `All` and `Errors only` resets to off
+
+### Requirement: Filter Correctness During Live Polling
+
+When a timeline filter is active on a running trace, newly arrived events from polling updates SHALL be subject to the same filter predicate as existing events. The filter SHALL NOT require user interaction to apply to incrementally merged events.
+
+#### Scenario: Active filter applies to polled events on a running trace
+- **WHEN** the segmented control is set to `Effects & waits` and the trace is running and a poll tick merges new events including an `effect` event and a `log` event
+- **THEN** the newly arrived `effect` event is displayed and the newly arrived `log` event is hidden, without the user needing to re-select the filter
+
+### Requirement: Filtered Empty State Messages
+
+The `Timeline` component SHALL display context-appropriate empty-state messages based on the active filter combination when no events match.
+
+Filtered empty-state messages SHALL only be evaluated after the existing loading and initial-error precedence branches. When the component is in a loading state (`isLoading && events.length === 0`) or an error state (`error && events.length === 0`), those states SHALL take precedence over any filter-derived empty-state message.
+
+The messages SHALL be:
+- `All` (errors off): `No timeline events recorded for this trace yet.`
+- `Errors only` (segmented `All`): `No error events for this trace.`
+- `Semantic` (errors off): `No semantic events for this trace.`
+- `Effects & waits` (errors off): `No effect or wait events for this trace.`
+- `Semantic` + `Errors only`: `No error-level semantic events for this trace.`
+- `Effects & waits` + `Errors only`: `No error-level effect or wait events for this trace.`
+
+#### Scenario: Semantic filter with no matching events
+- **WHEN** the segmented control is set to `Semantic` and no explicit `state_change`, `decision`, `effect`, or `wait` events exist for the trace
+- **THEN** the empty state displays `No semantic events for this trace.`
+
+#### Scenario: Effects & waits plus errors only with no matching events
+- **WHEN** the segmented control is set to `Effects & waits` and `Errors only` is active and no error-level effect or wait events exist
+- **THEN** the empty state displays `No error-level effect or wait events for this trace.`
+
+#### Scenario: Base empty state unchanged
+- **WHEN** the segmented control is `All` and `Errors only` is off and no events exist
+- **THEN** the empty state displays `No timeline events recorded for this trace yet.`

--- a/openspec/changes/add-basic-semantic-timeline-surfaces/specs/timeline-ui/spec.md
+++ b/openspec/changes/add-basic-semantic-timeline-surfaces/specs/timeline-ui/spec.md
@@ -1,0 +1,151 @@
+## ADDED Requirements
+
+### Requirement: Effect Payload Extraction
+
+The system SHALL provide a `getEffectDetails()` function in `eventSemantics.ts` that extracts structured effect information from timeline event payloads.
+
+The function SHALL return a typed object containing `effectKind` (string), `hasExternalSideEffect` (boolean), and optional `effectId` (string), `idempotent` (boolean), and `idempotencyKey` (string) when the event has `event_type` of `effect` and the payload contains the required fields `effect_kind` (string) and `has_external_side_effect` (boolean).
+
+The function SHALL return `null` when the event type is not `effect`, the payload is missing, or required fields are absent or have incorrect types.
+
+#### Scenario: Well-formed effect payload with all fields
+- **WHEN** a timeline event has `event_type: "effect"` and payload `{ effect_kind: "api_call", has_external_side_effect: true, effect_id: "effect_abc123", idempotent: false, idempotency_key: "key-1" }`
+- **THEN** `getEffectDetails()` returns `{ effectKind: "api_call", hasExternalSideEffect: true, effectId: "effect_abc123", idempotent: false, idempotencyKey: "key-1" }`
+
+#### Scenario: Minimal effect payload with required fields only
+- **WHEN** a timeline event has `event_type: "effect"` and payload `{ effect_kind: "model_call", has_external_side_effect: false }`
+- **THEN** `getEffectDetails()` returns `{ effectKind: "model_call", hasExternalSideEffect: false }` with optional fields undefined
+
+#### Scenario: Missing required field returns null
+- **WHEN** a timeline event has `event_type: "effect"` and payload `{ effect_kind: "model_call" }` (missing `has_external_side_effect`)
+- **THEN** `getEffectDetails()` returns `null`
+
+#### Scenario: Wrong event type returns null
+- **WHEN** a timeline event has `event_type: "log"` with an effect-shaped payload
+- **THEN** `getEffectDetails()` returns `null`
+
+#### Scenario: Missing payload returns null
+- **WHEN** a timeline event has `event_type: "effect"` and no payload
+- **THEN** `getEffectDetails()` returns `null`
+
+### Requirement: Wait Payload Extraction
+
+The system SHALL provide a `getWaitDetails()` function in `eventSemantics.ts` that extracts structured wait information from timeline event payloads.
+
+The function SHALL return a typed object containing `waitKind` (string), `phase` (string), and optional `resolution` (string) and `waitId` (string) when the event has `event_type` of `wait` and the payload contains the required fields `wait_kind` (string) and `phase` (string).
+
+The function SHALL return `null` when the event type is not `wait`, the payload is missing, or required fields are absent or have incorrect types.
+
+#### Scenario: Well-formed wait payload with all fields
+- **WHEN** a timeline event has `event_type: "wait"` and payload `{ wait_kind: "human_approval", phase: "resolved", resolution: "approved", wait_id: "wait_xyz789" }`
+- **THEN** `getWaitDetails()` returns `{ waitKind: "human_approval", phase: "resolved", resolution: "approved", waitId: "wait_xyz789" }`
+
+#### Scenario: Minimal wait payload with required fields only
+- **WHEN** a timeline event has `event_type: "wait"` and payload `{ wait_kind: "human_approval", phase: "entered" }`
+- **THEN** `getWaitDetails()` returns `{ waitKind: "human_approval", phase: "entered" }` with optional fields undefined
+
+#### Scenario: Missing required phase field returns null
+- **WHEN** a timeline event has `event_type: "wait"` and payload `{ wait_kind: "external" }` (missing `phase`)
+- **THEN** `getWaitDetails()` returns `null`
+
+#### Scenario: Wrong event type returns null
+- **WHEN** a timeline event has `event_type: "decision"` with a wait-shaped payload
+- **THEN** `getWaitDetails()` returns `null`
+
+### Requirement: Effect Event Summary Text
+
+The `summarizeTimelineEvent()` function SHALL produce structured summary text for `effect` events when `getEffectDetails()` returns a non-null result.
+
+The summary format SHALL be `"{effectKind} (mutating)"` when `hasExternalSideEffect` is `true`, and `"{effectKind} (read-only)"` when `hasExternalSideEffect` is `false`.
+
+When extraction fails, the function SHALL fall back to `event.message` if present, or `"effect"` otherwise.
+
+#### Scenario: Effect with external side effect
+- **WHEN** `summarizeTimelineEvent()` is called with an effect event where `getEffectDetails()` returns `{ effectKind: "api_call", hasExternalSideEffect: true }`
+- **THEN** the summary returns `"api_call (mutating)"`
+
+#### Scenario: Read-only effect
+- **WHEN** `summarizeTimelineEvent()` is called with an effect event where `getEffectDetails()` returns `{ effectKind: "model_call", hasExternalSideEffect: false }`
+- **THEN** the summary returns `"model_call (read-only)"`
+
+#### Scenario: Effect extraction fails with message fallback
+- **WHEN** `summarizeTimelineEvent()` is called with an effect event where `getEffectDetails()` returns `null` and `event.message` is "Custom effect note"
+- **THEN** the summary returns `"Custom effect note"`
+
+#### Scenario: Effect extraction fails without message
+- **WHEN** `summarizeTimelineEvent()` is called with an effect event where `getEffectDetails()` returns `null` and `event.message` is undefined
+- **THEN** the summary returns `"effect"`
+
+### Requirement: Wait Event Summary Text
+
+The `summarizeTimelineEvent()` function SHALL produce structured summary text for `wait` events when `getWaitDetails()` returns a non-null result.
+
+The summary format SHALL be `"{waitKind} ({phase})"` when no resolution is present, and `"{waitKind} ({phase}) → {resolution}"` when a resolution is present.
+
+When extraction fails, the function SHALL fall back to `event.message` if present, or `"wait"` otherwise.
+
+#### Scenario: Wait with resolution
+- **WHEN** `summarizeTimelineEvent()` is called with a wait event where `getWaitDetails()` returns `{ waitKind: "human_approval", phase: "resolved", resolution: "approved" }`
+- **THEN** the summary returns `"human_approval (resolved) → approved"`
+
+#### Scenario: Wait without resolution
+- **WHEN** `summarizeTimelineEvent()` is called with a wait event where `getWaitDetails()` returns `{ waitKind: "human_approval", phase: "entered" }`
+- **THEN** the summary returns `"human_approval (entered)"`
+
+#### Scenario: Wait extraction fails
+- **WHEN** `summarizeTimelineEvent()` is called with a wait event where `getWaitDetails()` returns `null`
+- **THEN** the summary falls back to `event.message` or `"wait"`
+
+### Requirement: Effect Preview Component
+
+The `Timeline` component SHALL render an `EffectPreview` component for timeline events where `getEffectDetails()` returns a non-null result.
+
+The preview SHALL display the effect kind as primary text and a badge indicating whether the effect is externally mutating or read-only based on `hasExternalSideEffect`. Opaque identifiers (`effectId`, `idempotencyKey`) and the `idempotent` flag SHALL remain accessible via the expanded payload panel and SHALL NOT be rendered as collapsed-row badges.
+
+The preview SHALL be rendered in the `TimelineRow` chain after the `DecisionPreview` check and before the generic text fallback.
+
+#### Scenario: Externally mutating effect
+- **WHEN** a timeline row renders an effect event with `{ effectKind: "tool_call", hasExternalSideEffect: true }`
+- **THEN** the row displays "tool_call" as the kind and a mutating badge
+
+#### Scenario: Read-only effect
+- **WHEN** a timeline row renders an effect event with `{ effectKind: "model_call", hasExternalSideEffect: false }`
+- **THEN** the row displays "model_call" as the kind and a read-only badge
+
+#### Scenario: Malformed effect payload degrades to generic rendering
+- **WHEN** a timeline row renders an effect event where `getEffectDetails()` returns `null`
+- **THEN** the row renders the generic text summary via `summarizeTimelineEvent()`
+
+### Requirement: Wait Preview Component
+
+The `Timeline` component SHALL render a `WaitPreview` component for timeline events where `getWaitDetails()` returns a non-null result.
+
+The preview SHALL display the wait kind as primary text, a phase badge (e.g. `entered`, `resolved`), and the resolution as an accent pill when present. The `waitId` SHALL remain accessible via the expanded payload panel and SHALL NOT be rendered as a collapsed-row badge.
+
+The preview SHALL be rendered in the `TimelineRow` chain after the `EffectPreview` check and before the generic text fallback.
+
+#### Scenario: Wait resolved with resolution
+- **WHEN** a timeline row renders a wait event with `{ waitKind: "human_approval", phase: "resolved", resolution: "approved" }`
+- **THEN** the row displays "human_approval" kind, "resolved" phase badge, and "approved" resolution pill
+
+#### Scenario: Wait entered without optional fields
+- **WHEN** a timeline row renders a wait event with `{ waitKind: "human_approval", phase: "entered" }`
+- **THEN** the row displays "human_approval" kind and "entered" phase badge, with no resolution pill
+
+#### Scenario: Malformed wait payload degrades to generic rendering
+- **WHEN** a timeline row renders a wait event where `getWaitDetails()` returns `null`
+- **THEN** the row renders the generic text summary via `summarizeTimelineEvent()`
+
+### Requirement: Existing Row Behavior Preservation
+
+The addition of effect and wait preview rendering SHALL NOT alter the behavior of existing timeline row features.
+
+Explicit vs synthetic row styling, expand/collapse details, raw payload inspection via JsonViewer, and span-jump navigation via `onSelectSpan` SHALL continue to function identically for all event types including effect and wait.
+
+#### Scenario: Effect event row expands to show payload
+- **WHEN** a user clicks "Show details" on an effect event row
+- **THEN** the raw payload is displayed in the JsonViewer, identical to any other event type
+
+#### Scenario: Wait event row navigates to span
+- **WHEN** a wait event has a `span_id` that exists in the `spanIndex` and the user clicks the span button
+- **THEN** the `onSelectSpan` callback is invoked with the span ID

--- a/openspec/changes/add-basic-semantic-timeline-surfaces/tasks.md
+++ b/openspec/changes/add-basic-semantic-timeline-surfaces/tasks.md
@@ -1,0 +1,37 @@
+## 1. Pre-Implementation Verification
+- [x] 1.1 Verify SDK payload source of truth: read `sdks/python/src/continua/span.py` `effect()` and `wait()` methods, confirm the reserved payload keys match the extractors planned (`effect_kind`, `has_external_side_effect`, `effect_id`, `idempotent`, `idempotency_key`, `wait_kind`, `phase`, `resolution`, `wait_id`)
+- [x] 1.2 Verify `docs/event-conventions.md` documents effect and wait payload schemas consistently with `span.py`
+- [x] 1.3 Verify current frontend baseline: confirm `effect` and `wait` hit the default branch in `summarizeTimelineEvent()` and render via generic fallback in `TimelineRow`
+
+## 2. Effect and Wait Payload Extraction
+- [x] 2.1 Add `EffectDetails` interface and `getEffectDetails()` function to `eventSemantics.ts` — guard on `event_type === 'effect'`, require `effect_kind` (string) and `has_external_side_effect` (boolean), optional `effect_id`, `idempotent`, `idempotency_key`; return `null` on any guard failure
+- [x] 2.2 Add `WaitDetails` interface and `getWaitDetails()` function to `eventSemantics.ts` — guard on `event_type === 'wait'`, require `wait_kind` (string) and `phase` (string), optional `resolution`, `wait_id`; return `null` on any guard failure
+- [x] 2.3 Add extractor unit tests in `eventSemantics.test.ts`: well-formed payloads with all fields, minimal payloads with required fields only, missing required fields return `null`, wrong event type returns `null`, missing payload returns `null`, incorrect field types return `null`
+
+## 3. Effect and Wait Summary Text
+- [x] 3.1 Add `effect` case to `summarizeTimelineEvent()` in `timeline.ts`: format as `"{effectKind} (mutating)"` or `"{effectKind} (read-only)"`; fall back to `event.message ?? 'effect'` when extraction returns `null`
+- [x] 3.2 Add `wait` case to `summarizeTimelineEvent()` in `timeline.ts`: format as `"{waitKind} ({phase})"` or `"{waitKind} ({phase}) → {resolution}"`; fall back to `event.message ?? 'wait'` when extraction returns `null`
+- [x] 3.3 Add summary unit tests in `timeline.test.ts`: effect mutating, effect read-only, effect fallback to message, effect fallback to type name, wait with resolution, wait without resolution, wait fallback to message, wait fallback to type name
+
+## 4. Effect and Wait Preview Components
+- [x] 4.1 Add `EffectPreview` component in `Timeline.tsx`: display effect kind as primary text, mutating/read-only badge from `hasExternalSideEffect`; opaque IDs and idempotency metadata stay in expanded payload panel
+- [x] 4.2 Add `WaitPreview` component in `Timeline.tsx`: display wait kind as primary text, phase badge, resolution as accent pill when present; `waitId` stays in expanded payload panel
+- [x] 4.3 Wire `EffectPreview` and `WaitPreview` into `TimelineRow` rendering chain: after `DecisionPreview` check, before generic text fallback
+- [x] 4.4 Add component tests in `Timeline.test.tsx`: effect preview renders kind and mutating badge, effect preview renders read-only badge, wait preview renders kind and phase, wait preview renders resolution pill, malformed payloads degrade to generic rendering
+
+## 5. Timeline Segmented Filter
+- [x] 5.1 Add `TimelineFilterMode` type (`'all' | 'semantic' | 'effects-waits'`) and `filterMode` state to `Timeline` component
+- [x] 5.2 Implement `SegmentedFilter` as a `role="radiogroup"` with three `role="radio"` buttons, `aria-checked` state, and arrow-key navigation handler
+- [x] 5.3 Wire filter logic: compose `filterMode` with `showErrorsOnly` by intersection to compute `visibleEvents`; `semantic` filters to explicit events with `event_type` in `{state_change, decision, effect, wait}`; `effects-waits` filters to `{effect, wait}`
+- [x] 5.4 Implement six empty-state messages based on filter combination (see spec)
+- [x] 5.5 Add filter component tests in `Timeline.test.tsx`: segmented control defaults to All, selecting Semantic hides synthetic events, selecting Effects & waits shows only effect/wait, combined Semantic + Errors only intersection, combined Effects & waits + Errors only intersection, all six empty-state messages render correctly, loading/error states take precedence over filtered empty states
+- [x] 5.6 Add accessibility tests in `Timeline.test.tsx`: radiogroup role present, aria-checked reflects active option, arrow key moves selection
+- [x] 5.7 Add polling-aware filter test in `Timeline.test.tsx`: with a filter active, re-render with new events appended (simulating a poll merge) and verify the filter applies to newly arrived events without user interaction
+
+## 6. Page-Level Integration Tests
+- [x] 6.1 Add `TraceDetailPage.test.tsx` test: segmented filter persists across inspector tab switches (Timeline → Details → Timeline), parallel to existing `Errors only` persistence coverage
+- [x] 6.2 Add `TraceDetailPage.test.tsx` test: segmented filter resets to `All` on trace navigation (route change triggering page remount)
+
+## 7. Final Verification
+- [x] 7.1 Run `pnpm --filter web test` and confirm all new and existing tests pass
+- [x] 7.2 Run `go test ./internal/api/...` as backend invariant check (no new backend assertions expected)

--- a/web/src/components/Timeline.test.tsx
+++ b/web/src/components/Timeline.test.tsx
@@ -1,79 +1,679 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { createTimelineEvent } from '../test/traceFixtures';
+import { createSpan, createTimelineEvent } from '../test/traceFixtures';
 import { Timeline } from './Timeline';
+
+type TimelineProps = Parameters<typeof Timeline>[0];
+
+function renderTimeline(overrides: Partial<TimelineProps> = {}) {
+  const props: TimelineProps = {
+    events: [],
+    traceStatus: 'COMPLETED',
+    isLive: false,
+    isLoading: false,
+    error: null,
+    onSelectSpan: vi.fn(),
+    spanIndex: new Map(),
+    ...overrides,
+  };
+
+  return {
+    ...render(<Timeline {...props} />),
+    props,
+  };
+}
 
 describe('Timeline semantic event rendering', () => {
   it('renders state_change rows with inline old/new values', () => {
-    render(
-      <Timeline
-        events={[
-          createTimelineEvent({
-            event_type: 'state_change',
-            payload: {
-              key: 'status',
-              old_value: 'pending',
-              new_value: 'approved',
-            },
-          }),
-        ]}
-        traceStatus="COMPLETED"
-        isLive={false}
-        onSelectSpan={vi.fn()}
-        spanIndex={new Map()}
-      />
-    );
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'state_change',
+          payload: {
+            key: 'status',
+            old_value: 'pending',
+            new_value: 'approved',
+          },
+        }),
+      ],
+    });
 
     expect(screen.getByText('status')).toBeInTheDocument();
     expect(screen.getByText('pending')).toBeInTheDocument();
     expect(screen.getByText('approved')).toBeInTheDocument();
   });
 
-  it('falls back to the message when semantic fields are missing', () => {
-    render(
-      <Timeline
-        events={[
-          createTimelineEvent({
-            event_type: 'decision',
-            message: 'Generic fallback',
-            payload: {
-              chosen: 'gpt-4.1',
-            },
-          }),
-        ]}
-        traceStatus="COMPLETED"
-        isLive={false}
-        onSelectSpan={vi.fn()}
-        spanIndex={new Map()}
-      />
-    );
+  it('falls back to the message when decision semantic fields are missing', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'decision',
+          message: 'Generic fallback',
+          payload: {
+            chosen: 'gpt-4.1',
+          },
+        }),
+      ],
+    });
 
     expect(screen.getByText('Generic fallback')).toBeInTheDocument();
   });
 
   it('renders decision alternatives inline when they are present', () => {
-    render(
-      <Timeline
-        events={[
-          createTimelineEvent({
-            event_type: 'decision',
-            payload: {
-              question: 'Which model?',
-              chosen: 'gpt-4.1',
-              alternatives: ['gpt-4o-mini', 'claude-3-haiku'],
-            },
-          }),
-        ]}
-        traceStatus="COMPLETED"
-        isLive={false}
-        onSelectSpan={vi.fn()}
-        spanIndex={new Map()}
-      />
-    );
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'decision',
+          payload: {
+            question: 'Which model?',
+            chosen: 'gpt-4.1',
+            alternatives: ['gpt-4o-mini', 'claude-3-haiku'],
+          },
+        }),
+      ],
+    });
 
     expect(screen.getByText('Which model?')).toBeInTheDocument();
     expect(screen.getByText('Alternatives')).toBeInTheDocument();
     expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument();
     expect(screen.getByText('claude-3-haiku')).toBeInTheDocument();
+  });
+
+  it('renders effect previews with the kind and mutating badge', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'tool_call',
+            has_external_side_effect: true,
+            effect_id: 'effect-1',
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByText('tool_call')).toBeInTheDocument();
+    expect(screen.getByText('mutating')).toBeInTheDocument();
+  });
+
+  it('renders effect previews with the read-only badge', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'model_call',
+            has_external_side_effect: false,
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByText('model_call')).toBeInTheDocument();
+    expect(screen.getByText('read-only')).toBeInTheDocument();
+  });
+
+  it('renders wait previews with the kind, phase, and resolution pill', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'wait',
+          payload: {
+            wait_kind: 'human_approval',
+            phase: 'resolved',
+            resolution: 'approved',
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByText('human_approval')).toBeInTheDocument();
+    expect(screen.getByText('resolved')).toBeInTheDocument();
+    expect(screen.getByText('approved')).toBeInTheDocument();
+  });
+
+  it('degrades malformed effect and wait payloads to generic rendering', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          id: 'bad-effect',
+          event_type: 'effect',
+          message: 'Fallback effect summary',
+          payload: {
+            effect_kind: 'api_call',
+          },
+        }),
+        createTimelineEvent({
+          id: 'bad-wait',
+          event_type: 'wait',
+          message: 'Fallback wait summary',
+          payload: {
+            wait_kind: 'human_approval',
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Fallback effect summary')).toBeInTheDocument();
+    expect(screen.getByText('Fallback wait summary')).toBeInTheDocument();
+    expect(screen.queryByText('mutating')).not.toBeInTheDocument();
+    expect(screen.queryByText('read-only')).not.toBeInTheDocument();
+  });
+
+  it('preserves effect payload inspection and wait span navigation', async () => {
+    const user = userEvent.setup();
+    const onSelectSpan = vi.fn();
+    const effectSpan = createSpan({ span_id: 'effect-span', name: 'Effect span' });
+    const waitSpan = createSpan({ span_id: 'wait-span', name: 'Wait span' });
+
+    renderTimeline({
+      onSelectSpan,
+      spanIndex: new Map([
+        [effectSpan.span_id, effectSpan],
+        [waitSpan.span_id, waitSpan],
+      ]),
+      events: [
+        createTimelineEvent({
+          id: 'effect-event',
+          span_id: effectSpan.span_id,
+          span_name: effectSpan.name,
+          event_type: 'effect',
+          message: 'Effect payload',
+          payload: {
+            effect_kind: 'tool_call',
+            has_external_side_effect: true,
+            effect_id: 'effect-1',
+          },
+        }),
+        createTimelineEvent({
+          id: 'wait-event',
+          span_id: waitSpan.span_id,
+          span_name: waitSpan.name,
+          event_type: 'wait',
+          payload: {
+            wait_kind: 'human_approval',
+            phase: 'entered',
+            wait_id: 'wait-1',
+          },
+        }),
+      ],
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Show details' })[0]);
+    expect(screen.getByText('effect_id')).toBeInTheDocument();
+    expect(screen.getByText('"effect-1"')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: waitSpan.name }));
+    expect(onSelectSpan).toHaveBeenCalledWith(waitSpan.span_id);
+  });
+});
+
+describe('Timeline segmented filter', () => {
+  it('defaults to All and shows all events', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          id: 'message-event',
+          event_type: 'message',
+          message: 'Narrative event',
+        }),
+        createTimelineEvent({
+          id: 'effect-event',
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'api_call',
+            has_external_side_effect: true,
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByRole('radio', { name: 'All' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getByText('Narrative event')).toBeInTheDocument();
+    expect(screen.getByText('api_call')).toBeInTheDocument();
+  });
+
+  it('filters to semantic explicit events when Semantic is selected', async () => {
+    const user = userEvent.setup();
+
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          id: 'message-event',
+          event_type: 'message',
+          message: 'Narrative event',
+        }),
+        createTimelineEvent({
+          id: 'state-event',
+          event_type: 'state_change',
+          payload: {
+            key: 'status',
+            old_value: 'pending',
+            new_value: 'approved',
+          },
+        }),
+        createTimelineEvent({
+          id: 'effect-event',
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'api_call',
+            has_external_side_effect: true,
+          },
+        }),
+        createTimelineEvent({
+          id: 'synthetic-event',
+          event_type: 'span_completed',
+          source: 'synthetic',
+          span_name: 'Synthetic root',
+        }),
+      ],
+    });
+
+    await user.click(screen.getByRole('radio', { name: 'Semantic' }));
+
+    expect(screen.queryByText('Narrative event')).not.toBeInTheDocument();
+    expect(screen.queryByText('Synthetic root completed')).not.toBeInTheDocument();
+    expect(screen.getByText('status')).toBeInTheDocument();
+    expect(screen.getByText('api_call')).toBeInTheDocument();
+  });
+
+  it('filters to effect and wait events when Effects & waits is selected', async () => {
+    const user = userEvent.setup();
+
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          id: 'decision-event',
+          event_type: 'decision',
+          payload: {
+            question: 'Which model?',
+            chosen: 'gpt-4.1',
+          },
+        }),
+        createTimelineEvent({
+          id: 'effect-event',
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'tool_call',
+            has_external_side_effect: true,
+          },
+        }),
+        createTimelineEvent({
+          id: 'wait-event',
+          event_type: 'wait',
+          payload: {
+            wait_kind: 'human_approval',
+            phase: 'entered',
+          },
+        }),
+      ],
+    });
+
+    await user.click(screen.getByRole('radio', { name: 'Effects & waits' }));
+
+    expect(screen.queryByText('Which model?')).not.toBeInTheDocument();
+    expect(screen.getByText('tool_call')).toBeInTheDocument();
+    expect(screen.getByText('human_approval')).toBeInTheDocument();
+  });
+
+  it('intersects the Semantic filter with Errors only', async () => {
+    const user = userEvent.setup();
+
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          id: 'semantic-error',
+          event_type: 'effect',
+          level: 'error',
+          payload: {
+            effect_kind: 'api_call',
+            has_external_side_effect: true,
+          },
+        }),
+        createTimelineEvent({
+          id: 'semantic-info',
+          event_type: 'decision',
+          payload: {
+            question: 'Which model?',
+            chosen: 'gpt-4.1',
+          },
+        }),
+        createTimelineEvent({
+          id: 'non-semantic-error',
+          event_type: 'log',
+          level: 'error',
+          message: 'Non-semantic error log',
+        }),
+        createTimelineEvent({
+          id: 'synthetic-error',
+          event_type: 'span_failed',
+          source: 'synthetic',
+          span_name: 'Synthetic failed span',
+        }),
+      ],
+    });
+
+    await user.click(screen.getByRole('radio', { name: 'Semantic' }));
+    await user.click(screen.getByRole('button', { name: 'Show error events only' }));
+
+    expect(screen.getByText('api_call')).toBeInTheDocument();
+    expect(screen.queryByText('Which model?')).not.toBeInTheDocument();
+    expect(screen.queryByText('Non-semantic error log')).not.toBeInTheDocument();
+    expect(screen.queryByText('Synthetic failed span failed')).not.toBeInTheDocument();
+  });
+
+  it('intersects the Effects & waits filter with Errors only', async () => {
+    const user = userEvent.setup();
+
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          id: 'effect-error',
+          event_type: 'effect',
+          level: 'error',
+          payload: {
+            effect_kind: 'tool_call',
+            has_external_side_effect: true,
+          },
+        }),
+        createTimelineEvent({
+          id: 'wait-info',
+          event_type: 'wait',
+          payload: {
+            wait_kind: 'human_approval',
+            phase: 'entered',
+          },
+        }),
+        createTimelineEvent({
+          id: 'log-error',
+          event_type: 'log',
+          level: 'error',
+          message: 'Plain error log',
+        }),
+      ],
+    });
+
+    await user.click(screen.getByRole('radio', { name: 'Effects & waits' }));
+    await user.click(screen.getByRole('button', { name: 'Show error events only' }));
+
+    expect(screen.getByText('tool_call')).toBeInTheDocument();
+    expect(screen.queryByText('human_approval')).not.toBeInTheDocument();
+    expect(screen.queryByText('Plain error log')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      name: 'all with errors off',
+      events: [],
+      filterLabel: 'All',
+      showErrorsOnly: false,
+      message: 'No timeline events recorded for this trace yet.',
+    },
+    {
+      name: 'all with errors only',
+      events: [
+        createTimelineEvent({
+          event_type: 'message',
+          message: 'Non-error event',
+        }),
+      ],
+      filterLabel: 'All',
+      showErrorsOnly: true,
+      message: 'No error events for this trace.',
+    },
+    {
+      name: 'semantic with errors off',
+      events: [
+        createTimelineEvent({
+          event_type: 'message',
+          message: 'Narrative event',
+        }),
+      ],
+      filterLabel: 'Semantic',
+      showErrorsOnly: false,
+      message: 'No semantic events for this trace.',
+    },
+    {
+      name: 'effects and waits with errors off',
+      events: [
+        createTimelineEvent({
+          event_type: 'decision',
+          payload: {
+            question: 'Which model?',
+            chosen: 'gpt-4.1',
+          },
+        }),
+      ],
+      filterLabel: 'Effects & waits',
+      showErrorsOnly: false,
+      message: 'No effect or wait events for this trace.',
+    },
+    {
+      name: 'semantic with errors only',
+      events: [
+        createTimelineEvent({
+          event_type: 'decision',
+          payload: {
+            question: 'Which model?',
+            chosen: 'gpt-4.1',
+          },
+        }),
+      ],
+      filterLabel: 'Semantic',
+      showErrorsOnly: true,
+      message: 'No error-level semantic events for this trace.',
+    },
+    {
+      name: 'effects and waits with errors only',
+      events: [
+        createTimelineEvent({
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'tool_call',
+            has_external_side_effect: false,
+          },
+        }),
+      ],
+      filterLabel: 'Effects & waits',
+      showErrorsOnly: true,
+      message: 'No error-level effect or wait events for this trace.',
+    },
+  ])('renders the correct empty state for $name', async ({
+    events,
+    filterLabel,
+    showErrorsOnly,
+    message,
+  }) => {
+    const user = userEvent.setup();
+
+    renderTimeline({ events });
+
+    if (filterLabel !== 'All') {
+      await user.click(screen.getByRole('radio', { name: filterLabel }));
+    }
+    if (showErrorsOnly) {
+      await user.click(screen.getByRole('button', { name: 'Show error events only' }));
+    }
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
+
+  it('lets loading and error states take precedence over filtered empty states', async () => {
+    const user = userEvent.setup();
+    const onSelectSpan = vi.fn();
+    const spanIndex = new Map();
+
+    const { rerender } = render(
+      <Timeline
+        events={[
+          createTimelineEvent({
+            event_type: 'message',
+            message: 'Narrative event',
+          }),
+        ]}
+        traceStatus="RUNNING"
+        isLive={true}
+        onSelectSpan={onSelectSpan}
+        spanIndex={spanIndex}
+      />
+    );
+
+    await user.click(screen.getByRole('radio', { name: 'Semantic' }));
+    expect(screen.getByText('No semantic events for this trace.')).toBeInTheDocument();
+
+    rerender(
+      <Timeline
+        events={[]}
+        traceStatus="RUNNING"
+        isLive={true}
+        isLoading={true}
+        onSelectSpan={onSelectSpan}
+        spanIndex={spanIndex}
+      />
+    );
+    expect(screen.getByText('Loading timeline...')).toBeInTheDocument();
+
+    rerender(
+      <Timeline
+        events={[]}
+        traceStatus="FAILED"
+        isLive={false}
+        error="Timeline failed"
+        onSelectSpan={onSelectSpan}
+        spanIndex={spanIndex}
+      />
+    );
+    expect(screen.getByText('Timeline failed')).toBeInTheDocument();
+  });
+
+  it('exposes the segmented control as a radiogroup with aria-checked state', async () => {
+    const user = userEvent.setup();
+
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'tool_call',
+            has_external_side_effect: true,
+          },
+        }),
+      ],
+    });
+
+    expect(
+      screen.getByRole('radiogroup', { name: 'Timeline event filter' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'All' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getByRole('radio', { name: 'Semantic' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
+
+    await user.click(screen.getByRole('radio', { name: 'Semantic' }));
+    expect(screen.getByRole('radio', { name: 'Semantic' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getByRole('radio', { name: 'All' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
+  });
+
+  it('supports arrow-key navigation within the segmented control', async () => {
+    const user = userEvent.setup();
+
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'tool_call',
+            has_external_side_effect: true,
+          },
+        }),
+      ],
+    });
+
+    const all = screen.getByRole('radio', { name: 'All' });
+    const semantic = screen.getByRole('radio', { name: 'Semantic' });
+
+    all.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(semantic).toHaveFocus();
+    expect(semantic).toHaveAttribute('aria-checked', 'true');
+
+    await user.keyboard('{ArrowLeft}');
+    expect(all).toHaveFocus();
+    expect(all).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('applies an active filter to newly appended polled events', async () => {
+    const user = userEvent.setup();
+    const onSelectSpan = vi.fn();
+    const spanIndex = new Map();
+
+    const { rerender } = render(
+      <Timeline
+        events={[
+          createTimelineEvent({
+            id: 'initial-log',
+            event_type: 'message',
+            message: 'Initial log event',
+          }),
+        ]}
+        traceStatus="RUNNING"
+        isLive={true}
+        onSelectSpan={onSelectSpan}
+        spanIndex={spanIndex}
+      />
+    );
+
+    await user.click(screen.getByRole('radio', { name: 'Effects & waits' }));
+    expect(
+      screen.getByText('No effect or wait events for this trace.')
+    ).toBeInTheDocument();
+
+    rerender(
+      <Timeline
+        events={[
+          createTimelineEvent({
+            id: 'initial-log',
+            event_type: 'message',
+            message: 'Initial log event',
+          }),
+          createTimelineEvent({
+            id: 'polled-effect',
+            event_type: 'effect',
+            payload: {
+              effect_kind: 'tool_call',
+              has_external_side_effect: true,
+            },
+          }),
+          createTimelineEvent({
+            id: 'polled-log',
+            event_type: 'log',
+            message: 'Poll update log',
+          }),
+        ]}
+        traceStatus="RUNNING"
+        isLive={true}
+        onSelectSpan={onSelectSpan}
+        spanIndex={spanIndex}
+      />
+    );
+
+    expect(screen.getByText('tool_call')).toBeInTheDocument();
+    expect(screen.queryByText('Initial log event')).not.toBeInTheDocument();
+    expect(screen.queryByText('Poll update log')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useRef, useState, type KeyboardEvent } from 'react';
 import { Span, TimelineEvent, TimelineTraceStatus } from '../api/client';
 import { JsonViewer } from './JsonViewer';
 import {
   formatInlineSemanticValue,
   getDecisionDetails,
+  getEffectDetails,
   getStateChangeDetails,
+  getWaitDetails,
 } from '../utils/eventSemantics';
 import {
   isTimelineErrorEvent,
@@ -22,6 +24,28 @@ interface TimelineProps {
   spanIndex: Map<string, Span>;
 }
 
+type TimelineFilterMode = 'all' | 'semantic' | 'effects-waits';
+
+const TIMELINE_FILTER_OPTIONS: Array<{
+  label: string;
+  mode: TimelineFilterMode;
+}> = [
+  { label: 'All', mode: 'all' },
+  { label: 'Semantic', mode: 'semantic' },
+  { label: 'Effects & waits', mode: 'effects-waits' },
+];
+
+const SEMANTIC_EVENT_TYPES = new Set<TimelineEvent['event_type']>([
+  'state_change',
+  'decision',
+  'effect',
+  'wait',
+]);
+const EFFECT_WAIT_EVENT_TYPES = new Set<TimelineEvent['event_type']>([
+  'effect',
+  'wait',
+]);
+
 /**
  * Chronological timeline view for trace events and synthetic lifecycle markers.
  */
@@ -36,9 +60,12 @@ export function Timeline({
   spanIndex,
 }: TimelineProps) {
   const [showErrorsOnly, setShowErrorsOnly] = useState(false);
-  const visibleEvents = showErrorsOnly
-    ? events.filter((event) => isTimelineErrorEvent(event))
-    : events;
+  const [filterMode, setFilterMode] = useState<TimelineFilterMode>('all');
+  const visibleEvents = events.filter(
+    (event) =>
+      matchesTimelineFilterMode(event, filterMode) &&
+      (!showErrorsOnly || isTimelineErrorEvent(event))
+  );
 
   return (
     <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
@@ -52,6 +79,7 @@ export function Timeline({
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          <SegmentedFilter filterMode={filterMode} onChange={setFilterMode} />
           <button
             type="button"
             className={`rounded-full border px-3 py-1 text-xs font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
@@ -88,9 +116,7 @@ export function Timeline({
         <div className="px-4 py-12 text-center text-sm text-red-600">{error}</div>
       ) : visibleEvents.length === 0 ? (
         <div className="px-4 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
-          {showErrorsOnly
-            ? 'No error events for this trace.'
-            : 'No timeline events recorded for this trace yet.'}
+          {getTimelineEmptyStateMessage(filterMode, showErrorsOnly)}
         </div>
       ) : (
         <div className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -128,6 +154,8 @@ function TimelineRow({
   const isError = isTimelineErrorEvent(event);
   const stateChange = getStateChangeDetails(event);
   const decision = getDecisionDetails(event);
+  const effectDetails = getEffectDetails(event);
+  const waitDetails = getWaitDetails(event);
   const rowAccent = isError
     ? 'border-red-200 bg-red-50/70 dark:border-red-500/40 dark:bg-red-500/10'
     : event.source === 'synthetic'
@@ -170,6 +198,10 @@ function TimelineRow({
                 <StateChangePreview stateChange={stateChange} />
               ) : decision ? (
                 <DecisionPreview decision={decision} />
+              ) : effectDetails ? (
+                <EffectPreview effect={effectDetails} />
+              ) : waitDetails ? (
+                <WaitPreview wait={waitDetails} />
               ) : (
                 <p className="mt-3 text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
                   {summarizeTimelineEvent(event)}
@@ -241,6 +273,64 @@ function TimelineRow({
   );
 }
 
+function SegmentedFilter({
+  filterMode,
+  onChange,
+}: {
+  filterMode: TimelineFilterMode;
+  onChange: (mode: TimelineFilterMode) => void;
+}) {
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const handleKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    const nextIndex = getSegmentedFilterTargetIndex(event.key, index);
+    if (nextIndex === null) {
+      return;
+    }
+
+    event.preventDefault();
+    onChange(TIMELINE_FILTER_OPTIONS[nextIndex].mode);
+    optionRefs.current[nextIndex]?.focus();
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Timeline event filter"
+      className="flex items-center gap-1 rounded-full border border-slate-200 bg-white p-1 text-xs font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+    >
+      {TIMELINE_FILTER_OPTIONS.map((option, index) => {
+        const active = option.mode === filterMode;
+
+        return (
+          <button
+            key={option.mode}
+            ref={(element) => {
+              optionRefs.current[index] = element;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            tabIndex={active ? 0 : -1}
+            className={`rounded-full px-3 py-1 transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
+              active
+                ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+                : 'text-slate-600 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800'
+            }`}
+            onClick={() => onChange(option.mode)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 function StateChangePreview({
   stateChange,
 }: {
@@ -297,6 +387,45 @@ function DecisionPreview({
   );
 }
 
+function EffectPreview({
+  effect,
+}: {
+  effect: NonNullable<ReturnType<typeof getEffectDetails>>;
+}) {
+  return (
+    <div className="mt-3 space-y-2">
+      <p className="text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
+        {effect.effectKind}
+      </p>
+      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+        <SemanticValuePill tone={effect.hasExternalSideEffect ? 'accent' : 'neutral'}>
+          {effect.hasExternalSideEffect ? 'mutating' : 'read-only'}
+        </SemanticValuePill>
+      </div>
+    </div>
+  );
+}
+
+function WaitPreview({
+  wait,
+}: {
+  wait: NonNullable<ReturnType<typeof getWaitDetails>>;
+}) {
+  return (
+    <div className="mt-3 space-y-2">
+      <p className="text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
+        {wait.waitKind}
+      </p>
+      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+        <SemanticValuePill>{wait.phase}</SemanticValuePill>
+        {wait.resolution ? (
+          <SemanticValuePill tone="accent">{wait.resolution}</SemanticValuePill>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 function SemanticValuePill({
   children,
   tone = 'neutral',
@@ -328,6 +457,71 @@ function formatTimelineTime(timestamp: string): string {
 
 function formatEventType(eventType: TimelineEvent['event_type']): string {
   return eventType.replace(/_/g, ' ');
+}
+
+function matchesTimelineFilterMode(
+  event: TimelineEvent,
+  filterMode: TimelineFilterMode
+): boolean {
+  if (filterMode === 'all') {
+    return true;
+  }
+
+  if (event.source !== 'explicit') {
+    return false;
+  }
+
+  if (filterMode === 'semantic') {
+    return SEMANTIC_EVENT_TYPES.has(event.event_type);
+  }
+
+  return EFFECT_WAIT_EVENT_TYPES.has(event.event_type);
+}
+
+function getTimelineEmptyStateMessage(
+  filterMode: TimelineFilterMode,
+  showErrorsOnly: boolean
+): string {
+  if (showErrorsOnly) {
+    if (filterMode === 'semantic') {
+      return 'No error-level semantic events for this trace.';
+    }
+    if (filterMode === 'effects-waits') {
+      return 'No error-level effect or wait events for this trace.';
+    }
+    return 'No error events for this trace.';
+  }
+
+  if (filterMode === 'semantic') {
+    return 'No semantic events for this trace.';
+  }
+  if (filterMode === 'effects-waits') {
+    return 'No effect or wait events for this trace.';
+  }
+  return 'No timeline events recorded for this trace yet.';
+}
+
+function getSegmentedFilterTargetIndex(
+  key: string,
+  currentIndex: number
+): number | null {
+  switch (key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      return (currentIndex + 1) % TIMELINE_FILTER_OPTIONS.length;
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      return (
+        (currentIndex - 1 + TIMELINE_FILTER_OPTIONS.length) %
+        TIMELINE_FILTER_OPTIONS.length
+      );
+    case 'Home':
+      return 0;
+    case 'End':
+      return TIMELINE_FILTER_OPTIONS.length - 1;
+    default:
+      return null;
+  }
 }
 
 function timelineStatusLabel(

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -1015,6 +1015,74 @@ describe('TraceDetailPage', () => {
     expect(view.router.state.location.search).toBe('?span=running-child');
   }, 10000);
 
+  it('persists the segmented timeline filter across inspector tab switches', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({ span_id: 'semantic-root', name: 'Semantic root' });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse({ ...TRACE_DETAIL, status: 'COMPLETED', error_count: 0 }),
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'narrative-event',
+                span_id: 'semantic-root',
+                span_name: 'Semantic root',
+                event_type: 'message',
+                message: 'Narrative event',
+              }),
+              createTimelineEvent({
+                id: 'semantic-effect',
+                span_id: 'semantic-root',
+                span_name: 'Semantic root',
+                event_type: 'effect',
+                payload: {
+                  effect_kind: 'tool_call',
+                  has_external_side_effect: true,
+                },
+              }),
+            ],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Timeline' }));
+    expect(screen.getByText('Narrative event')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: 'Semantic' }));
+    expect(screen.getByRole('radio', { name: 'Semantic' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.queryByText('Narrative event')).not.toBeInTheDocument();
+    expect(screen.getByText('tool_call')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Details' }));
+    expect(screen.getByRole('button', { name: 'Details' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Timeline' }));
+    expect(screen.getByRole('button', { name: 'Timeline' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByRole('radio', { name: 'Semantic' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.queryByText('Narrative event')).not.toBeInTheDocument();
+    expect(screen.getByText('tool_call')).toBeInTheDocument();
+  });
+
   it('resets selection and timeline filter state when navigating between traces', async () => {
     const user = userEvent.setup();
     const traceADetail: TraceDetail = {
@@ -1116,6 +1184,11 @@ describe('TraceDetailPage', () => {
     expect(view.router.state.location.search).toBe('?span=trace-a-root');
 
     await user.click(screen.getByRole('button', { name: 'Timeline' }));
+    await user.click(screen.getByRole('radio', { name: 'Semantic' }));
+    expect(screen.getByRole('radio', { name: 'Semantic' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
     await user.click(screen.getByRole('button', { name: 'Show error events only' }));
     expect(screen.getByRole('button', { name: 'Show error events only' })).toHaveAttribute(
       'aria-pressed',
@@ -1131,6 +1204,14 @@ describe('TraceDetailPage', () => {
     expect(screen.getByText('Select a span to view details')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Timeline' }));
     expect(screen.getByText('Beta info event')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'All' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getByRole('radio', { name: 'Semantic' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
     expect(screen.getByRole('button', { name: 'Show error events only' })).toHaveAttribute(
       'aria-pressed',
       'false'

--- a/web/src/utils/eventSemantics.test.ts
+++ b/web/src/utils/eventSemantics.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+import { createTimelineEvent } from '../test/traceFixtures';
+import { getEffectDetails, getWaitDetails } from './eventSemantics';
+
+describe('getEffectDetails', () => {
+  it('extracts a well-formed effect payload with all fields', () => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      payload: {
+        effect_kind: 'api_call',
+        has_external_side_effect: true,
+        effect_id: 'effect_abc123',
+        idempotent: false,
+        idempotency_key: 'key-1',
+      },
+    });
+
+    expect(getEffectDetails(event)).toEqual({
+      effectKind: 'api_call',
+      hasExternalSideEffect: true,
+      effectId: 'effect_abc123',
+      idempotent: false,
+      idempotencyKey: 'key-1',
+    });
+  });
+
+  it('extracts a minimal effect payload with required fields only', () => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      payload: {
+        effect_kind: 'model_call',
+        has_external_side_effect: false,
+      },
+    });
+
+    expect(getEffectDetails(event)).toEqual({
+      effectKind: 'model_call',
+      hasExternalSideEffect: false,
+      effectId: undefined,
+      idempotent: undefined,
+      idempotencyKey: undefined,
+    });
+  });
+
+  it('returns null when required fields are missing', () => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      payload: {
+        effect_kind: 'model_call',
+      },
+    });
+
+    expect(getEffectDetails(event)).toBeNull();
+  });
+
+  it('returns null for the wrong event type', () => {
+    const event = createTimelineEvent({
+      event_type: 'log',
+      payload: {
+        effect_kind: 'api_call',
+        has_external_side_effect: true,
+      },
+    });
+
+    expect(getEffectDetails(event)).toBeNull();
+  });
+
+  it('returns null when the payload is missing', () => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      payload: undefined,
+    });
+
+    expect(getEffectDetails(event)).toBeNull();
+  });
+
+  it.each([
+    {
+      label: 'effect_kind is not a string',
+      payload: {
+        effect_kind: 123,
+        has_external_side_effect: true,
+      },
+    },
+    {
+      label: 'effect_kind is an empty string',
+      payload: {
+        effect_kind: '',
+        has_external_side_effect: true,
+      },
+    },
+    {
+      label: 'has_external_side_effect is not a boolean',
+      payload: {
+        effect_kind: 'api_call',
+        has_external_side_effect: 'true',
+      },
+    },
+    {
+      label: 'effect_id is not a string',
+      payload: {
+        effect_kind: 'api_call',
+        has_external_side_effect: true,
+        effect_id: 42,
+      },
+    },
+    {
+      label: 'idempotent is not a boolean',
+      payload: {
+        effect_kind: 'api_call',
+        has_external_side_effect: true,
+        idempotent: 'yes',
+      },
+    },
+    {
+      label: 'idempotency_key is not a string',
+      payload: {
+        effect_kind: 'api_call',
+        has_external_side_effect: true,
+        idempotency_key: 42,
+      },
+    },
+  ])('returns null when $label', ({ payload }) => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      payload,
+    });
+
+    expect(getEffectDetails(event)).toBeNull();
+  });
+});
+
+describe('getWaitDetails', () => {
+  it('extracts a well-formed wait payload with all fields', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        wait_kind: 'human_approval',
+        phase: 'resolved',
+        resolution: 'approved',
+        wait_id: 'wait_xyz789',
+      },
+    });
+
+    expect(getWaitDetails(event)).toEqual({
+      waitKind: 'human_approval',
+      phase: 'resolved',
+      resolution: 'approved',
+      waitId: 'wait_xyz789',
+    });
+  });
+
+  it('extracts a minimal wait payload with required fields only', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        wait_kind: 'human_approval',
+        phase: 'entered',
+      },
+    });
+
+    expect(getWaitDetails(event)).toEqual({
+      waitKind: 'human_approval',
+      phase: 'entered',
+      resolution: undefined,
+      waitId: undefined,
+    });
+  });
+
+  it('returns null when required fields are missing', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        wait_kind: 'external',
+      },
+    });
+
+    expect(getWaitDetails(event)).toBeNull();
+  });
+
+  it('returns null for the wrong event type', () => {
+    const event = createTimelineEvent({
+      event_type: 'decision',
+      payload: {
+        wait_kind: 'human_approval',
+        phase: 'entered',
+      },
+    });
+
+    expect(getWaitDetails(event)).toBeNull();
+  });
+
+  it('returns null when the payload is missing', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      payload: undefined,
+    });
+
+    expect(getWaitDetails(event)).toBeNull();
+  });
+
+  it.each([
+    {
+      label: 'wait_kind is not a string',
+      payload: {
+        wait_kind: 123,
+        phase: 'entered',
+      },
+    },
+    {
+      label: 'wait_kind is an empty string',
+      payload: {
+        wait_kind: '',
+        phase: 'entered',
+      },
+    },
+    {
+      label: 'phase is not a string',
+      payload: {
+        wait_kind: 'human_approval',
+        phase: false,
+      },
+    },
+    {
+      label: 'phase is an empty string',
+      payload: {
+        wait_kind: 'human_approval',
+        phase: '',
+      },
+    },
+    {
+      label: 'resolution is not a string',
+      payload: {
+        wait_kind: 'human_approval',
+        phase: 'resolved',
+        resolution: 42,
+      },
+    },
+    {
+      label: 'wait_id is not a string',
+      payload: {
+        wait_kind: 'human_approval',
+        phase: 'entered',
+        wait_id: 42,
+      },
+    },
+  ])('returns null when $label', ({ payload }) => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      payload,
+    });
+
+    expect(getWaitDetails(event)).toBeNull();
+  });
+});

--- a/web/src/utils/eventSemantics.ts
+++ b/web/src/utils/eventSemantics.ts
@@ -14,6 +14,21 @@ export interface DecisionDetails {
   reasoning?: string;
 }
 
+export interface EffectDetails {
+  effectKind: string;
+  hasExternalSideEffect: boolean;
+  effectId?: string;
+  idempotent?: boolean;
+  idempotencyKey?: string;
+}
+
+export interface WaitDetails {
+  waitKind: string;
+  phase: string;
+  resolution?: string;
+  waitId?: string;
+}
+
 export function getStateChangeDetails(
   event: TimelineEvent
 ): StateChangeDetails | null {
@@ -55,6 +70,56 @@ export function getDecisionDetails(event: TimelineEvent): DecisionDetails | null
   };
 }
 
+export function getEffectDetails(event: TimelineEvent): EffectDetails | null {
+  if (event.event_type !== 'effect' || !event.payload) {
+    return null;
+  }
+
+  const effectKind = getNonEmptyString(event.payload, 'effect_kind');
+  const hasExternalSideEffect = getBoolean(event.payload, 'has_external_side_effect');
+  const effectId = getOptionalNonEmptyString(event.payload, 'effect_id');
+  const idempotent = getOptionalBoolean(event.payload, 'idempotent');
+  const idempotencyKey = getOptionalNonEmptyString(event.payload, 'idempotency_key');
+  if (
+    !effectKind ||
+    hasExternalSideEffect === null ||
+    effectId === null ||
+    idempotent === null ||
+    idempotencyKey === null
+  ) {
+    return null;
+  }
+
+  return {
+    effectKind,
+    hasExternalSideEffect,
+    effectId,
+    idempotent,
+    idempotencyKey,
+  };
+}
+
+export function getWaitDetails(event: TimelineEvent): WaitDetails | null {
+  if (event.event_type !== 'wait' || !event.payload) {
+    return null;
+  }
+
+  const waitKind = getNonEmptyString(event.payload, 'wait_kind');
+  const phase = getNonEmptyString(event.payload, 'phase');
+  const resolution = getOptionalNonEmptyString(event.payload, 'resolution');
+  const waitId = getOptionalNonEmptyString(event.payload, 'wait_id');
+  if (!waitKind || !phase || resolution === null || waitId === null) {
+    return null;
+  }
+
+  return {
+    waitKind,
+    phase,
+    resolution,
+    waitId,
+  };
+}
+
 export function formatInlineSemanticValue(value: unknown): string {
   if (value === undefined) {
     return 'unset';
@@ -83,4 +148,35 @@ function getNonEmptyString(
 ): string | null {
   const value = payload[key];
   return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function getOptionalNonEmptyString(
+  payload: Record<string, unknown>,
+  key: string
+): string | undefined | null {
+  // `undefined` means the optional field is absent; `null` means it was present
+  // but malformed, so callers can reject partially-invalid semantic payloads.
+  if (!Object.prototype.hasOwnProperty.call(payload, key)) {
+    return undefined;
+  }
+
+  return getNonEmptyString(payload, key);
+}
+
+function getBoolean(payload: Record<string, unknown>, key: string): boolean | null {
+  const value = payload[key];
+  return typeof value === 'boolean' ? value : null;
+}
+
+function getOptionalBoolean(
+  payload: Record<string, unknown>,
+  key: string
+): boolean | undefined | null {
+  // `undefined` means the optional field is absent; `null` means it was present
+  // but malformed, so callers can reject partially-invalid semantic payloads.
+  if (!Object.prototype.hasOwnProperty.call(payload, key)) {
+    return undefined;
+  }
+
+  return getBoolean(payload, key);
 }

--- a/web/src/utils/timeline.test.ts
+++ b/web/src/utils/timeline.test.ts
@@ -50,4 +50,105 @@ describe('summarizeTimelineEvent', () => {
     expect(summarizeTimelineEvent(stateEvent)).toBe('state fallback');
     expect(summarizeTimelineEvent(decisionEvent)).toBe('decision fallback');
   });
+
+  it('summarizes mutating effects from semantic payload fields', () => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      message: 'fallback effect',
+      payload: {
+        effect_kind: 'api_call',
+        has_external_side_effect: true,
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('api_call (mutating)');
+  });
+
+  it('summarizes read-only effects from semantic payload fields', () => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      message: 'fallback effect',
+      payload: {
+        effect_kind: 'model_call',
+        has_external_side_effect: false,
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('model_call (read-only)');
+  });
+
+  it('falls back to the message for malformed effects', () => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      message: 'Custom effect note',
+      payload: {
+        effect_kind: 'api_call',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('Custom effect note');
+  });
+
+  it('falls back to the event type for malformed effects without a message', () => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      payload: {
+        effect_kind: 'api_call',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('effect');
+  });
+
+  it('summarizes waits with a resolution from semantic payload fields', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      message: 'fallback wait',
+      payload: {
+        wait_kind: 'human_approval',
+        phase: 'resolved',
+        resolution: 'approved',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe(
+      'human_approval (resolved) → approved'
+    );
+  });
+
+  it('summarizes waits without a resolution from semantic payload fields', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      message: 'fallback wait',
+      payload: {
+        wait_kind: 'human_approval',
+        phase: 'entered',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('human_approval (entered)');
+  });
+
+  it('falls back to the message for malformed waits', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      message: 'Custom wait note',
+      payload: {
+        wait_kind: 'human_approval',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('Custom wait note');
+  });
+
+  it('falls back to the event type for malformed waits without a message', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        wait_kind: 'human_approval',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('wait');
+  });
 });

--- a/web/src/utils/timeline.ts
+++ b/web/src/utils/timeline.ts
@@ -2,7 +2,9 @@ import { TimelineEvent } from '../api/client';
 import {
   formatInlineSemanticValue,
   getDecisionDetails,
+  getEffectDetails,
   getStateChangeDetails,
+  getWaitDetails,
 } from './eventSemantics';
 
 /**
@@ -77,6 +79,24 @@ export function summarizeTimelineEvent(event: TimelineEvent): string {
         return `${details.question} → ${formatInlineSemanticValue(details.chosen)}`;
       }
       return event.message ?? 'decision';
+    }
+    case 'effect': {
+      const details = getEffectDetails(event);
+      if (details) {
+        return `${details.effectKind} (${
+          details.hasExternalSideEffect ? 'mutating' : 'read-only'
+        })`;
+      }
+      return event.message ?? 'effect';
+    }
+    case 'wait': {
+      const details = getWaitDetails(event);
+      if (details) {
+        return details.resolution
+          ? `${details.waitKind} (${details.phase}) → ${details.resolution}`
+          : `${details.waitKind} (${details.phase})`;
+      }
+      return event.message ?? 'wait';
     }
     case 'span_started':
       return `${event.span_name ?? event.span_id ?? 'Span'} started`;


### PR DESCRIPTION
## Summary
- add effect and wait semantic extraction plus structured timeline summaries
- add effect/wait previews, segmented timeline filtering, and page-level filter lifecycle coverage
- add the approved OpenSpec change files and restore the local ignore entries requested for `Study/` and `continua`

## Testing
- `pnpm --filter web test`
- `go test ./internal/api/...`
- `openspec validate add-basic-semantic-timeline-surfaces --strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semantic timeline surfaces for effect and wait events with dedicated previews.
  * Implemented segmented timeline filter with modes: All, Semantic, and Effects & waits.
  * Filter state persists across inspector tabs and resets on trace navigation.

* **Documentation**
  * Added design specifications, proposal, and detailed specs for semantic timeline features.

* **Tests**
  * Comprehensive test coverage for semantic event parsing and timeline filtering.

* **Chores**
  * Updated `.gitignore` with new exclusion entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->