### PR TITLE
Add retry safety classification

### DIFF
--- a/openspec/changes/add-retry-safety-classification/design.md
+++ b/openspec/changes/add-retry-safety-classification/design.md
@@ -1,0 +1,65 @@
+## Context
+
+The debugger renders `effect` events with structured semantic payloads (`effect_kind`, `has_external_side_effect`, `idempotent`, `idempotency_key`) via `getEffectDetails()` in `eventSemantics.ts`. This change adds advisory retry-safety guidance derived from those payloads, scoped to failed traces only. The classification is purely client-side — no backend, API, or storage changes.
+
+Key codebase constraints:
+- `getEffectDetails()` returns `null` for any malformation (missing required fields, wrong types, malformed optional fields). The classifier must distinguish "well-formed effect with clear signal" from "effect event where extraction fails."
+- `useTraceTimeline` emits a new `events` array reference on each poll cycle even when content hasn't changed. Naive `useMemo` on `events` would recompute every poll.
+- `buildFailureAnalysis` and `findPrimaryFailedSpan` are separate concerns. Retry-safety must not alter failure-first navigation.
+- Span statuses are `SCHEDULED | STARTED | COMPLETED | FAILED` — no cancelled/error states exist.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Surface advisory retry-safety guidance on failed traces
+  - Classify individual effect events, aggregate per failed span, aggregate per trace
+  - Keep classification stable across timeline poll updates that add non-effect events
+  - Use existing `getEffectDetails()` — no independent payload parsing
+
+- Non-Goals:
+  - Automated retry or resume
+  - Backend retry-safety storage or API fields
+  - Classification from `wait`, `decision`, `state_change`, or error events
+  - Policy enforcement or blocking
+  - Classification on non-failed traces
+
+## Decisions
+
+### Decision: Reuse `getEffectDetails()` with null-means-malformed semantics
+`getEffectDetails()` already validates required fields and types. A `null` return on an `effect`-typed event means malformed payload → `unknown / malformed_effect_payload`. Well-formed payloads flow through the classification rules.
+
+Alternatives considered:
+- Separate retry-safety parser: rejected — duplicates validation logic, risks divergence with `eventSemantics.ts`.
+- Extend `getEffectDetails()` to return partial results: rejected — changes existing contract used by Timeline previews.
+
+### Decision: Stable output across irrelevant poll updates
+The hook must produce identical output (classifications, reasons, decisive evidence) when timeline polls add events that don't affect the set of failed spans or their effect events. The implementation strategy (signature-based memoization, deep comparison, etc.) is left to the implementer. The contract is output stability, not a specific caching mechanism.
+
+Rejected alternative approaches for context:
+- Naive `useMemo` on `events` array: recomputes every poll since `useTraceTimeline` emits a new array reference.
+- Debounced recomputation: introduces stale windows, harder to test.
+
+### Decision: Separate from `buildFailureAnalysis`
+Retry-safety and failure analysis serve different purposes (safety guidance vs. failure triage). Merging them would couple their evolution and make the failure analysis function harder to test. The retry-safety hook consumes spans and events independently.
+
+### Decision: Badge component is visual-only
+`RetrySafetyBadge` takes classification, variant, and optional `aria-label` props and renders a styled label. No `tooltip` prop — if a surface needs hover text later, it can wrap the badge locally. Explanation text, evidence details, and advisory copy live in the consuming components (FailureSummary, SpanDetail) using shared helper functions from `retrySafety.ts`. This keeps the badge reusable and testable in isolation.
+
+### Decision: Prop threading — page-level aggregation, local row classification
+`TraceDetailPage` owns the `useRetrySafetyAnalysis` hook and threads aggregated results down via explicit props. Span-indexed surfaces (`SpanTree`, `ExecutionWaterfall`) receive a `Map<string, RetrySafetyAssessment>` keyed by span id. Single-assessment surfaces (`FailureSummary`, `SpanDetail`) receive a nullable `RetrySafetyAssessment`.
+
+`Timeline` does NOT receive event-level assessments as a prop. It already has `traceStatus` and imports `getEffectDetails`, so it classifies effect rows locally using the shared `classifyEffectEvent()` utility. This avoids redundant prop churn and keeps the Timeline self-contained for row-level rendering.
+
+`FailureSummary` reuses its existing `onJumpToPrimaryFailedSpan: (spanId: string) => void` callback for decisive-span navigation rather than introducing a new callback.
+
+New props on leaf display components are optional with null/empty defaults for backward compatibility. `TraceDetailPage` passes them explicitly at the wiring site — optionality is a component-level contract, not an excuse to skip wiring.
+
+## Risks / Trade-offs
+
+- **Incomplete classification**: effects without `idempotent` or `idempotency_key` produce `unknown`, which may feel unhelpful. Mitigation: explanation text clearly states what's missing, encouraging SDK users to provide richer metadata.
+- **Effect-only scope**: classification ignores `wait` resolution, error messages, and trace-level status. This is intentional for Phase 4 — expanding to multi-signal classification is a future phase.
+- **Poll signature cost**: building the signature requires iterating effect events each poll. In practice, effect events are a small subset of timeline events, so this is negligible.
+
+## Open Questions
+
+None — the plan is fully specified.

--- a/openspec/changes/add-retry-safety-classification/proposal.md
+++ b/openspec/changes/add-retry-safety-classification/proposal.md
@@ -1,0 +1,58 @@
+# Change: Add Retry Safety Classification
+
+## Why
+
+The debugger now surfaces `effect` events with structured semantic payloads (Phase 3: `add-basic-semantic-timeline-surfaces`), but provides no guidance on whether a failed trace can be safely retried. Operators inspecting failures must manually read effect payloads to determine whether external mutations were idempotent. This phase adds a purely advisory, read-only retry-safety classification derived from `effect` metadata, visible only on failed traces and failed spans. No automated retry, no resume, no enforcement — just surfaced guidance to help operators make informed retry decisions.
+
+## What Changes
+
+### Pure classification utility (`web/src/utils/retrySafety.ts`)
+- New `RetrySafetyClassification` type: `retryable | unsafe | unknown`
+- New `RetrySafetyReason` enum covering seven reason codes
+- New `RetrySafetyAssessment` shape carrying classification, reason, decisive span/event evidence, and extracted effect fields
+- Event-level classifier using `getEffectDetails()` from `eventSemantics.ts` — no independent payload parsing
+- Span-level aggregation across effect events on a single failed span with `unsafe > unknown > retryable` precedence
+- Trace-level aggregation across all failed spans with the same precedence, carrying the decisive span identity
+- Explanation text mapping from reason codes to fixed human-readable strings
+
+### Stable analysis hook (`web/src/pages/useRetrySafetyAnalysis.ts`)
+- Page-level hook backed by the pure utility
+- Effect-relevant signature (failed span ids + effect event classifier inputs) prevents recomputation when non-effect timeline events arrive from polling
+
+### Badge component (`web/src/components/RetrySafetyBadge.tsx`)
+- Visual-only badge with `Retryable`, `Unsafe`, `Unknown` labels
+- Compact and full variants
+- Tailwind semantic classes with dark-mode support
+
+### UI surface integration (failure-only)
+- Failure summary: aggregated trace retry-safety badge/stat with advisory copy and reason explanation
+- Span tree: compact badges on failed spans only
+- Execution waterfall: compact badge in left metadata column
+- Selected span detail: dedicated `Retry Safety` section for failed spans
+- Timeline: effect rows on failed traces render retry-safety badges
+
+### Component prop changes
+- `FailureSummary`: new optional `traceRetrySafety: RetrySafetyAssessment | null` prop; reuses existing `onJumpToPrimaryFailedSpan` callback shape for decisive-span navigation (no new callback)
+- `SpanTree`: new optional `spanAssessments: Map<string, RetrySafetyAssessment>` prop keyed by span id
+- `SpanDetail`: new optional `retrySafety: RetrySafetyAssessment | null` prop
+- `ExecutionWaterfall`: new optional `spanAssessments: Map<string, RetrySafetyAssessment>` prop keyed by span id
+- `Timeline`: no new props — classifies effect rows locally using the shared `classifyEffectEvent()` utility and its existing `traceStatus` prop to gate badge rendering to failed traces
+
+New props on leaf display components (`SpanTree`, `SpanDetail`, `ExecutionWaterfall`, `FailureSummary`) are optional with null/empty defaults for backward compatibility with existing test harnesses. `TraceDetailPage` passes them explicitly at the wiring site.
+
+## Impact
+- Affected specs: `retry-safety-classification` (new capability)
+- Affected code:
+  - `web/src/utils/retrySafety.ts` — new pure utility
+  - `web/src/utils/retrySafety.test.ts` — classifier and aggregation tests
+  - `web/src/pages/useRetrySafetyAnalysis.ts` — new hook
+  - `web/src/components/RetrySafetyBadge.tsx` — new badge component
+  - `web/src/components/FailureSummary.tsx` — trace-level badge integration (new props)
+  - `web/src/components/SpanTree.tsx` — failed span badge integration (new props)
+  - `web/src/components/SpanDetail.tsx` — retry safety section (new props)
+  - `web/src/components/ExecutionWaterfall.tsx` — waterfall label badge integration (new props)
+  - `web/src/components/Timeline.tsx` — effect row badge integration (local classification, no new props)
+  - `web/src/pages/TraceDetailPage.tsx` — hook wiring and prop threading
+  - Component and page-level test files for all touched surfaces
+- No backend, API, DB, SDK, ingest, contract, migration, or engine changes
+- No changes to `findPrimaryFailedSpan()`, `buildFailureAnalysis`, or failure-first navigation

--- a/openspec/changes/add-retry-safety-classification/specs/retry-safety-classification/spec.md
+++ b/openspec/changes/add-retry-safety-classification/specs/retry-safety-classification/spec.md
@@ -1,0 +1,279 @@
+## ADDED Requirements
+
+### Requirement: Event-Level Retry Safety Classification
+
+The system SHALL provide a pure function that classifies a single timeline event into a `RetrySafetyAssessment` containing a `classification` (`retryable | unsafe | unknown`) and a `reason` code, or returns `null` if the event is not an `effect` event.
+
+The function SHALL return `null` without classification when the input event has an `event_type` other than `effect`. Only events with `event_type === 'effect'` SHALL proceed to classification.
+
+The function SHALL use `getEffectDetails()` from `eventSemantics.ts` for semantic validation and SHALL NOT independently parse effect payloads.
+
+Classification rules:
+- `has_external_side_effect` is `false` → `retryable` / `read_only_effect`
+- `has_external_side_effect` is `true` and `idempotent` is `false` → `unsafe` / `mutating_non_idempotent`
+- `has_external_side_effect` is `true` and `idempotent` is `true` and `idempotency_key` is a non-empty string → `retryable` / `mutating_idempotent_with_key`
+- `has_external_side_effect` is `true` and `idempotent` is `undefined` → `unknown` / `mutating_missing_idempotent`
+- `has_external_side_effect` is `true` and `idempotent` is `true` and `idempotency_key` is `undefined` → `unknown` / `mutating_idempotent_missing_key`
+- `event_type` is `effect` but `getEffectDetails()` returns `null` → `unknown` / `malformed_effect_payload`
+
+The assessment SHALL carry optional evidence fields: `decisiveEventId`, `effectKind`, `hasExternalSideEffect`, `idempotent`, and `idempotencyKey`.
+
+#### Scenario: Read-only effect classified as retryable
+- **WHEN** a timeline event has `event_type: "effect"` and `getEffectDetails()` returns `{ effectKind: "model_call", hasExternalSideEffect: false }`
+- **THEN** the classification is `retryable` with reason `read_only_effect`
+
+#### Scenario: Mutating non-idempotent effect classified as unsafe
+- **WHEN** a timeline event has `event_type: "effect"` and `getEffectDetails()` returns `{ effectKind: "api_call", hasExternalSideEffect: true, idempotent: false }`
+- **THEN** the classification is `unsafe` with reason `mutating_non_idempotent`
+
+#### Scenario: Mutating idempotent effect with key classified as retryable
+- **WHEN** a timeline event has `event_type: "effect"` and `getEffectDetails()` returns `{ effectKind: "api_call", hasExternalSideEffect: true, idempotent: true, idempotencyKey: "key-1" }`
+- **THEN** the classification is `retryable` with reason `mutating_idempotent_with_key`
+
+#### Scenario: Mutating effect with missing idempotent flag classified as unknown
+- **WHEN** a timeline event has `event_type: "effect"` and `getEffectDetails()` returns `{ effectKind: "tool_call", hasExternalSideEffect: true }` with `idempotent` undefined
+- **THEN** the classification is `unknown` with reason `mutating_missing_idempotent`
+
+#### Scenario: Mutating idempotent effect with missing key classified as unknown
+- **WHEN** a timeline event has `event_type: "effect"` and `getEffectDetails()` returns `{ effectKind: "tool_call", hasExternalSideEffect: true, idempotent: true }` with `idempotencyKey` undefined
+- **THEN** the classification is `unknown` with reason `mutating_idempotent_missing_key`
+
+#### Scenario: Malformed effect payload classified as unknown
+- **WHEN** a timeline event has `event_type: "effect"` but `getEffectDetails()` returns `null`
+- **THEN** the classification is `unknown` with reason `malformed_effect_payload`
+
+#### Scenario: Non-effect event returns null
+- **WHEN** a timeline event has `event_type: "log"` or any type other than `effect`
+- **THEN** the function returns `null` without producing an assessment
+
+### Requirement: Span-Level Retry Safety Aggregation
+
+The system SHALL provide a function that aggregates event-level classifications into a single `RetrySafetyAssessment` for a failed span.
+
+The function SHALL evaluate only explicit `effect` events attached to that span. Only spans with `status === 'FAILED'` SHALL be eligible for assessment.
+
+Aggregation precedence SHALL be `unsafe > unknown > retryable`. Within the winning classification class, the function SHALL select the latest matching event (by timeline ordering) as evidence.
+
+If a failed span has no `effect` events, the assessment SHALL be `unknown` with reason `no_effect_events`.
+
+The assessment SHALL carry `decisiveSpanId`, `decisiveSpanName`, and `decisiveEventId` identifying the evidence.
+
+#### Scenario: Single retryable effect on failed span
+- **WHEN** a failed span has one effect event classified as `retryable`
+- **THEN** the span assessment is `retryable` with the event as evidence
+
+#### Scenario: Mixed effects with unsafe taking precedence
+- **WHEN** a failed span has one `retryable` effect event and one `unsafe` effect event
+- **THEN** the span assessment is `unsafe` with the unsafe event as evidence
+
+#### Scenario: Mixed effects with unknown taking precedence over retryable
+- **WHEN** a failed span has one `retryable` effect event and one `unknown` effect event
+- **THEN** the span assessment is `unknown` with the unknown event as evidence
+
+#### Scenario: Failed span with no effect events
+- **WHEN** a failed span has no effect events
+- **THEN** the span assessment is `unknown` with reason `no_effect_events`
+
+#### Scenario: Non-failed span excluded from assessment
+- **WHEN** a span has `status` of `COMPLETED` and has effect events
+- **THEN** the span is not eligible for retry-safety assessment
+
+#### Scenario: Latest event wins within same classification
+- **WHEN** a failed span has two `unsafe` effect events at different timestamps
+- **THEN** the span assessment selects the later event as decisive evidence
+
+### Requirement: Trace-Level Retry Safety Aggregation
+
+The system SHALL provide a function that aggregates span-level assessments into a single `RetrySafetyAssessment` for a failed trace.
+
+The function SHALL aggregate across all failed spans in the trace, not just the primary failed span.
+
+Aggregation precedence SHALL be `unsafe > unknown > retryable`. The assessment SHALL carry the `decisiveSpanId` and `decisiveSpanName` of the span whose assessment determined the trace-level result.
+
+If the trace is failed but contains no assessable failed spans, the assessment SHALL be `unknown`.
+
+#### Scenario: Single failed span determines trace assessment
+- **WHEN** a failed trace has one failed span assessed as `retryable`
+- **THEN** the trace assessment is `retryable` carrying that span as decisive
+
+#### Scenario: Multiple failed spans with unsafe taking precedence
+- **WHEN** a failed trace has one failed span assessed as `retryable` and another assessed as `unsafe`
+- **THEN** the trace assessment is `unsafe` carrying the unsafe span as decisive
+
+#### Scenario: Decisive span differs from primary failed span
+- **WHEN** a failed trace's primary failed span is assessed as `retryable` but a secondary failed span is assessed as `unsafe`
+- **THEN** the trace assessment is `unsafe` and the decisive span is the secondary failed span, not the primary
+
+#### Scenario: Failed trace with no assessable failed spans
+- **WHEN** a failed trace has no failed spans (e.g., trace-level failure without span failures)
+- **THEN** the trace assessment is `unknown`
+
+### Requirement: Poll-Stable Retry Safety Analysis
+
+The system SHALL provide a page-level hook (recommended name `useRetrySafetyAnalysis`) that computes retry-safety analysis from spans and timeline events.
+
+The hook SHALL produce stable output — identical classifications, reasons, and decisive span/event identifiers — when timeline polling adds events that do not change the set of failed spans or the effect events attached to them.
+
+The hook SHALL produce updated output when the set of failed spans changes or when effect events on failed spans are added, removed, or modified.
+
+#### Scenario: Non-effect poll update produces stable results
+- **WHEN** a timeline poll adds a new `log` event but no new effect events and no span status changes
+- **THEN** the retry-safety analysis returns the same classifications, reasons, and decisive span/event identifiers as the previous result
+
+#### Scenario: New effect event triggers recomputation
+- **WHEN** a timeline poll adds a new `effect` event on a failed span
+- **THEN** the retry-safety analysis result is recomputed with the new event included
+
+#### Scenario: Span status change triggers recomputation
+- **WHEN** a timeline poll changes a span from `STARTED` to `FAILED`
+- **THEN** the retry-safety analysis result is recomputed to include the newly failed span
+
+### Requirement: Retry Safety Badge Component
+
+The system SHALL provide a `RetrySafetyBadge` component in `web/src/components/RetrySafetyBadge.tsx`.
+
+The badge SHALL accept `classification` (`retryable | unsafe | unknown`) and `variant` (`compact | full`) props, plus an optional `aria-label` string.
+
+Visible labels SHALL be single words: `Retryable`, `Unsafe`, `Unknown`. The badge SHALL NOT contain long-form evidence text.
+
+The badge SHALL use Tailwind semantic color classes with dark-mode variants. No hardcoded hex color values.
+
+#### Scenario: Retryable badge renders with appropriate styling
+- **WHEN** `RetrySafetyBadge` is rendered with `classification="retryable"` and `variant="compact"`
+- **THEN** it displays "Retryable" with a green-family Tailwind color class and dark-mode variant
+
+#### Scenario: Unsafe badge renders with appropriate styling
+- **WHEN** `RetrySafetyBadge` is rendered with `classification="unsafe"` and `variant="full"`
+- **THEN** it displays "Unsafe" with a red-family Tailwind color class and dark-mode variant
+
+#### Scenario: Unknown badge renders with appropriate styling
+- **WHEN** `RetrySafetyBadge` is rendered with `classification="unknown"`
+- **THEN** it displays "Unknown" with a yellow/amber-family Tailwind color class and dark-mode variant
+
+#### Scenario: Badge supports accessibility label
+- **WHEN** `RetrySafetyBadge` is rendered with an `aria-label` of "Retry safety advisory: retryable. Inferred from effect metadata."
+- **THEN** the badge element has the corresponding `aria-label` attribute
+
+### Requirement: Retry Safety Explanation Text
+
+The system SHALL provide a mapping from each `RetrySafetyReason` to fixed human-readable explanation text:
+
+- `read_only_effect`: "Retry would repeat a read-only effect with no recorded external mutation."
+- `mutating_non_idempotent`: "Recorded effect mutates external state and is explicitly non-idempotent."
+- `mutating_idempotent_with_key`: "Recorded effect mutates external state but is marked idempotent and includes an idempotency key."
+- `no_effect_events`: "No effect events were recorded for this failed span."
+- `malformed_effect_payload`: "An effect event was recorded, but its retry-safety fields were malformed or incomplete."
+- `mutating_missing_idempotent`: "An effect may mutate external state, but no idempotency flag was recorded."
+- `mutating_idempotent_missing_key`: "An effect is marked idempotent, but no idempotency key was recorded."
+
+The system SHALL provide a shared accessible summary template: `"Retry safety advisory: {classification}. Inferred from effect metadata."`
+
+#### Scenario: Each reason code maps to explanation text
+- **WHEN** the explanation helper is called with any valid `RetrySafetyReason`
+- **THEN** it returns the corresponding fixed explanation string
+
+#### Scenario: Accessible summary uses classification
+- **WHEN** the accessible summary helper is called with classification `unsafe`
+- **THEN** it returns "Retry safety advisory: unsafe. Inferred from effect metadata."
+
+### Requirement: Failure Summary Retry Safety Surface
+
+The `FailureSummary` component SHALL display a `Trace retry safety` badge/stat showing the aggregated trace-level retry-safety assessment when the trace is failed.
+
+The badge SHALL NOT be attached to the primary failed span title, because the decisive span may differ.
+
+The surface SHALL show advisory copy plus a reason-specific explanation string.
+
+When the decisive failed span differs from the primary failed span, the surface SHALL state this explicitly and provide a secondary action to navigate to the decisive span, reusing the existing span-navigation callback (`onJumpToPrimaryFailedSpan`).
+
+#### Scenario: Trace-level retryable assessment in failure summary
+- **WHEN** the trace is failed and the aggregated assessment is `retryable` with reason `read_only_effect`
+- **THEN** the failure summary shows a `Retryable` badge, the advisory text, and the read-only explanation
+
+#### Scenario: Decisive span differs from primary span
+- **WHEN** the trace assessment is `unsafe` and the decisive span is not the primary failed span
+- **THEN** the failure summary states the decisive span name and provides an action to navigate to it
+
+#### Scenario: Non-failed trace shows no retry safety
+- **WHEN** the trace status is `COMPLETED` or `RUNNING`
+- **THEN** the failure summary does not render any retry-safety badge or section
+
+### Requirement: Span Tree Retry Safety Badges
+
+The `SpanTree` component SHALL display compact retry-safety badges on failed spans only.
+
+Existing `Selected`, `Failure path`, and `Failed` chips SHALL remain unchanged.
+
+Non-failed spans SHALL NOT display retry-safety badges regardless of their effect events.
+
+#### Scenario: Failed span shows compact retry badge
+- **WHEN** a span in the tree has `status === 'FAILED'` and a span-level assessment of `unsafe`
+- **THEN** the span tree node displays a compact `Unsafe` badge alongside existing status indicators
+
+#### Scenario: Completed span shows no retry badge
+- **WHEN** a span in the tree has `status === 'COMPLETED'` and effect events exist
+- **THEN** the span tree node does not display any retry-safety badge
+
+### Requirement: Execution Waterfall Retry Safety Badges
+
+The execution waterfall SHALL display compact retry-safety badges in the left metadata column for failed spans, never inside the timing bar.
+
+The existing layout constraint SHALL be preserved: span name truncates first, badge stays single-line, no third text line is introduced.
+
+#### Scenario: Failed span waterfall label shows retry badge
+- **WHEN** a failed span is rendered in the execution waterfall with a span-level assessment
+- **THEN** the compact retry-safety badge is rendered within the left label container, not inside the timing bar element
+
+#### Scenario: Waterfall layout preserves truncation structure
+- **WHEN** a failed span has a long name and a retry-safety badge
+- **THEN** the span name container retains its truncation CSS class, the badge element has `whitespace-nowrap`, and both remain within the same label row container
+
+### Requirement: Selected Span Detail Retry Safety Section
+
+The `SpanDetail` component SHALL render a `Retry Safety` section for failed selected spans only.
+
+The section SHALL display the retry-safety badge, advisory copy, reason-specific explanation, and supporting semantic fields (`effect_kind`, `has_external_side_effect`, `idempotent`, `idempotency_key`) when present in the assessment.
+
+Non-failed selected spans SHALL NOT render the section.
+
+#### Scenario: Failed span with read-only effect shows retryable detail
+- **WHEN** the selected span has `status === 'FAILED'` and a span-level assessment of `retryable` with reason `read_only_effect` and `effectKind: "model_call"`
+- **THEN** the detail section shows the `Retryable` badge, advisory text, read-only explanation, and `effectKind: model_call`
+
+#### Scenario: Failed span with mutating non-idempotent effect shows unsafe detail
+- **WHEN** the selected span has `status === 'FAILED'` and a span-level assessment of `unsafe` with reason `mutating_non_idempotent`
+- **THEN** the detail section shows the `Unsafe` badge, advisory text, and non-idempotent explanation
+
+#### Scenario: Failed span with incomplete semantics shows unknown detail
+- **WHEN** the selected span has `status === 'FAILED'` and a span-level assessment of `unknown` with reason `mutating_missing_idempotent`
+- **THEN** the detail section shows the `Unknown` badge, advisory text, and missing-idempotent explanation
+
+#### Scenario: Completed span shows no retry safety section
+- **WHEN** the selected span has `status === 'COMPLETED'`
+- **THEN** no `Retry Safety` section is rendered
+
+### Requirement: Timeline Effect Row Retry Safety Badges
+
+On failed traces only, `effect` timeline rows SHALL render a retry-safety badge alongside existing content. The `Timeline` component SHALL classify effect rows locally using the shared `classifyEffectEvent()` utility and its existing `traceStatus` prop to gate badge rendering — no page-threaded event assessment props are required.
+
+Well-formed effect rows SHALL keep the current effect preview plus the new badge.
+
+Malformed effect rows SHALL keep generic summary text and display an `Unknown` badge. The malformed-payload explanation SHALL NOT appear inline in the collapsed row; it is accessible only via the expanded payload panel.
+
+Non-effect rows SHALL remain unchanged. Non-failed traces SHALL NOT render retry-safety badges on any rows.
+
+#### Scenario: Well-formed retryable effect on failed trace shows badge
+- **WHEN** a failed trace's timeline contains an effect row with `getEffectDetails()` returning `{ effectKind: "model_call", hasExternalSideEffect: false }`
+- **THEN** the row renders the existing `EffectPreview` content plus a `Retryable` badge
+
+#### Scenario: Malformed effect on failed trace shows unknown badge
+- **WHEN** a failed trace's timeline contains an effect row where `getEffectDetails()` returns `null`
+- **THEN** the row renders generic summary text and an `Unknown` badge
+
+#### Scenario: Effect row on completed trace shows no badge
+- **WHEN** a completed trace's timeline contains an effect row
+- **THEN** the row renders the `EffectPreview` content with no retry-safety badge
+
+#### Scenario: Non-effect row on failed trace unchanged
+- **WHEN** a failed trace's timeline contains a `log` or `state_change` row
+- **THEN** the row renders identically to its current behavior with no retry-safety badge

--- a/openspec/changes/add-retry-safety-classification/tasks.md
+++ b/openspec/changes/add-retry-safety-classification/tasks.md
@@ -1,0 +1,60 @@
+## 1. Pre-Implementation Verification
+- [x] 1.1 Verify `getEffectDetails()` in `eventSemantics.ts` returns `null` for malformed payloads and confirm the `EffectDetails` interface shape matches classifier expectations (`effectKind`, `hasExternalSideEffect`, `idempotent?`, `idempotencyKey?`)
+- [x] 1.2 Verify `buildFailureAnalysis` and `findPrimaryFailedSpan` in `failureAnalysis.ts` — confirm retry-safety will not alter these functions or their call sites
+- [x] 1.3 Verify `useTraceTimeline` poll behavior — confirm it emits a new `events` array reference on each poll even when content is unchanged, validating the need for an effect-relevant signature
+- [x] 1.4 Verify span status enum — confirm only `SCHEDULED | STARTED | COMPLETED | FAILED` are used in `client.ts` and downstream components
+
+## 2. Pure Classification Utility
+- [x] 2.1 Create `web/src/utils/retrySafety.ts` with `RetrySafetyClassification` type (`retryable | unsafe | unknown`), `RetrySafetyReason` type (seven reason codes), and `RetrySafetyAssessment` interface
+- [x] 2.2 Implement `classifyEffectEvent()` — takes a `TimelineEvent`, returns `null` for non-effect events, calls `getEffectDetails()` for effect events and returns `RetrySafetyAssessment` following the six classification rules
+- [x] 2.3 Implement `assessSpanRetrySafety()` — takes a failed span's effect events, aggregates with `unsafe > unknown > retryable` precedence, selects latest event within winning class as evidence, returns `unknown / no_effect_events` when no effects present
+- [x] 2.4 Implement `assessTraceRetrySafety()` — takes span-level assessments from all failed spans, aggregates with same precedence, carries decisive span identity
+- [x] 2.5 Implement `getReasonExplanation()` — maps each reason code to fixed explanation text
+- [x] 2.6 Implement `getAccessibleSummary()` — returns `"Retry safety advisory: {classification}. Inferred from effect metadata."`
+
+## 3. Classification Utility Tests
+- [x] 3.1 Add `web/src/utils/retrySafety.test.ts` with event-level tests: all six classification branches including `read_only_effect`, `mutating_non_idempotent`, `mutating_idempotent_with_key`, `mutating_missing_idempotent`, `mutating_idempotent_missing_key`, `malformed_effect_payload`, plus non-effect event returns `null`
+- [x] 3.2 Add span-level aggregation tests: single effect, mixed effects with precedence, no effects → `no_effect_events`, latest event wins within same class, non-failed spans excluded
+- [x] 3.3 Add trace-level aggregation tests: single failed span, multiple failed spans with precedence, decisive span differs from primary, no assessable failed spans → `unknown`
+- [x] 3.4 Add explanation text tests: each reason maps to correct string, accessible summary interpolates classification
+
+## 4. Poll-Stable Analysis Hook
+- [x] 4.1 Create `web/src/pages/useRetrySafetyAnalysis.ts` — build effect-relevant signature from failed span ids and per-effect classifier inputs, memoize on signature
+- [x] 4.2 Add hook tests verifying: non-effect poll updates produce stable classifications/reasons/evidence, new effect events trigger recomputation, span status changes trigger recomputation
+
+## 5. Badge Component
+- [x] 5.1 Create `web/src/components/RetrySafetyBadge.tsx` — visual-only badge with `classification`, `variant` (compact/full), and optional `aria-label` props; Tailwind semantic colors with dark-mode variants
+- [x] 5.2 Add badge component tests: renders correct label for each classification, applies correct color classes, supports compact and full variants, passes through aria-label, no hardcoded hex colors in output
+
+## 6. Failure Summary Integration
+- [x] 6.1 Add trace-level retry-safety badge/stat to `FailureSummary.tsx` — show only when trace is failed, display advisory copy and reason explanation
+- [x] 6.2 When decisive span differs from primary span, show explicit text naming the decisive span and a secondary action to navigate to it via the existing `onJumpToPrimaryFailedSpan` callback
+- [x] 6.3 Add failure summary tests: retryable/unsafe/unknown badge renders with correct explanation, decisive-span-differs case shows navigation action, non-failed trace shows no retry-safety surface
+
+## 7. Span Tree Integration
+- [x] 7.1 Add compact retry-safety badges to failed span nodes in `SpanTree.tsx` — keep existing `Selected`, `Failure path`, and `Failed` chips unchanged
+- [x] 7.2 Add span tree tests: failed span shows compact badge, completed span shows no badge, existing chips remain
+
+## 8. Execution Waterfall Integration
+- [x] 8.1 Add compact retry-safety badge to left label container of failed spans in `ExecutionWaterfall.tsx` — badge inside label container not timing bar, span name retains truncation class, badge has `whitespace-nowrap`
+- [x] 8.2 Add waterfall tests: badge rendered within label container for failed spans, span name container has truncation class, badge element has non-wrapping class, no badge on non-failed spans
+
+## 9. Selected Span Detail Integration
+- [x] 9.1 Add `Retry Safety` section to `SpanDetail.tsx` for failed spans — badge, advisory copy, reason explanation, supporting semantic fields
+- [x] 9.2 Add span detail tests: retryable/unsafe/unknown sections with correct content, non-failed span shows no section
+
+## 10. Timeline Effect Row Integration
+- [x] 10.1 Add retry-safety badge to effect rows in `Timeline.tsx` on failed traces only — classify locally using `classifyEffectEvent()` and existing `traceStatus` prop; well-formed rows show badge alongside `EffectPreview`, malformed rows show `Unknown` badge with generic text (explanation accessible via expanded panel only)
+- [x] 10.2 Add timeline tests: badge on retryable/unsafe/unknown effects on failed traces, malformed effect shows Unknown, no badges on completed/running traces, non-effect rows unchanged
+
+## 11. Page-Level Wiring and Integration Tests
+- [x] 11.1 Wire `useRetrySafetyAnalysis` in `TraceDetailPage.tsx` and thread assessments to FailureSummary, SpanTree, SpanDetail, and ExecutionWaterfall (Timeline classifies locally, no prop threading needed)
+- [x] 11.2 Add page-level integration tests: consistent classifications across failure summary, span tree, waterfall, span detail, and timeline effect rows
+- [x] 11.3 Add poll-stability regression test at page level: aggregate results stable when non-effect events arrive
+
+## 12. Theme and Accessibility Verification
+- [x] 12.1 Add theming regression check: badge styles work in both light and dark themes at component level
+- [x] 12.2 Verify accessible labels propagate correctly across all surfaces
+
+## 13. Final Verification
+- [x] 13.1 Run `pnpm --filter web test` and confirm all new and existing tests pass

--- a/web/src/components/ExecutionWaterfall.test.tsx
+++ b/web/src/components/ExecutionWaterfall.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAccessibleSummary, type RetrySafetyAssessment } from '../utils/retrySafety';
+import { buildSpanTree, deriveVisibleRows } from '../utils/spanTree';
+import {
+  createSpan,
+  resetTestEntityCounter,
+} from '../test/traceFixtures';
+import { ExecutionWaterfall } from './ExecutionWaterfall';
+
+beforeEach(() => {
+  resetTestEntityCounter();
+});
+
+describe('ExecutionWaterfall retry safety', () => {
+  it('renders failed-span badges in the label container without breaking truncation', () => {
+    const rootSpan = createSpan({
+      span_id: 'waterfall-root',
+      name: 'Waterfall root',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:00.000Z',
+      ended_at: '2026-03-14T10:00:04.000Z',
+      latency_ms: 4000,
+    });
+    const failedSpan = createSpan({
+      span_id: 'waterfall-failed',
+      name: 'Failed waterfall span',
+      parent_span_id: rootSpan.span_id,
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:01.000Z',
+      ended_at: '2026-03-14T10:00:02.000Z',
+      latency_ms: 1000,
+    });
+    const completedSpan = createSpan({
+      span_id: 'waterfall-completed',
+      name: 'Completed waterfall span',
+      parent_span_id: rootSpan.span_id,
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:02.000Z',
+      ended_at: '2026-03-14T10:00:03.000Z',
+      latency_ms: 1000,
+    });
+
+    const rows = deriveVisibleRows(
+      buildSpanTree([rootSpan, failedSpan, completedSpan]),
+      new Set([rootSpan.span_id])
+    );
+
+    render(
+      <ExecutionWaterfall
+        events={[]}
+        rows={rows}
+        selectedSpanId={null}
+        onSelectSpanAndShowDetails={vi.fn()}
+        revealTarget={null}
+        revealVersion={0}
+        spans={[rootSpan, failedSpan, completedSpan]}
+        traceStartedAt={rootSpan.started_at}
+        traceEndedAt={rootSpan.ended_at}
+        spanAssessments={
+          new Map<string, RetrySafetyAssessment>([
+            [
+              failedSpan.span_id,
+              {
+                classification: 'unsafe',
+                reason: 'mutating_non_idempotent',
+                decisiveSpanId: failedSpan.span_id,
+                decisiveSpanName: failedSpan.name,
+                decisiveEventId: 'effect-1',
+              },
+            ],
+          ])
+        }
+      />
+    );
+
+    const section = screen
+      .getByRole('heading', { name: 'Execution Waterfall' })
+      .closest('section');
+    expect(section).not.toBeNull();
+
+    const badge = within(section!).getByLabelText(getAccessibleSummary('unsafe'));
+    expect(badge).toHaveClass('whitespace-nowrap');
+
+    const failedName = Array.from(section!.querySelectorAll('div')).find(
+      (element) =>
+        element.textContent === 'Failed waterfall span' &&
+        element.className.includes('truncate')
+    );
+    expect(failedName).not.toBeUndefined();
+    expect(failedName).toHaveClass('truncate');
+
+    const failedBar = screen.getByRole('button', {
+      name: 'Select waterfall span Failed waterfall span',
+    });
+    expect(
+      within(failedBar).queryByLabelText(getAccessibleSummary('unsafe'))
+    ).not.toBeInTheDocument();
+
+    const completedName = Array.from(section!.querySelectorAll('div')).find(
+      (element) =>
+        element.textContent === 'Completed waterfall span' &&
+        element.className.includes('truncate')
+    );
+    expect(completedName).not.toBeUndefined();
+    expect(completedName).toHaveClass('truncate');
+    expect(
+      within(section!).getAllByLabelText(getAccessibleSummary('unsafe'))
+    ).toHaveLength(1);
+  });
+});

--- a/web/src/components/ExecutionWaterfall.tsx
+++ b/web/src/components/ExecutionWaterfall.tsx
@@ -2,12 +2,17 @@ import { useEffect, useMemo, useRef } from 'react';
 import type { Span, TimelineEvent } from '../api/client';
 import { useVirtualRows } from '../hooks/useVirtualRows';
 import { formatDuration } from '../utils/format';
+import {
+  getAccessibleSummary,
+  type RetrySafetyAssessment,
+} from '../utils/retrySafety';
 import type { SpanTreeRow } from '../utils/spanTree';
 import {
   buildWaterfallTicks,
   deriveWaterfallWindow,
   getWaterfallBarLayout,
 } from '../utils/waterfallTime';
+import { RetrySafetyBadge } from './RetrySafetyBadge';
 
 interface ExecutionWaterfallProps {
   events: TimelineEvent[];
@@ -19,11 +24,13 @@ interface ExecutionWaterfallProps {
   spans: Span[];
   traceEndedAt?: string;
   traceStartedAt?: string;
+  spanAssessments?: ReadonlyMap<string, RetrySafetyAssessment>;
 }
 
 const MIN_BAR_WIDTH_REM = 0.875;
 const WATERFALL_ROW_HEIGHT = 68;
 const TICK_LINE_COLOR = 'var(--continua-waterfall-tick-color)';
+const EMPTY_SPAN_ASSESSMENTS = new Map<string, RetrySafetyAssessment>();
 
 export function ExecutionWaterfall({
   events,
@@ -35,6 +42,7 @@ export function ExecutionWaterfall({
   spans,
   traceEndedAt,
   traceStartedAt,
+  spanAssessments = EMPTY_SPAN_ASSESSMENTS,
 }: ExecutionWaterfallProps) {
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
   const window = useMemo(
@@ -141,6 +149,7 @@ export function ExecutionWaterfall({
           {virtualRows.map(({ row }) => {
             const bar = getWaterfallBarLayout(row.span, window);
             const isSelected = row.span.span_id === selectedSpanId;
+            const retrySafety = spanAssessments.get(row.span.span_id) ?? null;
 
             return (
               <div
@@ -165,10 +174,19 @@ export function ExecutionWaterfall({
                   onClick={() => onSelectSpanAndShowDetails(row.span.span_id)}
                 >
                   <div
-                    className="truncate text-sm font-medium text-slate-900 dark:text-slate-100"
+                    className="flex items-center gap-2"
                     style={{ paddingLeft: `${row.depth * 12}px` }}
                   >
-                    {row.span.name}
+                    <div className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                      {row.span.name}
+                    </div>
+                    {row.span.status === 'FAILED' && retrySafety ? (
+                      <RetrySafetyBadge
+                        classification={retrySafety.classification}
+                        variant="compact"
+                        aria-label={getAccessibleSummary(retrySafety.classification)}
+                      />
+                    ) : null}
                   </div>
                   <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                     {row.span.status} · {formatDuration(row.span.latency_ms)}

--- a/web/src/components/FailureSummary.test.tsx
+++ b/web/src/components/FailureSummary.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FailureSummary as FailureSummaryData } from '../utils/failureAnalysis';
+import {
+  getAccessibleSummary,
+  getReasonExplanation,
+  type RetrySafetyAssessment,
+} from '../utils/retrySafety';
+import { createSpan, resetTestEntityCounter } from '../test/traceFixtures';
+import { FailureSummary } from './FailureSummary';
+
+beforeEach(() => {
+  resetTestEntityCounter();
+});
+
+describe('FailureSummary retry safety', () => {
+  it.each([
+    ['retryable', 'read_only_effect'],
+    ['unsafe', 'mutating_non_idempotent'],
+    ['unknown', 'mutating_missing_idempotent'],
+  ] as const)(
+    'renders the %s badge and explanation when a trace assessment is present',
+    (classification, reason) => {
+      render(
+        <FailureSummary
+          summary={createSummary()}
+          onJumpToPrimaryFailedSpan={vi.fn()}
+          traceRetrySafety={createAssessment({ classification, reason })}
+        />
+      );
+
+      expect(screen.getByText('Trace retry safety')).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(getAccessibleSummary(classification))
+      ).toBeInTheDocument();
+      expect(screen.getByText(getReasonExplanation(reason))).toBeInTheDocument();
+    }
+  );
+
+  it('renders decisive-span navigation when the decisive span differs from the primary span', async () => {
+    const user = userEvent.setup();
+    const onJump = vi.fn();
+
+    render(
+      <FailureSummary
+        summary={createSummary()}
+        onJumpToPrimaryFailedSpan={onJump}
+        traceRetrySafety={createAssessment({
+          classification: 'unsafe',
+          reason: 'mutating_non_idempotent',
+          decisiveSpanId: 'secondary-failed',
+          decisiveSpanName: 'Secondary failed',
+        })}
+      />
+    );
+
+    expect(
+      screen.getByText(/Determined by failed span/i)
+    ).toHaveTextContent('Secondary failed');
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Jump to decisive span Secondary failed',
+      })
+    );
+
+    expect(onJump).toHaveBeenCalledWith('secondary-failed');
+  });
+
+  it('renders no retry-safety panel when no assessment is provided', () => {
+    render(
+      <FailureSummary
+        summary={createSummary()}
+        onJumpToPrimaryFailedSpan={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Trace retry safety')).not.toBeInTheDocument();
+  });
+});
+
+function createSummary(
+  overrides: Partial<FailureSummaryData> = {}
+): FailureSummaryData {
+  const primaryFailedSpan = createSpan({
+    span_id: 'primary-failed',
+    name: 'Primary failed',
+    status: 'FAILED',
+  });
+
+  return {
+    primaryFailedSpan,
+    failedSpanCount: 1,
+    errorEventCount: 2,
+    errorPreview: 'Primary failed inline preview',
+    failureTimestamp: '2026-03-14T10:00:01.000Z',
+    breadcrumbPath: [{ spanId: primaryFailedSpan.span_id, name: primaryFailedSpan.name }],
+    ...overrides,
+  };
+}
+
+function createAssessment(
+  overrides: Partial<RetrySafetyAssessment> = {}
+): RetrySafetyAssessment {
+  return {
+    classification: overrides.classification ?? 'retryable',
+    reason: overrides.reason ?? 'read_only_effect',
+    decisiveSpanId: overrides.decisiveSpanId ?? 'primary-failed',
+    decisiveSpanName: overrides.decisiveSpanName ?? 'Primary failed',
+    decisiveEventId: overrides.decisiveEventId ?? 'effect-1',
+    effectKind: overrides.effectKind,
+    hasExternalSideEffect: overrides.hasExternalSideEffect,
+    idempotent: overrides.idempotent,
+    idempotencyKey: overrides.idempotencyKey,
+  };
+}

--- a/web/src/components/FailureSummary.tsx
+++ b/web/src/components/FailureSummary.tsx
@@ -1,17 +1,30 @@
 import type { FailureSummary as FailureSummaryData } from '../utils/failureAnalysis';
 import { formatTimestamp } from '../utils/format';
+import {
+  getAccessibleSummary,
+  getReasonExplanation,
+  type RetrySafetyAssessment,
+} from '../utils/retrySafety';
+import { RetrySafetyBadge } from './RetrySafetyBadge';
 import { SpanBreadcrumb } from './SpanBreadcrumb';
 
 interface FailureSummaryProps {
   summary: FailureSummaryData;
   onJumpToPrimaryFailedSpan: (spanId: string) => void;
+  traceRetrySafety?: RetrySafetyAssessment | null;
 }
 
 export function FailureSummary({
   summary,
   onJumpToPrimaryFailedSpan,
+  traceRetrySafety = null,
 }: FailureSummaryProps) {
   const primaryFailedSpan = summary.primaryFailedSpan;
+  const decisiveSpanDiffers =
+    Boolean(traceRetrySafety?.decisiveSpanId) &&
+    traceRetrySafety?.decisiveSpanId !== primaryFailedSpan?.span_id;
+  const decisiveSpanLabel =
+    traceRetrySafety?.decisiveSpanName ?? traceRetrySafety?.decisiveSpanId ?? 'decisive span';
 
   return (
     <section className="overflow-hidden rounded-xl border border-red-200 bg-white shadow-sm dark:border-red-500/40 dark:bg-slate-900">
@@ -72,6 +85,15 @@ export function FailureSummary({
               />
             </div>
 
+            {traceRetrySafety ? (
+              <RetrySafetyPanel
+                assessment={traceRetrySafety}
+                decisiveSpanDiffers={decisiveSpanDiffers}
+                decisiveSpanLabel={decisiveSpanLabel}
+                onJumpToSpan={onJumpToPrimaryFailedSpan}
+              />
+            ) : null}
+
             <div>
               <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
                 Failure path
@@ -98,6 +120,14 @@ export function FailureSummary({
                 value={String(summary.errorEventCount)}
               />
             </div>
+            {traceRetrySafety ? (
+              <RetrySafetyPanel
+                assessment={traceRetrySafety}
+                decisiveSpanDiffers={decisiveSpanDiffers}
+                decisiveSpanLabel={decisiveSpanLabel}
+                onJumpToSpan={onJumpToPrimaryFailedSpan}
+              />
+            ) : null}
           </>
         )}
       </div>
@@ -112,6 +142,54 @@ function SummaryStat({ label, value }: { label: string; value: string }) {
         {label}
       </div>
       <div className="mt-2 text-sm font-medium text-slate-900 dark:text-slate-100">{value}</div>
+    </div>
+  );
+}
+
+function RetrySafetyPanel({
+  assessment,
+  decisiveSpanDiffers,
+  decisiveSpanLabel,
+  onJumpToSpan,
+}: {
+  assessment: RetrySafetyAssessment;
+  decisiveSpanDiffers: boolean;
+  decisiveSpanLabel: string;
+  onJumpToSpan: (spanId: string) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/70">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+          Trace retry safety
+        </div>
+        <RetrySafetyBadge
+          classification={assessment.classification}
+          variant="full"
+          aria-label={getAccessibleSummary(assessment.classification)}
+        />
+      </div>
+      <p className="mt-3 text-sm text-slate-700 dark:text-slate-200">
+        Advisory only. Retry safety is inferred from recorded effect metadata.
+      </p>
+      <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+        {getReasonExplanation(assessment.reason)}
+      </p>
+      {decisiveSpanDiffers && assessment.decisiveSpanId ? (
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Determined by failed span <span className="font-medium">{decisiveSpanLabel}</span>.
+          </p>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-800"
+            aria-label={`Jump to decisive span ${decisiveSpanLabel}`}
+            onClick={() => onJumpToSpan(assessment.decisiveSpanId!)}
+          >
+            Jump to decisive span
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/RetrySafetyBadge.test.tsx
+++ b/web/src/components/RetrySafetyBadge.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RetrySafetyBadge } from './RetrySafetyBadge';
+
+describe('RetrySafetyBadge', () => {
+  it.each([
+    ['retryable', 'Retryable', 'emerald'],
+    ['unsafe', 'Unsafe', 'red'],
+    ['unknown', 'Unknown', 'amber'],
+  ] as const)('renders %s with semantic color classes', (classification, label, color) => {
+    render(
+      <RetrySafetyBadge
+        classification={classification}
+        variant="compact"
+      />
+    );
+
+    const badge = screen.getByText(label);
+    expect(badge).toHaveClass(`bg-${color}-100`);
+    expect(badge).toHaveClass(`text-${color}-800`);
+    expect(badge).toHaveClass(`dark:bg-${color}-500/15`);
+    expect(badge).toHaveClass(`dark:text-${color}-200`);
+    expect(badge.className).not.toContain('#');
+  });
+
+  it('supports compact and full variants', () => {
+    const { rerender } = render(
+      <RetrySafetyBadge classification="retryable" variant="compact" />
+    );
+
+    expect(screen.getByText('Retryable')).toHaveClass('text-[10px]');
+
+    rerender(<RetrySafetyBadge classification="retryable" variant="full" />);
+    expect(screen.getByText('Retryable')).toHaveClass('text-[11px]');
+  });
+
+  it('passes through aria-labels', () => {
+    render(
+      <RetrySafetyBadge
+        classification="unsafe"
+        variant="full"
+        aria-label="Retry safety advisory: unsafe. Inferred from effect metadata."
+      />
+    );
+
+    expect(
+      screen.getByLabelText(
+        'Retry safety advisory: unsafe. Inferred from effect metadata.'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/RetrySafetyBadge.tsx
+++ b/web/src/components/RetrySafetyBadge.tsx
@@ -1,0 +1,36 @@
+import {
+  getRetrySafetyLabel,
+  type RetrySafetyClassification,
+} from '../utils/retrySafety';
+
+interface RetrySafetyBadgeProps {
+  classification: RetrySafetyClassification;
+  variant: 'compact' | 'full';
+  'aria-label'?: string;
+}
+
+const BADGE_TONES: Record<RetrySafetyClassification, string> = {
+  retryable:
+    'border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-200',
+  unsafe:
+    'border-red-200 bg-red-100 text-red-800 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-200',
+  unknown:
+    'border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-200',
+};
+
+export function RetrySafetyBadge({
+  classification,
+  variant,
+  'aria-label': ariaLabel,
+}: RetrySafetyBadgeProps) {
+  return (
+    <span
+      className={`inline-flex whitespace-nowrap rounded-full border font-semibold uppercase tracking-[0.16em] ${
+        variant === 'compact' ? 'px-2 py-0.5 text-[10px]' : 'px-2.5 py-1 text-[11px]'
+      } ${BADGE_TONES[classification]}`}
+      aria-label={ariaLabel}
+    >
+      {getRetrySafetyLabel(classification)}
+    </span>
+  );
+}

--- a/web/src/components/SpanDetail.test.tsx
+++ b/web/src/components/SpanDetail.test.tsx
@@ -2,6 +2,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import type { Span, TimelineEvent } from '../api/client';
+import {
+  getAccessibleSummary,
+  getReasonExplanation,
+  type RetrySafetyAssessment,
+} from '../utils/retrySafety';
 import { SpanDetail } from './SpanDetail';
 
 function createSpan(overrides: Partial<Span> = {}): Span {
@@ -33,6 +38,22 @@ function createSpan(overrides: Partial<Span> = {}): Span {
     output_original_size_bytes: overrides.output_original_size_bytes,
     output_truncation_reason: overrides.output_truncation_reason,
     metadata: overrides.metadata,
+  };
+}
+
+function createRetrySafetyAssessment(
+  overrides: Partial<RetrySafetyAssessment> = {}
+): RetrySafetyAssessment {
+  return {
+    classification: overrides.classification ?? 'retryable',
+    reason: overrides.reason ?? 'read_only_effect',
+    decisiveSpanId: overrides.decisiveSpanId ?? 'span-1',
+    decisiveSpanName: overrides.decisiveSpanName ?? 'span-1',
+    decisiveEventId: overrides.decisiveEventId ?? 'effect-1',
+    effectKind: overrides.effectKind,
+    hasExternalSideEffect: overrides.hasExternalSideEffect,
+    idempotent: overrides.idempotent,
+    idempotencyKey: overrides.idempotencyKey,
   };
 }
 
@@ -168,5 +189,75 @@ describe('SpanDetail parent navigation', () => {
     expect(screen.getByText('Which model?')).toBeInTheDocument();
     expect(screen.getByText('gpt-4.1')).toBeInTheDocument();
     expect(screen.queryByText('Should be hidden')).not.toBeInTheDocument();
+  });
+});
+
+describe('SpanDetail retry safety', () => {
+  it.each([
+    ['retryable', 'read_only_effect'],
+    ['unsafe', 'mutating_non_idempotent'],
+    ['unknown', 'no_effect_events'],
+  ] as const)(
+    'renders the %s retry safety section for failed spans',
+    (classification, reason) => {
+      render(
+        <SpanDetail
+          span={createSpan({ span_id: 'failed-span', status: 'FAILED' })}
+          breadcrumbPath={[{ spanId: 'failed-span', name: 'failed-span' }]}
+          onSelectSpan={vi.fn()}
+          spanIndex={new Map()}
+          retrySafety={createRetrySafetyAssessment({
+            classification,
+            reason,
+          })}
+        />
+      );
+
+      expect(screen.getByText('Retry Safety')).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(getAccessibleSummary(classification))
+      ).toBeInTheDocument();
+      expect(screen.getByText(getReasonExplanation(reason))).toBeInTheDocument();
+    }
+  );
+
+  it('shows supporting semantic fields when effect metadata is available', () => {
+    render(
+      <SpanDetail
+        span={createSpan({ span_id: 'failed-span', status: 'FAILED' })}
+        breadcrumbPath={[{ spanId: 'failed-span', name: 'failed-span' }]}
+        onSelectSpan={vi.fn()}
+        spanIndex={new Map()}
+        retrySafety={createRetrySafetyAssessment({
+          effectKind: 'api_call',
+          hasExternalSideEffect: true,
+          idempotent: true,
+          idempotencyKey: 'key-1',
+          reason: 'mutating_idempotent_with_key',
+        })}
+      />
+    );
+
+    expect(screen.getByText('effect_kind:')).toBeInTheDocument();
+    expect(screen.getByText('api_call')).toBeInTheDocument();
+    expect(screen.getByText('has_external_side_effect:')).toBeInTheDocument();
+    expect(screen.getAllByText('true')).toHaveLength(2);
+    expect(screen.getByText('idempotent:')).toBeInTheDocument();
+    expect(screen.getByText('idempotency_key:')).toBeInTheDocument();
+    expect(screen.getByText('key-1')).toBeInTheDocument();
+  });
+
+  it('omits the retry safety section for non-failed spans', () => {
+    render(
+      <SpanDetail
+        span={createSpan({ span_id: 'completed-span', status: 'COMPLETED' })}
+        breadcrumbPath={[{ spanId: 'completed-span', name: 'completed-span' }]}
+        onSelectSpan={vi.fn()}
+        spanIndex={new Map()}
+        retrySafety={createRetrySafetyAssessment()}
+      />
+    );
+
+    expect(screen.queryByText('Retry Safety')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -14,6 +14,12 @@ import {
   formatInlineSemanticValue,
   getDecisionDetails,
 } from '../utils/eventSemantics';
+import {
+  getAccessibleSummary,
+  getReasonExplanation,
+  type RetrySafetyAssessment,
+} from '../utils/retrySafety';
+import { RetrySafetyBadge } from './RetrySafetyBadge';
 import { SpanBreadcrumb } from './SpanBreadcrumb';
 import { TruncationBanner } from './TruncationBanner';
 
@@ -23,6 +29,7 @@ interface SpanDetailProps {
   onSelectSpan: (spanId: string) => void;
   spanIndex: ReadonlyMap<string, Span>;
   events?: TimelineEvent[];
+  retrySafety?: RetrySafetyAssessment | null;
 }
 
 /**
@@ -34,6 +41,7 @@ export function SpanDetail({
   onSelectSpan,
   spanIndex,
   events = [],
+  retrySafety = null,
 }: SpanDetailProps) {
   if (!span) {
     return (
@@ -194,6 +202,61 @@ export function SpanDetail({
           </div>
         </div>
       )}
+
+      {span.status === 'FAILED' && retrySafety ? (
+        <div className="mb-6">
+          <h3 className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+            Retry Safety
+          </h3>
+          <div className="rounded border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/70">
+            <div className="flex flex-wrap items-center gap-3">
+              <RetrySafetyBadge
+                classification={retrySafety.classification}
+                variant="full"
+                aria-label={getAccessibleSummary(retrySafety.classification)}
+              />
+              <span className="text-sm text-slate-700 dark:text-slate-200">
+                Advisory only. Retry safety is inferred from recorded effect metadata.
+              </span>
+            </div>
+            <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
+              {getReasonExplanation(retrySafety.reason)}
+            </p>
+            {(retrySafety.effectKind !== undefined ||
+              retrySafety.hasExternalSideEffect !== undefined ||
+              retrySafety.idempotent !== undefined ||
+              retrySafety.idempotencyKey !== undefined) ? (
+              <div className="mt-4 rounded border border-slate-200 bg-white p-3 text-sm dark:border-slate-700 dark:bg-slate-900">
+                <DetailRow label="effect_kind" value={retrySafety.effectKind} mono />
+                {retrySafety.hasExternalSideEffect !== undefined ? (
+                  <DetailRow
+                    label="has_external_side_effect"
+                    value={formatInlineSemanticValue(retrySafety.hasExternalSideEffect)}
+                    mono
+                    className="mt-1"
+                  />
+                ) : null}
+                {retrySafety.idempotent !== undefined ? (
+                  <DetailRow
+                    label="idempotent"
+                    value={formatInlineSemanticValue(retrySafety.idempotent)}
+                    mono
+                    className="mt-1"
+                  />
+                ) : null}
+                {retrySafety.idempotencyKey !== undefined ? (
+                  <DetailRow
+                    label="idempotency_key"
+                    value={retrySafety.idempotencyKey}
+                    mono
+                    className="mt-1"
+                  />
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
 
       {/* IDs */}
       <div className="mb-6">

--- a/web/src/components/SpanTree.test.tsx
+++ b/web/src/components/SpanTree.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAccessibleSummary, type RetrySafetyAssessment } from '../utils/retrySafety';
+import { buildSpanTree, deriveVisibleRows } from '../utils/spanTree';
+import {
+  createSpan,
+  resetTestEntityCounter,
+} from '../test/traceFixtures';
+import { SpanTree } from './SpanTree';
+
+beforeEach(() => {
+  resetTestEntityCounter();
+});
+
+describe('SpanTree retry safety', () => {
+  it('shows compact retry-safety badges on failed spans while preserving existing chips', () => {
+    const rootSpan = createSpan({
+      span_id: 'root-span',
+      name: 'Root span',
+      status: 'COMPLETED',
+    });
+    const failedSpan = createSpan({
+      span_id: 'failed-span',
+      name: 'Failed span',
+      parent_span_id: rootSpan.span_id,
+      status: 'FAILED',
+    });
+    const completedSpan = createSpan({
+      span_id: 'completed-span',
+      name: 'Completed span',
+      parent_span_id: rootSpan.span_id,
+      status: 'COMPLETED',
+    });
+
+    const rows = deriveVisibleRows(buildSpanTree([rootSpan, failedSpan, completedSpan]), new Set([rootSpan.span_id]));
+
+    render(
+      <SpanTree
+        rows={rows}
+        expandedSpanIds={new Set([rootSpan.span_id])}
+        selectedSpanId={failedSpan.span_id}
+        onSelectSpan={vi.fn()}
+        onToggleExpand={vi.fn()}
+        failedSpanIds={new Set([failedSpan.span_id])}
+        primaryAncestorPath={new Set([rootSpan.span_id, failedSpan.span_id])}
+        revealPath={new Set()}
+        revealKey={0}
+        inlineErrorPreviews={new Map()}
+        spanAssessments={
+          new Map<string, RetrySafetyAssessment>([
+            [
+              failedSpan.span_id,
+              {
+                classification: 'unsafe',
+                reason: 'mutating_non_idempotent',
+                decisiveSpanId: failedSpan.span_id,
+                decisiveSpanName: failedSpan.name,
+                decisiveEventId: 'effect-1',
+              },
+            ],
+          ])
+        }
+      />
+    );
+
+    const failedRow = screen.getByRole('button', { name: 'Select span Failed span' });
+    expect(within(failedRow).getByText('Selected')).toBeInTheDocument();
+    expect(within(failedRow).getByText('Failure path')).toBeInTheDocument();
+    expect(within(failedRow).getByText('Failed')).toBeInTheDocument();
+    expect(
+      within(failedRow).getByLabelText(getAccessibleSummary('unsafe'))
+    ).toBeInTheDocument();
+
+    const completedRow = screen.getByRole('button', { name: 'Select span Completed span' });
+    expect(
+      within(completedRow).queryByLabelText(getAccessibleSummary('unsafe'))
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/SpanTree.tsx
+++ b/web/src/components/SpanTree.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef } from 'react';
 import { formatCost, formatDuration, formatTokens } from '../utils/format';
+import {
+  getAccessibleSummary,
+  type RetrySafetyAssessment,
+} from '../utils/retrySafety';
 import type { SpanTreeRow } from '../utils/spanTree';
+import { RetrySafetyBadge } from './RetrySafetyBadge';
 import { StatusBadge } from './StatusBadge';
 
 interface SpanTreeProps {
@@ -16,6 +21,7 @@ interface SpanTreeProps {
   inlineErrorPreviews: ReadonlyMap<string, string>;
   showMetrics?: boolean;
   matchedSpanIds?: ReadonlySet<string> | null;
+  spanAssessments?: ReadonlyMap<string, RetrySafetyAssessment>;
 }
 
 const kindColors: Record<string, string> = {
@@ -25,6 +31,7 @@ const kindColors: Record<string, string> = {
   AGENT: 'bg-green-100 text-green-800 dark:bg-green-500/15 dark:text-green-200',
   CUSTOM: 'bg-gray-100 text-gray-800 dark:bg-slate-800 dark:text-slate-200',
 };
+const EMPTY_SPAN_ASSESSMENTS = new Map<string, RetrySafetyAssessment>();
 
 export function SpanTree({
   rows,
@@ -39,6 +46,7 @@ export function SpanTree({
   inlineErrorPreviews,
   showMetrics = false,
   matchedSpanIds = null,
+  spanAssessments = EMPTY_SPAN_ASSESSMENTS,
 }: SpanTreeProps) {
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
 
@@ -73,6 +81,7 @@ export function SpanTree({
         const rowStateId = `span-row-state-${span.id}`;
         const isMatch = matchedSpanIds?.has(span.span_id) ?? false;
         const shouldDim = matchedSpanIds !== null && !isMatch;
+        const retrySafety = spanAssessments.get(span.span_id) ?? null;
 
         const rowClasses = isSelected
           ? 'border-blue-200 bg-blue-50 shadow-sm ring-1 ring-blue-200 dark:border-sky-500/50 dark:bg-sky-500/10 dark:ring-sky-500/40'
@@ -158,6 +167,13 @@ export function SpanTree({
                       <span className="rounded-full border border-red-200 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-red-700 dark:border-red-500/40 dark:bg-slate-950 dark:text-red-200">
                         Failed
                       </span>
+                    ) : null}
+                    {isFailed && retrySafety ? (
+                      <RetrySafetyBadge
+                        classification={retrySafety.classification}
+                        variant="compact"
+                        aria-label={getAccessibleSummary(retrySafety.classification)}
+                      />
                     ) : null}
                   </div>
 

--- a/web/src/components/Timeline.test.tsx
+++ b/web/src/components/Timeline.test.tsx
@@ -1,28 +1,40 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { getAccessibleSummary } from '../utils/retrySafety';
 import { createTimelineEvent } from '../test/traceFixtures';
 import { Timeline } from './Timeline';
 
+type TimelineProps = Parameters<typeof Timeline>[0];
+
+function renderTimeline(overrides: Partial<TimelineProps> = {}) {
+  const props: TimelineProps = {
+    events: [],
+    traceStatus: 'COMPLETED',
+    isLive: false,
+    isLoading: false,
+    error: null,
+    onSelectSpan: vi.fn(),
+    spanIndex: new Map(),
+    ...overrides,
+  };
+
+  return render(<Timeline {...props} />);
+}
+
 describe('Timeline semantic event rendering', () => {
   it('renders state_change rows with inline old/new values', () => {
-    render(
-      <Timeline
-        events={[
-          createTimelineEvent({
-            event_type: 'state_change',
-            payload: {
-              key: 'status',
-              old_value: 'pending',
-              new_value: 'approved',
-            },
-          }),
-        ]}
-        traceStatus="COMPLETED"
-        isLive={false}
-        onSelectSpan={vi.fn()}
-        spanIndex={new Map()}
-      />
-    );
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'state_change',
+          payload: {
+            key: 'status',
+            old_value: 'pending',
+            new_value: 'approved',
+          },
+        }),
+      ],
+    });
 
     expect(screen.getByText('status')).toBeInTheDocument();
     expect(screen.getByText('pending')).toBeInTheDocument();
@@ -30,50 +42,135 @@ describe('Timeline semantic event rendering', () => {
   });
 
   it('falls back to the message when semantic fields are missing', () => {
-    render(
-      <Timeline
-        events={[
-          createTimelineEvent({
-            event_type: 'decision',
-            message: 'Generic fallback',
-            payload: {
-              chosen: 'gpt-4.1',
-            },
-          }),
-        ]}
-        traceStatus="COMPLETED"
-        isLive={false}
-        onSelectSpan={vi.fn()}
-        spanIndex={new Map()}
-      />
-    );
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'decision',
+          message: 'Generic fallback',
+          payload: {
+            chosen: 'gpt-4.1',
+          },
+        }),
+      ],
+    });
 
     expect(screen.getByText('Generic fallback')).toBeInTheDocument();
   });
 
   it('renders decision alternatives inline when they are present', () => {
-    render(
-      <Timeline
-        events={[
-          createTimelineEvent({
-            event_type: 'decision',
-            payload: {
-              question: 'Which model?',
-              chosen: 'gpt-4.1',
-              alternatives: ['gpt-4o-mini', 'claude-3-haiku'],
-            },
-          }),
-        ]}
-        traceStatus="COMPLETED"
-        isLive={false}
-        onSelectSpan={vi.fn()}
-        spanIndex={new Map()}
-      />
-    );
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'decision',
+          payload: {
+            question: 'Which model?',
+            chosen: 'gpt-4.1',
+            alternatives: ['gpt-4o-mini', 'claude-3-haiku'],
+          },
+        }),
+      ],
+    });
 
     expect(screen.getByText('Which model?')).toBeInTheDocument();
     expect(screen.getByText('Alternatives')).toBeInTheDocument();
     expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument();
     expect(screen.getByText('claude-3-haiku')).toBeInTheDocument();
+  });
+});
+
+describe('Timeline retry safety badges', () => {
+  it('renders retry-safety badges for well-formed effect rows on failed traces', () => {
+    renderTimeline({
+      traceStatus: 'FAILED',
+      events: [
+        createTimelineEvent({
+          id: 'retryable-effect',
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'model_call',
+            has_external_side_effect: false,
+          },
+        }),
+        createTimelineEvent({
+          id: 'unsafe-effect',
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'api_call',
+            has_external_side_effect: true,
+            idempotent: false,
+          },
+        }),
+        createTimelineEvent({
+          id: 'unknown-effect',
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'tool_call',
+            has_external_side_effect: true,
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByLabelText(getAccessibleSummary('retryable'))).toBeInTheDocument();
+    expect(screen.getByLabelText(getAccessibleSummary('unsafe'))).toBeInTheDocument();
+    expect(screen.getByLabelText(getAccessibleSummary('unknown'))).toBeInTheDocument();
+  });
+
+  it('renders an Unknown badge for malformed effect rows on failed traces', () => {
+    renderTimeline({
+      traceStatus: 'FAILED',
+      events: [
+        createTimelineEvent({
+          id: 'bad-effect',
+          event_type: 'effect',
+          message: 'Malformed effect summary',
+          payload: {
+            effect_kind: 'api_call',
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Malformed effect summary')).toBeInTheDocument();
+    expect(screen.getByLabelText(getAccessibleSummary('unknown'))).toBeInTheDocument();
+  });
+
+  it.each(['COMPLETED', 'RUNNING'] as const)(
+    'does not render retry-safety badges for effect rows on %s traces',
+    (traceStatus) => {
+      renderTimeline({
+        traceStatus,
+        events: [
+          createTimelineEvent({
+            event_type: 'effect',
+            payload: {
+              effect_kind: 'model_call',
+              has_external_side_effect: false,
+            },
+          }),
+        ],
+      });
+
+      expect(screen.queryByLabelText(getAccessibleSummary('retryable'))).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(getAccessibleSummary('unsafe'))).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(getAccessibleSummary('unknown'))).not.toBeInTheDocument();
+    }
+  );
+
+  it('keeps non-effect rows unchanged on failed traces', () => {
+    renderTimeline({
+      traceStatus: 'FAILED',
+      events: [
+        createTimelineEvent({
+          event_type: 'message',
+          message: 'Non-effect row',
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Non-effect row')).toBeInTheDocument();
+    expect(screen.queryByLabelText(getAccessibleSummary('retryable'))).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(getAccessibleSummary('unsafe'))).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(getAccessibleSummary('unknown'))).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -4,12 +4,19 @@ import { JsonViewer } from './JsonViewer';
 import {
   formatInlineSemanticValue,
   getDecisionDetails,
+  getEffectDetails,
   getStateChangeDetails,
 } from '../utils/eventSemantics';
 import {
   isTimelineErrorEvent,
   summarizeTimelineEvent,
 } from '../utils/timeline';
+import {
+  classifyEffectEvent,
+  getAccessibleSummary,
+  type RetrySafetyAssessment,
+} from '../utils/retrySafety';
+import { RetrySafetyBadge } from './RetrySafetyBadge';
 
 interface TimelineProps {
   events: TimelineEvent[];
@@ -101,6 +108,7 @@ export function Timeline({
               isSelectedSpan={selectedSpanId === event.span_id}
               onSelectSpan={onSelectSpan}
               spanIndex={spanIndex}
+              traceStatus={traceStatus}
             />
           ))}
         </div>
@@ -114,6 +122,7 @@ interface TimelineRowProps {
   isSelectedSpan: boolean;
   onSelectSpan: (spanId: string) => void;
   spanIndex: Map<string, Span>;
+  traceStatus: TimelineTraceStatus | null;
 }
 
 function TimelineRow({
@@ -121,6 +130,7 @@ function TimelineRow({
   isSelectedSpan,
   onSelectSpan,
   spanIndex,
+  traceStatus,
 }: TimelineRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const hasDetails = Boolean(event.message || event.payload);
@@ -128,6 +138,9 @@ function TimelineRow({
   const isError = isTimelineErrorEvent(event);
   const stateChange = getStateChangeDetails(event);
   const decision = getDecisionDetails(event);
+  const retrySafety =
+    traceStatus === 'FAILED' ? classifyEffectEvent(event) : null;
+  const effectDetails = retrySafety ? getEffectDetails(event) : null;
   const rowAccent = isError
     ? 'border-red-200 bg-red-50/70 dark:border-red-500/40 dark:bg-red-500/10'
     : event.source === 'synthetic'
@@ -170,6 +183,16 @@ function TimelineRow({
                 <StateChangePreview stateChange={stateChange} />
               ) : decision ? (
                 <DecisionPreview decision={decision} />
+              ) : effectDetails ? (
+                <EffectPreview
+                  effect={effectDetails}
+                  retrySafety={retrySafety}
+                />
+              ) : retrySafety ? (
+                <MalformedEffectPreview
+                  event={event}
+                  retrySafety={retrySafety}
+                />
               ) : (
                 <p className="mt-3 text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
                   {summarizeTimelineEvent(event)}
@@ -293,6 +316,59 @@ function DecisionPreview({
           ))}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function EffectPreview({
+  effect,
+  retrySafety,
+}: {
+  effect: NonNullable<ReturnType<typeof getEffectDetails>>;
+  retrySafety: RetrySafetyAssessment | null;
+}) {
+  return (
+    <div className="mt-3 space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <p className="text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
+          {effect.effectKind}
+        </p>
+        {retrySafety ? (
+          <RetrySafetyBadge
+            classification={retrySafety.classification}
+            variant="compact"
+            aria-label={getAccessibleSummary(retrySafety.classification)}
+          />
+        ) : null}
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+        <SemanticValuePill tone={effect.hasExternalSideEffect ? 'accent' : 'neutral'}>
+          {effect.hasExternalSideEffect ? 'mutating' : 'read-only'}
+        </SemanticValuePill>
+      </div>
+    </div>
+  );
+}
+
+function MalformedEffectPreview({
+  event,
+  retrySafety,
+}: {
+  event: TimelineEvent;
+  retrySafety: RetrySafetyAssessment;
+}) {
+  return (
+    <div className="mt-3 space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <p className="text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
+          {summarizeTimelineEvent(event)}
+        </p>
+        <RetrySafetyBadge
+          classification={retrySafety.classification}
+          variant="compact"
+          aria-label={getAccessibleSummary(retrySafety.classification)}
+        />
+      </div>
     </div>
   );
 }

--- a/web/src/components/TreeRail.tsx
+++ b/web/src/components/TreeRail.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react';
 import type { Span } from '../api/client';
 import { useTreeRailState } from '../hooks/useTreeRailState';
+import type { RetrySafetyAssessment } from '../utils/retrySafety';
 import { useVirtualRows } from '../hooks/useVirtualRows';
 import { deriveVisibleRows, type SpanTreeNode } from '../utils/spanTree';
 import { SpanTree } from './SpanTree';
@@ -26,10 +27,12 @@ interface TreeRailProps {
   spanTree: SpanTreeNode[];
   spans: Span[];
   onVisibleRowsChange: (rows: ReturnType<typeof deriveVisibleRows>) => void;
+  spanAssessments?: ReadonlyMap<string, RetrySafetyAssessment>;
 }
 
 const TREE_ROW_HEIGHT = 72;
 const TREE_ROW_HEIGHT_WITH_METRICS = 94;
+const EMPTY_SPAN_ASSESSMENTS = new Map<string, RetrySafetyAssessment>();
 
 export function TreeRail({
   expandableSpanIds,
@@ -47,6 +50,7 @@ export function TreeRail({
   spanTree,
   spans,
   onVisibleRowsChange,
+  spanAssessments = EMPTY_SPAN_ASSESSMENTS,
 }: TreeRailProps) {
   const {
     effectiveExpandedSpanIds,
@@ -196,6 +200,7 @@ export function TreeRail({
             inlineErrorPreviews={inlineErrorPreviews}
             showMetrics={showMetrics}
             matchedSpanIds={matchedSpanIds}
+            spanAssessments={spanAssessments}
           />
         </div>
       </div>

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearApiKey, setApiKey, type TraceDetail } from '../api/client';
 import { setMatchMediaMatches } from '../test/matchMedia';
+import { getAccessibleSummary, getReasonExplanation } from '../utils/retrySafety';
 import {
   SESSION_EXTERNAL_ID,
   SESSION_ID,
@@ -15,6 +16,7 @@ import {
   createTimelineEvent,
   jsonResponse,
   mockClipboard,
+  readRequestUrl,
   renderTraceRoutes,
   resetTestEntityCounter,
 } from './testUtils';
@@ -475,6 +477,135 @@ describe('TraceDetailPage', () => {
     ).toBeInTheDocument();
     expect(
       within(screen.getByLabelText('Span breadcrumb')).getByText('Failed tool')
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces consistent retry-safety guidance across failure summary, tree, waterfall, span detail, and timeline', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({
+      span_id: 'retry-root',
+      name: 'Retry root',
+      status: 'COMPLETED',
+      ended_at: '2026-03-14T10:00:20.000Z',
+    });
+    const primaryFailedSpan = createSpan({
+      span_id: 'retry-primary',
+      name: 'Primary failed',
+      parent_span_id: 'retry-root',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:01.000Z',
+      ended_at: '2026-03-14T10:00:05.000Z',
+      error_message: 'Read-only failure',
+    });
+    const secondaryFailedSpan = createSpan({
+      span_id: 'retry-secondary',
+      name: 'Secondary failed',
+      parent_span_id: 'retry-root',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:06.000Z',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      error_message: 'Unsafe failure',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(TRACE_DETAIL),
+        spans: () =>
+          jsonResponse({
+            spans: [rootSpan, primaryFailedSpan, secondaryFailedSpan],
+          }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'primary-effect',
+                span_id: primaryFailedSpan.span_id,
+                span_name: primaryFailedSpan.name,
+                event_type: 'effect',
+                timestamp: '2026-03-14T10:00:04.000Z',
+                payload: {
+                  effect_kind: 'model_call',
+                  has_external_side_effect: false,
+                },
+              }),
+              createTimelineEvent({
+                id: 'secondary-effect',
+                span_id: secondaryFailedSpan.span_id,
+                span_name: secondaryFailedSpan.name,
+                event_type: 'effect',
+                timestamp: '2026-03-14T10:00:09.000Z',
+                payload: {
+                  effect_kind: 'api_call',
+                  has_external_side_effect: true,
+                  idempotent: false,
+                },
+              }),
+            ],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    const failureSummarySection = (
+      await screen.findByRole('heading', { name: 'Failure Summary' })
+    ).closest('section');
+    expect(failureSummarySection).not.toBeNull();
+    expect(
+      within(failureSummarySection!).getByLabelText(getAccessibleSummary('unsafe'))
+    ).toBeInTheDocument();
+    expect(
+      within(failureSummarySection!).getByText(
+        getReasonExplanation('mutating_non_idempotent')
+      )
+    ).toBeInTheDocument();
+
+    const treeSection = screen.getByRole('heading', { name: 'Spans (3)' }).closest('section');
+    expect(treeSection).not.toBeNull();
+    expect(
+      within(treeSection!).getByLabelText(getAccessibleSummary('retryable'))
+    ).toBeInTheDocument();
+    expect(
+      within(treeSection!).getByLabelText(getAccessibleSummary('unsafe'))
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Expand all' }));
+
+    const waterfallSection = screen
+      .getByRole('heading', { name: 'Execution Waterfall' })
+      .closest('section');
+    expect(waterfallSection).not.toBeNull();
+    await screen.findByRole('button', {
+      name: 'Select waterfall span Secondary failed',
+    });
+    expect(
+      within(waterfallSection!).getByLabelText(getAccessibleSummary('unsafe'))
+    ).toBeInTheDocument();
+
+    await user.click(
+      within(failureSummarySection!).getByRole('button', {
+        name: 'Jump to decisive span Secondary failed',
+      })
+    );
+
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Secondary failed')
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Retry Safety')).toBeInTheDocument();
+    expect(screen.getByText('effect_kind:')).toBeInTheDocument();
+    expect(screen.getAllByText('api_call').length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole('button', { name: 'Timeline' }));
+
+    const timelineSection = screen.getByRole('heading', { name: 'Timeline' }).closest('section');
+    expect(timelineSection).not.toBeNull();
+    expect(
+      within(timelineSection!).getByLabelText(getAccessibleSummary('retryable'))
+    ).toBeInTheDocument();
+    expect(
+      within(timelineSection!).getByLabelText(getAccessibleSummary('unsafe'))
     ).toBeInTheDocument();
   });
 
@@ -1014,6 +1145,189 @@ describe('TraceDetailPage', () => {
     ).toBeInTheDocument();
     expect(view.router.state.location.search).toBe('?span=running-child');
   }, 10000);
+
+  it('keeps failed-trace retry-safety surfaces stable when timeline data refreshes with only non-effect updates', async () => {
+    const user = userEvent.setup();
+    const failedTraceDetail: TraceDetail = {
+      ...TRACE_DETAIL,
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:02.000Z',
+      error_count: 1,
+    };
+    const failedSpan = createSpan({
+      span_id: 'poll-failed',
+      name: 'Polling failed span',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:00.000Z',
+      ended_at: '2026-03-14T10:00:02.000Z',
+      error_message: 'Initial failure',
+    });
+    let currentTimelineEvents = [
+      createTimelineEvent({
+        id: 'bootstrap-effect',
+        span_id: failedSpan.span_id,
+        span_name: failedSpan.name,
+        event_type: 'effect',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        payload: {
+          effect_kind: 'model_call',
+          has_external_side_effect: false,
+        },
+      }),
+    ];
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(failedTraceDetail),
+        spans: () => jsonResponse({ spans: [failedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: currentTimelineEvents,
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}?span=poll-failed`]);
+
+    expect(await screen.findByText('Retry Safety')).toBeInTheDocument();
+    const treeSection = screen.getByRole('heading', { name: 'Spans (1)' }).closest('section');
+    const waterfallSection = screen
+      .getByRole('heading', { name: 'Execution Waterfall' })
+      .closest('section');
+    expect(treeSection).not.toBeNull();
+    expect(waterfallSection).not.toBeNull();
+    expect(
+      within(treeSection!).getAllByLabelText(getAccessibleSummary('retryable'))
+    ).toHaveLength(1);
+    expect(
+      within(waterfallSection!).getAllByLabelText(getAccessibleSummary('retryable'))
+    ).toHaveLength(1);
+
+    currentTimelineEvents = [
+      ...currentTimelineEvents,
+      createTimelineEvent({
+        id: 'refreshed-log',
+        span_id: failedSpan.span_id,
+        span_name: failedSpan.name,
+        event_type: 'message',
+        timestamp: '2026-03-14T10:00:03.000Z',
+        message: 'non-effect refresh update',
+      }),
+    ];
+
+    await act(async () => {
+      await view.queryClient.invalidateQueries({
+        queryKey: ['timeline', TRACE_ONE.id, 'bootstrap'],
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) => {
+          const url = new URL(readRequestUrl(input), 'http://localhost');
+          return url.pathname === `/api/traces/${TRACE_ONE.id}/events`;
+        })
+      ).toBe(true);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Timeline' }));
+    expect(await screen.findByText('non-effect refresh update')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Details' }));
+
+    const refreshedTreeSection = screen
+      .getByRole('heading', { name: 'Spans (1)' })
+      .closest('section');
+    const refreshedWaterfallSection = screen
+      .getByRole('heading', { name: 'Execution Waterfall' })
+      .closest('section');
+    expect(refreshedTreeSection).not.toBeNull();
+    expect(refreshedWaterfallSection).not.toBeNull();
+    expect(screen.getByText('Retry Safety')).toBeInTheDocument();
+    expect(
+      within(refreshedTreeSection!).getAllByLabelText(getAccessibleSummary('retryable'))
+    ).toHaveLength(1);
+    expect(
+      within(refreshedWaterfallSection!).getAllByLabelText(getAccessibleSummary('retryable'))
+    ).toHaveLength(1);
+    expect(screen.getByRole('heading', { name: 'Failure Summary' })).toBeInTheDocument();
+  }, 10000);
+
+  it.each(['RUNNING', 'COMPLETED'] as const)(
+    'does not surface retry-safety UI on %s traces',
+    async (traceStatus) => {
+      const user = userEvent.setup();
+      const traceDetail: TraceDetail =
+        traceStatus === 'RUNNING'
+          ? {
+              ...TRACE_DETAIL,
+              status: 'RUNNING',
+              ended_at: undefined,
+              error_count: 0,
+            }
+          : {
+              ...TRACE_DETAIL,
+              status: 'COMPLETED',
+              ended_at: '2026-03-14T10:00:05.000Z',
+              error_count: 0,
+            };
+      const failedSpan = createSpan({
+        span_id: `${traceStatus.toLowerCase()}-failed`,
+        name: `${traceStatus} failed span`,
+        status: 'FAILED',
+        started_at: '2026-03-14T10:00:00.000Z',
+        ended_at: '2026-03-14T10:00:02.000Z',
+        error_message: 'Out-of-scope failure',
+      });
+
+      fetchMock.mockImplementation(
+        buildFetchHandler({
+          detail: () => jsonResponse(traceDetail),
+          spans: () => jsonResponse({ spans: [failedSpan] }),
+          timeline: () =>
+            jsonResponse({
+              events: [
+                createTimelineEvent({
+                  id: `${traceStatus.toLowerCase()}-effect`,
+                  span_id: failedSpan.span_id,
+                  span_name: failedSpan.name,
+                  event_type: 'effect',
+                  payload: {
+                    effect_kind: 'model_call',
+                    has_external_side_effect: false,
+                  },
+                }),
+              ],
+              trace_status: traceStatus,
+              has_more: false,
+            }),
+        })
+      );
+
+      renderTraceRoutes([`/traces/${TRACE_ONE.id}?span=${failedSpan.span_id}`]);
+
+      expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'Failure Summary' })).not.toBeInTheDocument();
+      expect(screen.queryByText('Retry Safety')).not.toBeInTheDocument();
+
+      const treeSection = screen.getByRole('heading', { name: 'Spans (1)' }).closest('section');
+      const waterfallSection = screen
+        .getByRole('heading', { name: 'Execution Waterfall' })
+        .closest('section');
+      expect(treeSection).not.toBeNull();
+      expect(waterfallSection).not.toBeNull();
+      expect(
+        within(treeSection!).queryByLabelText(getAccessibleSummary('retryable'))
+      ).not.toBeInTheDocument();
+      expect(
+        within(waterfallSection!).queryByLabelText(getAccessibleSummary('retryable'))
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Timeline' }));
+      expect(screen.queryByLabelText(getAccessibleSummary('retryable'))).not.toBeInTheDocument();
+    }
+  );
 
   it('resets selection and timeline filter state when navigating between traces', async () => {
     const user = userEvent.setup();

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -38,7 +38,9 @@ import { useMediaQuery } from '../hooks/useMediaQuery';
 import { useRequireApiKey } from '../hooks/useRequireApiKey';
 import { useTraceDetailSearchParams } from '../hooks/useTraceDetailSearchParams';
 import { useWorkspaceState } from '../hooks/useWorkspaceState';
+import type { RetrySafetyAssessment } from '../utils/retrySafety';
 import { useTraceTimeline } from './useTraceTimeline';
+import { useRetrySafetyAnalysis } from './useRetrySafetyAnalysis';
 import {
   calculateDuration,
   formatCost,
@@ -64,6 +66,7 @@ import {
 } from '../utils/spanTree';
 
 const EMPTY_SPANS: Span[] = [];
+const EMPTY_RETRY_SAFETY_ASSESSMENTS = new Map<string, RetrySafetyAssessment>();
 const EMPTY_STALE_TRACE_SIGNAL: StaleTraceSignal = {
   shouldDisplay: false,
   latestActivityAt: null,
@@ -181,6 +184,11 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
         : EMPTY_STALE_TRACE_SIGNAL,
     [spans, timeline.events, timeline.hasSnapshot, timelineStatus, trace?.started_at]
   );
+  const retrySafetyAnalysis = useRetrySafetyAnalysis(spans, timeline.events);
+  const showRetrySafety = timelineStatus === 'FAILED';
+  const visibleRetrySafetyAssessments = showRetrySafety
+    ? retrySafetyAnalysis.spanAssessments
+    : EMPTY_RETRY_SAFETY_ASSESSMENTS;
 
   const handleSelectSpan = useCallback((spanId: string) => {
     selectSpan(spanId);
@@ -258,6 +266,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
       staleTraceSignal={staleTraceSignal}
       timelineStatus={timelineStatus}
       failureAnalysis={failureAnalysis}
+      retrySafetyAnalysis={showRetrySafety ? retrySafetyAnalysis : null}
       onSelectSpan={handleSelectSpanAndShowDetails}
       selectedBreadcrumbPath={selectedBreadcrumbPath}
       selectedSpan={selectedSpan}
@@ -349,6 +358,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
             revealTarget={waterfallRevealTarget}
             selectedSpanId={selectedSpanExternalId}
             setExpandedSpanIds={setExpandedSpanIds}
+            spanAssessments={visibleRetrySafetyAssessments}
             spanIndex={spanIndex}
             spanTree={spanTree}
             spans={spans}
@@ -384,6 +394,7 @@ interface TraceWorkspaceProps {
   revealTarget: string | null;
   selectedSpanId: string | null;
   setExpandedSpanIds: Dispatch<SetStateAction<Set<string>>>;
+  spanAssessments: ReadonlyMap<string, RetrySafetyAssessment>;
   spanIndex: ReadonlyMap<string, Span>;
   spanTree: SpanTreeNode[];
   spans: Span[];
@@ -414,6 +425,7 @@ function TraceWorkspace({
   revealTarget,
   selectedSpanId,
   setExpandedSpanIds,
+  spanAssessments,
   spanIndex,
   spanTree,
   spans,
@@ -451,6 +463,7 @@ function TraceWorkspace({
           spanIndex={spanIndex}
           spanTree={spanTree}
           spans={spans}
+          spanAssessments={spanAssessments}
         />
       }
       waterfall={
@@ -462,6 +475,7 @@ function TraceWorkspace({
           revealTarget={revealTarget}
           revealVersion={revealKey}
           spans={spans}
+          spanAssessments={spanAssessments}
           traceEndedAt={traceEndedAt}
           traceStartedAt={traceStartedAt}
         />
@@ -506,6 +520,7 @@ function TraceDetailsSurface({
   staleTraceSignal,
   timelineStatus,
   failureAnalysis,
+  retrySafetyAnalysis,
   onSelectSpan,
   selectedBreadcrumbPath,
   selectedSpan,
@@ -516,6 +531,7 @@ function TraceDetailsSurface({
   staleTraceSignal: StaleTraceSignal;
   timelineStatus: 'RUNNING' | 'COMPLETED' | 'FAILED' | null;
   failureAnalysis: ReturnType<typeof buildFailureAnalysis>;
+  retrySafetyAnalysis: ReturnType<typeof useRetrySafetyAnalysis> | null;
   onSelectSpan: (spanId: string) => void;
   selectedBreadcrumbPath: ReturnType<typeof buildBreadcrumbPath>;
   selectedSpan: Span | null;
@@ -532,6 +548,7 @@ function TraceDetailsSurface({
           <FailureSummary
             summary={failureAnalysis.summary}
             onJumpToPrimaryFailedSpan={onSelectSpan}
+            traceRetrySafety={retrySafetyAnalysis?.traceAssessment ?? null}
           />
         ) : null}
 
@@ -546,6 +563,11 @@ function TraceDetailsSurface({
             onSelectSpan={onSelectSpan}
             spanIndex={spanIndex}
             events={events}
+            retrySafety={
+              selectedSpan?.status === 'FAILED' && retrySafetyAnalysis
+                ? retrySafetyAnalysis.spanAssessments.get(selectedSpan.span_id) ?? null
+                : null
+            }
           />
         </div>
       </div>

--- a/web/src/pages/useRetrySafetyAnalysis.test.tsx
+++ b/web/src/pages/useRetrySafetyAnalysis.test.tsx
@@ -1,0 +1,157 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  createSpan,
+  createTimelineEvent,
+  resetTestEntityCounter,
+} from '../test/traceFixtures';
+import { useRetrySafetyAnalysis } from './useRetrySafetyAnalysis';
+
+beforeEach(() => {
+  resetTestEntityCounter();
+});
+
+describe('useRetrySafetyAnalysis', () => {
+  it('keeps analysis stable when polling adds non-effect events', () => {
+    const failedSpan = createSpan({
+      span_id: 'failed-span',
+      status: 'FAILED',
+      name: 'Failed span',
+    });
+    const effectEvent = createTimelineEvent({
+      id: 'effect-event',
+      span_id: failedSpan.span_id,
+      event_type: 'effect',
+      payload: {
+        effect_kind: 'model_call',
+        has_external_side_effect: false,
+      },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ spans, events }) => useRetrySafetyAnalysis(spans, events),
+      {
+        initialProps: {
+          spans: [failedSpan],
+          events: [effectEvent],
+        },
+      }
+    );
+
+    const firstResult = result.current;
+
+    rerender({
+      spans: [failedSpan],
+      events: [
+        effectEvent,
+        createTimelineEvent({
+          id: 'later-log',
+          span_id: failedSpan.span_id,
+          event_type: 'message',
+          message: 'poll update',
+          timestamp: '2026-03-14T10:00:01.000Z',
+        }),
+      ],
+    });
+
+    expect(result.current).toBe(firstResult);
+    expect(result.current.traceAssessment).toBe(firstResult.traceAssessment);
+    expect(result.current.spanAssessments).toBe(firstResult.spanAssessments);
+  });
+
+  it('recomputes when a new effect event changes the failed-span assessment', () => {
+    const failedSpan = createSpan({
+      span_id: 'failed-span',
+      status: 'FAILED',
+      name: 'Failed span',
+    });
+    const effectEvent = createTimelineEvent({
+      id: 'effect-event',
+      span_id: failedSpan.span_id,
+      event_type: 'effect',
+      payload: {
+        effect_kind: 'model_call',
+        has_external_side_effect: false,
+      },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ spans, events }) => useRetrySafetyAnalysis(spans, events),
+      {
+        initialProps: {
+          spans: [failedSpan],
+          events: [effectEvent],
+        },
+      }
+    );
+
+    const firstResult = result.current;
+
+    rerender({
+      spans: [failedSpan],
+      events: [
+        effectEvent,
+        createTimelineEvent({
+          id: 'unsafe-effect',
+          span_id: failedSpan.span_id,
+          event_type: 'effect',
+          timestamp: '2026-03-14T10:00:01.000Z',
+          payload: {
+            effect_kind: 'api_call',
+            has_external_side_effect: true,
+            idempotent: false,
+          },
+        }),
+      ],
+    });
+
+    expect(result.current).not.toBe(firstResult);
+    expect(result.current.traceAssessment.classification).toBe('unsafe');
+    expect(result.current.traceAssessment.reason).toBe('mutating_non_idempotent');
+  });
+
+  it('recomputes when a span becomes failed', () => {
+    const span = createSpan({
+      span_id: 'candidate-span',
+      status: 'STARTED',
+      name: 'Candidate span',
+    });
+    const effectEvent = createTimelineEvent({
+      id: 'candidate-effect',
+      span_id: span.span_id,
+      event_type: 'effect',
+      payload: {
+        effect_kind: 'model_call',
+        has_external_side_effect: false,
+      },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ spans, events }) => useRetrySafetyAnalysis(spans, events),
+      {
+        initialProps: {
+          spans: [span],
+          events: [effectEvent],
+        },
+      }
+    );
+
+    const firstResult = result.current;
+
+    rerender({
+      spans: [
+        {
+          ...span,
+          status: 'FAILED',
+          ended_at: '2026-03-14T10:00:02.000Z',
+        },
+      ],
+      events: [effectEvent],
+    });
+
+    expect(result.current).not.toBe(firstResult);
+    expect(result.current.spanAssessments.get(span.span_id)?.classification).toBe(
+      'retryable'
+    );
+  });
+});

--- a/web/src/pages/useRetrySafetyAnalysis.ts
+++ b/web/src/pages/useRetrySafetyAnalysis.ts
@@ -1,0 +1,99 @@
+import { useRef } from 'react';
+import type { Span, TimelineEvent } from '../api/client';
+import { buildTimelineEventsBySpanId } from '../utils/failureAnalysis';
+import {
+  assessSpanRetrySafety,
+  assessTraceRetrySafety,
+  classifyEffectEvent,
+  type RetrySafetyAssessment,
+} from '../utils/retrySafety';
+
+export interface RetrySafetyAnalysis {
+  spanAssessments: Map<string, RetrySafetyAssessment>;
+  traceAssessment: RetrySafetyAssessment;
+}
+
+interface RetrySafetyAnalysisCache {
+  signature: string;
+  result: RetrySafetyAnalysis;
+}
+
+export function useRetrySafetyAnalysis(
+  spans: Span[],
+  events: TimelineEvent[]
+): RetrySafetyAnalysis {
+  const signature = buildRetrySafetySignature(spans, events);
+  const cacheRef = useRef<RetrySafetyAnalysisCache | null>(null);
+
+  if (!cacheRef.current || cacheRef.current.signature !== signature) {
+    cacheRef.current = {
+      signature,
+      result: computeRetrySafetyAnalysis(spans, events),
+    };
+  }
+
+  return cacheRef.current.result;
+}
+
+function computeRetrySafetyAnalysis(
+  spans: Span[],
+  events: TimelineEvent[]
+): RetrySafetyAnalysis {
+  const failedSpans = spans.filter((span) => span.status === 'FAILED');
+  const eventsBySpanId = buildTimelineEventsBySpanId(events);
+  const spanAssessments = new Map<string, RetrySafetyAssessment>();
+
+  for (const span of failedSpans) {
+    const assessment = assessSpanRetrySafety(
+      span,
+      eventsBySpanId.get(span.span_id) ?? []
+    );
+    if (!assessment) {
+      continue;
+    }
+
+    spanAssessments.set(span.span_id, assessment);
+  }
+
+  return {
+    spanAssessments,
+    traceAssessment: assessTraceRetrySafety(spanAssessments.values()),
+  };
+}
+
+function buildRetrySafetySignature(spans: Span[], events: TimelineEvent[]): string {
+  const failedSpans = spans
+    .filter((span) => span.status === 'FAILED')
+    .map((span) => `${span.span_id}:${span.name}:${span.status}`)
+    .join('|');
+
+  const failedSpanIds = new Set(
+    spans
+      .filter((span) => span.status === 'FAILED')
+      .map((span) => span.span_id)
+  );
+
+  const effectInputs = events
+    .filter(
+      (event) => event.event_type === 'effect' && Boolean(event.span_id) && failedSpanIds.has(event.span_id!)
+    )
+    .map((event) => {
+      const assessment = classifyEffectEvent(event);
+      return [
+        event.id,
+        event.span_id,
+        event.timestamp,
+        event.sequence ?? '',
+        assessment?.classification ?? 'non-effect',
+        assessment?.reason ?? 'non-effect',
+        assessment?.effectKind ?? '',
+        assessment?.hasExternalSideEffect ?? '',
+        assessment?.idempotent ?? '',
+        assessment?.idempotencyKey ?? '',
+        JSON.stringify(event.payload ?? null),
+      ].join(':');
+    })
+    .join('|');
+
+  return `${failedSpans}::${effectInputs}`;
+}

--- a/web/src/utils/eventSemantics.ts
+++ b/web/src/utils/eventSemantics.ts
@@ -14,6 +14,14 @@ export interface DecisionDetails {
   reasoning?: string;
 }
 
+export interface EffectDetails {
+  effectKind: string;
+  hasExternalSideEffect: boolean;
+  effectId?: string;
+  idempotent?: boolean;
+  idempotencyKey?: string;
+}
+
 export function getStateChangeDetails(
   event: TimelineEvent
 ): StateChangeDetails | null {
@@ -55,6 +63,42 @@ export function getDecisionDetails(event: TimelineEvent): DecisionDetails | null
   };
 }
 
+export function getEffectDetails(event: TimelineEvent): EffectDetails | null {
+  if (event.event_type !== 'effect' || !event.payload) {
+    return null;
+  }
+
+  const effectKind = getNonEmptyString(event.payload, 'effect_kind');
+  const hasExternalSideEffect = getBoolean(
+    event.payload,
+    'has_external_side_effect'
+  );
+  const effectId = getOptionalNonEmptyString(event.payload, 'effect_id');
+  const idempotent = getOptionalBoolean(event.payload, 'idempotent');
+  const idempotencyKey = getOptionalNonEmptyString(
+    event.payload,
+    'idempotency_key'
+  );
+
+  if (
+    !effectKind ||
+    hasExternalSideEffect === null ||
+    effectId === null ||
+    idempotent === null ||
+    idempotencyKey === null
+  ) {
+    return null;
+  }
+
+  return {
+    effectKind,
+    hasExternalSideEffect,
+    effectId,
+    idempotent,
+    idempotencyKey,
+  };
+}
+
 export function formatInlineSemanticValue(value: unknown): string {
   if (value === undefined) {
     return 'unset';
@@ -83,4 +127,31 @@ function getNonEmptyString(
 ): string | null {
   const value = payload[key];
   return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function getOptionalNonEmptyString(
+  payload: Record<string, unknown>,
+  key: string
+): string | undefined | null {
+  if (!Object.prototype.hasOwnProperty.call(payload, key)) {
+    return undefined;
+  }
+
+  return getNonEmptyString(payload, key);
+}
+
+function getBoolean(payload: Record<string, unknown>, key: string): boolean | null {
+  const value = payload[key];
+  return typeof value === 'boolean' ? value : null;
+}
+
+function getOptionalBoolean(
+  payload: Record<string, unknown>,
+  key: string
+): boolean | undefined | null {
+  if (!Object.prototype.hasOwnProperty.call(payload, key)) {
+    return undefined;
+  }
+
+  return getBoolean(payload, key);
 }

--- a/web/src/utils/retrySafety.test.ts
+++ b/web/src/utils/retrySafety.test.ts
@@ -1,0 +1,442 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  createSpan,
+  createTimelineEvent,
+  resetTestEntityCounter,
+} from '../test/traceFixtures';
+import {
+  assessSpanRetrySafety,
+  assessTraceRetrySafety,
+  classifyEffectEvent,
+  getAccessibleSummary,
+  getReasonExplanation,
+  type RetrySafetyAssessment,
+  type RetrySafetyReason,
+} from './retrySafety';
+
+beforeEach(() => {
+  resetTestEntityCounter();
+});
+
+describe('classifyEffectEvent', () => {
+  it('returns null for non-effect events', () => {
+    expect(
+      classifyEffectEvent(
+        createTimelineEvent({
+          event_type: 'message',
+          message: 'non-effect',
+        })
+      )
+    ).toBeNull();
+  });
+
+  it.each([
+    {
+      name: 'read_only_effect',
+      payload: {
+        effect_kind: 'model_call',
+        has_external_side_effect: false,
+      },
+      expected: {
+        classification: 'retryable',
+        reason: 'read_only_effect',
+      },
+    },
+    {
+      name: 'mutating_non_idempotent',
+      payload: {
+        effect_kind: 'api_call',
+        has_external_side_effect: true,
+        idempotent: false,
+      },
+      expected: {
+        classification: 'unsafe',
+        reason: 'mutating_non_idempotent',
+      },
+    },
+    {
+      name: 'mutating_idempotent_with_key',
+      payload: {
+        effect_kind: 'api_call',
+        has_external_side_effect: true,
+        idempotent: true,
+        idempotency_key: 'key-1',
+      },
+      expected: {
+        classification: 'retryable',
+        reason: 'mutating_idempotent_with_key',
+      },
+    },
+    {
+      name: 'mutating_missing_idempotent',
+      payload: {
+        effect_kind: 'tool_call',
+        has_external_side_effect: true,
+      },
+      expected: {
+        classification: 'unknown',
+        reason: 'mutating_missing_idempotent',
+      },
+    },
+    {
+      name: 'mutating_idempotent_missing_key',
+      payload: {
+        effect_kind: 'tool_call',
+        has_external_side_effect: true,
+        idempotent: true,
+      },
+      expected: {
+        classification: 'unknown',
+        reason: 'mutating_idempotent_missing_key',
+      },
+    },
+  ])('classifies $name', ({ payload, expected }) => {
+    expect(
+      classifyEffectEvent(
+        createTimelineEvent({
+          id: `event-${expected.reason}`,
+          span_id: 'failed-span',
+          span_name: 'Failed span',
+          event_type: 'effect',
+          payload,
+        })
+      )
+    ).toMatchObject({
+      ...expected,
+      decisiveEventId: `event-${expected.reason}`,
+      decisiveSpanId: 'failed-span',
+      decisiveSpanName: 'Failed span',
+    });
+  });
+
+  it('classifies malformed effect payloads as unknown', () => {
+    expect(
+      classifyEffectEvent(
+        createTimelineEvent({
+          id: 'bad-effect',
+          event_type: 'effect',
+          payload: {
+            effect_kind: 'api_call',
+          },
+        })
+      )
+    ).toEqual({
+      classification: 'unknown',
+      reason: 'malformed_effect_payload',
+      decisiveEventId: 'bad-effect',
+      decisiveSpanId: undefined,
+      decisiveSpanName: undefined,
+    });
+  });
+});
+
+describe('assessSpanRetrySafety', () => {
+  it('returns retryable for a failed span with a single retryable effect', () => {
+    const failedSpan = createSpan({
+      span_id: 'failed-span',
+      name: 'Failed span',
+      status: 'FAILED',
+    });
+
+    const assessment = assessSpanRetrySafety(failedSpan, [
+      createTimelineEvent({
+        id: 'retryable-effect',
+        span_id: failedSpan.span_id,
+        event_type: 'effect',
+        payload: {
+          effect_kind: 'model_call',
+          has_external_side_effect: false,
+        },
+      }),
+    ]);
+
+    expect(assessment).toMatchObject({
+      classification: 'retryable',
+      reason: 'read_only_effect',
+      decisiveSpanId: failedSpan.span_id,
+      decisiveSpanName: failedSpan.name,
+      decisiveEventId: 'retryable-effect',
+    });
+  });
+
+  it('uses unsafe over retryable when a failed span has mixed effects', () => {
+    const failedSpan = createSpan({
+      span_id: 'failed-span',
+      name: 'Failed span',
+      status: 'FAILED',
+    });
+
+    const assessment = assessSpanRetrySafety(failedSpan, [
+      createTimelineEvent({
+        id: 'retryable-effect',
+        span_id: failedSpan.span_id,
+        timestamp: '2026-03-14T10:00:00.000Z',
+        event_type: 'effect',
+        payload: {
+          effect_kind: 'model_call',
+          has_external_side_effect: false,
+        },
+      }),
+      createTimelineEvent({
+        id: 'unsafe-effect',
+        span_id: failedSpan.span_id,
+        timestamp: '2026-03-14T10:00:01.000Z',
+        event_type: 'effect',
+        payload: {
+          effect_kind: 'api_call',
+          has_external_side_effect: true,
+          idempotent: false,
+        },
+      }),
+    ]);
+
+    expect(assessment?.classification).toBe('unsafe');
+    expect(assessment?.reason).toBe('mutating_non_idempotent');
+    expect(assessment?.decisiveEventId).toBe('unsafe-effect');
+  });
+
+  it('uses unknown over retryable when an effect is missing idempotency metadata', () => {
+    const failedSpan = createSpan({
+      span_id: 'failed-span',
+      name: 'Failed span',
+      status: 'FAILED',
+    });
+
+    const assessment = assessSpanRetrySafety(failedSpan, [
+      createTimelineEvent({
+        id: 'retryable-effect',
+        span_id: failedSpan.span_id,
+        timestamp: '2026-03-14T10:00:00.000Z',
+        event_type: 'effect',
+        payload: {
+          effect_kind: 'model_call',
+          has_external_side_effect: false,
+        },
+      }),
+      createTimelineEvent({
+        id: 'unknown-effect',
+        span_id: failedSpan.span_id,
+        timestamp: '2026-03-14T10:00:01.000Z',
+        event_type: 'effect',
+        payload: {
+          effect_kind: 'tool_call',
+          has_external_side_effect: true,
+        },
+      }),
+    ]);
+
+    expect(assessment?.classification).toBe('unknown');
+    expect(assessment?.reason).toBe('mutating_missing_idempotent');
+    expect(assessment?.decisiveEventId).toBe('unknown-effect');
+  });
+
+  it('returns unknown with no_effect_events when a failed span has no effect events', () => {
+    const failedSpan = createSpan({
+      span_id: 'failed-span',
+      name: 'Failed span',
+      status: 'FAILED',
+    });
+
+    expect(
+      assessSpanRetrySafety(failedSpan, [
+        createTimelineEvent({
+          span_id: failedSpan.span_id,
+          event_type: 'message',
+          message: 'no effect',
+        }),
+      ])
+    ).toEqual({
+      classification: 'unknown',
+      reason: 'no_effect_events',
+      decisiveSpanId: failedSpan.span_id,
+      decisiveSpanName: failedSpan.name,
+    });
+  });
+
+  it('returns null for non-failed spans', () => {
+    expect(
+      assessSpanRetrySafety(
+        createSpan({
+          span_id: 'completed-span',
+          status: 'COMPLETED',
+        }),
+        [
+          createTimelineEvent({
+            span_id: 'completed-span',
+            event_type: 'effect',
+            payload: {
+              effect_kind: 'api_call',
+              has_external_side_effect: true,
+              idempotent: false,
+            },
+          }),
+        ]
+      )
+    ).toBeNull();
+  });
+
+  it('selects the latest event within the winning class as decisive evidence', () => {
+    const failedSpan = createSpan({
+      span_id: 'failed-span',
+      name: 'Failed span',
+      status: 'FAILED',
+    });
+
+    const assessment = assessSpanRetrySafety(failedSpan, [
+      createTimelineEvent({
+        id: 'unsafe-effect-earlier',
+        span_id: failedSpan.span_id,
+        timestamp: '2026-03-14T10:00:00.000Z',
+        event_type: 'effect',
+        payload: {
+          effect_kind: 'api_call',
+          has_external_side_effect: true,
+          idempotent: false,
+        },
+      }),
+      createTimelineEvent({
+        id: 'unsafe-effect-later',
+        span_id: failedSpan.span_id,
+        timestamp: '2026-03-14T10:00:01.000Z',
+        event_type: 'effect',
+        payload: {
+          effect_kind: 'tool_call',
+          has_external_side_effect: true,
+          idempotent: false,
+        },
+      }),
+    ]);
+
+    expect(assessment?.decisiveEventId).toBe('unsafe-effect-later');
+    expect(assessment?.effectKind).toBe('tool_call');
+  });
+});
+
+describe('assessTraceRetrySafety', () => {
+  it('uses a single failed span assessment as the trace assessment', () => {
+    expect(
+      assessTraceRetrySafety([
+        createAssessment({
+          classification: 'retryable',
+          reason: 'read_only_effect',
+          decisiveSpanId: 'failed-span',
+          decisiveSpanName: 'Failed span',
+        }),
+      ])
+    ).toMatchObject({
+      classification: 'retryable',
+      reason: 'read_only_effect',
+      decisiveSpanId: 'failed-span',
+    });
+  });
+
+  it('uses precedence across multiple failed spans', () => {
+    expect(
+      assessTraceRetrySafety([
+        createAssessment({
+          classification: 'retryable',
+          reason: 'read_only_effect',
+          decisiveSpanId: 'primary-failed',
+          decisiveSpanName: 'Primary failed',
+        }),
+        createAssessment({
+          classification: 'unsafe',
+          reason: 'mutating_non_idempotent',
+          decisiveSpanId: 'secondary-failed',
+          decisiveSpanName: 'Secondary failed',
+        }),
+      ])
+    ).toMatchObject({
+      classification: 'unsafe',
+      decisiveSpanId: 'secondary-failed',
+      decisiveSpanName: 'Secondary failed',
+    });
+  });
+
+  it('can point to a decisive span that differs from the primary failed span', () => {
+    const traceAssessment = assessTraceRetrySafety([
+      createAssessment({
+        classification: 'retryable',
+        reason: 'read_only_effect',
+        decisiveSpanId: 'primary-failed',
+        decisiveSpanName: 'Primary failed',
+      }),
+      createAssessment({
+        classification: 'unsafe',
+        reason: 'mutating_non_idempotent',
+        decisiveSpanId: 'secondary-failed',
+        decisiveSpanName: 'Secondary failed',
+      }),
+    ]);
+
+    expect(traceAssessment.decisiveSpanId).toBe('secondary-failed');
+    expect(traceAssessment.decisiveSpanName).toBe('Secondary failed');
+  });
+
+  it('returns unknown when there are no assessable failed spans', () => {
+    expect(assessTraceRetrySafety([])).toEqual({
+      classification: 'unknown',
+      reason: 'no_effect_events',
+    });
+  });
+});
+
+describe('retry safety explanations', () => {
+  it.each([
+    [
+      'read_only_effect',
+      'Retry would repeat a read-only effect with no recorded external mutation.',
+    ],
+    [
+      'mutating_non_idempotent',
+      'Recorded effect mutates external state and is explicitly non-idempotent.',
+    ],
+    [
+      'mutating_idempotent_with_key',
+      'Recorded effect mutates external state but is marked idempotent and includes an idempotency key.',
+    ],
+    [
+      'no_effect_events',
+      'No effect events were recorded for this failed span.',
+    ],
+    [
+      'malformed_effect_payload',
+      'An effect event was recorded, but its retry-safety fields were malformed or incomplete.',
+    ],
+    [
+      'mutating_missing_idempotent',
+      'An effect may mutate external state, but no idempotency flag was recorded.',
+    ],
+    [
+      'mutating_idempotent_missing_key',
+      'An effect is marked idempotent, but no idempotency key was recorded.',
+    ],
+  ] satisfies Array<[RetrySafetyReason, string]>)(
+    'maps %s to the fixed explanation text',
+    (reason, explanation) => {
+      expect(getReasonExplanation(reason)).toBe(explanation);
+    }
+  );
+
+  it('builds the accessible summary from the classification', () => {
+    expect(getAccessibleSummary('unsafe')).toBe(
+      'Retry safety advisory: unsafe. Inferred from effect metadata.'
+    );
+  });
+});
+
+function createAssessment(
+  overrides: Partial<RetrySafetyAssessment> = {}
+): RetrySafetyAssessment {
+  return {
+    classification: overrides.classification ?? 'retryable',
+    reason: overrides.reason ?? 'read_only_effect',
+    decisiveSpanId: overrides.decisiveSpanId ?? 'failed-span',
+    decisiveSpanName: overrides.decisiveSpanName ?? 'Failed span',
+    decisiveEventId: overrides.decisiveEventId,
+    effectKind: overrides.effectKind,
+    hasExternalSideEffect: overrides.hasExternalSideEffect,
+    idempotent: overrides.idempotent,
+    idempotencyKey: overrides.idempotencyKey,
+  };
+}

--- a/web/src/utils/retrySafety.ts
+++ b/web/src/utils/retrySafety.ts
@@ -1,0 +1,228 @@
+import type { Span, TimelineEvent } from '../api/client';
+import { getEffectDetails } from './eventSemantics';
+import { compareTimelineEvents } from './timeline';
+
+export type RetrySafetyClassification = 'retryable' | 'unsafe' | 'unknown';
+
+export type RetrySafetyReason =
+  | 'read_only_effect'
+  | 'mutating_non_idempotent'
+  | 'mutating_idempotent_with_key'
+  | 'no_effect_events'
+  | 'malformed_effect_payload'
+  | 'mutating_missing_idempotent'
+  | 'mutating_idempotent_missing_key';
+
+export interface RetrySafetyAssessment {
+  classification: RetrySafetyClassification;
+  reason: RetrySafetyReason;
+  decisiveEventId?: string;
+  decisiveSpanId?: string;
+  decisiveSpanName?: string;
+  effectKind?: string;
+  hasExternalSideEffect?: boolean;
+  idempotent?: boolean;
+  idempotencyKey?: string;
+}
+
+const CLASSIFICATION_PRIORITY: Record<RetrySafetyClassification, number> = {
+  retryable: 0,
+  unknown: 1,
+  unsafe: 2,
+};
+
+const CLASSIFICATION_LABELS: Record<RetrySafetyClassification, string> = {
+  retryable: 'Retryable',
+  unsafe: 'Unsafe',
+  unknown: 'Unknown',
+};
+
+const REASON_EXPLANATIONS: Record<RetrySafetyReason, string> = {
+  read_only_effect:
+    'Retry would repeat a read-only effect with no recorded external mutation.',
+  mutating_non_idempotent:
+    'Recorded effect mutates external state and is explicitly non-idempotent.',
+  mutating_idempotent_with_key:
+    'Recorded effect mutates external state but is marked idempotent and includes an idempotency key.',
+  no_effect_events: 'No effect events were recorded for this failed span.',
+  malformed_effect_payload:
+    'An effect event was recorded, but its retry-safety fields were malformed or incomplete.',
+  mutating_missing_idempotent:
+    'An effect may mutate external state, but no idempotency flag was recorded.',
+  mutating_idempotent_missing_key:
+    'An effect is marked idempotent, but no idempotency key was recorded.',
+};
+
+export function classifyEffectEvent(
+  event: TimelineEvent
+): RetrySafetyAssessment | null {
+  if (event.event_type !== 'effect') {
+    return null;
+  }
+
+  const effectDetails = getEffectDetails(event);
+  const eventEvidence = {
+    decisiveEventId: event.id,
+    decisiveSpanId: event.span_id ?? undefined,
+    decisiveSpanName: event.span_name ?? undefined,
+  };
+
+  if (!effectDetails) {
+    return {
+      classification: 'unknown',
+      reason: 'malformed_effect_payload',
+      ...eventEvidence,
+    };
+  }
+
+  const effectEvidence = {
+    ...eventEvidence,
+    effectKind: effectDetails.effectKind,
+    hasExternalSideEffect: effectDetails.hasExternalSideEffect,
+    idempotent: effectDetails.idempotent,
+    idempotencyKey: effectDetails.idempotencyKey,
+  };
+
+  if (!effectDetails.hasExternalSideEffect) {
+    return {
+      classification: 'retryable',
+      reason: 'read_only_effect',
+      ...effectEvidence,
+    };
+  }
+
+  if (effectDetails.idempotent === false) {
+    return {
+      classification: 'unsafe',
+      reason: 'mutating_non_idempotent',
+      ...effectEvidence,
+    };
+  }
+
+  if (effectDetails.idempotent === undefined) {
+    return {
+      classification: 'unknown',
+      reason: 'mutating_missing_idempotent',
+      ...effectEvidence,
+    };
+  }
+
+  if (effectDetails.idempotencyKey === undefined) {
+    return {
+      classification: 'unknown',
+      reason: 'mutating_idempotent_missing_key',
+      ...effectEvidence,
+    };
+  }
+
+  return {
+    classification: 'retryable',
+    reason: 'mutating_idempotent_with_key',
+    ...effectEvidence,
+  };
+}
+
+export function assessSpanRetrySafety(
+  span: Span,
+  events: TimelineEvent[]
+): RetrySafetyAssessment | null {
+  if (span.status !== 'FAILED') {
+    return null;
+  }
+
+  const effectEvents = events
+    .filter((event) => event.span_id === span.span_id && event.event_type === 'effect')
+    .sort(compareTimelineEvents);
+
+  if (effectEvents.length === 0) {
+    return {
+      classification: 'unknown',
+      reason: 'no_effect_events',
+      decisiveSpanId: span.span_id,
+      decisiveSpanName: span.name,
+    };
+  }
+
+  let decisiveAssessment: RetrySafetyAssessment | null = null;
+
+  for (const event of effectEvents) {
+    const eventAssessment = classifyEffectEvent(event);
+    if (!eventAssessment) {
+      continue;
+    }
+
+    decisiveAssessment = chooseDecisiveAssessment(
+      decisiveAssessment,
+      eventAssessment
+    );
+  }
+
+  if (!decisiveAssessment) {
+    return {
+      classification: 'unknown',
+      reason: 'no_effect_events',
+      decisiveSpanId: span.span_id,
+      decisiveSpanName: span.name,
+    };
+  }
+
+  return {
+    ...decisiveAssessment,
+    decisiveSpanId: span.span_id,
+    decisiveSpanName: span.name,
+  };
+}
+
+export function assessTraceRetrySafety(
+  spanAssessments: Iterable<RetrySafetyAssessment>
+): RetrySafetyAssessment {
+  let decisiveAssessment: RetrySafetyAssessment | null = null;
+
+  for (const assessment of spanAssessments) {
+    decisiveAssessment = chooseDecisiveAssessment(
+      decisiveAssessment,
+      assessment
+    );
+  }
+
+  return (
+    decisiveAssessment ?? {
+      classification: 'unknown',
+      reason: 'no_effect_events',
+    }
+  );
+}
+
+export function getReasonExplanation(reason: RetrySafetyReason): string {
+  return REASON_EXPLANATIONS[reason];
+}
+
+export function getAccessibleSummary(
+  classification: RetrySafetyClassification
+): string {
+  return `Retry safety advisory: ${classification}. Inferred from effect metadata.`;
+}
+
+export function getRetrySafetyLabel(
+  classification: RetrySafetyClassification
+): string {
+  return CLASSIFICATION_LABELS[classification];
+}
+
+function chooseDecisiveAssessment(
+  current: RetrySafetyAssessment | null,
+  candidate: RetrySafetyAssessment
+): RetrySafetyAssessment {
+  if (!current) {
+    return candidate;
+  }
+
+  if (
+    CLASSIFICATION_PRIORITY[candidate.classification] >=
+    CLASSIFICATION_PRIORITY[current.classification]
+  ) {
+    return candidate;
+  }
+
+  return current;
+}


### PR DESCRIPTION
## Summary
- add the retry-safety classifier, stable analysis hook, and badge component
- surface failed-trace retry-safety guidance in failure summary, span tree, waterfall, span detail, and timeline
- add targeted web tests and update the OpenSpec change package/tasks

## Verification
- `pnpm --filter web type-check`
- `pnpm --filter web test`
- `openspec validate add-retry-safety-classification --strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry-safety classification system for failed traces showing `retryable`, `unsafe`, or `unknown` status based on effect event semantics.
  * Added visual badges and "Retry Safety" sections displaying across failure summary, span details, span tree, execution waterfall, and timeline for failed traces.
  * Included human-readable explanations for each classification reason and idempotency metadata display.

* **Documentation**
  * Added design, specification, and implementation task documentation for retry-safety feature.

* **Tests**
  * Added comprehensive test coverage for classification logic, new components, UI integration, and polling stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->