### PR TITLE
Add wait stall analysis for running traces

### DIFF
--- a/openspec/changes/add-wait-stall-analysis/design.md
+++ b/openspec/changes/add-wait-stall-analysis/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The debugger's running-trace experience currently consists of a single binary stale-trace warning panel. Phase 5 replaces this with a multi-level advisory classifier that explains *why* a running trace appears to be in its current state. The classifier is frontend-only and advisory — it never blocks user actions, never triggers backend changes, and always prefers explicit or inferred evidence over heuristic guesses.
+
+Key constraints:
+- No backend changes; all data already arrives via existing timeline and span APIs
+- Must produce stable classifications during polling (timing fields update every cycle, but the classification itself must not flicker when evidence has not changed)
+- Must compose with the existing stale heuristic, not replace or refactor it
+- Must avoid recomputation on irrelevant poll churn (the `useRetrySafetyAnalysis` signature-cache pattern is a good default, but the mechanism is an implementation choice)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface advisory running-state explanations in trace detail
+- Parse `wait` events for declared wait detection
+- Infer wait state from open span kinds (LLM, TOOL)
+- Distinguish active execution from genuine stalls
+- Improve timeline rendering for `wait` event rows
+
+**Non-Goals:**
+- Automated stall recovery or retry
+- Backend storage of classification state
+- Tree/waterfall/list-page badge surfaces (deferred)
+- Incremental wait pairing optimization (deferred unless perf proves necessary)
+- Changing stale threshold values
+
+## Decisions
+
+### Classification precedence is fixed, not configurable
+The six-level precedence (declared wait > model > tool > active > stale > unknown) is hardcoded. Explicit evidence always wins over inferred, which always wins over heuristic. This avoids configuration complexity and makes the classifier deterministic.
+
+**Alternatives considered:** Weighted scoring, user-configurable thresholds. Rejected because the classifier is advisory and the precedence is already well-motivated by evidence strength.
+
+### Wait pairing uses `wait_id` only, never fuzzy matching
+A resolved wait must carry the same `wait_id` as the entered wait to close it. Waits without `wait_id` are never paired. This is strict but predictable.
+
+**Alternatives considered:** Fuzzy matching by `wait_kind` + span affinity. Rejected because false closures are worse than unclosed waits for an advisory classifier.
+
+### Open generic spans stay `actively_executing` even when stale thresholds are exceeded
+An `AGENT`, `CHAIN`, or `CUSTOM` span that is still `STARTED` is stronger evidence of activity than the absence of recent events. Only when there are no open spans at all does the stale heuristic become the deciding factor.
+
+**Alternatives considered:** Letting stale thresholds override open generic spans. Rejected because this would produce confusing flip-flops between `actively_executing` and `possibly_stalled` for long-running agent spans.
+
+### `decisiveEventId` is kept on the assessment for UI label resolution
+Instead of copying wait payload fields into the assessment, the assessment carries `decisiveEventId` so the panel can look up the event from the current event list. This keeps the assessment shape stable and avoids payload-field drift between the utility and the UI.
+
+### Add span refetching for running traces
+The current `TraceDetailPage` fetches spans once and only invalidates on terminal status. Span-based classifications (`waiting_on_model`, `waiting_on_tool`, `open_generic_span`) would be stale during live execution without a refresh path. The fix is minimal: add `refetchInterval` to the spans query matching the existing timeline poll cadence, gated on `RUNNING` status.
+
+**Alternatives considered:** Deriving span state from synthetic timeline events instead of refetching. Rejected because synthetic events don't carry `span.status` or `span.kind`, which the classifier needs.
+
+### Wait pairing sorts internally
+`computeOpenWaits()` sorts events using the existing timeline comparator before pairing, so callers are not required to pass pre-sorted input. This makes the utility safe for standalone tests and future callers.
+
+**Alternatives considered:** Requiring callers to pre-sort. Rejected because it's a fragile precondition for a pure utility that should work correctly regardless of input order.
+
+### Reuse `evaluateStaleTraceSignal` unchanged
+The existing stale helper is called as a black box. The classifier copies its timing fields (`latestActivityAt`, `runtimeMs`, `inactivityMs`) and uses only `shouldDisplay` to decide the `possibly_stalled` branch. This avoids touching a well-tested helper and ensures backward compatibility for any other consumers.
+
+## Risks / Trade-offs
+
+- **Full recomputation on every analysis pass:** Acceptable for v1 since wait event counts are typically low. If wait-heavy traces emerge, incremental pairing can be added as a follow-up.
+- **Stale panel replacement requires test migration:** Existing test assertions referencing "Experimental stale trace signal" will need updating since the new panel subsumes the old one. This is internal debugger copy, not a public API surface.
+- **`unknown` may be confusing to users:** Mitigated by conservative copy ("the debugger cannot yet explain where it is waiting") that sets correct expectations.
+
+## Open Questions
+
+None — the plan is fully specified.

--- a/openspec/changes/add-wait-stall-analysis/proposal.md
+++ b/openspec/changes/add-wait-stall-analysis/proposal.md
@@ -1,0 +1,61 @@
+# Change: Add Wait / Stall Analysis for Running Traces
+
+## Why
+
+The debugger currently shows a single "stale trace" warning when a running trace exceeds both runtime and inactivity thresholds. This is useful but coarse — it cannot distinguish between a trace waiting on a declared external dependency, one blocked on an in-flight model call, one actively executing between spans, and one that is genuinely stalled. Phase 5 adds a frontend-only running-trace classifier that uses wait event pairing, open span inference, and the existing stale heuristic to surface advisory state explanations directly in the trace detail workspace.
+
+This builds on three existing foundations:
+- `wait` events already round-trip through ingest and timeline APIs (Phase 3 semantic foundation)
+- the debugger already has a stale-running heuristic in `evaluateStaleTraceSignal`
+- `useRetrySafetyAnalysis` establishes the poll-stable, signature-cached, client-side classification pattern
+
+## What Changes
+
+### 1. Wait parsing in `eventSemantics.ts`
+- Add `WaitDetails` interface and `getWaitDetails(event)` strict parser
+- Only `event_type === 'wait'` with non-empty `wait_kind` and `phase` strings qualifies
+- Optional `wait_id` and `resolution` fields
+- Malformed waits return `null`
+
+### 2. Pure classification utility (`web/src/utils/waitStallAnalysis.ts`)
+- `WaitStallClassification`: `declared_wait | waiting_on_model | waiting_on_tool | actively_executing | possibly_stalled | unknown`
+- `WaitStallBasis`: `declared | inferred | heuristic`
+- `WaitStallReason`: seven reason codes
+- `WaitStallAssessment`: classification + basis + reason + decisive evidence + timing fields
+- Client-side wait pairing using `wait_id`-only matching on `entered`/`resolved` phases
+- Fixed-precedence classifier: declared wait > model span > tool span > active execution > stale heuristic > unknown
+- Reuses `evaluateStaleTraceSignal` unchanged for timing and stale detection
+
+### 3. Classification-stable hook (`web/src/pages/useWaitStallAnalysis.ts`)
+- Hook that recomputes timing fields on every poll cycle (since `runtimeMs`/`inactivityMs` depend on current time) but produces stable classifications when underlying evidence has not changed
+- Returns `WaitStallAssessment | null` (null when trace is not RUNNING or initial snapshot not loaded)
+- Recomputation triggers include: span state changes, new wait events, new explicit events (which affect execution evidence and `latestActivityAt`), trace status changes, and stale heuristic flips
+
+### 4. Running-trace span freshness
+- Add `refetchInterval` to the spans query in `TraceDetailPage.tsx` while the trace is `RUNNING`, matching the existing timeline poll cadence
+- Stops refetching once the trace reaches terminal status (existing invalidation handles that)
+- Without this, span-based classifications (`waiting_on_model`, `waiting_on_tool`, `open_generic_span`) would be stale during live execution
+
+### 5. Running-state panel in trace detail
+- Replaces `StaleTraceSignalPanel` with generalized `RunningStatePanel`
+- Shows classification label, basis, advisory copy, timing, and decisive span jump action
+- For `declared_wait`, resolves wait-specific label from `decisiveEventId` + current events
+
+### 6. Timeline wait row rendering
+- Well-formed waits: `Entered wait: <kind>` / `Resolved wait: <kind> → <resolution>`
+- Phase-only fallback: `<Capitalized phase> wait`
+- Generic fallback for malformed waits
+- Implementation may use `summarizeTimelineEvent()` or direct component rendering branches; the requirement is behavioral
+
+## Impact
+- Affected specs: `wait-stall-classification` (new capability)
+- Affected code:
+  - `web/src/utils/eventSemantics.ts` — `WaitDetails` + `getWaitDetails()`
+  - `web/src/utils/waitStallAnalysis.ts` — new pure utility
+  - `web/src/utils/waitStallAnalysis.test.ts` — classifier and pairing tests
+  - `web/src/pages/useWaitStallAnalysis.ts` — new hook
+  - `web/src/pages/TraceDetailPage.tsx` — replace `StaleTraceSignalPanel` with `RunningStatePanel`; add span refetch interval for running traces
+  - `web/src/utils/timeline.ts` and/or `web/src/components/Timeline.tsx` — wait row rendering
+  - Component and page test files for touched surfaces
+- No backend, API, DB, SDK, ingest, contract, migration, or engine changes
+- No changes to `evaluateStaleTraceSignal`, `buildFailureAnalysis`, or failure-first navigation

--- a/openspec/changes/add-wait-stall-analysis/specs/wait-stall-classification/spec.md
+++ b/openspec/changes/add-wait-stall-analysis/specs/wait-stall-classification/spec.md
@@ -1,0 +1,225 @@
+## ADDED Requirements
+
+### Requirement: Wait Event Parsing
+
+The debugger SHALL parse `wait` timeline events into structured `WaitDetails` using a strict parser in `eventSemantics.ts`.
+
+The parser SHALL require `event_type === 'wait'`, a non-empty `wait_kind` string, and a non-empty `phase` string. It SHALL accept optional `wait_id` and `resolution` fields. Malformed events SHALL return `null`.
+
+The parser SHALL NOT validate `wait_kind` or `phase` vocabulary beyond non-empty string checks.
+
+#### Scenario: Well-formed wait event with all fields
+- **WHEN** a timeline event has `event_type: 'wait'` and payload contains `wait_kind: 'model_response'`, `phase: 'entered'`, `wait_id: 'w-1'`
+- **THEN** `getWaitDetails()` returns `{ waitKind: 'model_response', phase: 'entered', waitId: 'w-1', resolution: undefined }`
+
+#### Scenario: Minimal well-formed wait event
+- **WHEN** a timeline event has `event_type: 'wait'` and payload contains `wait_kind: 'tool_call'`, `phase: 'resolved'` with no `wait_id`
+- **THEN** `getWaitDetails()` returns `{ waitKind: 'tool_call', phase: 'resolved', waitId: undefined, resolution: undefined }`
+
+#### Scenario: Malformed wait event missing required field
+- **WHEN** a timeline event has `event_type: 'wait'` but payload is missing `wait_kind`
+- **THEN** `getWaitDetails()` returns `null`
+
+#### Scenario: Non-wait event type
+- **WHEN** a timeline event has `event_type: 'effect'`
+- **THEN** `getWaitDetails()` returns `null`
+
+---
+
+### Requirement: Wait Pairing Lifecycle
+
+The classifier SHALL compute open waits entirely client-side from the full currently loaded event set using `wait_id`-only matching. The `computeOpenWaits()` utility SHALL sort events internally using the existing timeline comparator before pairing, so callers are not required to pass a pre-sorted list.
+
+Only exact `phase === 'entered'` SHALL open a wait. Only exact `phase === 'resolved'` SHALL close a wait. Entered/resolved pairing SHALL use `wait_id` as the sole matching key. When multiple `entered` waits share the same `wait_id`, a single `resolved` wait SHALL close the earliest unmatched `entered` wait with that `wait_id` in timeline order (FIFO). A resolved wait with no matching earlier unmatched `entered` `wait_id` SHALL close nothing. Waits without `wait_id` SHALL never be fuzzy-matched or close any other wait. Non-`entered` / non-`resolved` phases SHALL NOT affect pairing. The decisive open wait SHALL be the latest unmatched entered wait in timeline order.
+
+#### Scenario: Single entered wait remains open
+- **WHEN** the event set contains one `entered` wait with `wait_id: 'w-1'` and no corresponding `resolved` wait
+- **THEN** the wait pairing reports one open wait with `wait_id: 'w-1'`
+
+#### Scenario: Entered and resolved pair with same wait_id
+- **WHEN** the event set contains an `entered` wait with `wait_id: 'w-1'` followed by a `resolved` wait with `wait_id: 'w-1'`
+- **THEN** the wait pairing reports zero open waits
+
+#### Scenario: Resolved before entered self-heals across recomputation
+- **WHEN** the event set initially contains only a `resolved` wait with `wait_id: 'w-1'`, and a later poll adds an `entered` wait with `wait_id: 'w-1'` that precedes the resolved event in timeline order
+- **THEN** recomputation from the full event set reports zero open waits
+
+#### Scenario: Waits without wait_id never close other waits
+- **WHEN** the event set contains an `entered` wait with `wait_id: 'w-1'` and a `resolved` wait without `wait_id`
+- **THEN** the entered wait with `wait_id: 'w-1'` remains open
+
+#### Scenario: Duplicate wait_id FIFO pairing
+- **WHEN** the event set contains two `entered` waits with `wait_id: 'w-1'` (at t1 and t2, t1 before t2) followed by one `resolved` wait with `wait_id: 'w-1'`
+- **THEN** the resolved wait closes the t1 entered wait, and the t2 entered wait remains open as the decisive open wait
+
+#### Scenario: Two resolves close two enters with same wait_id
+- **WHEN** the event set contains two `entered` waits with `wait_id: 'w-1'` (at t1 and t2) followed by two `resolved` waits with `wait_id: 'w-1'` (at t3 and t4)
+- **THEN** the t3 resolved closes the t1 entered, the t4 resolved closes the t2 entered, and zero open waits remain
+
+#### Scenario: Unsorted input produces correct pairing
+- **WHEN** events are passed to `computeOpenWaits()` in arbitrary order (e.g., resolved at t2 before entered at t1)
+- **THEN** the utility sorts internally and produces the same pairing as if events were pre-sorted in timeline order
+
+#### Scenario: Unsupported phase does not affect pairing
+- **WHEN** a wait event has `phase: 'suspended'` with `wait_id: 'w-1'`
+- **THEN** it neither opens nor closes any wait
+
+---
+
+### Requirement: Running Trace Classification
+
+The classifier SHALL produce a `WaitStallAssessment` for running traces after the initial timeline snapshot is loaded. It SHALL return `null` when the trace status is not `RUNNING` or the initial snapshot has not loaded.
+
+The classifier SHALL use `span.status === 'STARTED'` as the definition of an open span. `SCHEDULED` spans SHALL NOT count as active execution.
+
+The classifier SHALL apply a fixed precedence of six classification levels.
+
+"Execution evidence beyond trace start" means at least one explicit timeline event exists, or at least one span exists with status `STARTED`, `COMPLETED`, or `FAILED`. A trace whose only activity evidence is the trace start timestamp itself does not have execution evidence beyond trace start.
+
+When multiple spans of the same kind qualify as "latest-started," the classifier SHALL use array order (i.e., the last matching span in the input array) as the tie-break. This is a determinism convention, not a semantic guarantee.
+
+#### Scenario: Declared wait classification
+- **WHEN** the trace is `RUNNING` and there is at least one open declared wait (entered, not resolved)
+- **THEN** the assessment is `classification: 'declared_wait'`, `basis: 'declared'`, `reason: 'open_declared_wait'` with `decisiveEventId` set to the latest unmatched entered wait event
+
+#### Scenario: Waiting on model classification
+- **WHEN** the trace is `RUNNING`, there is no open declared wait, and at least one open `LLM` span exists
+- **THEN** the assessment is `classification: 'waiting_on_model'`, `basis: 'inferred'`, `reason: 'open_model_span'` with `decisiveSpanId` and `decisiveSpanName` set to the latest-started open `LLM` span
+
+#### Scenario: Waiting on tool classification
+- **WHEN** the trace is `RUNNING`, there is no open declared wait, no open `LLM` span, and at least one open `TOOL` span exists
+- **THEN** the assessment is `classification: 'waiting_on_tool'`, `basis: 'inferred'`, `reason: 'open_tool_span'` with `decisiveSpanId` and `decisiveSpanName` set to the latest-started open `TOOL` span
+
+#### Scenario: Actively executing with open generic span
+- **WHEN** the trace is `RUNNING`, there is no higher-priority state, and at least one open `AGENT`, `CHAIN`, or `CUSTOM` span exists
+- **THEN** the assessment is `classification: 'actively_executing'`, `basis: 'heuristic'`, `reason: 'open_generic_span'` with `decisiveSpanId` and `decisiveSpanName` set to the latest-started open generic span
+
+#### Scenario: Actively executing between spans with recent activity
+- **WHEN** the trace is `RUNNING`, there are no open spans, but execution evidence beyond trace start exists and activity is recent
+- **THEN** the assessment is `classification: 'actively_executing'`, `basis: 'heuristic'`, `reason: 'recent_activity_without_open_span'` with no `decisiveSpanId`
+
+#### Scenario: Possibly stalled classification
+- **WHEN** the trace is `RUNNING`, there is no higher-priority state, and the existing stale trace heuristic returns `shouldDisplay: true`
+- **THEN** the assessment is `classification: 'possibly_stalled'`, `basis: 'heuristic'`, `reason: 'stale_without_stronger_signal'`
+
+#### Scenario: Unknown classification for zero-evidence trace
+- **WHEN** the trace is `RUNNING`, there are zero spans, zero explicit events, and the stale heuristic returns `shouldDisplay: false`
+- **THEN** the assessment is `classification: 'unknown'`, `basis: 'heuristic'`, `reason: 'insufficient_running_evidence'`
+
+#### Scenario: Scheduled-only trace is unknown
+- **WHEN** the trace is `RUNNING` and all spans have `status: 'SCHEDULED'` with no explicit events
+- **THEN** the assessment is `classification: 'unknown'`
+
+#### Scenario: Open generic span beats stale heuristic
+- **WHEN** the trace is `RUNNING`, an `AGENT` span is `STARTED`, and the stale heuristic returns `shouldDisplay: true`
+- **THEN** the assessment is `classification: 'actively_executing'`, not `possibly_stalled`
+
+#### Scenario: Declared wait beats model and tool spans
+- **WHEN** the trace is `RUNNING`, there is an open declared wait, an open `LLM` span, and an open `TOOL` span
+- **THEN** the assessment is `classification: 'declared_wait'`
+
+#### Scenario: Model span beats tool span
+- **WHEN** the trace is `RUNNING`, there is no open declared wait, and both an open `LLM` span and an open `TOOL` span exist
+- **THEN** the assessment is `classification: 'waiting_on_model'`
+
+#### Scenario: Non-running trace returns null
+- **WHEN** the trace status is `COMPLETED`
+- **THEN** the hook returns `null`
+
+---
+
+### Requirement: Poll-Stable Analysis Hook
+
+The `useWaitStallAnalysis` hook SHALL recompute timing fields (`runtimeMs`, `inactivityMs`, `latestActivityAt`) and the stale heuristic on every poll cycle, since these depend on the current time. However, the hook SHALL produce a stable classification when the underlying evidence (span states, wait events, explicit events, and trace status) has not changed and the stale heuristic result has not flipped. The hook MAY use any caching or memoization strategy to achieve this.
+
+#### Scenario: Classification stable across time-only advance
+- **WHEN** a poll cycle passes with no new events or span state changes, and the stale heuristic result has not flipped
+- **THEN** the hook returns the same `classification` and `reason`
+
+#### Scenario: Time advance flips stale heuristic
+- **WHEN** enough time passes that `evaluateStaleTraceSignal` flips from `shouldDisplay: false` to `shouldDisplay: true`, with no other evidence changes
+- **THEN** the hook transitions to `possibly_stalled` (assuming no higher-priority state)
+
+#### Scenario: New explicit event updates evidence and timing
+- **WHEN** a new `log` event arrives during a poll cycle, providing execution evidence beyond trace start and refreshing `latestActivityAt`
+- **THEN** the hook recomputes and may change classification (e.g., `unknown` to `actively_executing`)
+
+#### Scenario: New open wait changes result
+- **WHEN** a new `entered` wait event appears in a poll cycle
+- **THEN** the hook recomputes and returns an updated assessment
+
+---
+
+### Requirement: Running-Trace Span Freshness
+
+The trace detail page SHALL periodically refresh spans while the trace status is `RUNNING`, so that span-based classifications (`waiting_on_model`, `waiting_on_tool`, `actively_executing` via `open_generic_span`) reflect current execution state rather than the initial load snapshot.
+
+The refresh SHALL piggyback on the existing timeline poll cadence. When the trace reaches a terminal status, the existing terminal-refresh invalidation already covers the final span state.
+
+#### Scenario: New span visible during live execution
+- **WHEN** a trace is `RUNNING` and a new `LLM` span with status `STARTED` is created server-side after the initial page load
+- **THEN** the span becomes visible to the classifier within one poll cycle, and the classification updates accordingly
+
+#### Scenario: Span completion visible during live execution
+- **WHEN** a trace is `RUNNING` and an open `TOOL` span transitions to `COMPLETED` server-side
+- **THEN** the span status change becomes visible to the classifier within one poll cycle
+
+#### Scenario: No span refetch after terminal status
+- **WHEN** the trace has reached `COMPLETED` or `FAILED`
+- **THEN** span refetching stops (the existing terminal-refresh invalidation handles the final state)
+
+---
+
+### Requirement: Running-State Panel
+
+The trace detail workspace SHALL display a running-state panel for running traces after the initial timeline snapshot is loaded. This panel SHALL replace the previous stale-only `StaleTraceSignalPanel`.
+
+The panel SHALL display the classification label, basis label, advisory copy, latest activity timestamp, and runtime/inactivity durations when available. When `decisiveSpanId` exists, the panel SHALL offer a jump-to-span action. For `declared_wait`, the panel SHALL resolve a human-readable wait label from `decisiveEventId` and the current event list.
+
+The panel SHALL NOT appear on non-running traces. The running-state classification SHALL NOT be surfaced on tree badges, waterfall badges, span detail sections, or list-page surfaces.
+
+#### Scenario: Declared wait panel shows wait-specific label
+- **WHEN** the assessment is `declared_wait` with `decisiveEventId` pointing to a wait event with `wait_kind: 'model_response'`
+- **THEN** the panel displays "Declared wait" label, the copy "Execution declared a wait and has not yet recorded a matching resolution.", and the resolved wait kind "model_response"
+
+#### Scenario: Model wait panel shows jump action
+- **WHEN** the assessment is `waiting_on_model` with `decisiveSpanId: 'span-1'` and `decisiveSpanName: 'gpt-4o call'`
+- **THEN** the panel displays "Waiting on model" label, the copy "Execution appears to be waiting on an in-flight model span.", and a jump action targeting span `span-1`
+
+#### Scenario: Possibly stalled panel shows timing
+- **WHEN** the assessment is `possibly_stalled` with `latestActivityAt`, `runtimeMs`, and `inactivityMs` populated
+- **THEN** the panel displays "Possibly stalled" label, the copy "Execution is still marked running, but recent activity is sparse.", the latest activity timestamp, and duration information
+
+#### Scenario: Panel not shown for completed trace
+- **WHEN** the trace status is `COMPLETED`
+- **THEN** no running-state panel is rendered
+
+---
+
+### Requirement: Timeline Wait Row Rendering
+
+The timeline SHALL render improved summaries for `wait` event rows, whether via the summary helper or direct component rendering.
+
+When `getWaitDetails()` succeeds, the timeline SHALL render `Entered wait: <kind>` or `Resolved wait: <kind>`, appending `→ <resolution>` when resolution exists. When strict parsing fails but the raw payload contains a non-empty `phase` string, the timeline SHALL render `<Capitalized phase> wait`. Otherwise the timeline SHALL fall back to existing generic summary/message behavior.
+
+Phase-only waits SHALL NOT count as declared waits for classification purposes.
+
+#### Scenario: Well-formed entered wait rendering
+- **WHEN** a timeline event has `event_type: 'wait'` with `wait_kind: 'tool_call'`, `phase: 'entered'`
+- **THEN** the timeline row summary reads "Entered wait: tool_call"
+
+#### Scenario: Well-formed resolved wait with resolution
+- **WHEN** a timeline event has `event_type: 'wait'` with `wait_kind: 'model_response'`, `phase: 'resolved'`, `resolution: 'success'`
+- **THEN** the timeline row summary reads "Resolved wait: model_response → success"
+
+#### Scenario: Phase-only fallback rendering
+- **WHEN** a timeline event has `event_type: 'wait'` and strict parsing fails but `payload.phase` is `'paused'`
+- **THEN** the timeline row summary reads "Paused wait"
+
+#### Scenario: Generic fallback for fully malformed wait
+- **WHEN** a timeline event has `event_type: 'wait'` and strict parsing fails and `payload.phase` is missing or empty
+- **THEN** the timeline falls back to existing `message` or `event_type` summary behavior
+
+#### Scenario: Non-wait rows unchanged
+- **WHEN** a timeline event has `event_type: 'log'`
+- **THEN** the timeline row rendering is unchanged

--- a/openspec/changes/add-wait-stall-analysis/tasks.md
+++ b/openspec/changes/add-wait-stall-analysis/tasks.md
@@ -1,0 +1,77 @@
+## 1. Wait parsing foundation
+- [x] 1.1 Add `WaitDetails` interface and `getWaitDetails(event)` to `web/src/utils/eventSemantics.ts`
+- [x] 1.2 Add unit tests for `getWaitDetails` in `web/src/utils/eventSemantics.test.ts` (well-formed, minimal, malformed, non-wait)
+
+## 2. Pure classification utility
+- [x] 2.1 Create `web/src/utils/waitStallAnalysis.ts` with types: `WaitStallClassification`, `WaitStallBasis`, `WaitStallReason`, `WaitStallAssessment`
+- [x] 2.2 Implement `computeOpenWaits()` wait-pairing function using `wait_id`-only matching on entered/resolved phases; utility sorts events internally using the existing timeline comparator
+- [x] 2.3 Implement `classifyRunningTrace()` with the six-level fixed-precedence classifier calling `evaluateStaleTraceSignal` for timing and stale detection
+- [x] 2.4 Add comprehensive tests in `web/src/utils/waitStallAnalysis.test.ts`:
+  - open entered wait → `declared_wait`
+  - entered + resolved with same `wait_id` → wait closes
+  - resolved before entered self-heals on recomputation
+  - waits without `wait_id` never close other waits
+  - duplicate `wait_id`: one resolve closes earliest unmatched enter (FIFO), later enter remains open
+  - duplicate `wait_id`: two resolves close both enters, zero open waits
+  - unsorted input produces correct pairing (utility sorts internally)
+  - unsupported phases do not affect pairing
+  - open `LLM` span → `waiting_on_model`
+  - open `TOOL` span → `waiting_on_tool`
+  - open `AGENT`/`CHAIN`/`CUSTOM` span → `actively_executing` with `open_generic_span`
+  - no open spans but recent activity → `actively_executing` with `recent_activity_without_open_span`
+  - zero spans and zero events → `unknown`
+  - scheduled-only trace → `unknown`
+  - stale heuristic true with no stronger signal → `possibly_stalled`
+  - precedence: declared wait beats model/tool, model beats tool, generic span beats stale, stale beats unknown
+  - tie-break: two open spans of same kind with equal `started_at` selects last in input array
+- [x] 2.5 Add decisive evidence assertions to classification tests:
+  - `declared_wait` sets `decisiveEventId` (and `decisiveSpanId`/`decisiveSpanName` when the wait belongs to a known span)
+  - `waiting_on_model` sets `decisiveSpanId` and `decisiveSpanName` to the latest-started open `LLM` span
+  - `waiting_on_tool` sets `decisiveSpanId` and `decisiveSpanName` to the latest-started open `TOOL` span
+  - `actively_executing` with `open_generic_span` sets `decisiveSpanId`/`decisiveSpanName`; with `recent_activity_without_open_span` leaves them unset
+  - `possibly_stalled` and `unknown` leave `decisiveSpanId`, `decisiveSpanName`, and `decisiveEventId` unset
+- [x] 2.6 Add null-gating tests:
+  - hook returns `null` when trace status is `COMPLETED`
+  - hook returns `null` when trace status is `FAILED`
+  - hook returns `null` when initial timeline snapshot has not loaded
+
+## 3. Classification-stable hook
+- [x] 3.1 Create `web/src/pages/useWaitStallAnalysis.ts` with hook that recomputes timing on every cycle but produces stable classifications when evidence has not changed
+- [x] 3.2 Add classification-stability and recomputation tests:
+  - classification stays stable when no evidence changes and stale heuristic has not flipped
+  - timing fields (`runtimeMs`, `inactivityMs`) update on every poll cycle even without data changes
+  - time advance that flips stale heuristic transitions classification to `possibly_stalled`
+  - new explicit event (e.g., `log`) triggers recomputation and can change classification (e.g., `unknown` → `actively_executing`)
+  - new wait event triggers recomputation
+  - span status change triggers recomputation
+
+## 4. Running-trace span freshness
+- [x] 4.1 Add `refetchInterval` to the spans query in `TraceDetailPage.tsx` while the trace is `RUNNING`, matching the existing timeline poll cadence (`TIMELINE_POLL_INTERVAL_MS`)
+- [x] 4.2 Verify refetching stops once trace reaches terminal status
+- [x] 4.3 Add test coverage: new span or span status change becomes visible within one poll cycle during live execution
+
+## 5. Timeline wait row rendering
+- [x] 5.1 Implement wait row rendering (well-formed → phase-only fallback → generic fallback) in the appropriate location (summary helper and/or `Timeline.tsx` component)
+- [x] 5.2 Add helper-level tests for wait summary text (well-formed waits, phase-only waits, malformed waits, non-wait rows)
+- [x] 5.3 Add component-level timeline tests verifying that `wait` event rows render the correct text in the actual `Timeline.tsx` component, covering well-formed, phase-only, and malformed cases
+
+## 6. Running-state panel in trace detail
+- [x] 6.1 Replace `StaleTraceSignalPanel` with `RunningStatePanel` in `web/src/pages/TraceDetailPage.tsx`
+- [x] 6.2 Wire `useWaitStallAnalysis` hook into `TraceDetailPage` and pass assessment to `RunningStatePanel`
+- [x] 6.3 Implement panel UI: classification label, basis, advisory copy, timing, decisive span jump action, declared-wait label resolution from `decisiveEventId`
+
+## 7. Test updates for replaced stale panel
+- [x] 7.1 Update or remove existing test assertions referencing "Experimental stale trace signal", the old stale-only copy, or `StaleTraceSignalPanel`
+- [x] 7.2 Add trace detail tests:
+  - running-state panel appears only for running traces after initial snapshot
+  - panel does not appear for completed or failed traces
+  - declared wait resolves wait-specific text from decisive event
+  - model/tool states expose correct jump-to-span action using `decisiveSpanId`
+  - active-between-spans renders `actively_executing`, not `unknown`
+  - stale running trace with no stronger state renders `possibly_stalled`
+  - unknown renders conservative copy
+  - panel correctly handles `null` assessment (non-running or pre-snapshot)
+
+## 8. Final verification
+- [x] 8.1 Run `pnpm --filter web test` and confirm all tests pass
+- [x] 8.2 Run `pnpm --filter web build` and confirm no build errors

--- a/web/src/components/Timeline.test.tsx
+++ b/web/src/components/Timeline.test.tsx
@@ -76,6 +76,62 @@ describe('Timeline semantic event rendering', () => {
     expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument();
     expect(screen.getByText('claude-3-haiku')).toBeInTheDocument();
   });
+
+  it('renders well-formed wait rows with semantic summaries', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'wait',
+          payload: {
+            wait_kind: 'tool_call',
+            phase: 'entered',
+          },
+        }),
+        createTimelineEvent({
+          event_type: 'wait',
+          payload: {
+            wait_kind: 'model_response',
+            phase: 'resolved',
+            resolution: 'success',
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Entered wait: tool_call')).toBeInTheDocument();
+    expect(
+      screen.getByText('Resolved wait: model_response → success')
+    ).toBeInTheDocument();
+  });
+
+  it('renders phase-only wait fallbacks when strict parsing fails', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'wait',
+          payload: {
+            phase: 'paused',
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Paused wait')).toBeInTheDocument();
+  });
+
+  it('falls back to generic wait text when the wait payload is fully malformed', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'wait',
+          message: 'Generic wait fallback',
+          payload: {},
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Generic wait fallback')).toBeInTheDocument();
+  });
 });
 
 describe('Timeline retry safety badges', () => {

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -1,4 +1,5 @@
 import { act } from 'react';
+import { focusManager, onlineManager } from '@tanstack/react-query';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -22,6 +23,25 @@ import {
 } from './testUtils';
 
 let fetchMock: ReturnType<typeof vi.fn>;
+
+function createRunningTraceDetail(
+  overrides: Partial<TraceDetail> = {}
+): TraceDetail {
+  return {
+    ...TRACE_DETAIL,
+    status: 'RUNNING',
+    ended_at: undefined,
+    error_count: 0,
+    ...overrides,
+  };
+}
+
+function countRequests(pathname: string): number {
+  return fetchMock.mock.calls.filter(([input]) => {
+    const url = new URL(readRequestUrl(input), 'http://localhost');
+    return url.pathname === pathname;
+  }).length;
+}
 
 beforeEach(() => {
   resetTestEntityCounter();
@@ -1619,7 +1639,7 @@ describe('TraceDetailPage', () => {
     expect(view.router.state.location.search).toBe('');
   });
 
-  it('waits for the initial timeline snapshot before evaluating the stale trace signal', async () => {
+  it('waits for the initial timeline snapshot before showing the running-state panel', async () => {
     const now = Date.now();
     const staleStartedAt = new Date(now - 20 * 60 * 1000).toISOString();
     const recentActivityAt = new Date(now - 60 * 1000).toISOString();
@@ -1627,14 +1647,7 @@ describe('TraceDetailPage', () => {
 
     fetchMock.mockImplementation(
       buildFetchHandler({
-        detail: () =>
-          jsonResponse({
-            ...TRACE_DETAIL,
-            status: 'RUNNING',
-            started_at: staleStartedAt,
-            ended_at: undefined,
-            error_count: 0,
-          }),
+        detail: () => jsonResponse(createRunningTraceDetail({ started_at: staleStartedAt })),
         spans: () =>
           jsonResponse({
             spans: [
@@ -1652,9 +1665,7 @@ describe('TraceDetailPage', () => {
 
     renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
     expect(await screen.findByText('Trace Context')).toBeInTheDocument();
-    expect(
-      screen.queryByText(/still marked running\. recent activity is sparse/i)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Running state')).not.toBeInTheDocument();
 
     await act(async () => {
       timelineResponse.resolve(
@@ -1676,12 +1687,399 @@ describe('TraceDetailPage', () => {
       await Promise.resolve();
     });
 
+    expect(await screen.findByText('Running state')).toBeInTheDocument();
+    expect(screen.getByText('Actively executing')).toBeInTheDocument();
     await userEvent.setup().click(screen.getByRole('button', { name: 'Timeline' }));
     expect(await screen.findByText('Recent activity')).toBeInTheDocument();
-    expect(
-      screen.queryByText(/still marked running\. recent activity is sparse/i)
-    ).not.toBeInTheDocument();
   });
+
+  it.each(['COMPLETED', 'FAILED'] as const)(
+    'does not render the running-state panel for %s traces',
+    async (traceStatus) => {
+      fetchMock.mockImplementation(
+        buildFetchHandler({
+          detail: () =>
+            jsonResponse({
+              ...TRACE_DETAIL,
+              status: traceStatus,
+              ended_at: '2026-03-14T10:03:00.000Z',
+            }),
+          spans: () => jsonResponse({ spans: [] }),
+          timeline: () =>
+            jsonResponse({
+              events: [],
+              trace_status: traceStatus,
+              has_more: false,
+            }),
+        })
+      );
+
+      renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+      expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+      expect(screen.queryByText('Running state')).not.toBeInTheDocument();
+    }
+  );
+
+  it('renders declared waits with wait-specific text from the decisive event', async () => {
+    const waitingSpan = createSpan({
+      span_id: 'wait-span',
+      name: 'Waiting span',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:00:30.000Z',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createRunningTraceDetail()),
+        spans: () => jsonResponse({ spans: [waitingSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'wait-event',
+                span_id: waitingSpan.span_id,
+                span_name: waitingSpan.name,
+                event_type: 'wait',
+                timestamp: '2026-03-14T10:01:30.000Z',
+                payload: {
+                  wait_kind: 'model_response',
+                  phase: 'entered',
+                  wait_id: 'wait-1',
+                },
+              }),
+            ],
+            trace_status: 'RUNNING',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(await screen.findByText('Declared wait')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Execution declared a wait and has not yet recorded a matching resolution.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Current wait')).toBeInTheDocument();
+    expect(screen.getByText('model_response')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Jump to Waiting span' })
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      kind: 'LLM' as const,
+      label: 'Waiting on model',
+      spanId: 'model-span',
+      spanName: 'Model call',
+    },
+    {
+      kind: 'TOOL' as const,
+      label: 'Waiting on tool',
+      spanId: 'tool-span',
+      spanName: 'Tool call',
+    },
+  ])(
+    'uses the decisive span jump action for $label states',
+    async ({ kind, label, spanId, spanName }) => {
+      const user = userEvent.setup();
+      const decisiveSpan = createSpan({
+        span_id: spanId,
+        name: spanName,
+        kind,
+        status: 'STARTED',
+        started_at: '2026-03-14T10:01:00.000Z',
+      });
+
+      fetchMock.mockImplementation(
+        buildFetchHandler({
+          detail: () => jsonResponse(createRunningTraceDetail()),
+          spans: () => jsonResponse({ spans: [decisiveSpan] }),
+          timeline: () =>
+            jsonResponse({
+              events: [],
+              trace_status: 'RUNNING',
+              has_more: false,
+            }),
+        })
+      );
+
+      renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+      expect(await screen.findByText(label)).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: `Jump to ${spanName}` }));
+      expect(
+        within(screen.getByLabelText('Span breadcrumb')).getByText(spanName)
+      ).toBeInTheDocument();
+    }
+  );
+
+  it('renders actively executing for recent work between spans', async () => {
+    const now = Date.now();
+    const traceStartedAt = new Date(now - 2 * 60 * 1000).toISOString();
+
+    const completedSpan = createSpan({
+      span_id: 'completed-work',
+      name: 'Completed work',
+      status: 'COMPLETED',
+      started_at: new Date(now - 90 * 1000).toISOString(),
+      ended_at: new Date(now - 30 * 1000).toISOString(),
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse(createRunningTraceDetail({ started_at: traceStartedAt })),
+        spans: () => jsonResponse({ spans: [completedSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Actively executing')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Recent activity suggests execution is still progressing between spans.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Unknown')).not.toBeInTheDocument();
+  });
+
+  it('renders possibly stalled when a running trace has no stronger signal', async () => {
+    const traceStartedAt = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createRunningTraceDetail({ started_at: traceStartedAt })),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Possibly stalled')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Execution is still marked running, but recent activity is sparse.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders unknown with conservative copy when the debugger lacks running evidence', async () => {
+    const traceStartedAt = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createRunningTraceDetail({ started_at: traceStartedAt })),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Unknown')).toBeInTheDocument();
+    expect(
+      screen.getByText('The debugger cannot yet explain where it is waiting.')
+    ).toBeInTheDocument();
+  });
+
+  it('refreshes spans during live execution so new spans become visible within one poll cycle', async () => {
+    const now = Date.now();
+    const traceStartedAt = new Date(now - 2 * 60 * 1000).toISOString();
+
+    let currentSpans = [
+      createSpan({
+        span_id: 'root-running',
+        name: 'Root running span',
+        kind: 'CHAIN',
+        status: 'STARTED',
+        started_at: new Date(now - 90 * 1000).toISOString(),
+      }),
+    ];
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse(createRunningTraceDetail({ started_at: traceStartedAt })),
+        spans: () => jsonResponse({ spans: currentSpans }),
+        timeline: (url) => {
+          if (url.searchParams.get('after') === 'cursor-live') {
+            return jsonResponse({
+              events: [],
+              trace_status: 'RUNNING',
+              has_more: false,
+              poll_cursor: 'cursor-live',
+            });
+          }
+
+          return jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+            poll_cursor: 'cursor-live',
+          });
+        },
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Actively executing')).toBeInTheDocument();
+
+    currentSpans = [
+      ...currentSpans,
+      createSpan({
+        span_id: 'llm-live',
+        name: 'Live model span',
+        kind: 'LLM',
+        status: 'STARTED',
+        started_at: new Date(now - 30 * 1000).toISOString(),
+      }),
+    ];
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3100));
+    });
+
+    expect(await screen.findByText('Waiting on model')).toBeInTheDocument();
+    expect(countRequests(`/api/traces/${TRACE_ONE.id}/spans`)).toBeGreaterThanOrEqual(2);
+  }, 10000);
+
+  it('updates the running-state classification when an open span completes during live execution', async () => {
+    const now = Date.now();
+    const traceStartedAt = new Date(now - 2 * 60 * 1000).toISOString();
+
+    let currentSpans = [
+      createSpan({
+        span_id: 'tool-live',
+        name: 'Live tool span',
+        kind: 'TOOL',
+        status: 'STARTED',
+        started_at: new Date(now - 45 * 1000).toISOString(),
+      }),
+    ];
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse(createRunningTraceDetail({ started_at: traceStartedAt })),
+        spans: () => jsonResponse({ spans: currentSpans }),
+        timeline: (url) => {
+          if (url.searchParams.get('after') === 'cursor-live-complete') {
+            return jsonResponse({
+              events: [],
+              trace_status: 'RUNNING',
+              has_more: false,
+              poll_cursor: 'cursor-live-complete',
+            });
+          }
+
+          return jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+            poll_cursor: 'cursor-live-complete',
+          });
+        },
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Waiting on tool')).toBeInTheDocument();
+
+    currentSpans = [
+      {
+        ...currentSpans[0],
+        status: 'COMPLETED',
+        ended_at: new Date(now - 5 * 1000).toISOString(),
+      },
+    ];
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3100));
+    });
+
+    expect(await screen.findByText('Actively executing')).toBeInTheDocument();
+    expect(screen.queryByText('Waiting on tool')).not.toBeInTheDocument();
+  }, 10000);
+
+  it.each(['COMPLETED', 'FAILED'] as const)(
+    'does not refresh spans for %s traces after terminal status',
+    async (traceStatus) => {
+      fetchMock.mockImplementation(
+        buildFetchHandler({
+          detail: () =>
+            jsonResponse({
+              ...TRACE_DETAIL,
+              status: traceStatus,
+              ended_at: '2026-03-14T10:04:00.000Z',
+            }),
+          spans: () =>
+            jsonResponse({
+              spans: [
+                createSpan({
+                  span_id: `${traceStatus.toLowerCase()}-root`,
+                  name: `${traceStatus} root span`,
+                  status: traceStatus === 'FAILED' ? 'FAILED' : 'COMPLETED',
+                }),
+              ],
+            }),
+          timeline: () =>
+            jsonResponse({
+              events: [],
+              trace_status: traceStatus,
+              has_more: false,
+            }),
+        })
+      );
+
+      renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+      expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+      const initialSpansRequestCount = countRequests(
+        `/api/traces/${TRACE_ONE.id}/spans`
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3100));
+      });
+
+      expect(countRequests(`/api/traces/${TRACE_ONE.id}/spans`)).toBe(
+        initialSpansRequestCount
+      );
+
+      await act(async () => {
+        focusManager.setFocused(false);
+        focusManager.setFocused(true);
+        onlineManager.setOnline(false);
+        onlineManager.setOnline(true);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+
+      expect(countRequests(`/api/traces/${TRACE_ONE.id}/spans`)).toBe(
+        initialSpansRequestCount
+      );
+
+      focusManager.setFocused(undefined);
+    }
+  );
 
   it('auto-expands matching ancestors during search and restores prior expansion when cleared', async () => {
     const user = userEvent.setup();

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -1,9 +1,9 @@
 import {
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
+  useMemo,
   type Dispatch,
   type MutableRefObject,
   type ReactNode,
@@ -39,8 +39,12 @@ import { useRequireApiKey } from '../hooks/useRequireApiKey';
 import { useTraceDetailSearchParams } from '../hooks/useTraceDetailSearchParams';
 import { useWorkspaceState } from '../hooks/useWorkspaceState';
 import type { RetrySafetyAssessment } from '../utils/retrySafety';
-import { useTraceTimeline } from './useTraceTimeline';
+import {
+  TIMELINE_POLL_INTERVAL_MS,
+  useTraceTimeline,
+} from './useTraceTimeline';
 import { useRetrySafetyAnalysis } from './useRetrySafetyAnalysis';
+import { useWaitStallAnalysis } from './useWaitStallAnalysis';
 import {
   calculateDuration,
   formatCost,
@@ -53,11 +57,11 @@ import {
   buildBreadcrumbPath,
   buildFailureAnalysis,
   buildSpanIndex,
-  evaluateStaleTraceSignal,
-  type StaleTraceSignal,
 } from '../utils/failureAnalysis';
+import { getWaitDetails } from '../utils/eventSemantics';
 import { extractStateChanges } from '../utils/stateChanges';
 import { serializeSpanParam } from '../utils/traceDetailSearchParams';
+import type { WaitStallAssessment } from '../utils/waitStallAnalysis';
 import {
   buildSpanTree,
   collectExpandableSpanIds,
@@ -67,12 +71,6 @@ import {
 
 const EMPTY_SPANS: Span[] = [];
 const EMPTY_RETRY_SAFETY_ASSESSMENTS = new Map<string, RetrySafetyAssessment>();
-const EMPTY_STALE_TRACE_SIGNAL: StaleTraceSignal = {
-  shouldDisplay: false,
-  latestActivityAt: null,
-  runtimeMs: null,
-  inactivityMs: null,
-};
 const DESKTOP_MEDIA_QUERY = '(min-width: 1024px)';
 
 function queryErrorMessage(error: unknown): string {
@@ -119,11 +117,16 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
     queryKey: ['trace', traceId],
     queryFn: () => fetchTrace(traceId),
   });
+  const timeline = useTraceTimeline(traceId);
+  const liveTraceStatus = timeline.traceStatus ?? traceQuery.data?.status ?? null;
   const spansQuery = useQuery({
     queryKey: ['spans', traceId],
     queryFn: () => fetchSpans(traceId),
+    refetchInterval:
+      liveTraceStatus === 'RUNNING' ? TIMELINE_POLL_INTERVAL_MS : false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
-  const timeline = useTraceTimeline(traceId);
   const trace = traceQuery.data ?? null;
   const spans = spansQuery.data?.spans ?? EMPTY_SPANS;
   const timelineAuthError = isAuthError(timeline.rawError);
@@ -172,18 +175,13 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
     () => buildBreadcrumbPath(selectedSpan, spanIndex),
     [selectedSpan, spanIndex]
   );
-  const staleTraceSignal = useMemo(
-    () =>
-      timeline.hasSnapshot
-        ? evaluateStaleTraceSignal({
-            traceStatus: timelineStatus,
-            traceStartedAt: trace?.started_at,
-            spans,
-            events: timeline.events,
-          })
-        : EMPTY_STALE_TRACE_SIGNAL,
-    [spans, timeline.events, timeline.hasSnapshot, timelineStatus, trace?.started_at]
-  );
+  const waitStallAssessment = useWaitStallAnalysis({
+    traceStatus: timelineStatus,
+    traceStartedAt: trace?.started_at,
+    spans,
+    events: timeline.events,
+    hasTimelineSnapshot: timeline.hasSnapshot,
+  });
   const retrySafetyAnalysis = useRetrySafetyAnalysis(spans, timeline.events);
   const showRetrySafety = timelineStatus === 'FAILED';
   const visibleRetrySafetyAssessments = showRetrySafety
@@ -263,7 +261,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
 
   const detailsContent = (
     <TraceDetailsSurface
-      staleTraceSignal={staleTraceSignal}
+      runningStateAssessment={waitStallAssessment}
       timelineStatus={timelineStatus}
       failureAnalysis={failureAnalysis}
       retrySafetyAnalysis={showRetrySafety ? retrySafetyAnalysis : null}
@@ -517,7 +515,7 @@ function getReturnToDestination(state: unknown): string {
 }
 
 function TraceDetailsSurface({
-  staleTraceSignal,
+  runningStateAssessment,
   timelineStatus,
   failureAnalysis,
   retrySafetyAnalysis,
@@ -528,7 +526,7 @@ function TraceDetailsSurface({
   events,
   traceContext,
 }: {
-  staleTraceSignal: StaleTraceSignal;
+  runningStateAssessment: WaitStallAssessment | null;
   timelineStatus: 'RUNNING' | 'COMPLETED' | 'FAILED' | null;
   failureAnalysis: ReturnType<typeof buildFailureAnalysis>;
   retrySafetyAnalysis: ReturnType<typeof useRetrySafetyAnalysis> | null;
@@ -552,8 +550,12 @@ function TraceDetailsSurface({
           />
         ) : null}
 
-        {staleTraceSignal.shouldDisplay ? (
-          <StaleTraceSignalPanel staleTraceSignal={staleTraceSignal} />
+        {runningStateAssessment ? (
+          <RunningStatePanel
+            assessment={runningStateAssessment}
+            events={events}
+            onSelectSpan={onSelectSpan}
+          />
         ) : null}
 
         <div className="min-h-[22rem] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
@@ -735,28 +737,172 @@ function TracePayloadPanel({ title, data }: { title: string; data: unknown }) {
   );
 }
 
-function StaleTraceSignalPanel({
-  staleTraceSignal,
+function RunningStatePanel({
+  assessment,
+  events,
+  onSelectSpan,
 }: {
-  staleTraceSignal: StaleTraceSignal;
+  assessment: WaitStallAssessment;
+  events: TimelineEvent[];
+  onSelectSpan: (spanId: string) => void;
 }) {
+  const waitKind = resolveDeclaredWaitKind(assessment, events);
+  const panelTone = getRunningStatePanelTone(assessment.classification);
+  const summary = getRunningStateSummary(assessment);
+
   return (
-    <section className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-sm">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-800">
-        Experimental stale trace signal
+    <section className={`rounded-xl border px-4 py-4 shadow-sm ${panelTone}`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em]">
+            Running state
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <h2 className="text-base font-semibold">{summary.label}</h2>
+            <span className="rounded-full border border-current/15 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.14em]">
+              {formatRunningStateBasis(assessment.basis)}
+            </span>
+          </div>
+          <p className="mt-2 max-w-3xl text-sm leading-6">{summary.copy}</p>
+        </div>
+
+        {assessment.decisiveSpanId ? (
+          <button
+            type="button"
+            className="rounded-full border border-current/20 bg-white/70 px-3 py-1.5 text-xs font-medium transition hover:bg-white dark:bg-slate-950/40 dark:hover:bg-slate-950/70"
+            onClick={() => onSelectSpan(assessment.decisiveSpanId!)}
+          >
+            Jump to {assessment.decisiveSpanName ?? assessment.decisiveSpanId}
+          </button>
+        ) : null}
       </div>
-      <p className="mt-2">
-        Still marked running. Recent activity is sparse, so this trace may be stale
-        or incomplete.
-      </p>
-      {staleTraceSignal.latestActivityAt ? (
-        <p className="mt-2 text-xs text-amber-800">
-          Latest activity: {formatTimestamp(staleTraceSignal.latestActivityAt)} (
-          {formatRelativeTime(staleTraceSignal.latestActivityAt)})
-        </p>
-      ) : null}
+
+      <div className="mt-4 flex flex-wrap gap-4 text-xs">
+        {waitKind ? (
+          <div>
+            <div className="font-semibold uppercase tracking-[0.16em] opacity-75">
+              Current wait
+            </div>
+            <div className="mt-1 text-sm font-medium">{waitKind}</div>
+          </div>
+        ) : null}
+        {assessment.latestActivityAt ? (
+          <div>
+            <div className="font-semibold uppercase tracking-[0.16em] opacity-75">
+              Latest activity
+            </div>
+            <div className="mt-1 text-sm font-medium">
+              {formatTimestamp(assessment.latestActivityAt)} (
+              {formatRelativeTime(assessment.latestActivityAt)})
+            </div>
+          </div>
+        ) : null}
+        {assessment.runtimeMs !== null ? (
+          <div>
+            <div className="font-semibold uppercase tracking-[0.16em] opacity-75">
+              Runtime
+            </div>
+            <div className="mt-1 text-sm font-medium">
+              {formatDuration(assessment.runtimeMs)}
+            </div>
+          </div>
+        ) : null}
+        {assessment.inactivityMs !== null ? (
+          <div>
+            <div className="font-semibold uppercase tracking-[0.16em] opacity-75">
+              Inactivity
+            </div>
+            <div className="mt-1 text-sm font-medium">
+              {formatDuration(assessment.inactivityMs)}
+            </div>
+          </div>
+        ) : null}
+      </div>
     </section>
   );
+}
+
+function getRunningStateSummary(assessment: WaitStallAssessment): {
+  label: string;
+  copy: string;
+} {
+  switch (assessment.classification) {
+    case 'declared_wait':
+      return {
+        label: 'Declared wait',
+        copy: 'Execution declared a wait and has not yet recorded a matching resolution.',
+      };
+    case 'waiting_on_model':
+      return {
+        label: 'Waiting on model',
+        copy: 'Execution appears to be waiting on an in-flight model span.',
+      };
+    case 'waiting_on_tool':
+      return {
+        label: 'Waiting on tool',
+        copy: 'Execution appears to be waiting on an in-flight tool span.',
+      };
+    case 'actively_executing':
+      return assessment.reason === 'recent_activity_without_open_span'
+        ? {
+            label: 'Actively executing',
+            copy: 'Recent activity suggests execution is still progressing between spans.',
+          }
+        : {
+            label: 'Actively executing',
+            copy: 'A running span suggests execution is still actively progressing.',
+          };
+    case 'possibly_stalled':
+      return {
+        label: 'Possibly stalled',
+        copy: 'Execution is still marked running, but recent activity is sparse.',
+      };
+    case 'unknown':
+      return {
+        label: 'Unknown',
+        copy: 'The debugger cannot yet explain where it is waiting.',
+      };
+  }
+}
+
+function formatRunningStateBasis(basis: WaitStallAssessment['basis']): string {
+  switch (basis) {
+    case 'declared':
+      return 'Declared';
+    case 'inferred':
+      return 'Inferred';
+    case 'heuristic':
+      return 'Heuristic';
+  }
+}
+
+function getRunningStatePanelTone(
+  classification: WaitStallAssessment['classification']
+): string {
+  switch (classification) {
+    case 'declared_wait':
+    case 'waiting_on_model':
+    case 'waiting_on_tool':
+      return 'border-sky-200 bg-sky-50 text-sky-950 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-100';
+    case 'actively_executing':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-950 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100';
+    case 'possibly_stalled':
+      return 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100';
+    case 'unknown':
+      return 'border-slate-200 bg-slate-100 text-slate-900 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100';
+  }
+}
+
+function resolveDeclaredWaitKind(
+  assessment: WaitStallAssessment,
+  events: TimelineEvent[]
+): string | null {
+  if (assessment.classification !== 'declared_wait' || !assessment.decisiveEventId) {
+    return null;
+  }
+
+  const decisiveEvent = events.find((event) => event.id === assessment.decisiveEventId);
+  return decisiveEvent ? getWaitDetails(decisiveEvent)?.waitKind ?? null : null;
 }
 
 function renderContextText(value: string | undefined, monospace = false) {

--- a/web/src/pages/useTraceTimeline.ts
+++ b/web/src/pages/useTraceTimeline.ts
@@ -8,7 +8,7 @@ import {
 import { mergeTimelineEvents } from '../utils/timeline';
 
 const TIMELINE_PAGE_LIMIT = 100;
-const TIMELINE_POLL_INTERVAL_MS = 3000;
+export const TIMELINE_POLL_INTERVAL_MS = 3000;
 
 interface TimelineSnapshot {
   events: TimelineEvent[];

--- a/web/src/pages/useWaitStallAnalysis.test.tsx
+++ b/web/src/pages/useWaitStallAnalysis.test.tsx
@@ -1,0 +1,254 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSpan,
+  createTimelineEvent,
+  resetTestEntityCounter,
+} from '../test/traceFixtures';
+import { useWaitStallAnalysis } from './useWaitStallAnalysis';
+
+const TRACE_STARTED_AT = '2026-03-14T10:00:00.000Z';
+
+beforeEach(() => {
+  resetTestEntityCounter();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-03-14T10:02:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useWaitStallAnalysis', () => {
+  it.each(['COMPLETED', 'FAILED'] as const)(
+    'returns null when trace status is %s',
+    (traceStatus) => {
+      const { result } = renderHook(() =>
+        useWaitStallAnalysis({
+          traceStatus,
+          traceStartedAt: TRACE_STARTED_AT,
+          spans: [],
+          events: [],
+          hasTimelineSnapshot: true,
+        })
+      );
+
+      expect(result.current).toBeNull();
+    }
+  );
+
+  it('returns null before the initial timeline snapshot loads', () => {
+    const { result } = renderHook(() =>
+      useWaitStallAnalysis({
+        traceStatus: 'RUNNING',
+        traceStartedAt: TRACE_STARTED_AT,
+        spans: [],
+        events: [],
+        hasTimelineSnapshot: false,
+      })
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it('keeps classification stable when only time advances and stale does not flip', () => {
+    const completedSpan = createSpan({
+      span_id: 'completed-work',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:30.000Z',
+      ended_at: '2026-03-14T10:01:00.000Z',
+    });
+
+    const { result, rerender } = renderHook(
+      ({ spans, events }) =>
+        useWaitStallAnalysis({
+          traceStatus: 'RUNNING',
+          traceStartedAt: TRACE_STARTED_AT,
+          spans,
+          events,
+          hasTimelineSnapshot: true,
+        }),
+      {
+        initialProps: {
+          spans: [completedSpan],
+          events: [] as ReturnType<typeof createTimelineEvent>[],
+        },
+      }
+    );
+
+    const firstAssessment = result.current;
+    vi.setSystemTime(new Date('2026-03-14T10:04:00.000Z'));
+    rerender({
+      spans: [completedSpan],
+      events: [],
+    });
+
+    expect(firstAssessment?.classification).toBe('actively_executing');
+    expect(result.current?.classification).toBe('actively_executing');
+    expect(result.current?.reason).toBe(firstAssessment?.reason);
+  });
+
+  it('updates timing fields on every poll cycle even when evidence is unchanged', () => {
+    const completedSpan = createSpan({
+      span_id: 'completed-work',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:30.000Z',
+      ended_at: '2026-03-14T10:01:00.000Z',
+    });
+
+    const { result, rerender } = renderHook(
+      () =>
+        useWaitStallAnalysis({
+          traceStatus: 'RUNNING',
+          traceStartedAt: TRACE_STARTED_AT,
+          spans: [completedSpan],
+          events: [],
+          hasTimelineSnapshot: true,
+        })
+    );
+
+    const firstRuntimeMs = result.current?.runtimeMs ?? 0;
+    const firstInactivityMs = result.current?.inactivityMs ?? 0;
+
+    vi.setSystemTime(new Date('2026-03-14T10:04:00.000Z'));
+    rerender();
+
+    expect((result.current?.runtimeMs ?? 0) - firstRuntimeMs).toBe(2 * 60 * 1000);
+    expect((result.current?.inactivityMs ?? 0) - firstInactivityMs).toBe(
+      2 * 60 * 1000
+    );
+  });
+
+  it('transitions to possibly stalled when time advance flips the stale heuristic', () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useWaitStallAnalysis({
+          traceStatus: 'RUNNING',
+          traceStartedAt: TRACE_STARTED_AT,
+          spans: [],
+          events: [],
+          hasTimelineSnapshot: true,
+        })
+    );
+
+    expect(result.current?.classification).toBe('unknown');
+
+    vi.setSystemTime(new Date('2026-03-14T10:20:00.000Z'));
+    rerender();
+
+    expect(result.current?.classification).toBe('possibly_stalled');
+    expect(result.current?.reason).toBe('stale_without_stronger_signal');
+  });
+
+  it('recomputes when a new explicit event arrives', () => {
+    const { result, rerender } = renderHook(
+      ({ events }) =>
+        useWaitStallAnalysis({
+          traceStatus: 'RUNNING',
+          traceStartedAt: TRACE_STARTED_AT,
+          spans: [],
+          events,
+          hasTimelineSnapshot: true,
+        }),
+      {
+        initialProps: {
+          events: [] as ReturnType<typeof createTimelineEvent>[],
+        },
+      }
+    );
+
+    expect(result.current?.classification).toBe('unknown');
+
+    rerender({
+      events: [
+        createTimelineEvent({
+          id: 'log-1',
+          event_type: 'log',
+          timestamp: '2026-03-14T10:01:30.000Z',
+          message: 'Fresh activity',
+        }),
+      ],
+    });
+
+    expect(result.current?.classification).toBe('actively_executing');
+    expect(result.current?.reason).toBe('recent_activity_without_open_span');
+  });
+
+  it('recomputes when a new wait event arrives', () => {
+    const { result, rerender } = renderHook(
+      ({ events }) =>
+        useWaitStallAnalysis({
+          traceStatus: 'RUNNING',
+          traceStartedAt: TRACE_STARTED_AT,
+          spans: [],
+          events,
+          hasTimelineSnapshot: true,
+        }),
+      {
+        initialProps: {
+          events: [] as ReturnType<typeof createTimelineEvent>[],
+        },
+      }
+    );
+
+    expect(result.current?.classification).toBe('unknown');
+
+    rerender({
+      events: [
+        createTimelineEvent({
+          id: 'wait-1',
+          event_type: 'wait',
+          timestamp: '2026-03-14T10:01:30.000Z',
+          payload: {
+            wait_kind: 'model_response',
+            phase: 'entered',
+            wait_id: 'wait-1',
+          },
+        }),
+      ],
+    });
+
+    expect(result.current?.classification).toBe('declared_wait');
+    expect(result.current?.decisiveEventId).toBe('wait-1');
+  });
+
+  it('recomputes when a span status changes', () => {
+    const toolSpan = createSpan({
+      span_id: 'tool-1',
+      name: 'Tool span',
+      kind: 'TOOL',
+      status: 'SCHEDULED',
+      started_at: '2026-03-14T10:01:00.000Z',
+    });
+
+    const { result, rerender } = renderHook(
+      ({ spans }) =>
+        useWaitStallAnalysis({
+          traceStatus: 'RUNNING',
+          traceStartedAt: TRACE_STARTED_AT,
+          spans,
+          events: [],
+          hasTimelineSnapshot: true,
+        }),
+      {
+        initialProps: {
+          spans: [toolSpan],
+        },
+      }
+    );
+
+    expect(result.current?.classification).toBe('unknown');
+
+    rerender({
+      spans: [
+        {
+          ...toolSpan,
+          status: 'STARTED',
+        },
+      ],
+    });
+
+    expect(result.current?.classification).toBe('waiting_on_tool');
+    expect(result.current?.decisiveSpanId).toBe('tool-1');
+  });
+});

--- a/web/src/pages/useWaitStallAnalysis.ts
+++ b/web/src/pages/useWaitStallAnalysis.ts
@@ -1,0 +1,122 @@
+import { useRef } from 'react';
+import type { Span, TimelineEvent, TimelineTraceStatus } from '../api/client';
+import { evaluateStaleTraceSignal } from '../utils/failureAnalysis';
+import {
+  classifyRunningTrace,
+  type WaitStallAssessment,
+} from '../utils/waitStallAnalysis';
+
+interface UseWaitStallAnalysisOptions {
+  traceStatus: TimelineTraceStatus | null;
+  traceStartedAt: string | undefined;
+  spans: Span[];
+  events: TimelineEvent[];
+  hasTimelineSnapshot: boolean;
+}
+
+interface WaitStallAnalysisCache {
+  signature: string;
+  staleShouldDisplay: boolean;
+  assessmentCore: Omit<
+    WaitStallAssessment,
+    'latestActivityAt' | 'runtimeMs' | 'inactivityMs'
+  >;
+}
+
+export function useWaitStallAnalysis({
+  traceStatus,
+  traceStartedAt,
+  spans,
+  events,
+  hasTimelineSnapshot,
+}: UseWaitStallAnalysisOptions): WaitStallAssessment | null {
+  const cacheRef = useRef<WaitStallAnalysisCache | null>(null);
+
+  if (!hasTimelineSnapshot || traceStatus !== 'RUNNING') {
+    return null;
+  }
+
+  const now = new Date();
+  const staleTraceSignal = evaluateStaleTraceSignal({
+    traceStatus,
+    traceStartedAt,
+    spans,
+    events,
+    now,
+  });
+  const signature = buildWaitStallSignature(traceStatus, spans, events);
+
+  if (
+    !cacheRef.current ||
+    cacheRef.current.signature !== signature ||
+    cacheRef.current.staleShouldDisplay !== staleTraceSignal.shouldDisplay
+  ) {
+    const assessment = classifyRunningTrace({
+      traceStatus,
+      traceStartedAt,
+      spans,
+      events,
+      now,
+    });
+
+    if (!assessment) {
+      return null;
+    }
+
+    cacheRef.current = {
+      signature,
+      staleShouldDisplay: staleTraceSignal.shouldDisplay,
+      assessmentCore: {
+        classification: assessment.classification,
+        basis: assessment.basis,
+        reason: assessment.reason,
+        decisiveEventId: assessment.decisiveEventId,
+        decisiveSpanId: assessment.decisiveSpanId,
+        decisiveSpanName: assessment.decisiveSpanName,
+      },
+    };
+  }
+
+  return {
+    ...cacheRef.current.assessmentCore,
+    latestActivityAt: staleTraceSignal.latestActivityAt,
+    runtimeMs: staleTraceSignal.runtimeMs,
+    inactivityMs: staleTraceSignal.inactivityMs,
+  };
+}
+
+function buildWaitStallSignature(
+  traceStatus: TimelineTraceStatus,
+  spans: Span[],
+  events: TimelineEvent[]
+): string {
+  const spanSignature = spans
+    .map((span) =>
+      [
+        span.span_id,
+        span.name,
+        span.kind,
+        span.status,
+        span.started_at,
+        span.ended_at ?? '',
+      ].join(':')
+    )
+    .join('|');
+  const eventSignature = events
+    .filter((event) => event.source === 'explicit' || event.event_type === 'wait')
+    .map((event) =>
+      [
+        event.id,
+        event.event_type,
+        event.timestamp,
+        event.source,
+        event.sequence ?? '',
+        event.span_id ?? '',
+        event.span_name ?? '',
+        JSON.stringify(event.payload ?? null),
+      ].join(':')
+    )
+    .join('|');
+
+  return `${traceStatus}::${spanSignature}::${eventSignature}`;
+}

--- a/web/src/utils/eventSemantics.test.ts
+++ b/web/src/utils/eventSemantics.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { createTimelineEvent } from '../test/traceFixtures';
+import { getWaitDetails } from './eventSemantics';
+
+describe('getWaitDetails', () => {
+  it('returns structured details for a well-formed wait event', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        wait_kind: 'model_response',
+        phase: 'entered',
+        wait_id: 'wait-1',
+        resolution: 'success',
+      },
+    });
+
+    expect(getWaitDetails(event)).toEqual({
+      waitKind: 'model_response',
+      phase: 'entered',
+      waitId: 'wait-1',
+      resolution: 'success',
+    });
+  });
+
+  it('accepts a minimal well-formed wait event', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        wait_kind: 'tool_call',
+        phase: 'resolved',
+      },
+    });
+
+    expect(getWaitDetails(event)).toEqual({
+      waitKind: 'tool_call',
+      phase: 'resolved',
+      waitId: undefined,
+      resolution: undefined,
+    });
+  });
+
+  it('returns null for malformed wait payloads', () => {
+    const missingWaitKind = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        phase: 'entered',
+        wait_id: 'wait-1',
+      },
+    });
+    const emptyPhase = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        wait_kind: 'model_response',
+        phase: '',
+      },
+    });
+
+    expect(getWaitDetails(missingWaitKind)).toBeNull();
+    expect(getWaitDetails(emptyPhase)).toBeNull();
+  });
+
+  it('returns null for non-wait events', () => {
+    const event = createTimelineEvent({
+      event_type: 'effect',
+      payload: {
+        wait_kind: 'model_response',
+        phase: 'entered',
+      },
+    });
+
+    expect(getWaitDetails(event)).toBeNull();
+  });
+});

--- a/web/src/utils/eventSemantics.ts
+++ b/web/src/utils/eventSemantics.ts
@@ -22,6 +22,13 @@ export interface EffectDetails {
   idempotencyKey?: string;
 }
 
+export interface WaitDetails {
+  waitKind: string;
+  phase: string;
+  waitId?: string;
+  resolution?: string;
+}
+
 export function getStateChangeDetails(
   event: TimelineEvent
 ): StateChangeDetails | null {
@@ -96,6 +103,28 @@ export function getEffectDetails(event: TimelineEvent): EffectDetails | null {
     effectId,
     idempotent,
     idempotencyKey,
+  };
+}
+
+export function getWaitDetails(event: TimelineEvent): WaitDetails | null {
+  if (event.event_type !== 'wait' || !event.payload) {
+    return null;
+  }
+
+  const waitKind = getNonEmptyString(event.payload, 'wait_kind');
+  const phase = getNonEmptyString(event.payload, 'phase');
+  const waitId = getOptionalNonEmptyString(event.payload, 'wait_id');
+  const resolution = getOptionalNonEmptyString(event.payload, 'resolution');
+
+  if (!waitKind || !phase || waitId === null || resolution === null) {
+    return null;
+  }
+
+  return {
+    waitKind,
+    phase,
+    waitId,
+    resolution,
   };
 }
 

--- a/web/src/utils/timeline.test.ts
+++ b/web/src/utils/timeline.test.ts
@@ -50,4 +50,58 @@ describe('summarizeTimelineEvent', () => {
     expect(summarizeTimelineEvent(stateEvent)).toBe('state fallback');
     expect(summarizeTimelineEvent(decisionEvent)).toBe('decision fallback');
   });
+
+  it('summarizes well-formed wait events', () => {
+    const enteredEvent = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        wait_kind: 'tool_call',
+        phase: 'entered',
+      },
+    });
+    const resolvedEvent = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        wait_kind: 'model_response',
+        phase: 'resolved',
+        resolution: 'success',
+      },
+    });
+
+    expect(summarizeTimelineEvent(enteredEvent)).toBe('Entered wait: tool_call');
+    expect(summarizeTimelineEvent(resolvedEvent)).toBe(
+      'Resolved wait: model_response → success'
+    );
+  });
+
+  it('falls back to the phase label for malformed wait events with a phase', () => {
+    const event = createTimelineEvent({
+      event_type: 'wait',
+      payload: {
+        phase: 'paused',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('Paused wait');
+  });
+
+  it('falls back to existing generic behavior for fully malformed wait events', () => {
+    const withMessage = createTimelineEvent({
+      event_type: 'wait',
+      message: 'generic wait fallback',
+      payload: {},
+    });
+    const withoutMessage = createTimelineEvent({
+      event_type: 'wait',
+      payload: {},
+    });
+    const nonWaitEvent = createTimelineEvent({
+      event_type: 'log',
+      message: 'plain log',
+    });
+
+    expect(summarizeTimelineEvent(withMessage)).toBe('generic wait fallback');
+    expect(summarizeTimelineEvent(withoutMessage)).toBe('wait');
+    expect(summarizeTimelineEvent(nonWaitEvent)).toBe('plain log');
+  });
 });

--- a/web/src/utils/timeline.ts
+++ b/web/src/utils/timeline.ts
@@ -3,6 +3,7 @@ import {
   formatInlineSemanticValue,
   getDecisionDetails,
   getStateChangeDetails,
+  getWaitDetails,
 } from './eventSemantics';
 
 /**
@@ -86,6 +87,8 @@ export function summarizeTimelineEvent(event: TimelineEvent): string {
       return `${event.span_name ?? event.span_id ?? 'Span'} failed`;
     case 'metric':
       return formatMetricSummary(event);
+    case 'wait':
+      return formatWaitSummary(event);
     default:
       if (event.message) {
         return event.message;
@@ -107,6 +110,41 @@ function formatMetricSummary(event: TimelineEvent): string {
   }
 
   return 'Metric recorded';
+}
+
+function formatWaitSummary(event: TimelineEvent): string {
+  const waitDetails = getWaitDetails(event);
+  if (waitDetails) {
+    if (waitDetails.phase === 'entered') {
+      return `Entered wait: ${waitDetails.waitKind}`;
+    }
+
+    if (waitDetails.phase === 'resolved') {
+      return waitDetails.resolution
+        ? `Resolved wait: ${waitDetails.waitKind} → ${waitDetails.resolution}`
+        : `Resolved wait: ${waitDetails.waitKind}`;
+    }
+
+    return `${capitalizeWaitPhase(waitDetails.phase)} wait`;
+  }
+
+  const rawPhase =
+    typeof event.payload?.phase === 'string' && event.payload.phase.length > 0
+      ? event.payload.phase
+      : null;
+  if (rawPhase) {
+    return `${capitalizeWaitPhase(rawPhase)} wait`;
+  }
+
+  if (event.message) {
+    return event.message;
+  }
+
+  return event.event_type.replace(/_/g, ' ');
+}
+
+function capitalizeWaitPhase(phase: string): string {
+  return phase.charAt(0).toUpperCase() + phase.slice(1);
 }
 
 function timelineSourceRank(source: TimelineEvent['source']): number {

--- a/web/src/utils/waitStallAnalysis.test.ts
+++ b/web/src/utils/waitStallAnalysis.test.ts
@@ -1,0 +1,596 @@
+import { describe, expect, it } from 'vitest';
+import type { Span, TimelineEvent } from '../api/client';
+import {
+  createSpan as createSpanFixture,
+  createTimelineEvent,
+} from '../test/traceFixtures';
+import {
+  classifyRunningTrace,
+  computeOpenWaits,
+} from './waitStallAnalysis';
+
+const RUNNING_STARTED_AT = '2026-03-14T10:00:00.000Z';
+const STALE_NOW = new Date('2026-03-14T10:20:00.000Z');
+const ACTIVE_NOW = new Date('2026-03-14T10:04:00.000Z');
+
+describe('computeOpenWaits', () => {
+  it('keeps a single entered wait open', () => {
+    const openWaits = computeOpenWaits([
+      createWaitEvent({
+        id: 'entered',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        payload: {
+          wait_kind: 'model_response',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+    ]);
+
+    expect(openWaits).toHaveLength(1);
+    expect(openWaits[0]?.event.id).toBe('entered');
+  });
+
+  it('closes matching entered and resolved waits', () => {
+    const openWaits = computeOpenWaits([
+      createWaitEvent({
+        id: 'entered',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'resolved',
+        timestamp: '2026-03-14T10:00:02.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'resolved',
+          wait_id: 'wait-1',
+        },
+      }),
+    ]);
+
+    expect(openWaits).toEqual([]);
+  });
+
+  it('self-heals when resolved appears before entered in the input order', () => {
+    const openWaits = computeOpenWaits([
+      createWaitEvent({
+        id: 'resolved',
+        timestamp: '2026-03-14T10:00:02.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'resolved',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'entered',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+    ]);
+
+    expect(openWaits).toEqual([]);
+  });
+
+  it('never lets a wait without wait_id close a different wait', () => {
+    const openWaits = computeOpenWaits([
+      createWaitEvent({
+        id: 'entered',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        payload: {
+          wait_kind: 'model_response',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'resolved-without-id',
+        timestamp: '2026-03-14T10:00:02.000Z',
+        payload: {
+          wait_kind: 'model_response',
+          phase: 'resolved',
+        },
+      }),
+    ]);
+
+    expect(openWaits.map((openWait) => openWait.event.id)).toEqual(['entered']);
+  });
+
+  it('closes duplicate wait ids in FIFO order', () => {
+    const openWaits = computeOpenWaits([
+      createWaitEvent({
+        id: 'entered-1',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        payload: {
+          wait_kind: 'model_response',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'entered-2',
+        timestamp: '2026-03-14T10:00:02.000Z',
+        payload: {
+          wait_kind: 'model_response',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'resolved-1',
+        timestamp: '2026-03-14T10:00:03.000Z',
+        payload: {
+          wait_kind: 'model_response',
+          phase: 'resolved',
+          wait_id: 'wait-1',
+        },
+      }),
+    ]);
+
+    expect(openWaits.map((openWait) => openWait.event.id)).toEqual(['entered-2']);
+  });
+
+  it('closes both entered waits when two resolves arrive', () => {
+    const openWaits = computeOpenWaits([
+      createWaitEvent({
+        id: 'entered-1',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'entered-2',
+        timestamp: '2026-03-14T10:00:02.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'resolved-1',
+        timestamp: '2026-03-14T10:00:03.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'resolved',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'resolved-2',
+        timestamp: '2026-03-14T10:00:04.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'resolved',
+          wait_id: 'wait-1',
+        },
+      }),
+    ]);
+
+    expect(openWaits).toEqual([]);
+  });
+
+  it('sorts internally before pairing', () => {
+    const openWaits = computeOpenWaits([
+      createWaitEvent({
+        id: 'resolved',
+        timestamp: '2026-03-14T10:00:02.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'resolved',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'entered',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+    ]);
+
+    expect(openWaits).toEqual([]);
+  });
+
+  it('ignores unsupported phases during pairing', () => {
+    const openWaits = computeOpenWaits([
+      createWaitEvent({
+        id: 'entered',
+        timestamp: '2026-03-14T10:00:01.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'entered',
+          wait_id: 'wait-1',
+        },
+      }),
+      createWaitEvent({
+        id: 'unsupported',
+        timestamp: '2026-03-14T10:00:02.000Z',
+        payload: {
+          wait_kind: 'tool_call',
+          phase: 'suspended',
+          wait_id: 'wait-1',
+        },
+      }),
+    ]);
+
+    expect(openWaits.map((openWait) => openWait.event.id)).toEqual(['entered']);
+  });
+});
+
+describe('classifyRunningTrace', () => {
+  it('classifies an open wait as a declared wait and records decisive evidence', () => {
+    const span = createSpan({
+      span_id: 'waiting-span',
+      name: 'Waiting span',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:00:01.000Z',
+    });
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [span],
+      events: [
+        createWaitEvent({
+          id: 'open-wait',
+          span_id: span.span_id,
+          span_name: span.name,
+          timestamp: '2026-03-14T10:01:00.000Z',
+          payload: {
+            wait_kind: 'model_response',
+            phase: 'entered',
+            wait_id: 'wait-1',
+          },
+        }),
+      ],
+      now: ACTIVE_NOW,
+    });
+
+    expect(assessment).toMatchObject({
+      classification: 'declared_wait',
+      basis: 'declared',
+      reason: 'open_declared_wait',
+      decisiveEventId: 'open-wait',
+      decisiveSpanId: span.span_id,
+      decisiveSpanName: span.name,
+    });
+  });
+
+  it('waits for model spans when no declared wait is open', () => {
+    const earlierOpenModel = createSpan({
+      span_id: 'llm-1',
+      name: 'First LLM span',
+      kind: 'LLM',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:01:00.000Z',
+    });
+    const laterOpenModel = createSpan({
+      span_id: 'llm-2',
+      name: 'Latest LLM span',
+      kind: 'LLM',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:02:00.000Z',
+    });
+
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [earlierOpenModel, laterOpenModel],
+      events: [],
+      now: ACTIVE_NOW,
+    });
+
+    expect(assessment).toMatchObject({
+      classification: 'waiting_on_model',
+      basis: 'inferred',
+      reason: 'open_model_span',
+      decisiveSpanId: 'llm-2',
+      decisiveSpanName: 'Latest LLM span',
+    });
+  });
+
+  it('waits for tool spans when no declared wait or model span is open', () => {
+    const openTool = createSpan({
+      span_id: 'tool-1',
+      name: 'Tool span',
+      kind: 'TOOL',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:02:00.000Z',
+    });
+
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [openTool],
+      events: [],
+      now: ACTIVE_NOW,
+    });
+
+    expect(assessment).toMatchObject({
+      classification: 'waiting_on_tool',
+      basis: 'inferred',
+      reason: 'open_tool_span',
+      decisiveSpanId: 'tool-1',
+      decisiveSpanName: 'Tool span',
+    });
+  });
+
+  it('treats open generic spans as actively executing and preserves decisive evidence', () => {
+    const openGeneric = createSpan({
+      span_id: 'agent-1',
+      name: 'Agent span',
+      kind: 'AGENT',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:01:30.000Z',
+    });
+
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [openGeneric],
+      events: [],
+      now: STALE_NOW,
+    });
+
+    expect(assessment).toMatchObject({
+      classification: 'actively_executing',
+      basis: 'heuristic',
+      reason: 'open_generic_span',
+      decisiveSpanId: 'agent-1',
+      decisiveSpanName: 'Agent span',
+    });
+  });
+
+  it('treats recent execution without open spans as actively executing', () => {
+    const completedSpan = createSpan({
+      span_id: 'completed-work',
+      name: 'Completed work',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:01:00.000Z',
+      ended_at: '2026-03-14T10:02:00.000Z',
+    });
+
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [completedSpan],
+      events: [],
+      now: ACTIVE_NOW,
+    });
+
+    expect(assessment).toMatchObject({
+      classification: 'actively_executing',
+      basis: 'heuristic',
+      reason: 'recent_activity_without_open_span',
+    });
+    expect(assessment?.decisiveSpanId).toBeUndefined();
+    expect(assessment?.decisiveSpanName).toBeUndefined();
+  });
+
+  it('returns unknown when there is no execution evidence', () => {
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [],
+      events: [],
+      now: ACTIVE_NOW,
+    });
+
+    expect(assessment).toMatchObject({
+      classification: 'unknown',
+      basis: 'heuristic',
+      reason: 'insufficient_running_evidence',
+    });
+    expect(assessment?.decisiveSpanId).toBeUndefined();
+    expect(assessment?.decisiveSpanName).toBeUndefined();
+    expect(assessment?.decisiveEventId).toBeUndefined();
+  });
+
+  it('returns unknown for scheduled-only traces', () => {
+    const scheduledSpan = createSpan({
+      span_id: 'scheduled',
+      name: 'Scheduled span',
+      status: 'SCHEDULED',
+      kind: 'LLM',
+    });
+
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [scheduledSpan],
+      events: [],
+      now: ACTIVE_NOW,
+    });
+
+    expect(assessment?.classification).toBe('unknown');
+  });
+
+  it('uses the stale heuristic when no stronger signal exists', () => {
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [],
+      events: [],
+      now: STALE_NOW,
+    });
+
+    expect(assessment).toMatchObject({
+      classification: 'possibly_stalled',
+      basis: 'heuristic',
+      reason: 'stale_without_stronger_signal',
+    });
+    expect(assessment?.decisiveSpanId).toBeUndefined();
+    expect(assessment?.decisiveSpanName).toBeUndefined();
+    expect(assessment?.decisiveEventId).toBeUndefined();
+  });
+
+  it('applies the declared-wait > model > tool precedence', () => {
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [
+        createSpan({
+          span_id: 'tool-1',
+          name: 'Tool span',
+          kind: 'TOOL',
+          status: 'STARTED',
+          started_at: '2026-03-14T10:01:00.000Z',
+        }),
+        createSpan({
+          span_id: 'llm-1',
+          name: 'Model span',
+          kind: 'LLM',
+          status: 'STARTED',
+          started_at: '2026-03-14T10:02:00.000Z',
+        }),
+      ],
+      events: [
+        createWaitEvent({
+          id: 'wait-1',
+          timestamp: '2026-03-14T10:03:00.000Z',
+          payload: {
+            wait_kind: 'model_response',
+            phase: 'entered',
+            wait_id: 'wait-1',
+          },
+        }),
+      ],
+      now: ACTIVE_NOW,
+    });
+
+    expect(assessment?.classification).toBe('declared_wait');
+  });
+
+  it('prefers model spans over tool spans when both are open', () => {
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [
+        createSpan({
+          span_id: 'tool-1',
+          name: 'Tool span',
+          kind: 'TOOL',
+          status: 'STARTED',
+          started_at: '2026-03-14T10:01:00.000Z',
+        }),
+        createSpan({
+          span_id: 'llm-1',
+          name: 'Model span',
+          kind: 'LLM',
+          status: 'STARTED',
+          started_at: '2026-03-14T10:02:00.000Z',
+        }),
+      ],
+      events: [],
+      now: ACTIVE_NOW,
+    });
+
+    expect(assessment?.classification).toBe('waiting_on_model');
+  });
+
+  it('keeps generic open spans above the stale heuristic', () => {
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [
+        createSpan({
+          span_id: 'generic-1',
+          name: 'Generic span',
+          kind: 'CUSTOM',
+          status: 'STARTED',
+          started_at: '2026-03-14T10:01:00.000Z',
+        }),
+      ],
+      events: [],
+      now: STALE_NOW,
+    });
+
+    expect(assessment?.classification).toBe('actively_executing');
+    expect(assessment?.reason).toBe('open_generic_span');
+  });
+
+  it('lets the stale heuristic beat unknown', () => {
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [],
+      events: [],
+      now: STALE_NOW,
+    });
+
+    expect(assessment?.classification).toBe('possibly_stalled');
+  });
+
+  it('breaks equal started_at ties by the later input span', () => {
+    const firstSpan = createSpan({
+      span_id: 'tool-1',
+      name: 'Earlier input',
+      kind: 'TOOL',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:02:00.000Z',
+    });
+    const secondSpan = createSpan({
+      span_id: 'tool-2',
+      name: 'Later input',
+      kind: 'TOOL',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:02:00.000Z',
+    });
+
+    const assessment = classifyRunningTrace({
+      traceStatus: 'RUNNING',
+      traceStartedAt: RUNNING_STARTED_AT,
+      spans: [firstSpan, secondSpan],
+      events: [],
+      now: ACTIVE_NOW,
+    });
+
+    expect(assessment).toMatchObject({
+      classification: 'waiting_on_tool',
+      decisiveSpanId: 'tool-2',
+      decisiveSpanName: 'Later input',
+    });
+  });
+
+  it.each(['COMPLETED', 'FAILED'] as const)(
+    'returns null for %s traces',
+    (traceStatus) => {
+      expect(
+        classifyRunningTrace({
+          traceStatus,
+          traceStartedAt: RUNNING_STARTED_AT,
+          spans: [],
+          events: [],
+          now: ACTIVE_NOW,
+        })
+      ).toBeNull();
+    }
+  );
+});
+
+function createWaitEvent(overrides: Partial<TimelineEvent> = {}): TimelineEvent {
+  return createTimelineEvent({
+    event_type: 'wait',
+    source: 'explicit',
+    ...overrides,
+  });
+}
+
+function createSpan(overrides: Partial<Span> = {}): Span {
+  return createSpanFixture(overrides);
+}

--- a/web/src/utils/waitStallAnalysis.ts
+++ b/web/src/utils/waitStallAnalysis.ts
@@ -1,0 +1,298 @@
+import type {
+  Span,
+  TimelineEvent,
+  TimelineTraceStatus,
+} from '../api/client';
+import {
+  evaluateStaleTraceSignal,
+  type StaleTraceSignal,
+} from './failureAnalysis';
+import { getWaitDetails, type WaitDetails } from './eventSemantics';
+import { compareTimelineEvents } from './timeline';
+
+export type WaitStallClassification =
+  | 'declared_wait'
+  | 'waiting_on_model'
+  | 'waiting_on_tool'
+  | 'actively_executing'
+  | 'possibly_stalled'
+  | 'unknown';
+
+export type WaitStallBasis = 'declared' | 'inferred' | 'heuristic';
+
+export type WaitStallReason =
+  | 'open_declared_wait'
+  | 'open_model_span'
+  | 'open_tool_span'
+  | 'open_generic_span'
+  | 'recent_activity_without_open_span'
+  | 'stale_without_stronger_signal'
+  | 'insufficient_running_evidence';
+
+export interface WaitStallAssessment {
+  classification: WaitStallClassification;
+  basis: WaitStallBasis;
+  reason: WaitStallReason;
+  decisiveEventId?: string;
+  decisiveSpanId?: string;
+  decisiveSpanName?: string;
+  latestActivityAt: string | null;
+  runtimeMs: number | null;
+  inactivityMs: number | null;
+}
+
+export interface OpenWait {
+  event: TimelineEvent;
+  details: WaitDetails;
+}
+
+interface ClassifyRunningTraceOptions {
+  traceStatus: TimelineTraceStatus | null;
+  traceStartedAt: string | undefined;
+  spans: Span[];
+  events: TimelineEvent[];
+  now?: Date | number;
+}
+
+const OPEN_SPAN_STATUS = 'STARTED';
+const EXECUTION_EVIDENCE_SPAN_STATUSES = new Set<Span['status']>([
+  'STARTED',
+  'COMPLETED',
+  'FAILED',
+]);
+const GENERIC_ACTIVE_KINDS = new Set<Span['kind']>(['AGENT', 'CHAIN', 'CUSTOM']);
+
+export function computeOpenWaits(events: TimelineEvent[]): OpenWait[] {
+  const sortedEvents = [...events].sort(compareTimelineEvents);
+  const unmatchedWaitsById = new Map<string, OpenWait[]>();
+  const anonymousOpenWaits: OpenWait[] = [];
+
+  for (const event of sortedEvents) {
+    const details = getWaitDetails(event);
+    if (!details) {
+      continue;
+    }
+
+    if (details.phase === 'entered') {
+      if (!details.waitId) {
+        anonymousOpenWaits.push({ event, details });
+        continue;
+      }
+
+      const openWaits = unmatchedWaitsById.get(details.waitId) ?? [];
+      openWaits.push({ event, details });
+      unmatchedWaitsById.set(details.waitId, openWaits);
+      continue;
+    }
+
+    if (details.phase === 'resolved') {
+      if (!details.waitId) {
+        continue;
+      }
+
+      const openWaits = unmatchedWaitsById.get(details.waitId);
+      if (!openWaits || openWaits.length === 0) {
+        continue;
+      }
+
+      openWaits.shift();
+      if (openWaits.length === 0) {
+        unmatchedWaitsById.delete(details.waitId);
+      }
+    }
+  }
+
+  return [...anonymousOpenWaits, ...Array.from(unmatchedWaitsById.values()).flat()]
+    .sort((left, right) => compareTimelineEvents(left.event, right.event));
+}
+
+export function classifyRunningTrace({
+  traceStatus,
+  traceStartedAt,
+  spans,
+  events,
+  now = new Date(),
+}: ClassifyRunningTraceOptions): WaitStallAssessment | null {
+  if (traceStatus !== 'RUNNING') {
+    return null;
+  }
+
+  const staleTraceSignal = evaluateStaleTraceSignal({
+    traceStatus,
+    traceStartedAt,
+    spans,
+    events,
+    now,
+  });
+  const spanIndex = new Map(spans.map((span) => [span.span_id, span]));
+  const openWait = computeOpenWaits(events).at(-1);
+
+  if (openWait) {
+    const decisiveSpan = openWait.event.span_id
+      ? spanIndex.get(openWait.event.span_id)
+      : undefined;
+
+    return buildAssessment(
+      staleTraceSignal,
+      {
+        classification: 'declared_wait',
+        basis: 'declared',
+        reason: 'open_declared_wait',
+        decisiveEventId: openWait.event.id,
+        decisiveSpanId: decisiveSpan?.span_id,
+        decisiveSpanName: decisiveSpan?.name,
+      }
+    );
+  }
+
+  const openModelSpan = selectLatestStartedOpenSpan(spans, ['LLM']);
+  if (openModelSpan) {
+    return buildAssessment(
+      staleTraceSignal,
+      {
+        classification: 'waiting_on_model',
+        basis: 'inferred',
+        reason: 'open_model_span',
+        decisiveSpanId: openModelSpan.span_id,
+        decisiveSpanName: openModelSpan.name,
+      }
+    );
+  }
+
+  const openToolSpan = selectLatestStartedOpenSpan(spans, ['TOOL']);
+  if (openToolSpan) {
+    return buildAssessment(
+      staleTraceSignal,
+      {
+        classification: 'waiting_on_tool',
+        basis: 'inferred',
+        reason: 'open_tool_span',
+        decisiveSpanId: openToolSpan.span_id,
+        decisiveSpanName: openToolSpan.name,
+      }
+    );
+  }
+
+  const openGenericSpan = selectLatestStartedOpenSpan(
+    spans,
+    Array.from(GENERIC_ACTIVE_KINDS)
+  );
+  if (openGenericSpan) {
+    return buildAssessment(
+      staleTraceSignal,
+      {
+        classification: 'actively_executing',
+        basis: 'heuristic',
+        reason: 'open_generic_span',
+        decisiveSpanId: openGenericSpan.span_id,
+        decisiveSpanName: openGenericSpan.name,
+      }
+    );
+  }
+
+  if (
+    hasExecutionEvidenceBeyondTraceStart(spans, events) &&
+    !staleTraceSignal.shouldDisplay
+  ) {
+    return buildAssessment(
+      staleTraceSignal,
+      {
+        classification: 'actively_executing',
+        basis: 'heuristic',
+        reason: 'recent_activity_without_open_span',
+      }
+    );
+  }
+
+  if (staleTraceSignal.shouldDisplay) {
+    return buildAssessment(
+      staleTraceSignal,
+      {
+        classification: 'possibly_stalled',
+        basis: 'heuristic',
+        reason: 'stale_without_stronger_signal',
+      }
+    );
+  }
+
+  return buildAssessment(
+    staleTraceSignal,
+    {
+      classification: 'unknown',
+      basis: 'heuristic',
+      reason: 'insufficient_running_evidence',
+    }
+  );
+}
+
+function buildAssessment(
+  staleTraceSignal: StaleTraceSignal,
+  decision: Omit<
+    WaitStallAssessment,
+    'latestActivityAt' | 'runtimeMs' | 'inactivityMs'
+  >
+): WaitStallAssessment {
+  return {
+    ...decision,
+    latestActivityAt: staleTraceSignal.latestActivityAt,
+    runtimeMs: staleTraceSignal.runtimeMs,
+    inactivityMs: staleTraceSignal.inactivityMs,
+  };
+}
+
+function hasExecutionEvidenceBeyondTraceStart(
+  spans: Span[],
+  events: TimelineEvent[]
+): boolean {
+  if (events.some((event) => event.source === 'explicit')) {
+    return true;
+  }
+
+  return spans.some((span) => EXECUTION_EVIDENCE_SPAN_STATUSES.has(span.status));
+}
+
+function selectLatestStartedOpenSpan(
+  spans: Span[],
+  kinds: Span['kind'][]
+): Span | null {
+  const allowedKinds = new Set(kinds);
+  let selectedSpan: Span | null = null;
+  let selectedStartedAt: number | null = null;
+
+  for (const span of spans) {
+    if (span.status !== OPEN_SPAN_STATUS || !allowedKinds.has(span.kind)) {
+      continue;
+    }
+
+    const startedAt = parseTimestamp(span.started_at);
+    if (selectedSpan === null) {
+      selectedSpan = span;
+      selectedStartedAt = startedAt;
+      continue;
+    }
+
+    if (startedAt === null && selectedStartedAt !== null) {
+      continue;
+    }
+
+    if (
+      selectedStartedAt === null ||
+      startedAt === null ||
+      startedAt >= selectedStartedAt
+    ) {
+      selectedSpan = span;
+      selectedStartedAt = startedAt;
+    }
+  }
+
+  return selectedSpan;
+}
+
+function parseTimestamp(timestamp: string | undefined): number | null {
+  if (!timestamp) {
+    return null;
+  }
+
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? null : parsed;
+}


### PR DESCRIPTION
## Summary
- add strict wait parsing and a pure running-trace wait/stall classifier
- surface stable running-state analysis in trace detail and improve wait event timeline rendering
- refresh spans on the timeline cadence for running traces and stop extra span refreshes after terminal status

## Testing
- pnpm --filter web test
- pnpm --filter web build
- openspec validate add-wait-stall-analysis --strict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added diagnostic analysis panel for running traces that classifies trace states (declared wait, waiting on model/tool, actively executing, possibly stalled, or unknown) with contextual guidance
- Enhanced timeline display of wait events with clear entry and resolution details
- Enabled real-time span updates during live trace execution for accurate state assessment and classification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->