### PR TITLE
Add trace reasoning and cost surfaces

### DIFF
--- a/openspec/changes/add-trace-reasoning-cost-surfaces/proposal.md
+++ b/openspec/changes/add-trace-reasoning-cost-surfaces/proposal.md
@@ -1,0 +1,22 @@
+# Change: Add trace-level reasoning tab and cost surfaces to debugger
+
+## Why
+The debugger workspace shows per-span decisions and metrics, but there is no trace-level view of the reasoning chain or cumulative cost shape. Operators debugging multi-span agent traces need a single chronological reasoning log and a visual cost curve without clicking through individual spans.
+
+## What Changes
+- Add a **Reasoning** tab to the desktop inspector and mobile workspace that lists all valid `decision` events across the trace in chronological order, with click-to-navigate to the originating span.
+- Add a **cumulative cost strip** as a fixed row between the waterfall time-axis header and the virtualized row scroller, rendered as an inline SVG step chart aligned to the existing time axis.
+- Add **per-row cost/token annotations** in the waterfall label column for spans with non-zero cost or token data.
+- All new behavior is derived client-side from existing `Span`, `TraceDetail`, and `TimelineEvent` data. No backend, API, migration, or storage changes.
+
+## Impact
+- Affected specs: new `debugger-reasoning`, new `debugger-cost-surfaces`
+- Affected code:
+  - `web/src/pages/TraceDetailPage.tsx` — derive reasoning entries and cost series, wire new tab
+  - `web/src/components/InspectorTabs.tsx` — add `reasoning` tab id and content slot
+  - `web/src/components/WorkspaceShell.tsx` — add `reasoning` mobile tab
+  - `web/src/components/ExecutionWaterfall.tsx` — cost strip and per-row annotations
+  - `web/src/components/ReasoningTab.tsx` — new component (trace-level decision list)
+  - `web/src/components/CostStrip.tsx` — new component (SVG step chart)
+  - `web/src/utils/reasoning.ts` — decision extraction and cost series derivation utilities
+  - `web/src/utils/reasoning.test.ts` — unit tests for the above

--- a/openspec/changes/add-trace-reasoning-cost-surfaces/specs/debugger-cost-surfaces/spec.md
+++ b/openspec/changes/add-trace-reasoning-cost-surfaces/specs/debugger-cost-surfaces/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Cumulative Cost Strip
+The execution waterfall SHALL display a fixed cumulative-cost strip between the time-axis header row and the virtualized row scroller.
+
+The strip SHALL use the same two-column grid as the waterfall: the left cell contains a static "Cumulative cost" label; the right cell contains a non-interactive inline SVG step chart aligned to the existing time axis.
+
+#### Scenario: Completed trace with cost-bearing spans
+- **WHEN** a completed trace has spans with non-zero `cost_usd`
+- **THEN** the cost strip renders a step chart where each step increment is anchored at the span's `ended_at` timestamp
+- **AND** a cumulative total label is displayed at the final step
+
+#### Scenario: Span missing ended_at uses started_at fallback
+- **WHEN** a terminal span has `cost_usd` but no `ended_at`
+- **THEN** the cost increment is anchored at the span's `started_at` timestamp
+
+#### Scenario: Running spans excluded from finalized cost
+- **WHEN** a trace is in RUNNING status and some spans are still running
+- **THEN** running spans are excluded from the cumulative cost computation
+- **AND** only currently terminal cost-bearing spans contribute to the strip
+
+#### Scenario: Running trace partial cost updates
+- **WHEN** a running trace receives updated span data from the existing polling refresh
+- **THEN** the cost strip re-derives from the updated spans without additional polling
+
+#### Scenario: Running trace partial indicator
+- **WHEN** a trace is in RUNNING status and the cost strip is visible
+- **THEN** the cumulative total label includes a "Partial" indicator to communicate that the shown total is not final
+
+#### Scenario: Zero-cost trace
+- **WHEN** no spans in the trace have `cost_usd` values
+- **THEN** `buildTraceCostSeries()` returns `null` (not an empty array)
+- **AND** the cost strip is hidden entirely and does not reserve vertical space
+
+#### Scenario: Tied anchor timestamps
+- **WHEN** two cost-bearing spans share the same terminal timestamp
+- **THEN** `buildTraceCostSeries()` collapses them into a single combined step at that timestamp
+- **AND** the SVG component receives pre-aggregated points and does not perform its own collapsing
+
+### Requirement: Waterfall Row Cost Annotations
+The execution waterfall label column SHALL display compact inline token count and cost annotations on the existing status/duration line for rows with non-zero token or cost data.
+
+Annotations MUST fit within the existing uniform `WATERFALL_ROW_HEIGHT` (68px) budget. The waterfall row height SHALL remain uniform across all rows; no variable-height rows are introduced. These annotations are independent of the span tree's "Show metrics" toggle.
+
+#### Scenario: Span with tokens and cost
+- **WHEN** a waterfall row represents a span with non-zero `tokens_in`, `tokens_out`, or `cost_usd`
+- **THEN** compact token and cost values are appended inline to the existing status/duration line in the label column
+- **AND** the row height remains `WATERFALL_ROW_HEIGHT` (68px)
+
+#### Scenario: Span with no cost or token data
+- **WHEN** a waterfall row represents a span with no token or cost data
+- **THEN** no annotation is rendered for that row and the status/duration line is unchanged
+
+#### Scenario: Annotations visible when tree metrics toggle is off
+- **WHEN** the span tree's "Show metrics" toggle is off
+- **THEN** waterfall row annotations are still displayed independently
+
+### Requirement: Cost Derivation Source
+The cost strip and row annotations SHALL derive values exclusively from existing span `cost_usd`, `tokens_in`, and `tokens_out` fields. No inferred or synthetic cost events are introduced. No runtime mismatch detection against `trace.total_cost_usd` is performed.
+
+#### Scenario: Cost derived from span fields only
+- **WHEN** the waterfall renders cost surfaces
+- **THEN** all values come from the in-memory span objects returned by existing queries
+- **AND** no additional API calls or synthetic cost events are created

--- a/openspec/changes/add-trace-reasoning-cost-surfaces/specs/debugger-reasoning/spec.md
+++ b/openspec/changes/add-trace-reasoning-cost-surfaces/specs/debugger-reasoning/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Trace-Level Reasoning Tab
+The debugger workspace SHALL provide a Reasoning tab that displays all valid `decision` timeline events across the entire trace, ordered using the existing `compareTimelineEvents()` comparator from `timeline.ts`.
+
+Each row SHALL display: timestamp, originating span name (from `event.span_name`, falling back to span lookup only when absent), question, chosen value, and optional reasoning and alternatives.
+
+The Reasoning tab SHALL appear in both the desktop inspector tab bar and the mobile workspace tab bar.
+
+#### Scenario: Trace with multiple decision events across spans
+- **WHEN** a trace contains valid decision events in three different spans
+- **THEN** the Reasoning tab lists all three decisions sorted by timestamp
+- **AND** each row shows the span name, question, and chosen value
+
+#### Scenario: Trace with no valid decision events
+- **WHEN** a trace contains no valid decision events
+- **THEN** the Reasoning tab displays an empty-state message
+
+#### Scenario: Malformed decision events are excluded
+- **WHEN** a trace contains decision events with missing `question` or `chosen` fields
+- **THEN** those events are excluded from the Reasoning tab
+- **AND** they remain visible in the generic timeline view
+
+#### Scenario: Decision events with tied timestamps
+- **WHEN** two decision events share the same timestamp
+- **THEN** both appear in the list ordered by `compareTimelineEvents()` (source rank, then sequence, then event id)
+
+### Requirement: Reasoning Tab Navigation
+Activating a row in the Reasoning tab SHALL select the originating span through the shared selection path and switch the view to the Details tab. Each row SHALL be rendered as a `<button>` element to match the existing keyboard-accessible selection pattern used in Timeline and ExecutionWaterfall.
+
+#### Scenario: Click reasoning row on desktop
+- **WHEN** the user clicks a reasoning row on a desktop layout
+- **THEN** the originating span is selected
+- **AND** the inspector switches to the Details tab via `switchToDetailsRef`
+
+#### Scenario: Click reasoning row on mobile
+- **WHEN** the user clicks a reasoning row on a mobile layout
+- **THEN** the originating span is selected
+- **AND** the active mobile workspace tab switches to `details`
+
+#### Scenario: Keyboard activation of reasoning row
+- **WHEN** the user focuses a reasoning row and presses Enter or Space
+- **THEN** the same navigation behavior fires as a click
+
+### Requirement: Reasoning Derivation Source
+The Reasoning tab SHALL derive its entries exclusively from `getDecisionDetails()` applied to `timeline.events`. No additional backend queries or data sources are introduced.
+
+#### Scenario: Derivation uses existing timeline data
+- **WHEN** the trace detail page loads timeline events
+- **THEN** the reasoning entries are computed client-side via `useMemo` over the existing events array
+- **AND** no additional API calls are made for the Reasoning tab

--- a/openspec/changes/add-trace-reasoning-cost-surfaces/tasks.md
+++ b/openspec/changes/add-trace-reasoning-cost-surfaces/tasks.md
@@ -1,0 +1,30 @@
+## 1. Reasoning utilities and tests
+- [x] 1.1 Create `web/src/utils/reasoning.ts` with `buildReasoningEntries(events, spans)` that filters valid decisions via `getDecisionDetails()`, resolves span name from `event.span_name` first (falling back to `spans` lookup only when absent), and sorts using `compareTimelineEvents()` from `timeline.ts`. Export `DecisionTraceEntry` type.
+- [x] 1.2 Create `buildTraceCostSeries(spans, traceStatus)` in the same file that derives `TraceCostPoint[]` and cumulative total from terminal span `cost_usd`, anchored at `ended_at` (fallback `started_at`), excluding running spans. Collapse tied anchor timestamps into single combined steps at the utility level. Return `null` (not an empty array) for zero-cost traces. Mark the series as `partial: true` when `traceStatus` is `RUNNING`. Export `TraceCostPoint` and `TraceCostSeries` types.
+- [x] 1.3 Add unit tests in `web/src/utils/reasoning.test.ts` covering: valid vs malformed decisions, tied timestamps (verify `compareTimelineEvents` ordering), cross-span ordering, missing span names (fallback path), completed traces, running traces with partial totals and `partial: true`, zero-cost traces (returns `null`), mixed costed/non-costed spans, tied anchor timestamps (verify aggregation), terminal spans missing `ended_at`.
+
+## 2. Reasoning tab component
+- [x] 2.1 Create `web/src/components/ReasoningTab.tsx` — chronological list of `DecisionTraceEntry` rows. Each row is a `<button>` element for keyboard accessibility. Shows timestamp, span name, question, chosen, optional reasoning/alternatives. Accept `onSelectSpan` callback. Render empty state when no entries.
+- [x] 2.2 Add component test for ReasoningTab: renders entries, renders empty state, click fires `onSelectSpan`, keyboard Enter/Space fires `onSelectSpan`.
+
+## 3. Wire Reasoning tab into workspace
+- [x] 3.1 Extend `InspectorTabId` in `InspectorTabs.tsx` to include `'reasoning'`. Add the tab button and content slot.
+- [x] 3.2 Extend `MobileWorkspaceTabId` in `WorkspaceShell.tsx` to include `'reasoning'`. Add the tab button and content projection. Acceptance: six tabs must remain reachable without horizontal overflow scrolling on 320px-wide viewports; wrapping is allowed.
+- [x] 3.3 In `TraceDetailPage.tsx`, add `useMemo` derivation for `DecisionTraceEntry[]` from `timeline.events` and `spans`. Wire into ReasoningTab with navigation: desktop uses `switchToDetailsRef`, mobile sets active tab to `details`.
+- [x] 3.4 Add integration test: clicking a Reasoning row selects span and switches to Details.
+
+## 4. Cost strip component
+- [x] 4.1 Create `web/src/components/CostStrip.tsx` — inline SVG step chart accepting pre-aggregated `TraceCostSeries` and waterfall `window`. Left cell: "Cumulative cost" label. Right cell: step line with endpoint marker and total label, aligned to waterfall time axis. When `series.partial` is true, append a "Partial" indicator next to the total label. The component does not perform timestamp collapsing; that is owned by `buildTraceCostSeries()`. When `series` is `null`, render nothing (no DOM output).
+- [x] 4.2 Add component test: renders step chart for cost series, renders "Partial" indicator for running traces, hidden entirely (no DOM output) when series is `null`.
+
+## 5. Waterfall integration
+- [x] 5.1 Insert `CostStrip` into `ExecutionWaterfall.tsx` between the time-axis header and the virtualized scroller. Pass derived cost series and waterfall window.
+- [x] 5.2 Add compact inline token/cost annotations to the existing status/duration line in the waterfall label column for rows with non-zero token or cost data. Use existing `formatTokens` and `formatCost` utilities. Annotations MUST fit within the existing uniform `WATERFALL_ROW_HEIGHT` (68px); no variable-height rows are introduced.
+- [x] 5.3 In `TraceDetailPage.tsx`, add `useMemo` derivation for `TraceCostSeries` from `spans` and trace status. Pass to waterfall.
+- [x] 5.4 Add integration test for running-trace cost update: mock a span query result update (simulating existing polling refresh), assert the cost strip re-derives with updated totals and shows partial indicator, and assert no new polling path is introduced.
+- [x] 5.5 Add waterfall label column test: verify annotation text appears for cost-bearing rows, does not appear for zero-cost rows, and row height remains uniform.
+
+## 6. Verify
+- [x] 6.1 Run `pnpm --filter web test` and confirm all new and existing tests pass.
+- [ ] 6.2 Manual QA (not jsdom geometry tests): SVG strip alignment against time axis, desktop resize behavior, waterfall scroll/virtualization interaction, mobile tab layout (six tabs reachable without clipping on small screens).
+- [ ] 6.3 Run existing workspace profiling script if the new strip measurably affects render cost.

--- a/web/src/components/CostStrip.test.tsx
+++ b/web/src/components/CostStrip.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CostStrip } from './CostStrip';
+
+const WINDOW = {
+  startMs: Date.parse('2026-03-14T10:00:00.000Z'),
+  endMs: Date.parse('2026-03-14T10:00:10.000Z'),
+  durationMs: 10_000,
+};
+
+describe('CostStrip', () => {
+  it('renders a step chart for a cost series', () => {
+    render(
+      <CostStrip
+        window={WINDOW}
+        series={{
+          partial: false,
+          points: [
+            {
+              anchorMs: Date.parse('2026-03-14T10:00:02.000Z'),
+              cumulativeCostUsd: 0.02,
+              incrementalCostUsd: 0.02,
+            },
+            {
+              anchorMs: Date.parse('2026-03-14T10:00:06.000Z'),
+              cumulativeCostUsd: 0.05,
+              incrementalCostUsd: 0.03,
+            },
+          ],
+          totalCostUsd: 0.05,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Cumulative cost')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cumulative cost chart')).toBeInTheDocument();
+    expect(screen.getByText('$0.05')).toBeInTheDocument();
+  });
+
+  it('renders the partial indicator for running traces', () => {
+    render(
+      <CostStrip
+        window={WINDOW}
+        series={{
+          partial: true,
+          points: [
+            {
+              anchorMs: Date.parse('2026-03-14T10:00:04.000Z'),
+              cumulativeCostUsd: 0.02,
+              incrementalCostUsd: 0.02,
+            },
+          ],
+          totalCostUsd: 0.02,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Partial')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no visible cost series', () => {
+    const { container } = render(<CostStrip window={WINDOW} series={null} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web/src/components/CostStrip.tsx
+++ b/web/src/components/CostStrip.tsx
@@ -1,0 +1,111 @@
+import { formatCost } from '../utils/format';
+import type { TraceCostSeries } from '../utils/reasoning';
+import type { WaterfallWindow } from '../utils/waterfallTime';
+
+interface CostStripProps {
+  series: TraceCostSeries | null;
+  window: WaterfallWindow;
+}
+
+const CHART_BOTTOM_Y = 24;
+const CHART_HEIGHT = 28;
+const CHART_TOP_Y = 4;
+const CHART_WIDTH = 100;
+
+export function CostStrip({ series, window }: CostStripProps) {
+  if (!series) {
+    return null;
+  }
+
+  const plottedPoints = series.points.map((point) => {
+    const leftPercent = clamp(
+      ((point.anchorMs - window.startMs) / window.durationMs) * 100,
+      0,
+      100
+    );
+    const x = (leftPercent / 100) * CHART_WIDTH;
+    const y =
+      CHART_BOTTOM_Y -
+      (point.cumulativeCostUsd / Math.max(series.totalCostUsd, Number.EPSILON)) *
+        (CHART_BOTTOM_Y - CHART_TOP_Y);
+
+    return {
+      ...point,
+      leftPercent,
+      x,
+      y,
+    };
+  });
+  const path = buildStepPath(plottedPoints);
+  const lastPoint = plottedPoints[plottedPoints.length - 1];
+  const labelLeftPercent = clamp(lastPoint.leftPercent + 1, 8, 82);
+
+  return (
+    <div className="grid grid-cols-[minmax(0,13rem)_minmax(0,1fr)] border-b border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+      <div className="border-r border-slate-200 px-4 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:border-slate-800 dark:text-slate-400">
+        Cumulative cost
+      </div>
+      <div className="relative px-4 py-3">
+        <svg
+          aria-label="Cumulative cost chart"
+          className="h-12 w-full overflow-visible"
+          viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+          preserveAspectRatio="none"
+        >
+          <path
+            d={`M 0 ${CHART_BOTTOM_Y} L ${CHART_WIDTH} ${CHART_BOTTOM_Y}`}
+            fill="none"
+            stroke="var(--continua-waterfall-tick-color)"
+            strokeWidth="1"
+            vectorEffect="non-scaling-stroke"
+          />
+          <path
+            d={path}
+            fill="none"
+            stroke="var(--continua-waterfall-success-selected-border)"
+            strokeWidth="1.8"
+            vectorEffect="non-scaling-stroke"
+          />
+          <circle
+            cx={lastPoint.x}
+            cy={lastPoint.y}
+            r="2.6"
+            fill="var(--continua-waterfall-success-selected-border)"
+          />
+        </svg>
+
+        <div
+          className="pointer-events-none absolute top-1/2 -translate-y-1/2"
+          style={{ left: `${labelLeftPercent}%` }}
+        >
+          <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/95 px-3 py-1 text-xs font-medium text-slate-700 shadow-sm dark:border-slate-700 dark:bg-slate-950/95 dark:text-slate-200">
+            <span>{formatCost(series.totalCostUsd)}</span>
+            {series.partial ? (
+              <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-800 dark:bg-amber-500/20 dark:text-amber-200">
+                Partial
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function buildStepPath(
+  points: Array<{ x: number; y: number }>
+): string {
+  let currentY = CHART_BOTTOM_Y;
+  let path = `M 0 ${CHART_BOTTOM_Y}`;
+
+  for (const point of points) {
+    path += ` L ${point.x} ${currentY} L ${point.x} ${point.y}`;
+    currentY = point.y;
+  }
+
+  return `${path} L ${CHART_WIDTH} ${currentY}`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/web/src/components/DecisionValuePill.tsx
+++ b/web/src/components/DecisionValuePill.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+interface DecisionValuePillProps {
+  children: ReactNode;
+  tone?: 'neutral' | 'accent';
+}
+
+export function DecisionValuePill({
+  children,
+  tone = 'neutral',
+}: DecisionValuePillProps) {
+  return (
+    <span
+      className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+        tone === 'accent'
+          ? 'border-blue-200 bg-white text-blue-800 dark:border-sky-500/40 dark:bg-slate-950 dark:text-sky-200'
+          : 'border-slate-200 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200'
+      }`}
+    >
+      {children}
+    </span>
+  );
+}

--- a/web/src/components/ExecutionWaterfall.test.tsx
+++ b/web/src/components/ExecutionWaterfall.test.tsx
@@ -6,7 +6,7 @@ import {
   createSpan,
   resetTestEntityCounter,
 } from '../test/traceFixtures';
-import { ExecutionWaterfall } from './ExecutionWaterfall';
+import { ExecutionWaterfall, WATERFALL_ROW_HEIGHT } from './ExecutionWaterfall';
 
 beforeEach(() => {
   resetTestEntityCounter();
@@ -107,5 +107,71 @@ describe('ExecutionWaterfall retry safety', () => {
     expect(
       within(section!).getAllByLabelText(getAccessibleSummary('unsafe'))
     ).toHaveLength(1);
+  });
+
+  it('shows inline token and cost annotations only for cost-bearing rows while keeping row height uniform', () => {
+    const rootSpan = createSpan({
+      span_id: 'annotation-root',
+      name: 'Annotation root',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:00.000Z',
+      ended_at: '2026-03-14T10:00:05.000Z',
+      latency_ms: 5000,
+    });
+    const annotatedSpan = createSpan({
+      span_id: 'annotation-costed',
+      name: 'Annotated span',
+      parent_span_id: rootSpan.span_id,
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:01.000Z',
+      ended_at: '2026-03-14T10:00:02.000Z',
+      latency_ms: 1000,
+      tokens_in: 12,
+      tokens_out: 33,
+      cost_usd: 0.05,
+    });
+    const plainSpan = createSpan({
+      span_id: 'annotation-plain',
+      name: 'Plain span',
+      parent_span_id: rootSpan.span_id,
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:02.000Z',
+      ended_at: '2026-03-14T10:00:03.000Z',
+      latency_ms: 1000,
+    });
+
+    const rows = deriveVisibleRows(
+      buildSpanTree([rootSpan, annotatedSpan, plainSpan]),
+      new Set([rootSpan.span_id])
+    );
+
+    render(
+      <ExecutionWaterfall
+        events={[]}
+        rows={rows}
+        selectedSpanId={null}
+        onSelectSpanAndShowDetails={vi.fn()}
+        revealTarget={null}
+        revealVersion={0}
+        spans={[rootSpan, annotatedSpan, plainSpan]}
+        traceStartedAt={rootSpan.started_at}
+        traceEndedAt={rootSpan.ended_at}
+      />
+    );
+
+    const annotatedLabel = screen.getByText('Annotated span').closest('button');
+    const plainLabel = screen.getByText('Plain span').closest('button');
+
+    expect(annotatedLabel).not.toBeNull();
+    expect(plainLabel).not.toBeNull();
+    expect(screen.getByText('45 tokens')).toBeInTheDocument();
+    expect(screen.getByText('$0.05')).toBeInTheDocument();
+    expect(screen.queryByText('0 tokens')).not.toBeInTheDocument();
+    expect(annotatedLabel!.parentElement).toHaveStyle(
+      `height: ${WATERFALL_ROW_HEIGHT}px`
+    );
+    expect(plainLabel!.parentElement).toHaveStyle(
+      `height: ${WATERFALL_ROW_HEIGHT}px`
+    );
   });
 });

--- a/web/src/components/ExecutionWaterfall.tsx
+++ b/web/src/components/ExecutionWaterfall.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef } from 'react';
 import type { Span, TimelineEvent } from '../api/client';
 import { useVirtualRows } from '../hooks/useVirtualRows';
-import { formatDuration } from '../utils/format';
+import { formatCost, formatDuration, formatTokens } from '../utils/format';
+import type { TraceCostSeries } from '../utils/reasoning';
 import {
   getAccessibleSummary,
   type RetrySafetyAssessment,
@@ -12,6 +13,7 @@ import {
   deriveWaterfallWindow,
   getWaterfallBarLayout,
 } from '../utils/waterfallTime';
+import { CostStrip } from './CostStrip';
 import { RetrySafetyBadge } from './RetrySafetyBadge';
 
 interface ExecutionWaterfallProps {
@@ -22,13 +24,14 @@ interface ExecutionWaterfallProps {
   revealTarget: string | null;
   revealVersion: number;
   spans: Span[];
+  costSeries?: TraceCostSeries | null;
   traceEndedAt?: string;
   traceStartedAt?: string;
   spanAssessments?: ReadonlyMap<string, RetrySafetyAssessment>;
 }
 
 const MIN_BAR_WIDTH_REM = 0.875;
-const WATERFALL_ROW_HEIGHT = 68;
+export const WATERFALL_ROW_HEIGHT = 68;
 const TICK_LINE_COLOR = 'var(--continua-waterfall-tick-color)';
 const EMPTY_SPAN_ASSESSMENTS = new Map<string, RetrySafetyAssessment>();
 
@@ -40,6 +43,7 @@ export function ExecutionWaterfall({
   revealTarget,
   revealVersion,
   spans,
+  costSeries = null,
   traceEndedAt,
   traceStartedAt,
   spanAssessments = EMPTY_SPAN_ASSESSMENTS,
@@ -134,6 +138,8 @@ export function ExecutionWaterfall({
         </div>
       </div>
 
+      <CostStrip series={costSeries} window={window} />
+
       <div
         ref={containerRef}
         className="min-h-0 flex-1 overflow-y-auto"
@@ -150,6 +156,9 @@ export function ExecutionWaterfall({
             const bar = getWaterfallBarLayout(row.span, window);
             const isSelected = row.span.span_id === selectedSpanId;
             const retrySafety = spanAssessments.get(row.span.span_id) ?? null;
+            const totalTokens = (row.span.tokens_in ?? 0) + (row.span.tokens_out ?? 0);
+            const hasTokenData = totalTokens !== 0;
+            const hasCostData = (row.span.cost_usd ?? 0) !== 0;
 
             return (
               <div
@@ -163,10 +172,11 @@ export function ExecutionWaterfall({
                   rowRefs.current.delete(row.span.span_id);
                 }}
                 className="grid grid-cols-[minmax(0,13rem)_minmax(0,1fr)]"
+                style={{ height: `${WATERFALL_ROW_HEIGHT}px` }}
               >
                 <button
                   type="button"
-                  className={`min-w-0 border-r border-slate-200 px-4 py-3 text-left transition dark:border-slate-800 ${
+                  className={`flex h-full min-w-0 items-center border-r border-slate-200 px-4 py-3 text-left transition dark:border-slate-800 ${
                     isSelected
                       ? 'bg-blue-50 dark:bg-sky-500/10'
                       : 'bg-white hover:bg-slate-50 dark:bg-slate-900 dark:hover:bg-slate-800/60'
@@ -174,28 +184,45 @@ export function ExecutionWaterfall({
                   onClick={() => onSelectSpanAndShowDetails(row.span.span_id)}
                 >
                   <div
-                    className="flex items-center gap-2"
+                    className="min-w-0"
                     style={{ paddingLeft: `${row.depth * 12}px` }}
                   >
-                    <div className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900 dark:text-slate-100">
-                      {row.span.name}
+                    <div className="flex items-center gap-2">
+                      <div className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                        {row.span.name}
+                      </div>
+                      {row.span.status === 'FAILED' && retrySafety ? (
+                        <RetrySafetyBadge
+                          classification={retrySafety.classification}
+                          variant="compact"
+                          aria-label={getAccessibleSummary(retrySafety.classification)}
+                        />
+                      ) : null}
                     </div>
-                    {row.span.status === 'FAILED' && retrySafety ? (
-                      <RetrySafetyBadge
-                        classification={retrySafety.classification}
-                        variant="compact"
-                        aria-label={getAccessibleSummary(retrySafety.classification)}
-                      />
-                    ) : null}
-                  </div>
-                  <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                    {row.span.status} · {formatDuration(row.span.latency_ms)}
+
+                    <div className="mt-1 flex items-center gap-1 overflow-hidden whitespace-nowrap text-xs text-slate-500 dark:text-slate-400">
+                      <span className="shrink-0">{row.span.status}</span>
+                      <span aria-hidden="true">·</span>
+                      <span className="shrink-0">{formatDuration(row.span.latency_ms)}</span>
+                      {hasTokenData ? (
+                        <>
+                          <span aria-hidden="true">·</span>
+                          <span className="truncate">{formatTokens(totalTokens)} tokens</span>
+                        </>
+                      ) : null}
+                      {hasCostData ? (
+                        <>
+                          <span aria-hidden="true">·</span>
+                          <span className="truncate">{formatCost(row.span.cost_usd)}</span>
+                        </>
+                      ) : null}
+                    </div>
                   </div>
                 </button>
 
-                <div className="px-4 py-3">
+                <div className="flex h-full items-center px-4 py-3">
                   <div
-                    className="relative h-11"
+                    className="relative h-11 w-full"
                     style={
                       timingGridBackground
                         ? {

--- a/web/src/components/InspectorTabs.test.tsx
+++ b/web/src/components/InspectorTabs.test.tsx
@@ -7,6 +7,7 @@ describe('InspectorTabs', () => {
     const { rerender } = render(
       <InspectorTabs
         details={<div>Details</div>}
+        reasoning={<div>Reasoning</div>}
         timeline={<div>Timeline</div>}
         state={<div>State</div>}
         stateCount={0}
@@ -18,6 +19,7 @@ describe('InspectorTabs', () => {
     rerender(
       <InspectorTabs
         details={<div>Details</div>}
+        reasoning={<div>Reasoning</div>}
         timeline={<div>Timeline</div>}
         state={<div>State</div>}
         stateCount={3}

--- a/web/src/components/InspectorTabs.tsx
+++ b/web/src/components/InspectorTabs.tsx
@@ -5,10 +5,11 @@ import {
   type ReactNode,
 } from 'react';
 
-export type InspectorTabId = 'details' | 'timeline' | 'state';
+export type InspectorTabId = 'details' | 'timeline' | 'reasoning' | 'state';
 
 interface InspectorTabsProps {
   details: ReactNode;
+  reasoning: ReactNode;
   timeline: ReactNode;
   state: ReactNode;
   stateCount: number;
@@ -17,6 +18,7 @@ interface InspectorTabsProps {
 
 export function InspectorTabs({
   details,
+  reasoning,
   timeline,
   state,
   stateCount,
@@ -54,6 +56,11 @@ export function InspectorTabs({
             onClick={() => setActiveTab('timeline')}
           />
           <InspectorTabButton
+            active={activeTab === 'reasoning'}
+            label="Reasoning"
+            onClick={() => setActiveTab('reasoning')}
+          />
+          <InspectorTabButton
             active={activeTab === 'state'}
             label="State"
             badgeCount={stateCount}
@@ -74,6 +81,12 @@ export function InspectorTabs({
           style={{ display: activeTab === 'timeline' ? 'block' : 'none' }}
         >
           {timeline}
+        </div>
+        <div
+          className="h-full"
+          style={{ display: activeTab === 'reasoning' ? 'block' : 'none' }}
+        >
+          {reasoning}
         </div>
         <div
           className="h-full"

--- a/web/src/components/ReasoningTab.test.tsx
+++ b/web/src/components/ReasoningTab.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { DecisionTraceEntry } from '../utils/reasoning';
+import { createTimelineEvent } from '../test/traceFixtures';
+import { ReasoningTab } from './ReasoningTab';
+
+const SAMPLE_ENTRIES: DecisionTraceEntry[] = [
+  {
+    event: createTimelineEvent({
+      id: 'reasoning-entry-1',
+      span_id: 'span-1',
+      span_name: 'Planner span',
+      event_type: 'decision',
+      timestamp: '2026-03-14T10:00:01.000Z',
+      payload: {
+        question: 'Which model?',
+        chosen: 'gpt-5.4',
+        reasoning: 'Need the higher-accuracy model.',
+        alternatives: ['gpt-5.4-mini'],
+      },
+    }),
+    spanId: 'span-1',
+    spanName: 'Planner span',
+    question: 'Which model?',
+    chosen: 'gpt-5.4',
+    reasoning: 'Need the higher-accuracy model.',
+    alternatives: ['gpt-5.4-mini'],
+  },
+];
+
+describe('ReasoningTab', () => {
+  it('renders decision entries', () => {
+    render(<ReasoningTab entries={SAMPLE_ENTRIES} onSelectSpan={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: 'Reasoning' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Planner span.*Which model\?/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Need the higher-accuracy model.')).toBeInTheDocument();
+    expect(screen.getByText('gpt-5.4-mini')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there are no reasoning entries', () => {
+    render(<ReasoningTab entries={[]} onSelectSpan={vi.fn()} />);
+
+    expect(
+      screen.getByText('No reasoning decisions recorded for this trace.')
+    ).toBeInTheDocument();
+  });
+
+  it('fires onSelectSpan on click and keyboard activation', async () => {
+    const user = userEvent.setup();
+    const onSelectSpan = vi.fn();
+
+    render(<ReasoningTab entries={SAMPLE_ENTRIES} onSelectSpan={onSelectSpan} />);
+
+    const row = screen.getByRole('button', {
+      name: /Planner span.*Which model\?/i,
+    });
+
+    await user.click(row);
+    row.focus();
+    await user.keyboard('{Enter}');
+    await user.keyboard('{Space}');
+
+    expect(onSelectSpan).toHaveBeenCalledTimes(3);
+    expect(onSelectSpan).toHaveBeenNthCalledWith(1, 'span-1');
+    expect(onSelectSpan).toHaveBeenNthCalledWith(2, 'span-1');
+    expect(onSelectSpan).toHaveBeenNthCalledWith(3, 'span-1');
+  });
+});

--- a/web/src/components/ReasoningTab.tsx
+++ b/web/src/components/ReasoningTab.tsx
@@ -1,0 +1,103 @@
+import { formatInlineSemanticValue } from '../utils/eventSemantics';
+import { type DecisionTraceEntry } from '../utils/reasoning';
+import { formatTimelineTime } from '../utils/timeline';
+import { DecisionValuePill } from './DecisionValuePill';
+
+interface ReasoningTabProps {
+  entries: DecisionTraceEntry[];
+  onSelectSpan: (spanId: string) => void;
+}
+
+export function ReasoningTab({ entries, onSelectSpan }: ReasoningTabProps) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">
+          Reasoning
+        </h2>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Chronological decision events across the full trace.
+        </p>
+      </div>
+
+      {entries.length === 0 ? (
+        <div className="px-4 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
+          No reasoning decisions recorded for this trace.
+        </div>
+      ) : (
+        <div className="divide-y divide-slate-100 dark:divide-slate-800">
+          {entries.map((entry) => {
+            const isNavigable = Boolean(entry.spanId);
+
+            return (
+              <button
+                key={entry.event.id}
+                type="button"
+                disabled={!isNavigable}
+                className={`flex w-full gap-4 p-4 text-left transition ${
+                  isNavigable
+                    ? 'hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:hover:bg-slate-800/70'
+                    : 'cursor-default opacity-80'
+                }`}
+                onClick={() => {
+                  if (entry.spanId) {
+                    onSelectSpan(entry.spanId);
+                  }
+                }}
+                onKeyDown={(event) => {
+                  if (
+                    !entry.spanId ||
+                    (event.key !== ' ' &&
+                      event.key !== 'Space' &&
+                      event.key !== 'Spacebar')
+                  ) {
+                    return;
+                  }
+
+                  event.preventDefault();
+                  onSelectSpan(entry.spanId);
+                }}
+              >
+                <div className="min-w-28 rounded-xl bg-slate-900 px-3 py-2 text-xs font-medium uppercase tracking-[0.18em] text-white dark:bg-slate-100 dark:text-slate-950">
+                  <div>{formatTimelineTime(entry.event.timestamp)}</div>
+                  <div className="mt-1 text-[10px] tracking-[0.25em] text-slate-300 dark:text-slate-600">
+                    {entry.spanName}
+                  </div>
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-semibold leading-6 text-slate-900 dark:text-slate-100">
+                    {entry.question}
+                  </div>
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                    <span>Chosen</span>
+                    <DecisionValuePill tone="accent">
+                      {formatInlineSemanticValue(entry.chosen)}
+                    </DecisionValuePill>
+                  </div>
+                  {entry.reasoning ? (
+                    <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                      {entry.reasoning}
+                    </p>
+                  ) : null}
+                  {entry.alternatives && entry.alternatives.length > 0 ? (
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      <span>Alternatives</span>
+                      {entry.alternatives.map((alternative, index) => (
+                        <DecisionValuePill
+                          key={`${entry.event.id}-alternative-${index}`}
+                        >
+                          {formatInlineSemanticValue(alternative)}
+                        </DecisionValuePill>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from 'react';
 import { Span, TimelineEvent } from '../api/client';
 import { CopyButton } from './CopyButton';
+import { DecisionValuePill } from './DecisionValuePill';
 import { StatusBadge } from './StatusBadge';
 import { JsonViewer } from './JsonViewer';
 import {
@@ -340,26 +341,6 @@ function MetricCard({ label, value }: MetricCardProps) {
       <div className="text-xl font-semibold text-slate-900 dark:text-slate-100">{value}</div>
       <div className="text-xs text-slate-500 mt-1 dark:text-slate-400">{label}</div>
     </div>
-  );
-}
-
-function DecisionValuePill({
-  children,
-  tone = 'neutral',
-}: {
-  children: string;
-  tone?: 'neutral' | 'accent';
-}) {
-  return (
-    <span
-      className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
-        tone === 'accent'
-          ? 'border-blue-200 bg-white text-blue-800 dark:border-sky-500/40 dark:bg-slate-950 dark:text-sky-200'
-          : 'border-slate-200 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200'
-      }`}
-    >
-      {children}
-    </span>
   );
 }
 

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -8,6 +8,7 @@ import {
   getStateChangeDetails,
 } from '../utils/eventSemantics';
 import {
+  formatTimelineTime,
   isTimelineErrorEvent,
   summarizeTimelineEvent,
 } from '../utils/timeline';
@@ -391,15 +392,6 @@ function SemanticValuePill({
       {children}
     </span>
   );
-}
-
-function formatTimelineTime(timestamp: string): string {
-  return new Date(timestamp).toLocaleTimeString([], {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  });
 }
 
 function formatEventType(eventType: TimelineEvent['event_type']): string {

--- a/web/src/components/WorkspaceShell.tsx
+++ b/web/src/components/WorkspaceShell.tsx
@@ -5,6 +5,7 @@ export type MobileWorkspaceTabId =
   | 'details'
   | 'waterfall'
   | 'tree'
+  | 'reasoning'
   | 'timeline'
   | 'state';
 
@@ -14,6 +15,7 @@ interface WorkspaceShellProps {
   waterfall: ReactNode;
   inspector: ReactNode;
   mobileDetails: ReactNode;
+  mobileReasoning: ReactNode;
   mobileTimeline: ReactNode;
   mobileState: ReactNode;
   activeMobileTab: MobileWorkspaceTabId;
@@ -25,6 +27,7 @@ const MOBILE_TABS: Array<{ id: MobileWorkspaceTabId; label: string }> = [
   { id: 'waterfall', label: 'Waterfall' },
   { id: 'tree', label: 'Tree' },
   { id: 'timeline', label: 'Timeline' },
+  { id: 'reasoning', label: 'Reasoning' },
   { id: 'state', label: 'State' },
 ];
 const USE_STATIC_DESKTOP_LAYOUT =
@@ -36,6 +39,7 @@ export function WorkspaceShell({
   waterfall,
   inspector,
   mobileDetails,
+  mobileReasoning,
   mobileTimeline,
   mobileState,
   activeMobileTab,
@@ -123,6 +127,12 @@ export function WorkspaceShell({
           style={{ display: activeMobileTab === 'timeline' ? 'block' : 'none' }}
         >
           {mobileTimeline}
+        </div>
+        <div
+          className="h-full"
+          style={{ display: activeMobileTab === 'reasoning' ? 'block' : 'none' }}
+        >
+          {mobileReasoning}
         </div>
         <div
           className="h-full"

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -162,6 +162,7 @@ describe('TraceDetailPage', () => {
     expect(screen.getByRole('button', { name: 'Waterfall' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Tree' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Timeline' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reasoning' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Trace Context/i })).toHaveAttribute(
       'aria-expanded',
       'false'
@@ -267,6 +268,141 @@ describe('TraceDetailPage', () => {
     expect(screen.getAllByText('running').length).toBeGreaterThan(0);
   });
 
+  it('selects a span from the reasoning tab and switches back to details', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({
+      span_id: 'reasoning-root',
+      name: 'Reasoning root',
+      status: 'COMPLETED',
+    });
+    const childSpan = createSpan({
+      span_id: 'reasoning-child',
+      name: 'Reasoning child',
+      parent_span_id: rootSpan.span_id,
+      status: 'COMPLETED',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse({ ...TRACE_DETAIL, status: 'COMPLETED', error_count: 0 }),
+        spans: () => jsonResponse({ spans: [rootSpan, childSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'reasoning-decision',
+                span_id: childSpan.span_id,
+                span_name: childSpan.name,
+                event_type: 'decision',
+                timestamp: '2026-03-14T10:00:03.000Z',
+                payload: {
+                  question: 'Choose a tool?',
+                  chosen: 'calculator',
+                  reasoning: 'The arithmetic branch needs deterministic output.',
+                },
+              }),
+            ],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(
+      await screen.findByRole('button', { name: 'Select span Reasoning root' })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Reasoning' }));
+    await user.click(
+      screen.getByRole('button', { name: /Reasoning child.*Choose a tool\?/i })
+    );
+
+    expect(view.router.state.location.search).toBe('?span=reasoning-child');
+    expect(screen.getByRole('button', { name: 'Details' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText('Reasoning child')
+    ).toBeInTheDocument();
+  });
+
+  it('selects a span from the reasoning tab and switches back to details on mobile', async () => {
+    setMatchMediaMatches(false);
+    const user = userEvent.setup();
+    const rootSpan = createSpan({
+      span_id: 'mobile-reasoning-root',
+      name: 'Mobile reasoning root',
+      status: 'COMPLETED',
+    });
+    const childSpan = createSpan({
+      span_id: 'mobile-reasoning-child',
+      name: 'Mobile reasoning child',
+      parent_span_id: rootSpan.span_id,
+      status: 'COMPLETED',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse({ ...TRACE_DETAIL, status: 'COMPLETED', error_count: 0 }),
+        spans: () => jsonResponse({ spans: [rootSpan, childSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                id: 'mobile-reasoning-decision',
+                span_id: childSpan.span_id,
+                span_name: childSpan.name,
+                event_type: 'decision',
+                timestamp: '2026-03-14T10:00:03.000Z',
+                payload: {
+                  question: 'Choose a mobile tool?',
+                  chosen: 'calculator',
+                },
+              }),
+            ],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(
+      await screen.findByRole('button', { name: 'Reasoning' })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Reasoning' }));
+    expect(screen.getByRole('button', { name: 'Reasoning' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /Mobile reasoning child.*Choose a mobile tool\?/i,
+      })
+    );
+
+    expect(view.router.state.location.search).toBe('?span=mobile-reasoning-child');
+    expect(screen.getByRole('button', { name: 'Details' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'Reasoning' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    expect(
+      within(screen.getByLabelText('Span breadcrumb')).getByText(
+        'Mobile reasoning child'
+      )
+    ).toBeInTheDocument();
+  });
+
   it('shows and hides inline tree metrics from the tree-rail toggle', async () => {
     const user = userEvent.setup();
     const rootSpan = createSpan({ span_id: 'metrics-root', name: 'Metrics root' });
@@ -295,18 +431,20 @@ describe('TraceDetailPage', () => {
     renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
     await screen.findByRole('button', { name: 'Select span Metrics child' });
 
-    expect(screen.queryByText('42 tokens')).not.toBeInTheDocument();
-    expect(screen.queryByText('$0.05')).not.toBeInTheDocument();
+    const treeSection = screen.getByRole('heading', { name: 'Spans (2)' }).closest('section');
+    expect(treeSection).not.toBeNull();
+    expect(within(treeSection!).queryByText('42 tokens')).not.toBeInTheDocument();
+    expect(within(treeSection!).queryByText('$0.05')).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Show metrics' }));
 
-    expect(screen.getByText('42 tokens')).toBeInTheDocument();
-    expect(screen.getByText('$0.05')).toBeInTheDocument();
+    expect(within(treeSection!).getByText('42 tokens')).toBeInTheDocument();
+    expect(within(treeSection!).getByText('$0.05')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Show metrics' }));
 
-    expect(screen.queryByText('42 tokens')).not.toBeInTheDocument();
-    expect(screen.queryByText('$0.05')).not.toBeInTheDocument();
+    expect(within(treeSection!).queryByText('42 tokens')).not.toBeInTheDocument();
+    expect(within(treeSection!).queryByText('$0.05')).not.toBeInTheDocument();
   });
 
   it('confirms before expand all when the projected reveal cost exceeds the threshold', async () => {
@@ -1164,6 +1302,88 @@ describe('TraceDetailPage', () => {
       within(screen.getByLabelText('Span breadcrumb')).getByText('Running child')
     ).toBeInTheDocument();
     expect(view.router.state.location.search).toBe('?span=running-child');
+  }, 10000);
+
+  it('re-derives the running-trace cost strip from the existing polling refresh without adding a new polling path', async () => {
+    const runningTraceDetail = createRunningTraceDetail({
+      total_cost_usd: 0.05,
+    });
+    const completedCostSpan = createSpan({
+      span_id: 'cost-completed',
+      name: 'Completed cost span',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:00.000Z',
+      ended_at: '2026-03-14T10:00:02.000Z',
+      latency_ms: 2000,
+      cost_usd: 0.05,
+    });
+    const runningSpanInitial = createSpan({
+      span_id: 'cost-running',
+      name: 'Running cost span',
+      parent_span_id: completedCostSpan.span_id,
+      status: 'STARTED',
+      started_at: '2026-03-14T10:00:02.000Z',
+      latency_ms: 1000,
+    });
+    const runningSpanCompleted = {
+      ...runningSpanInitial,
+      status: 'COMPLETED' as const,
+      ended_at: '2026-03-14T10:00:04.000Z',
+      latency_ms: 2000,
+      cost_usd: 0.12,
+    };
+    let currentSpans = [completedCostSpan, runningSpanInitial];
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(runningTraceDetail),
+        spans: () => jsonResponse({ spans: currentSpans }),
+        timeline: (url) =>
+          jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+            poll_cursor: url.searchParams.get('after') ?? 'cursor-running',
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    const waterfallSection = (
+      await screen.findByRole('heading', { name: 'Execution Waterfall' })
+    ).closest('section');
+    expect(waterfallSection).not.toBeNull();
+    expect(within(waterfallSection!).getByText('Cumulative cost')).toBeInTheDocument();
+    expect(within(waterfallSection!).getByLabelText('Cumulative cost chart')).toBeInTheDocument();
+    expect(within(waterfallSection!).getAllByText('$0.05').length).toBeGreaterThan(0);
+    expect(within(waterfallSection!).getByText('Partial')).toBeInTheDocument();
+
+    fetchMock.mockClear();
+    currentSpans = [completedCostSpan, runningSpanCompleted];
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3100));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('$0.17')).toBeInTheDocument();
+    });
+    expect(within(waterfallSection!).getByText('Partial')).toBeInTheDocument();
+
+    const polledPaths = new Set(
+      fetchMock.mock.calls.map(([input]) => {
+        const url = new URL(readRequestUrl(input), 'http://localhost');
+        return url.pathname;
+      })
+    );
+
+    expect(polledPaths).toEqual(
+      new Set([
+        `/api/traces/${TRACE_ONE.id}/events`,
+        `/api/traces/${TRACE_ONE.id}/spans`,
+      ])
+    );
   }, 10000);
 
   it('keeps failed-trace retry-safety surfaces stable when timeline data refreshes with only non-effect updates', async () => {

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -25,6 +25,7 @@ import { ExecutionWaterfall } from '../components/ExecutionWaterfall';
 import { FailureSummary } from '../components/FailureSummary';
 import { InspectorTabs } from '../components/InspectorTabs';
 import { JsonViewer } from '../components/JsonViewer';
+import { ReasoningTab } from '../components/ReasoningTab';
 import { SpanDetail } from '../components/SpanDetail';
 import { StateDiffViewer } from '../components/StateDiffViewer';
 import { StatusBadge } from '../components/StatusBadge';
@@ -60,6 +61,11 @@ import {
 } from '../utils/failureAnalysis';
 import { getWaitDetails } from '../utils/eventSemantics';
 import { extractStateChanges } from '../utils/stateChanges';
+import {
+  buildReasoningEntries,
+  buildTraceCostSeries,
+  type TraceCostSeries,
+} from '../utils/reasoning';
 import { serializeSpanParam } from '../utils/traceDetailSearchParams';
 import type { WaitStallAssessment } from '../utils/waitStallAnalysis';
 import {
@@ -139,6 +145,10 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
     () => extractStateChanges(timeline.events),
     [timeline.events]
   );
+  const reasoningEntries = useMemo(
+    () => buildReasoningEntries(timeline.events, spans),
+    [spans, timeline.events]
+  );
   const returnTo = getReturnToDestination(location.state);
   const spanIndex = useMemo(() => buildSpanIndex(spans), [spans]);
   const failureAnalysis = useMemo(
@@ -187,6 +197,10 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
   const visibleRetrySafetyAssessments = showRetrySafety
     ? retrySafetyAnalysis.spanAssessments
     : EMPTY_RETRY_SAFETY_ASSESSMENTS;
+  const traceCostSeries = useMemo(
+    () => buildTraceCostSeries(spans, timelineStatus),
+    [spans, timelineStatus]
+  );
 
   const handleSelectSpan = useCallback((spanId: string) => {
     selectSpan(spanId);
@@ -293,6 +307,12 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
       spanIndex={spanIndex}
     />
   );
+  const reasoningContent = (
+    <ReasoningTab
+      entries={reasoningEntries}
+      onSelectSpan={handleSelectSpanAndShowDetails}
+    />
+  );
   const stateContent = <StateDiffViewer changes={stateChanges} />;
 
   return (
@@ -354,6 +374,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
             revealKey={revealVersion}
             revealPath={revealPath}
             revealTarget={waterfallRevealTarget}
+            reasoningContent={reasoningContent}
             selectedSpanId={selectedSpanExternalId}
             setExpandedSpanIds={setExpandedSpanIds}
             spanAssessments={visibleRetrySafetyAssessments}
@@ -362,6 +383,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
             spans={spans}
             stateChangeCount={stateChanges.length}
             stateContent={stateContent}
+            traceCostSeries={traceCostSeries}
             timelineContent={timelineContent}
             traceEndedAt={trace.ended_at}
             traceStartedAt={trace.started_at}
@@ -390,6 +412,7 @@ interface TraceWorkspaceProps {
   revealKey: number;
   revealPath: ReadonlySet<string>;
   revealTarget: string | null;
+  reasoningContent: ReactNode;
   selectedSpanId: string | null;
   setExpandedSpanIds: Dispatch<SetStateAction<Set<string>>>;
   spanAssessments: ReadonlyMap<string, RetrySafetyAssessment>;
@@ -398,6 +421,7 @@ interface TraceWorkspaceProps {
   spans: Span[];
   stateChangeCount: number;
   stateContent: ReactNode;
+  traceCostSeries: TraceCostSeries | null;
   timelineContent: ReactNode;
   traceEndedAt?: string;
   traceStartedAt?: string;
@@ -421,6 +445,7 @@ function TraceWorkspace({
   revealKey,
   revealPath,
   revealTarget,
+  reasoningContent,
   selectedSpanId,
   setExpandedSpanIds,
   spanAssessments,
@@ -429,6 +454,7 @@ function TraceWorkspace({
   spans,
   stateChangeCount,
   stateContent,
+  traceCostSeries,
   timelineContent,
   traceEndedAt,
   traceStartedAt,
@@ -473,6 +499,7 @@ function TraceWorkspace({
           revealTarget={revealTarget}
           revealVersion={revealKey}
           spans={spans}
+          costSeries={traceCostSeries}
           spanAssessments={spanAssessments}
           traceEndedAt={traceEndedAt}
           traceStartedAt={traceStartedAt}
@@ -481,6 +508,7 @@ function TraceWorkspace({
       inspector={
         <InspectorTabs
           details={detailsContent}
+          reasoning={reasoningContent}
           timeline={timelineContent}
           state={stateContent}
           stateCount={stateChangeCount}
@@ -488,6 +516,7 @@ function TraceWorkspace({
         />
       }
       mobileDetails={detailsContent}
+      mobileReasoning={reasoningContent}
       mobileTimeline={timelineContent}
       mobileState={stateContent}
       activeMobileTab={activeMobileTab}

--- a/web/src/utils/reasoning.test.ts
+++ b/web/src/utils/reasoning.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from 'vitest';
+import { createSpan, createTimelineEvent } from '../test/traceFixtures';
+import {
+  buildReasoningEntries,
+  buildTraceCostSeries,
+} from './reasoning';
+
+describe('buildReasoningEntries', () => {
+  it('filters malformed decisions and falls back to the span lookup when the event name is absent', () => {
+    const span = createSpan({
+      span_id: 'reasoning-span',
+      name: 'Fallback span name',
+    });
+    const validDecision = createTimelineEvent({
+      id: 'valid-decision',
+      span_id: span.span_id,
+      event_type: 'decision',
+      payload: {
+        question: 'Pick a model?',
+        chosen: 'gpt-5.4',
+      },
+    });
+    const malformedDecision = createTimelineEvent({
+      id: 'malformed-decision',
+      span_id: span.span_id,
+      event_type: 'decision',
+      payload: {
+        question: 'Missing chosen field',
+      },
+    });
+    const messageEvent = createTimelineEvent({
+      id: 'plain-message',
+      span_id: span.span_id,
+      event_type: 'message',
+      message: 'not a decision',
+    });
+
+    expect(
+      buildReasoningEntries([malformedDecision, validDecision, messageEvent], [span])
+    ).toEqual([
+      {
+        event: validDecision,
+        spanId: span.span_id,
+        spanName: span.name,
+        question: 'Pick a model?',
+        chosen: 'gpt-5.4',
+        alternatives: undefined,
+        reasoning: undefined,
+      },
+    ]);
+  });
+
+  it('orders cross-span decision entries with the shared compareTimelineEvents comparator', () => {
+    const alphaSpan = createSpan({
+      span_id: 'alpha',
+      name: 'Alpha span',
+    });
+    const betaSpan = createSpan({
+      span_id: 'beta',
+      name: 'Beta span',
+    });
+    const firstDecision = createTimelineEvent({
+      id: 'decision-explicit-earlier-sequence',
+      span_id: betaSpan.span_id,
+      span_name: 'Beta event name',
+      event_type: 'decision',
+      timestamp: '2026-03-14T10:00:02.000Z',
+      source: 'explicit',
+      sequence: 1,
+      payload: {
+        question: 'First explicit decision?',
+        chosen: 'beta',
+      },
+    });
+    const secondDecision = createTimelineEvent({
+      id: 'decision-explicit-later-sequence',
+      span_id: alphaSpan.span_id,
+      span_name: 'Alpha event name',
+      event_type: 'decision',
+      timestamp: '2026-03-14T10:00:02.000Z',
+      source: 'explicit',
+      sequence: 2,
+      payload: {
+        question: 'Second explicit decision?',
+        chosen: 'alpha',
+      },
+    });
+    const syntheticDecision = createTimelineEvent({
+      id: 'decision-synthetic',
+      span_id: alphaSpan.span_id,
+      span_name: 'Synthetic span name',
+      event_type: 'decision',
+      timestamp: '2026-03-14T10:00:02.000Z',
+      source: 'synthetic',
+      payload: {
+        question: 'Synthetic decision?',
+        chosen: 'synthetic',
+      },
+    });
+    const earlierDecision = createTimelineEvent({
+      id: 'decision-earliest',
+      span_id: alphaSpan.span_id,
+      span_name: 'Alpha earliest',
+      event_type: 'decision',
+      timestamp: '2026-03-14T10:00:01.000Z',
+      payload: {
+        question: 'Earliest decision?',
+        chosen: 'first',
+      },
+    });
+
+    const entries = buildReasoningEntries(
+      [syntheticDecision, secondDecision, earlierDecision, firstDecision],
+      [alphaSpan, betaSpan]
+    );
+
+    expect(entries.map((entry) => entry.event.id)).toEqual([
+      earlierDecision.id,
+      firstDecision.id,
+      secondDecision.id,
+      syntheticDecision.id,
+    ]);
+  });
+});
+
+describe('buildTraceCostSeries', () => {
+  it('builds a completed-trace series from terminal cost-bearing spans and ignores non-costed spans', () => {
+    const completedSpan = createSpan({
+      span_id: 'completed-cost',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:00.000Z',
+      ended_at: '2026-03-14T10:00:03.000Z',
+      cost_usd: 0.02,
+    });
+    const failedSpan = createSpan({
+      span_id: 'failed-cost',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:01.000Z',
+      ended_at: '2026-03-14T10:00:04.000Z',
+      cost_usd: 0.03,
+    });
+    const zeroCostSpan = createSpan({
+      span_id: 'zero-cost',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:01.500Z',
+      ended_at: '2026-03-14T10:00:02.000Z',
+      cost_usd: 0,
+    });
+    const runningSpan = createSpan({
+      span_id: 'running-cost',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:00:02.000Z',
+      cost_usd: 0.99,
+    });
+
+    expect(
+      buildTraceCostSeries(
+        [completedSpan, failedSpan, zeroCostSpan, runningSpan],
+        'COMPLETED'
+      )
+    ).toEqual({
+      partial: false,
+      points: [
+        {
+          anchorMs: Date.parse('2026-03-14T10:00:03.000Z'),
+          cumulativeCostUsd: 0.02,
+          incrementalCostUsd: 0.02,
+        },
+        {
+          anchorMs: Date.parse('2026-03-14T10:00:04.000Z'),
+          cumulativeCostUsd: 0.05,
+          incrementalCostUsd: 0.03,
+        },
+      ],
+      totalCostUsd: 0.05,
+    });
+  });
+
+  it('marks running traces as partial and aggregates tied terminal timestamps into a single step', () => {
+    const firstCompletedSpan = createSpan({
+      span_id: 'running-completed-a',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:00.000Z',
+      ended_at: '2026-03-14T10:00:05.000Z',
+      cost_usd: 0.02,
+    });
+    const secondCompletedSpan = createSpan({
+      span_id: 'running-completed-b',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:02.000Z',
+      ended_at: '2026-03-14T10:00:05.000Z',
+      cost_usd: 0.03,
+    });
+    const stillRunningSpan = createSpan({
+      span_id: 'running-live',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:00:03.000Z',
+      cost_usd: 0.5,
+    });
+
+    expect(
+      buildTraceCostSeries(
+        [firstCompletedSpan, secondCompletedSpan, stillRunningSpan],
+        'RUNNING'
+      )
+    ).toEqual({
+      partial: true,
+      points: [
+        {
+          anchorMs: Date.parse('2026-03-14T10:00:05.000Z'),
+          cumulativeCostUsd: 0.05,
+          incrementalCostUsd: 0.05,
+        },
+      ],
+      totalCostUsd: 0.05,
+    });
+  });
+
+  it('uses started_at when a terminal span is missing ended_at', () => {
+    const terminalWithoutEnd = createSpan({
+      span_id: 'fallback-anchor',
+      status: 'COMPLETED',
+      started_at: '2026-03-14T10:00:07.000Z',
+      ended_at: undefined,
+      cost_usd: 0.04,
+    });
+
+    expect(buildTraceCostSeries([terminalWithoutEnd], 'COMPLETED')).toEqual({
+      partial: false,
+      points: [
+        {
+          anchorMs: Date.parse('2026-03-14T10:00:07.000Z'),
+          cumulativeCostUsd: 0.04,
+          incrementalCostUsd: 0.04,
+        },
+      ],
+      totalCostUsd: 0.04,
+    });
+  });
+
+  it('returns null for traces without any terminal non-zero cost data', () => {
+    const zeroCostSpan = createSpan({
+      span_id: 'zero-cost',
+      status: 'COMPLETED',
+      cost_usd: 0,
+    });
+    const undefinedCostSpan = createSpan({
+      span_id: 'undefined-cost',
+      status: 'FAILED',
+      cost_usd: undefined,
+    });
+    const runningCostSpan = createSpan({
+      span_id: 'ignored-running-cost',
+      status: 'STARTED',
+      cost_usd: 0.3,
+    });
+
+    expect(
+      buildTraceCostSeries(
+        [zeroCostSpan, undefinedCostSpan, runningCostSpan],
+        'RUNNING'
+      )
+    ).toBeNull();
+  });
+});

--- a/web/src/utils/reasoning.ts
+++ b/web/src/utils/reasoning.ts
@@ -29,30 +29,32 @@ export function buildReasoningEntries(
   spans: Span[]
 ): DecisionTraceEntry[] {
   const spanNamesById = new Map(spans.map((span) => [span.span_id, span.name]));
+  const entries: DecisionTraceEntry[] = [];
 
-  return events
-    .map((event) => {
-      const decision = getDecisionDetails(event);
-      if (!decision) {
-        return null;
-      }
+  for (const event of events) {
+    const decision = getDecisionDetails(event);
+    if (!decision) {
+      continue;
+    }
 
-      return {
-        event,
-        spanId: event.span_id ?? null,
-        spanName:
-          getNonEmptyString(event.span_name) ??
-          (event.span_id ? spanNamesById.get(event.span_id) : null) ??
-          event.span_id ??
-          'Unknown span',
-        question: decision.question,
-        chosen: decision.chosen,
-        alternatives: decision.alternatives,
-        reasoning: decision.reasoning,
-      };
-    })
-    .filter((entry): entry is DecisionTraceEntry => entry !== null)
-    .sort((left, right) => compareTimelineEvents(left.event, right.event));
+    entries.push({
+      event,
+      spanId: event.span_id ?? null,
+      spanName:
+        getNonEmptyString(event.span_name) ??
+        (event.span_id ? spanNamesById.get(event.span_id) : null) ??
+        event.span_id ??
+        'Unknown span',
+      question: decision.question,
+      chosen: decision.chosen,
+      alternatives: decision.alternatives,
+      reasoning: decision.reasoning,
+    });
+  }
+
+  return entries.sort((left, right) =>
+    compareTimelineEvents(left.event, right.event)
+  );
 }
 
 export function buildTraceCostSeries(

--- a/web/src/utils/reasoning.ts
+++ b/web/src/utils/reasoning.ts
@@ -1,0 +1,128 @@
+import type { Span, TimelineEvent, TimelineTraceStatus } from '../api/client';
+import { getDecisionDetails } from './eventSemantics';
+import { compareTimelineEvents } from './timeline';
+
+export interface DecisionTraceEntry {
+  event: TimelineEvent;
+  spanId: string | null;
+  spanName: string;
+  question: string;
+  chosen: unknown;
+  alternatives?: unknown[];
+  reasoning?: string;
+}
+
+export interface TraceCostPoint {
+  anchorMs: number;
+  cumulativeCostUsd: number;
+  incrementalCostUsd: number;
+}
+
+export interface TraceCostSeries {
+  partial: boolean;
+  points: TraceCostPoint[];
+  totalCostUsd: number;
+}
+
+export function buildReasoningEntries(
+  events: TimelineEvent[],
+  spans: Span[]
+): DecisionTraceEntry[] {
+  const spanNamesById = new Map(spans.map((span) => [span.span_id, span.name]));
+
+  return events
+    .map((event) => {
+      const decision = getDecisionDetails(event);
+      if (!decision) {
+        return null;
+      }
+
+      return {
+        event,
+        spanId: event.span_id ?? null,
+        spanName:
+          getNonEmptyString(event.span_name) ??
+          (event.span_id ? spanNamesById.get(event.span_id) : null) ??
+          event.span_id ??
+          'Unknown span',
+        question: decision.question,
+        chosen: decision.chosen,
+        alternatives: decision.alternatives,
+        reasoning: decision.reasoning,
+      };
+    })
+    .filter((entry): entry is DecisionTraceEntry => entry !== null)
+    .sort((left, right) => compareTimelineEvents(left.event, right.event));
+}
+
+export function buildTraceCostSeries(
+  spans: Span[],
+  traceStatus: TimelineTraceStatus | null
+): TraceCostSeries | null {
+  const incrementByAnchorMs = new Map<number, number>();
+
+  for (const span of spans) {
+    if (!isTerminalSpan(span)) {
+      continue;
+    }
+
+    const costUsd =
+      typeof span.cost_usd === 'number' && Number.isFinite(span.cost_usd)
+        ? span.cost_usd
+        : 0;
+    if (costUsd === 0) {
+      continue;
+    }
+
+    const anchorMs = parseTimestamp(span.ended_at ?? span.started_at);
+    if (anchorMs === null) {
+      continue;
+    }
+
+    incrementByAnchorMs.set(
+      anchorMs,
+      (incrementByAnchorMs.get(anchorMs) ?? 0) + costUsd
+    );
+  }
+
+  const sortedAnchors = Array.from(incrementByAnchorMs.entries()).sort(
+    ([leftAnchorMs], [rightAnchorMs]) => leftAnchorMs - rightAnchorMs
+  );
+  if (sortedAnchors.length === 0) {
+    return null;
+  }
+
+  let cumulativeCostUsd = 0;
+  const points = sortedAnchors.map(([anchorMs, incrementalCostUsd]) => {
+    cumulativeCostUsd += incrementalCostUsd;
+
+    return {
+      anchorMs,
+      cumulativeCostUsd,
+      incrementalCostUsd,
+    };
+  });
+
+  return {
+    partial: traceStatus === 'RUNNING',
+    points,
+    totalCostUsd: cumulativeCostUsd,
+  };
+}
+
+function isTerminalSpan(span: Span): boolean {
+  return span.status === 'COMPLETED' || span.status === 'FAILED';
+}
+
+function parseTimestamp(value: string | undefined | null): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function getNonEmptyString(value: string | undefined): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}

--- a/web/src/utils/timeline.ts
+++ b/web/src/utils/timeline.ts
@@ -97,6 +97,15 @@ export function summarizeTimelineEvent(event: TimelineEvent): string {
   }
 }
 
+export function formatTimelineTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
 function formatMetricSummary(event: TimelineEvent): string {
   const metricName =
     typeof event.payload?.metric_name === 'string' ? event.payload.metric_name : null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Reasoning tab (desktop + mobile) showing trace-level decision events with click/keyboard navigation to the originating span
  * Added a cumulative cost strip above the waterfall (step chart), with "Partial" indicator for running traces and hidden for zero-cost traces
  * Added per-row inline token and cost annotations for spans with non-zero values while keeping uniform row height

* **Documentation**
  * Added specs and implementation tasks detailing Reasoning and cost-surface behavior

* **Tests**
  * Added unit and integration tests covering reasoning entries, cost series, UI rendering, and interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->