### PR TITLE
Implement execution state enrichment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ setup: ## Install all dependencies
 	@echo "==> Installing Node.js dependencies..."
 	pnpm install
 	@echo "==> Installing Python SDK dependencies..."
-	cd sdks/python && uv sync --all-extras
+	cd sdks/python && uv sync
 	@echo "✅ Setup complete"
 
 # ============================================================================

--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -81,16 +81,17 @@ const (
 
 // Defines values for IngestEventType.
 const (
-	IngestEventTypeCustom      IngestEventType = "custom"
-	IngestEventTypeDecision    IngestEventType = "decision"
-	IngestEventTypeEffect      IngestEventType = "effect"
-	IngestEventTypeError       IngestEventType = "error"
-	IngestEventTypeException   IngestEventType = "exception"
-	IngestEventTypeLog         IngestEventType = "log"
-	IngestEventTypeMessage     IngestEventType = "message"
-	IngestEventTypeMetric      IngestEventType = "metric"
-	IngestEventTypeStateChange IngestEventType = "state_change"
-	IngestEventTypeWait        IngestEventType = "wait"
+	IngestEventTypeCustom         IngestEventType = "custom"
+	IngestEventTypeDecision       IngestEventType = "decision"
+	IngestEventTypeEffect         IngestEventType = "effect"
+	IngestEventTypeError          IngestEventType = "error"
+	IngestEventTypeException      IngestEventType = "exception"
+	IngestEventTypeLog            IngestEventType = "log"
+	IngestEventTypeMessage        IngestEventType = "message"
+	IngestEventTypeMetric         IngestEventType = "metric"
+	IngestEventTypeSnapshotMarker IngestEventType = "snapshot_marker"
+	IngestEventTypeStateChange    IngestEventType = "state_change"
+	IngestEventTypeWait           IngestEventType = "wait"
 )
 
 // Defines values for IngestResponseStatus.
@@ -182,19 +183,20 @@ const (
 
 // Defines values for TimelineEventType.
 const (
-	TimelineEventTypeCustom        TimelineEventType = "custom"
-	TimelineEventTypeDecision      TimelineEventType = "decision"
-	TimelineEventTypeEffect        TimelineEventType = "effect"
-	TimelineEventTypeError         TimelineEventType = "error"
-	TimelineEventTypeException     TimelineEventType = "exception"
-	TimelineEventTypeLog           TimelineEventType = "log"
-	TimelineEventTypeMessage       TimelineEventType = "message"
-	TimelineEventTypeMetric        TimelineEventType = "metric"
-	TimelineEventTypeSpanCompleted TimelineEventType = "span_completed"
-	TimelineEventTypeSpanFailed    TimelineEventType = "span_failed"
-	TimelineEventTypeSpanStarted   TimelineEventType = "span_started"
-	TimelineEventTypeStateChange   TimelineEventType = "state_change"
-	TimelineEventTypeWait          TimelineEventType = "wait"
+	TimelineEventTypeCustom         TimelineEventType = "custom"
+	TimelineEventTypeDecision       TimelineEventType = "decision"
+	TimelineEventTypeEffect         TimelineEventType = "effect"
+	TimelineEventTypeError          TimelineEventType = "error"
+	TimelineEventTypeException      TimelineEventType = "exception"
+	TimelineEventTypeLog            TimelineEventType = "log"
+	TimelineEventTypeMessage        TimelineEventType = "message"
+	TimelineEventTypeMetric         TimelineEventType = "metric"
+	TimelineEventTypeSnapshotMarker TimelineEventType = "snapshot_marker"
+	TimelineEventTypeSpanCompleted  TimelineEventType = "span_completed"
+	TimelineEventTypeSpanFailed     TimelineEventType = "span_failed"
+	TimelineEventTypeSpanStarted    TimelineEventType = "span_started"
+	TimelineEventTypeStateChange    TimelineEventType = "state_change"
+	TimelineEventTypeWait           TimelineEventType = "wait"
 )
 
 // Defines values for TimelineResponseTraceStatus.
@@ -388,7 +390,7 @@ type IngestEventInput struct {
 	Level          *IngestEventLevel `json:"level,omitempty"`
 	Message        *string           `json:"message,omitempty"`
 
-	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`; `snapshot_marker` is a debugger milestone event, not a checkpoint or resumability primitive, and conventionally uses `marker_kind` (a non-empty string; default vocabulary `milestone`) and `label` (a human-facing marker label).
 	Payload  *map[string]interface{} `json:"payload,omitempty"`
 	Sequence *int32                  `json:"sequence,omitempty"`
 

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -574,7 +574,7 @@ export interface components {
             depth?: number;
         };
         /** @enum {string} */
-        IngestEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision" | "effect" | "wait";
+        IngestEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision" | "effect" | "wait" | "snapshot_marker";
         /** @enum {string} */
         IngestEventLevel: "debug" | "info" | "warning" | "error";
         IngestEventInput: {
@@ -591,14 +591,14 @@ export interface components {
             /** Format: int32 */
             sequence?: number;
             message?: string;
-            /** @description Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+            /** @description Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`; `snapshot_marker` is a debugger milestone event, not a checkpoint or resumability primitive, and conventionally uses `marker_kind` (a non-empty string; default vocabulary `milestone`) and `label` (a human-facing marker label).
              *      */
             payload?: Record<string, never>;
             /** @description Optional key for event-level deduplication */
             idempotency_key?: string;
         };
         /** @enum {string} */
-        TimelineEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision" | "effect" | "wait" | "span_started" | "span_completed" | "span_failed";
+        TimelineEventType: "log" | "error" | "exception" | "message" | "metric" | "custom" | "state_change" | "decision" | "effect" | "wait" | "snapshot_marker" | "span_started" | "span_completed" | "span_failed";
         /** @enum {string} */
         TimelineEventSource: "explicit" | "synthetic";
         /** @enum {string} */

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -1341,6 +1341,7 @@ components:
         - decision
         - effect
         - wait
+        - snapshot_marker
     IngestEventLevel:
       type: string
       enum:
@@ -1379,7 +1380,7 @@ components:
         payload:
           type: object
           description: |
-            Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+            Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`; `snapshot_marker` is a debugger milestone event, not a checkpoint or resumability primitive, and conventionally uses `marker_kind` (a non-empty string; default vocabulary `milestone`) and `label` (a human-facing marker label).
         idempotency_key:
           type: string
           description: Optional key for event-level deduplication
@@ -1396,6 +1397,7 @@ components:
         - decision
         - effect
         - wait
+        - snapshot_marker
         - span_started
         - span_completed
         - span_failed

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -1256,7 +1256,7 @@ components:
 
     IngestEventType:
       type: string
-      enum: [log, error, exception, message, metric, custom, state_change, decision, effect, wait]
+      enum: [log, error, exception, message, metric, custom, state_change, decision, effect, wait, snapshot_marker]
 
     IngestEventLevel:
       type: string
@@ -1295,7 +1295,10 @@ components:
             `effect` may include reserved `effect_id`;
             `wait` may include reserved `wait_id`;
             `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`;
-            `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+            `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`;
+            `snapshot_marker` is a debugger milestone event, not a checkpoint or resumability primitive,
+            and conventionally uses `marker_kind` (a non-empty string; default vocabulary `milestone`)
+            and `label` (a human-facing marker label).
         idempotency_key:
           type: string
           description: Optional key for event-level deduplication
@@ -1314,6 +1317,7 @@ components:
           decision,
           effect,
           wait,
+          snapshot_marker,
           span_started,
           span_completed,
           span_failed,

--- a/docs/event-conventions.md
+++ b/docs/event-conventions.md
@@ -12,6 +12,7 @@ Use them to explain what happened during trace execution, not to model checkpoin
 - Use `decision` when the system chooses between alternatives and the debugger should show the branch point and rationale.
 - Use `effect` when the span performs an external action or model invocation that matters for debugging.
 - Use `wait` when progress is blocked on a human, external dependency, timer, or similar resolution outside the current span's direct control.
+- Use `snapshot_marker` when you want a first-class debugger milestone with a compact label and category.
 - Use `message` for lightweight narrative milestones.
 - Use `log`, `error`, and `exception` for operational logging and failures.
 - Use `metric` for structured numeric measurements.
@@ -31,6 +32,7 @@ Use them to explain what happened during trace execution, not to model checkpoin
 | `decision` | Branch point or choice with a selected outcome | `question`, `chosen`, optional `alternatives`, optional `reasoning` | `info` |
 | `effect` | External side effect, tool call, or model invocation worth surfacing in the debugger | `effect_kind`, `has_external_side_effect`, optional `effect_id`, optional `idempotent`, optional `idempotency_key` | `info` |
 | `wait` | Blocked or deferred progress that depends on later resolution | `wait_kind`, `phase`, optional `wait_id`, optional `resolution` | `info` |
+| `snapshot_marker` | Debugger milestone worth surfacing as a dedicated timeline semantic | `marker_kind`, `label`, plus any optional contextual payload | `info` |
 
 `message` and `custom` remain supported event types in this phase, but the Python SDK does not add dedicated `span.message()` or `span.custom()` helpers yet.
 
@@ -196,11 +198,40 @@ with span("review_order") as s:
     )
 ```
 
+### `snapshot_marker`
+
+Use `snapshot_marker` when the important debugging fact is that execution reached a notable milestone and you want that milestone to stay semantically distinct from generic logs or messages.
+
+Recommended payload shape:
+
+```json
+{
+  "marker_kind": "milestone",
+  "label": "Validation passed"
+}
+```
+
+- `marker_kind` is a conventionally required non-empty string. Start with `milestone` unless you have a clearer debugger-oriented vocabulary such as `phase` or `handoff`.
+- `label` is conventionally required and should be the human-facing marker text shown in the timeline.
+- `snapshot_marker` is a debugger milestone event, not a checkpoint, resume token, or replay primitive.
+
+Python SDK example:
+
+```python
+with span("checkout_flow") as s:
+    s.snapshot_marker(
+        "Inventory reserved",
+        marker_kind="phase",
+        payload={"reservation_id": "res-42"},
+    )
+```
+
 ## Quick Heuristics
 
 - If you want the debugger to show `old → new`, emit `state_change`.
 - If you want the debugger to show `question → chosen`, emit `decision`.
 - If you want the debugger to show "this span called out to something important", emit `effect`.
 - If you want the debugger to show "this span had to wait", emit `wait`.
+- If you want the debugger to show "execution reached this milestone", emit `snapshot_marker`.
 - If you only need a human-readable sentence, emit `message`.
 - If you need a free-form payload with no special UI, emit `custom`.

--- a/internal/api/ingest_handlers_test.go
+++ b/internal/api/ingest_handlers_test.go
@@ -199,6 +199,58 @@ func TestIngest_SyncTrueAcceptsUnknownExplicitEventType(t *testing.T) {
 	assert.Equal(t, "workflow_step", events[0].EventType)
 }
 
+func TestIngest_SyncSnapshotMarkerRoundTripsThroughTimeline(t *testing.T) {
+	server, _, q, projectID := newAsyncIngestServer(t)
+	traceID := "trace-" + uuid.NewString()[:8]
+	startTime := time.Now().UTC().Format(time.RFC3339Nano)
+	sync := true
+
+	rec := invokeIngest(
+		t,
+		server,
+		projectID,
+		`{
+			"batch_key":"batch-snapshot-marker",
+			"traces":[{"trace_id":"`+traceID+`","name":"snapshot marker trace"}],
+			"spans":[{"trace_id":"`+traceID+`","span_id":"span-1","name":"snapshot marker span","start_time":"`+startTime+`"}],
+			"events":[{"trace_id":"`+traceID+`","span_id":"span-1","event_type":"snapshot_marker","payload":{}}]
+		}`,
+		IngestParams{Sync: &sync},
+		nil,
+	)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeJSONBody[IngestResponse](t, rec)
+	assert.Equal(t, IngestResponseStatusOk, resp.Status)
+	require.NotNil(t, resp.EventCount)
+	assert.Equal(t, int32(1), *resp.EventCount)
+
+	trace, err := q.GetTraceByExternalID(context.Background(), platform.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   traceID,
+	})
+	require.NoError(t, err)
+
+	timelineRec := invokeGetTraceEvents(t, server, projectID, trace.ID, GetTraceEventsParams{
+		Limit: testutil.IntPtr(100),
+	})
+	require.Equal(t, http.StatusOK, timelineRec.Code)
+
+	timelineResp := decodeJSONBody[TimelineResponse](t, timelineRec)
+	snapshotEvents := make([]TimelineEvent, 0, len(timelineResp.Events))
+	for _, event := range timelineResp.Events {
+		if event.EventType == TimelineEventTypeSnapshotMarker {
+			snapshotEvents = append(snapshotEvents, event)
+		}
+	}
+
+	require.Len(t, snapshotEvents, 1)
+	assert.Equal(t, Explicit, snapshotEvents[0].Source)
+	assert.Equal(t, "span-1", *snapshotEvents[0].SpanId)
+	assert.NotNil(t, snapshotEvents[0].Payload)
+	assert.Empty(t, *snapshotEvents[0].Payload)
+}
+
 func TestIngest_InvalidAsyncVersionReturnsBadRequest(t *testing.T) {
 	server, _, _, projectID := newAsyncIngestServer(t)
 

--- a/internal/api/mapper.go
+++ b/internal/api/mapper.go
@@ -680,6 +680,8 @@ func mapExplicitTimelineEventType(eventType string) (TimelineEventType, bool) {
 		return TimelineEventTypeEffect, true
 	case "wait":
 		return TimelineEventTypeWait, true
+	case "snapshot_marker":
+		return TimelineEventTypeSnapshotMarker, true
 	default:
 		return TimelineEventTypeCustom, false
 	}

--- a/internal/api/mapper_timeline_test.go
+++ b/internal/api/mapper_timeline_test.go
@@ -40,6 +40,11 @@ func TestExplicitTimelineEventToAPI_PreservesSemanticEventTypes(t *testing.T) {
 			eventType: "wait",
 			expected:  TimelineEventTypeWait,
 		},
+		{
+			name:      "snapshot_marker",
+			eventType: "snapshot_marker",
+			expected:  TimelineEventTypeSnapshotMarker,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -81,16 +81,17 @@ const (
 
 // Defines values for IngestEventType.
 const (
-	IngestEventTypeCustom      IngestEventType = "custom"
-	IngestEventTypeDecision    IngestEventType = "decision"
-	IngestEventTypeEffect      IngestEventType = "effect"
-	IngestEventTypeError       IngestEventType = "error"
-	IngestEventTypeException   IngestEventType = "exception"
-	IngestEventTypeLog         IngestEventType = "log"
-	IngestEventTypeMessage     IngestEventType = "message"
-	IngestEventTypeMetric      IngestEventType = "metric"
-	IngestEventTypeStateChange IngestEventType = "state_change"
-	IngestEventTypeWait        IngestEventType = "wait"
+	IngestEventTypeCustom         IngestEventType = "custom"
+	IngestEventTypeDecision       IngestEventType = "decision"
+	IngestEventTypeEffect         IngestEventType = "effect"
+	IngestEventTypeError          IngestEventType = "error"
+	IngestEventTypeException      IngestEventType = "exception"
+	IngestEventTypeLog            IngestEventType = "log"
+	IngestEventTypeMessage        IngestEventType = "message"
+	IngestEventTypeMetric         IngestEventType = "metric"
+	IngestEventTypeSnapshotMarker IngestEventType = "snapshot_marker"
+	IngestEventTypeStateChange    IngestEventType = "state_change"
+	IngestEventTypeWait           IngestEventType = "wait"
 )
 
 // Defines values for IngestResponseStatus.
@@ -182,19 +183,20 @@ const (
 
 // Defines values for TimelineEventType.
 const (
-	TimelineEventTypeCustom        TimelineEventType = "custom"
-	TimelineEventTypeDecision      TimelineEventType = "decision"
-	TimelineEventTypeEffect        TimelineEventType = "effect"
-	TimelineEventTypeError         TimelineEventType = "error"
-	TimelineEventTypeException     TimelineEventType = "exception"
-	TimelineEventTypeLog           TimelineEventType = "log"
-	TimelineEventTypeMessage       TimelineEventType = "message"
-	TimelineEventTypeMetric        TimelineEventType = "metric"
-	TimelineEventTypeSpanCompleted TimelineEventType = "span_completed"
-	TimelineEventTypeSpanFailed    TimelineEventType = "span_failed"
-	TimelineEventTypeSpanStarted   TimelineEventType = "span_started"
-	TimelineEventTypeStateChange   TimelineEventType = "state_change"
-	TimelineEventTypeWait          TimelineEventType = "wait"
+	TimelineEventTypeCustom         TimelineEventType = "custom"
+	TimelineEventTypeDecision       TimelineEventType = "decision"
+	TimelineEventTypeEffect         TimelineEventType = "effect"
+	TimelineEventTypeError          TimelineEventType = "error"
+	TimelineEventTypeException      TimelineEventType = "exception"
+	TimelineEventTypeLog            TimelineEventType = "log"
+	TimelineEventTypeMessage        TimelineEventType = "message"
+	TimelineEventTypeMetric         TimelineEventType = "metric"
+	TimelineEventTypeSnapshotMarker TimelineEventType = "snapshot_marker"
+	TimelineEventTypeSpanCompleted  TimelineEventType = "span_completed"
+	TimelineEventTypeSpanFailed     TimelineEventType = "span_failed"
+	TimelineEventTypeSpanStarted    TimelineEventType = "span_started"
+	TimelineEventTypeStateChange    TimelineEventType = "state_change"
+	TimelineEventTypeWait           TimelineEventType = "wait"
 )
 
 // Defines values for TimelineResponseTraceStatus.
@@ -388,7 +390,7 @@ type IngestEventInput struct {
 	Level          *IngestEventLevel `json:"level,omitempty"`
 	Message        *string           `json:"message,omitempty"`
 
-	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.
+	// Payload Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`; `snapshot_marker` is a debugger milestone event, not a checkpoint or resumability primitive, and conventionally uses `marker_kind` (a non-empty string; default vocabulary `milestone`) and `label` (a human-facing marker label).
 	Payload  *map[string]interface{} `json:"payload,omitempty"`
 	Sequence *int32                  `json:"sequence,omitempty"`
 

--- a/openspec/changes/add-execution-state-enrichment/design.md
+++ b/openspec/changes/add-execution-state-enrichment/design.md
@@ -1,0 +1,63 @@
+## Context
+
+Phase 9 enriches two existing debugger surfaces without introducing new backend schema, migrations, or runtime semantics. The two tracks — unresolved-wait rows and `snapshot_marker` — are independent but ship together because both extend the trace-detail experience for running traces.
+
+Existing foundations:
+- `computeOpenWaits()` in `web/src/utils/waitStallAnalysis.ts` already derives paired/unpaired open waits from timeline events
+- `classifyRunningTrace()` and `useWaitStallAnalysis` already power the `RunningStatePanel` summary
+- The semantic event pipeline (contract -> mapper -> timeline -> frontend) is proven for `state_change`, `decision`, `effect`, and `wait`
+
+## Goals / Non-Goals
+
+- Goals:
+  - Surface all unresolved waits in the running-state panel so operators see the full wait picture
+  - Add `snapshot_marker` as a first-class debugger milestone type end-to-end
+  - Keep changes read-only and debugger-scoped
+
+- Non-Goals:
+  - Turn Lens or turn-boundary semantics
+  - Session-level marker surfaces or compare-time marker logic
+  - DB schema changes or new store queries
+  - Checkpoint/resume/replay semantics for markers
+  - Ingest-time validation warnings for snapshot_marker payloads
+  - Waterfall overlay or milestone aggregation views
+
+## Decisions
+
+### 1. `snapshot_marker` is convention-documented, not schema-enforced
+- `marker_kind` and `label` are documented as conventionally required but not OpenAPI-required
+- Raw callers omitting them get generic rendering, not ingest rejection
+- This matches the existing permissive ingest model for `effect`, `wait`, `state_change`, `decision`
+- Alternative considered: schema-required fields — rejected because it would break the established permissive pattern and add ingest-time validation for a debugger-only event type
+
+### 2. Unresolved-wait rows reuse `computeOpenWaits()` unchanged
+- The existing function already handles `wait_id` pairing, anonymous waits, and phase filtering
+- `TraceDetailPage` derives `openWaits` via `useMemo` and passes the array to `RunningStatePanel`
+- Alternative considered: new dedicated hook — rejected because the computation is a simple `useMemo` over already-available data and doesn't need its own stability/caching logic beyond what `useMemo` provides
+
+### 3. Open-wait duration refresh uses existing poll cadence only
+- No `setInterval` or `requestAnimationFrame` for duration updates
+- Durations refresh when the timeline poll returns new data and triggers re-render
+- This avoids timer proliferation and matches the existing `useWaitStallAnalysis` timing model
+- Alternative considered: per-second timer for live-updating durations — rejected because it adds complexity and visual noise without improving debugging actionability
+
+### 4. `snapshot_marker` included in Semantic filter, no new filter mode
+- `snapshot_marker` joins `state_change`, `decision`, `effect`, `wait` in the existing `Semantic` filter
+- No dedicated "Milestones" filter mode
+- Alternative considered: separate filter — rejected because milestone events are expected to be infrequent and adding a fourth filter mode fragments the UI for minimal benefit
+
+### 5. No backend ingest warnings for `snapshot_marker`
+- `state_change` and `decision` have processor warnings for missing semantic fields
+- `snapshot_marker` skips this because: marker_kind/label are convention, not contract; the frontend gracefully degrades malformed markers; and adding ingest-time log warnings for a single optional type adds maintenance cost without user benefit
+- Alternative considered: parity with state_change warnings — rejected for the reasons above
+
+## Risks / Trade-offs
+
+- **Risk:** `snapshot_marker` payloads vary widely across teams
+  - Mitigation: well-formed/malformed distinction in frontend extraction; generic fallback rendering for anything that doesn't have both `marker_kind` and `label`
+- **Risk:** many open waits could make `RunningStatePanel` tall
+  - Mitigation: waits are newest-first with the current gate prominent; in practice, traces rarely accumulate many concurrent waits; future phases can add collapsing if needed
+
+## Open Questions
+
+None — scope is intentionally narrow and builds entirely on proven patterns.

--- a/openspec/changes/add-execution-state-enrichment/proposal.md
+++ b/openspec/changes/add-execution-state-enrichment/proposal.md
@@ -1,0 +1,57 @@
+# Change: Add Execution State Enrichment
+
+## Why
+
+The debugger's running-state panel currently shows a single classification summary (e.g. "declared wait", "waiting on model") but hides the full set of unresolved waits behind that summary. Operators debugging a running trace with multiple concurrent wait gates have no way to see which waits are still open, when each was entered, or how long each has been pending. Separately, there is no first-class milestone event type: teams that want to mark notable progress points in a long-running trace must use `custom` events, which lose semantic meaning in the timeline.
+
+This phase adds two focused enrichments to the existing debugger surfaces:
+1. Unresolved-wait rows inside the existing `RunningStatePanel`, derived from the already-implemented `computeOpenWaits()` logic
+2. A new `snapshot_marker` event type that flows from contract through SDK to timeline UI, giving teams a dedicated milestone primitive
+
+## What Changes
+
+### 1. Contract: `snapshot_marker` event type
+- Add `snapshot_marker` to `IngestEventType` and `TimelineEventType` enums in `contracts/openapi/openapi.yaml`
+- Document payload conventions (`marker_kind`, `label`) without making them schema-required
+- State explicitly that `snapshot_marker` is a debugger milestone event, not a checkpoint or resumability primitive
+
+### 2. Backend: mapper passthrough
+- Update `mapExplicitTimelineEventType` in `internal/api/mapper.go` to recognize `snapshot_marker` so it passes through as-is rather than degrading to `custom`
+- No schema, migration, store, or ingest-warning changes
+
+### 3. Python SDK: `snapshot_marker()` helper
+- Add `span.snapshot_marker(label, *, marker_kind="milestone", payload=None, message=None)` in `sdks/python/src/continua/span.py`
+- Reject empty `label` and empty `marker_kind`
+- Default `message` to `label` when omitted
+- Helper-owned payload keys written last to override conflicting caller keys
+
+### 4. Frontend: `snapshot_marker` timeline rendering
+- Add `getSnapshotMarkerDetails()` in `web/src/utils/eventSemantics.ts`
+- Add `snapshot_marker` branch to `summarizeTimelineEvent()` in `web/src/utils/timeline.ts`
+- Add dedicated collapsed-row preview in `Timeline.tsx` with `label` as primary text and `marker_kind` pill
+- Include `snapshot_marker` in the `Semantic` filter mode
+- Add `snapshot_marker` to the manual TypeScript union in `web/src/api/client.ts`
+- Malformed markers (missing `marker_kind` or `label`) fall back to generic timeline rendering
+
+### 5. Frontend: unresolved-wait rows in `RunningStatePanel`
+- Derive `openWaits` once via `useMemo` from the existing `events` array in `TraceDetailPage.tsx`
+- Pass `openWaits` into `RunningStatePanel`
+- Render unresolved-wait rows beneath existing summary content, newest-first
+- Each row shows: gate title (`Approval gate` for `human_approval`, `Wait gate` otherwise), wait kind, entered timestamp, open duration, span jump action, optional `wait_id`, optional message
+- Resolved waits disappear on next poll cycle; anonymous waits without `wait_id` remain as standalone rows
+- Open durations refresh only on existing poll cadence, no separate timer
+
+## Impact
+- Affected specs: `event-taxonomy` (modified), `timeline-ui` (modified), `event-conventions` (modified), `trace-running-state-display` (new), `python-sdk-events` (modified)
+- Affected code:
+  - `contracts/openapi/openapi.yaml` — enum extensions
+  - `internal/api/mapper.go` — snapshot_marker case
+  - `sdks/python/src/continua/span.py` — new helper
+  - `web/src/api/client.ts` — union extension
+  - `web/src/utils/eventSemantics.ts` — new extractor
+  - `web/src/utils/timeline.ts` — new summary branch
+  - `web/src/components/Timeline.tsx` — new preview component, filter update
+  - `web/src/pages/TraceDetailPage.tsx` — openWaits derivation, RunningStatePanel enrichment
+  - `docs/event-conventions.md` — snapshot_marker documentation
+- No DB migrations, engine work, session-level changes, or compare-time logic
+- Turn Lens is deferred entirely

--- a/openspec/changes/add-execution-state-enrichment/specs/event-conventions/spec.md
+++ b/openspec/changes/add-execution-state-enrichment/specs/event-conventions/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Event Convention Documentation
+A `docs/event-conventions.md` document SHALL provide usage-oriented guidance for all supported event types. The document SHALL include a reference table of all explicit event types (including `snapshot_marker`) with expected payload fields and default levels, but its primary focus SHALL be guiding developers on when to use each event type. SDK usage examples SHALL demonstrate real-world patterns. The document SHALL explicitly state: "These are debugger semantics, not replay primitives." The `snapshot_marker` entry SHALL document:
+- `marker_kind`: conventionally required non-empty string with documented default vocabulary `milestone`
+- `label`: conventionally required human-facing marker label
+- That `snapshot_marker` is a debugger milestone event, not a checkpoint or resumability primitive
+
+#### Scenario: Usage guidance for event type selection
+- **WHEN** a developer reads `docs/event-conventions.md`
+- **THEN** they understand when to use `state_change`, `decision`, `custom`, and `snapshot_marker`
+
+#### Scenario: Snapshot marker documentation
+- **WHEN** a developer reads the snapshot_marker section
+- **THEN** they find documented payload conventions for `marker_kind` and `label`
+- **AND** a clear statement that markers are debugger milestones, not checkpoint/resume primitives
+
+#### Scenario: SDK usage examples
+- **WHEN** a developer reads the snapshot_marker section
+- **THEN** they find Python SDK examples showing `span.snapshot_marker()` in a realistic context
+
+#### Scenario: Scope guard present
+- **WHEN** a developer reads the document
+- **THEN** they find a clear statement that these are debugger/observability semantics and not replay or state-machine primitives

--- a/openspec/changes/add-execution-state-enrichment/specs/event-taxonomy/spec.md
+++ b/openspec/changes/add-execution-state-enrichment/specs/event-taxonomy/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Ingest Event Type Enum Extension
+The `IngestEventType` OpenAPI enum SHALL include `snapshot_marker` in addition to the existing values (`log`, `error`, `exception`, `message`, `metric`, `custom`, `state_change`, `decision`, `effect`, `wait`). The `TimelineEventType` enum SHALL include `snapshot_marker` alongside existing explicit and synthetic types.
+
+#### Scenario: Ingest a snapshot_marker event
+- **WHEN** a client sends `POST /v1/ingest` with an event having `event_type: "snapshot_marker"`
+- **THEN** the event is accepted and stored
+- **AND** the event appears in timeline responses with `event_type: "snapshot_marker"`
+
+## ADDED Requirements
+
+### Requirement: Snapshot Marker Backend Passthrough
+The backend mapper SHALL recognize `snapshot_marker` as a valid explicit event type and map it through to the timeline response without degradation. The existing permissive ingest model SHALL apply: any event with `event_type: "snapshot_marker"` is accepted regardless of payload content.
+
+#### Scenario: Mapper recognizes snapshot_marker
+- **WHEN** a stored event has `event_type` value `snapshot_marker`
+- **THEN** `mapExplicitTimelineEventType` returns `snapshot_marker` as a recognized type
+
+#### Scenario: Malformed snapshot_marker accepted and retrievable
+- **WHEN** a `snapshot_marker` event is ingested with an empty payload
+- **THEN** the event is accepted and stored
+- **AND** the event is retrievable via the timeline API with `event_type: "snapshot_marker"`

--- a/openspec/changes/add-execution-state-enrichment/specs/python-sdk-events/spec.md
+++ b/openspec/changes/add-execution-state-enrichment/specs/python-sdk-events/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Python SDK Snapshot Marker Helper
+The Python SDK `Span` class SHALL provide a `snapshot_marker(label, *, marker_kind="milestone", payload=None, message=None)` method that records an event with `event_type: "snapshot_marker"`. The helper SHALL reject empty `label` (raising `ValueError`). The helper SHALL reject empty `marker_kind` (raising `ValueError`). When `message` is omitted or `None`, the helper SHALL default `message` to the `label` value. Helper-owned payload keys (`marker_kind`, `label`) SHALL be written last so they override any conflicting keys in the caller-provided `payload` dict.
+
+#### Scenario: Record a snapshot marker via SDK
+- **WHEN** a user calls `span.snapshot_marker("Data loaded")`
+- **THEN** an event is recorded with `event_type: "snapshot_marker"`, `level: "info"`, and payload `{"marker_kind": "milestone", "label": "Data loaded"}`
+- **AND** the event `message` is `"Data loaded"`
+
+#### Scenario: Record a marker with custom kind
+- **WHEN** a user calls `span.snapshot_marker("Phase 2 complete", marker_kind="phase")`
+- **THEN** the payload includes `{"marker_kind": "phase", "label": "Phase 2 complete"}`
+
+#### Scenario: Record a marker with explicit message
+- **WHEN** a user calls `span.snapshot_marker("Validation passed", message="All input schemas validated successfully")`
+- **THEN** the event message is `"All input schemas validated successfully"`, not `"Validation passed"`
+
+#### Scenario: Record a marker with caller payload
+- **WHEN** a user calls `span.snapshot_marker("Done", payload={"extra": "data", "marker_kind": "wrong"})`
+- **THEN** the payload contains `{"extra": "data", "marker_kind": "milestone", "label": "Done"}`
+- **AND** the helper-owned `marker_kind` overrides the caller's conflicting value
+
+#### Scenario: Reject empty label
+- **WHEN** a user calls `span.snapshot_marker("")`
+- **THEN** a `ValueError` is raised
+
+#### Scenario: Reject empty marker_kind
+- **WHEN** a user calls `span.snapshot_marker("Test", marker_kind="")`
+- **THEN** a `ValueError` is raised
+
+### Requirement: Python SDK Snapshot Marker Docstring
+The Python SDK `Span.snapshot_marker()` method SHALL include a docstring with parameter descriptions, return type, and a usage example.
+
+#### Scenario: Docstring content
+- **WHEN** a developer inspects `span.snapshot_marker` via `help()` or IDE
+- **THEN** they see parameter descriptions for `label`, `marker_kind`, `payload`, and `message`

--- a/openspec/changes/add-execution-state-enrichment/specs/timeline-ui/spec.md
+++ b/openspec/changes/add-execution-state-enrichment/specs/timeline-ui/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Frontend Event Type Updates
+The frontend timeline event type definitions SHALL include `"snapshot_marker"` as a valid event type in the manual TypeScript union in `web/src/api/client.ts`. Timeline event summary logic SHALL return meaningful summaries for `snapshot_marker` events when well-formed.
+
+#### Scenario: Summarize a well-formed snapshot_marker
+- **WHEN** a `snapshot_marker` event has payload `{"marker_kind": "milestone", "label": "Data ingestion complete"}`
+- **THEN** `summarizeTimelineEvent` returns the `label` value as the summary text
+
+#### Scenario: Summarize a malformed snapshot_marker
+- **WHEN** a `snapshot_marker` event is missing `label` or `marker_kind` in its payload
+- **AND** the event has a `message` field
+- **THEN** `summarizeTimelineEvent` returns the `message` value
+
+## ADDED Requirements
+
+### Requirement: Snapshot Marker Payload Extraction
+The frontend SHALL provide a `getSnapshotMarkerDetails()` function in `web/src/utils/eventSemantics.ts` that extracts `marker_kind` and `label` from a `snapshot_marker` event payload. The function SHALL return `null` when the event is not `snapshot_marker` type, or when `marker_kind` or `label` are missing or empty strings.
+
+#### Scenario: Extract well-formed marker details
+- **WHEN** an event has `event_type: "snapshot_marker"` and payload `{"marker_kind": "milestone", "label": "Pipeline ready"}`
+- **THEN** `getSnapshotMarkerDetails` returns `{ markerKind: "milestone", label: "Pipeline ready" }`
+
+#### Scenario: Extract from malformed marker
+- **WHEN** an event has `event_type: "snapshot_marker"` but payload is missing `label`
+- **THEN** `getSnapshotMarkerDetails` returns `null`
+
+#### Scenario: Extract from wrong event type
+- **WHEN** an event has `event_type: "custom"` with payload containing `marker_kind` and `label`
+- **THEN** `getSnapshotMarkerDetails` returns `null`
+
+### Requirement: Snapshot Marker Timeline Row Rendering
+The `Timeline` component SHALL render `snapshot_marker` events with a dedicated collapsed-row preview when the marker is well-formed. The preview SHALL show `label` as primary text and `marker_kind` as a secondary pill. When the marker is malformed (missing `marker_kind` or `label`), the component SHALL fall back to generic timeline row rendering. Payload inspection and span navigation SHALL remain unchanged from existing event row behavior.
+
+#### Scenario: Render well-formed snapshot_marker
+- **WHEN** a timeline contains a `snapshot_marker` event with `marker_kind: "milestone"` and `label: "Data loaded"`
+- **THEN** the Timeline renders a row with "Data loaded" as primary text and a "milestone" pill
+
+#### Scenario: Render malformed snapshot_marker
+- **WHEN** a timeline contains a `snapshot_marker` event without `label` in the payload
+- **THEN** the Timeline renders the event as a generic event row
+
+### Requirement: Snapshot Marker Semantic Filter Inclusion
+The `snapshot_marker` event type SHALL be included in the existing `Semantic` filter mode alongside `state_change`, `decision`, `effect`, and `wait`. No new filter mode SHALL be added for milestone events.
+
+#### Scenario: Semantic filter includes snapshot_marker
+- **WHEN** a user selects the `Semantic` filter mode in the timeline
+- **THEN** `snapshot_marker` events are visible alongside other semantic event types
+- **AND** non-semantic event types (log, error, custom, etc.) are filtered out
+
+#### Scenario: All mode includes snapshot_marker
+- **WHEN** a user views the timeline in `All` mode
+- **THEN** `snapshot_marker` events are visible among all other events

--- a/openspec/changes/add-execution-state-enrichment/specs/trace-running-state-display/spec.md
+++ b/openspec/changes/add-execution-state-enrichment/specs/trace-running-state-display/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Unresolved Wait Rows in Running State Panel
+When a running trace has one or more unresolved (open) waits, the `RunningStatePanel` SHALL display individual unresolved-wait rows beneath the existing summary content. The existing summary behavior (classification label, basis, explanatory copy, timing fields, current-wait field, and decisive jump action) SHALL remain unchanged. Unresolved waits SHALL be derived once via `useMemo` from the existing `events` array using `computeOpenWaits()` in the trace-detail page layer, then passed into `RunningStatePanel`.
+
+#### Scenario: Single unresolved wait displayed
+- **WHEN** a running trace has one open wait event with `wait_kind: "human_approval"`
+- **THEN** the `RunningStatePanel` shows the existing summary content
+- **AND** an unresolved-wait row appears beneath with title "Approval gate"
+
+#### Scenario: No unresolved waits
+- **WHEN** a running trace has no open wait events
+- **THEN** the `RunningStatePanel` shows only the existing summary content without any wait rows
+
+#### Scenario: Non-running trace
+- **WHEN** a trace has terminal status (COMPLETED, FAILED)
+- **THEN** no `RunningStatePanel` or unresolved-wait rows are displayed
+
+### Requirement: Unresolved Wait Row Content
+Each unresolved-wait row SHALL display: a title ("Approval gate" when `wait_kind === "human_approval"`, otherwise "Wait gate"), the `wait_kind` value, the entered timestamp, the open duration, an originating span jump action when span context is available, the `wait_id` when present, and the original event message when present.
+
+#### Scenario: Human approval wait row content
+- **WHEN** an unresolved wait has `wait_kind: "human_approval"`, `wait_id: "approval-123"`, and a message "Awaiting manager sign-off"
+- **THEN** the row shows title "Approval gate", kind "human_approval", the entered timestamp, open duration, wait_id "approval-123", and message "Awaiting manager sign-off"
+
+#### Scenario: Generic wait row content
+- **WHEN** an unresolved wait has `wait_kind: "external_api"` and no `wait_id`
+- **THEN** the row shows title "Wait gate", kind "external_api", entered timestamp, and open duration
+- **AND** no wait_id is displayed
+
+#### Scenario: Wait row with span context
+- **WHEN** an unresolved wait has an associated span via `span_id` in the event
+- **THEN** the row includes a jump action to navigate to the originating span
+
+### Requirement: Unresolved Wait Ordering and Lifecycle
+Unresolved-wait rows SHALL be rendered newest-first so that the first row represents the current gate. When a matching `resolved` wait event arrives on the next poll cycle, the corresponding unresolved-wait row SHALL disappear. Anonymous waits without `wait_id` SHALL remain visible as standalone open-wait rows and SHALL NOT be auto-paired with resolved events. Open durations SHALL refresh only on the existing running-trace poll cadence; no separate interval timer SHALL be introduced.
+
+#### Scenario: Multiple unresolved waits ordered newest-first
+- **WHEN** a running trace has three unresolved waits entered at t=1, t=5, and t=10
+- **THEN** the wait rows appear in order: t=10 (first/top), t=5, t=1 (last/bottom)
+
+#### Scenario: Resolved wait disappears on poll
+- **WHEN** a wait with `wait_id: "w1"` is currently shown as unresolved
+- **AND** a new poll returns a `resolved` event matching `wait_id: "w1"`
+- **THEN** the "w1" unresolved-wait row is no longer displayed
+
+#### Scenario: Anonymous wait remains standalone
+- **WHEN** a wait event has `phase: "entered"` but no `wait_id`
+- **THEN** the wait appears as a standalone unresolved-wait row
+- **AND** it is never auto-paired with any resolved event
+
+#### Scenario: Open duration refreshes on poll only
+- **WHEN** the running-trace poll cadence fires and re-renders the panel
+- **THEN** open durations update to reflect current time
+- **AND** no separate `setInterval` or `requestAnimationFrame` timer is used for duration updates

--- a/openspec/changes/add-execution-state-enrichment/tasks.md
+++ b/openspec/changes/add-execution-state-enrichment/tasks.md
@@ -1,0 +1,57 @@
+## 1. Contract and Code Generation
+
+- [x] 1.1 Add `snapshot_marker` to `IngestEventType` enum in `contracts/openapi/openapi.yaml`
+- [x] 1.2 Add `snapshot_marker` to `TimelineEventType` enum in `contracts/openapi/openapi.yaml`
+- [x] 1.3 Add payload convention descriptions for `snapshot_marker` (`marker_kind`, `label`) in OpenAPI schema
+- [x] 1.4 Run `make generate` and verify generated Go, TypeScript, and Python artifacts include `snapshot_marker`
+
+## 2. Backend Mapper
+
+- [x] 2.1 Add `snapshot_marker` case to `mapExplicitTimelineEventType` in `internal/api/mapper.go`
+- [x] 2.2 Add mapper unit test proving `snapshot_marker` maps through as `snapshot_marker`
+- [x] 2.3 Add API-level ingest-to-timeline round-trip test for `snapshot_marker`
+
+## 3. Python SDK Helper
+
+- [x] 3.1 Implement `snapshot_marker()` method on `Span` class in `sdks/python/src/continua/span.py`
+- [x] 3.2 Add docstring with parameter descriptions and usage example
+- [x] 3.3 Add unit tests for validation (empty label, empty marker_kind)
+- [x] 3.4 Add unit tests for payload/message default behavior and key override
+- [x] 3.5 Add integration round-trip test for emitted `snapshot_marker`
+
+## 4. Frontend: Snapshot Marker Semantics
+
+- [x] 4.1 Add `snapshot_marker` to the TypeScript event type union in `web/src/api/client.ts`
+- [x] 4.2 Add `getSnapshotMarkerDetails()` in `web/src/utils/eventSemantics.ts`
+- [x] 4.3 Add `snapshot_marker` branch to `summarizeTimelineEvent()` in `web/src/utils/timeline.ts`
+- [x] 4.4 Add unit tests for `getSnapshotMarkerDetails()` (well-formed, malformed, wrong type)
+- [x] 4.5 Add unit tests for `summarizeTimelineEvent()` snapshot_marker summaries
+
+## 5. Frontend: Snapshot Marker Timeline Rendering
+
+- [x] 5.1 Add `SnapshotMarkerPreview` component in `Timeline.tsx` with label text and marker_kind pill
+- [x] 5.2 Wire `SnapshotMarkerPreview` into `TimelineRow` rendering chain with malformed fallback
+- [x] 5.3 Add `snapshot_marker` to `SEMANTIC_EVENT_TYPES` array in `Timeline.tsx`
+- [x] 5.4 Add rendering tests for marker preview and semantic-filter inclusion
+- [x] 5.5 Add component test proving `Timeline.tsx` falls back to generic row when `getSnapshotMarkerDetails()` returns `null` (malformed marker)
+
+## 6. Frontend: Unresolved Wait Rows
+
+- [x] 6.1 Derive `openWaits` via `useMemo` + `computeOpenWaits()` in `TraceDetailPage.tsx`
+- [x] 6.2 Pass `openWaits` into `RunningStatePanel` component
+- [x] 6.3 Render unresolved-wait rows beneath existing summary content (newest-first); existing summary (classification label, basis, explanatory copy, timing, current-wait, jump action) stays intact — this is additive only
+- [x] 6.4 Implement gate title logic (`Approval gate` for `human_approval`, `Wait gate` otherwise)
+- [x] 6.5 Show wait kind, entered timestamp, open duration, span jump action, optional wait_id, optional message per row
+- [x] 6.6 Add page tests: single wait, multiple waits newest-first, human_approval title, resolved wait disappears on poll, anonymous wait standalone, duration refresh on poll only
+
+## 7. Documentation
+
+- [x] 7.1 Add `snapshot_marker` entry to `docs/event-conventions.md` with payload conventions and SDK example
+- [x] 7.2 Add scope guard clarifying markers are debugger milestones, not checkpoint/resume primitives
+
+## 8. Verification
+
+- [x] 8.1 Run `go test ./internal/api/...`
+- [x] 8.2 Run `pnpm --filter web test`
+- [x] 8.3 Run `cd sdks/python && uv run pytest`
+- [x] 8.4 Run `openspec validate add-execution-state-enrichment --strict`

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -36,7 +36,7 @@ result = client.wait_for_batch(batch_id, timeout=30, poll_interval=0.5)
 
 ```bash
 # Install with dev dependencies
-uv sync --all-extras
+uv sync
 
 # Run tests
 uv run pytest

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "pydantic>=2.0.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
@@ -23,8 +23,14 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build]
+dev-mode-dirs = ["src"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/continua"]
+
+[tool.uv]
+default-groups = ["dev"]
 
 [tool.ruff]
 line-length = 100

--- a/sdks/python/src/continua/span.py
+++ b/sdks/python/src/continua/span.py
@@ -444,6 +444,51 @@ class SpanContext:
             payload=wait_payload,
         )
 
+    def snapshot_marker(
+        self,
+        label: str,
+        *,
+        marker_kind: str = "milestone",
+        payload: dict[str, Any] | None = None,
+        message: str | None = None,
+    ) -> None:
+        """Emit a debugger milestone marker for this span.
+
+        Args:
+            label: Human-facing label shown in milestone timeline previews.
+            marker_kind: Marker category used for compact semantic grouping.
+            payload: Optional additional structured data merged with marker fields.
+            message: Optional generic timeline fallback summary. Defaults to ``label``.
+
+        Returns:
+            None.
+
+        Example:
+            with span("checkout_flow") as s:
+                s.snapshot_marker(
+                    "Inventory reserved",
+                    marker_kind="phase",
+                    payload={"reservation_id": "res-42"},
+                )
+        """
+        self._require_non_empty_string("label", label)
+        self._require_non_empty_string("marker_kind", marker_kind)
+        marker_payload = self._merge_reserved_payload(
+            payload,
+            reserved_fields={
+                "marker_kind": marker_kind,
+                "label": label,
+            },
+            empty_string_keys=frozenset(),
+        )
+
+        self._record_event(
+            event_type="snapshot_marker",
+            level="info",
+            message=label if message is None else message,
+            payload=marker_payload,
+        )
+
     def __enter__(self) -> SpanContext:
         """Enter the span context."""
         self._token = _current_span.set(self)

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -387,6 +387,7 @@ class IngestEventType(Enum):
     decision = "decision"
     effect = "effect"
     wait = "wait"
+    snapshot_marker = "snapshot_marker"
 
 
 class IngestEventLevel(Enum):
@@ -406,7 +407,7 @@ class IngestEventInput(BaseModel):
     message: str | None = None
     payload: dict[str, Any] | None = Field(
         None,
-        description="Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`.\n",
+        description="Free-form event payload. Semantic debugger conventions apply for some event types: `effect` may include reserved `effect_id`; `wait` may include reserved `wait_id`; `state_change` expects `key`, `old_value`, `new_value`, and optional `namespace`; `decision` expects `question`, `chosen`, and optional `alternatives` and `reasoning`; `snapshot_marker` is a debugger milestone event, not a checkpoint or resumability primitive, and conventionally uses `marker_kind` (a non-empty string; default vocabulary `milestone`) and `label` (a human-facing marker label).\n",
     )
     idempotency_key: str | None = Field(
         None, description="Optional key for event-level deduplication"
@@ -424,6 +425,7 @@ class TimelineEventType(Enum):
     decision = "decision"
     effect = "effect"
     wait = "wait"
+    snapshot_marker = "snapshot_marker"
     span_started = "span_started"
     span_completed = "span_completed"
     span_failed = "span_failed"

--- a/sdks/python/tests/test_integration.py
+++ b/sdks/python/tests/test_integration.py
@@ -541,3 +541,54 @@ class TestIntegration:
         assert effect_event["payload"]["effect_kind"] == "api_call"
         assert effect_event["payload"]["effect_id"] == explicit_effect_id
         assert effect_event["payload"]["target"] == "billing"
+
+    def test_sync_snapshot_marker_round_trip(self):
+        """Snapshot marker helpers should round-trip through the timeline API."""
+        client = Continua.init(
+            api_key=CONTINUA_API_KEY,
+            endpoint=CONTINUA_ENDPOINT,
+            batch_size=100,
+            flush_interval=60.0,
+            ingest_mode="sync",
+        )
+        trace_name = f"sdk-snapshot-marker-{uuid.uuid4()}"
+
+        with TraceContext(name=trace_name):
+            with span("snapshot_marker_span", kind="default") as marker_span:
+                marker_span.snapshot_marker(
+                    "Validation passed",
+                    marker_kind="checkpoint",
+                    payload={
+                        "extra": "data",
+                        "marker_kind": "wrong",
+                        "label": "wrong",
+                    },
+                )
+                span_id = marker_span.span_id
+
+        client.flush()
+        trace_record = wait_for_trace_record(trace_name)
+        timeline = fetch_timeline(trace_record["id"])
+        span_events = [
+            event for event in timeline["events"] if event.get("span_id") == span_id
+        ]
+
+        assert [event["event_type"] for event in span_events] == [
+            "span_started",
+            "snapshot_marker",
+            "span_completed",
+        ]
+
+        marker_events = explicit_events_for_span(
+            timeline["events"], span_id, "snapshot_marker"
+        )
+        assert len(marker_events) == 1
+
+        marker_event = marker_events[0]
+        assert_timeline_sequence(marker_event, expected_sequence=1)
+        assert marker_event["message"] == "Validation passed"
+        assert marker_event["payload"] == {
+            "extra": "data",
+            "marker_kind": "checkpoint",
+            "label": "Validation passed",
+        }

--- a/sdks/python/tests/test_span.py
+++ b/sdks/python/tests/test_span.py
@@ -484,6 +484,60 @@ def test_wait_helper_rejects_empty_kind_or_phase():
         span_context.wait("human_approval", phase="")
 
 
+def test_snapshot_marker_helper_records_reserved_merge_semantics():
+    """Snapshot marker helper should merge payloads with helper-owned precedence."""
+    stub_client = StubClient()
+    caller_payload = {
+        "extra": "data",
+        "marker_kind": "wrong",
+        "label": "wrong",
+    }
+    original_payload = dict(caller_payload)
+
+    with traced_span(stub_client, span_name="marker_span") as s:
+        s.snapshot_marker("Validation passed", marker_kind="checkpoint", payload=caller_payload)
+
+    assert caller_payload == original_payload
+    event = stub_client.events[0]
+    assert_event_metadata(event, sequence=1)
+    assert event["event_type"] == "snapshot_marker"
+    assert event["level"] == "info"
+    assert event["message"] == "Validation passed"
+    assert event["payload"] == {
+        "extra": "data",
+        "marker_kind": "checkpoint",
+        "label": "Validation passed",
+    }
+
+
+def test_snapshot_marker_helper_defaults_message_and_allows_override():
+    """Snapshot marker helper should default message to label unless overridden."""
+    stub_client = StubClient()
+
+    with traced_span(stub_client, span_name="marker_span") as s:
+        s.snapshot_marker("Phase 1 complete")
+        s.snapshot_marker(
+            "Validation passed",
+            message="All input schemas validated successfully",
+        )
+
+    default_message_event, explicit_message_event = stub_client.events
+    assert_event_metadata(default_message_event, sequence=1)
+    assert_event_metadata(explicit_message_event, sequence=2)
+    assert default_message_event["message"] == "Phase 1 complete"
+    assert explicit_message_event["message"] == "All input schemas validated successfully"
+
+
+def test_snapshot_marker_helper_rejects_empty_label_or_marker_kind():
+    """Snapshot marker helper rejects empty semantic identifiers."""
+    span_context = SpanContext("marker_span")
+
+    with pytest.raises(ValueError, match="label must be a non-empty string"):
+        span_context.snapshot_marker("")
+    with pytest.raises(ValueError, match="marker_kind must be a non-empty string"):
+        span_context.snapshot_marker("Phase 1 complete", marker_kind="")
+
+
 def test_set_llm_response_emits_one_implicit_effect():
     """First set_llm_response call emits an implicit effect exactly once."""
     stub_client = StubClient()

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -126,7 +126,7 @@ dependencies = [
     { name = "pydantic" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "datamodel-code-generator" },
     { name = "mypy" },
@@ -138,16 +138,19 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.25.0" },
     { name = "httpx", specifier = ">=0.25.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "datamodel-code-generator", specifier = ">=0.25.0" },
+    { name = "mypy", specifier = ">=1.0.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "ruff", specifier = ">=0.1.0" },
+]
 
 [[package]]
 name = "coverage"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -213,6 +213,7 @@ export interface TimelineEvent {
     | 'decision'
     | 'effect'
     | 'wait'
+    | 'snapshot_marker'
     | 'span_started'
     | 'span_completed'
     | 'span_failed';

--- a/web/src/components/Timeline.test.tsx
+++ b/web/src/components/Timeline.test.tsx
@@ -132,6 +132,23 @@ describe('Timeline semantic event rendering', () => {
     expect(screen.getByText('approved')).toBeInTheDocument();
   });
 
+  it('renders snapshot marker previews with the label and marker kind pill', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'snapshot_marker',
+          payload: {
+            marker_kind: 'milestone',
+            label: 'Data loaded',
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Data loaded')).toBeInTheDocument();
+    expect(screen.getByText('milestone')).toBeInTheDocument();
+  });
+
   it('degrades malformed effect and wait payloads to generic rendering', () => {
     renderTimeline({
       events: [
@@ -158,6 +175,23 @@ describe('Timeline semantic event rendering', () => {
     expect(screen.getByText('Fallback wait summary')).toBeInTheDocument();
     expect(screen.queryByText('mutating')).not.toBeInTheDocument();
     expect(screen.queryByText('read-only')).not.toBeInTheDocument();
+  });
+
+  it('falls back to generic rendering for malformed snapshot markers', () => {
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          event_type: 'snapshot_marker',
+          message: 'Malformed marker fallback',
+          payload: {
+            marker_kind: 'milestone',
+          },
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Malformed marker fallback')).toBeInTheDocument();
+    expect(screen.queryByText('milestone')).not.toBeInTheDocument();
   });
 
   it('preserves effect payload inspection and wait span navigation', async () => {
@@ -234,6 +268,33 @@ describe('Timeline segmented filter', () => {
     );
     expect(screen.getByText('Narrative event')).toBeInTheDocument();
     expect(screen.getByText('api_call')).toBeInTheDocument();
+  });
+
+  it('includes snapshot markers in the Semantic filter mode', async () => {
+    const user = userEvent.setup();
+
+    renderTimeline({
+      events: [
+        createTimelineEvent({
+          id: 'message-event',
+          event_type: 'message',
+          message: 'Narrative event',
+        }),
+        createTimelineEvent({
+          id: 'marker-event',
+          event_type: 'snapshot_marker',
+          payload: {
+            marker_kind: 'milestone',
+            label: 'Data loaded',
+          },
+        }),
+      ],
+    });
+
+    await user.click(screen.getByRole('radio', { name: 'Semantic' }));
+
+    expect(screen.getByText('Data loaded')).toBeInTheDocument();
+    expect(screen.queryByText('Narrative event')).not.toBeInTheDocument();
   });
 
   it('filters to semantic explicit events when Semantic is selected', async () => {

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -5,6 +5,7 @@ import {
   formatInlineSemanticValue,
   getDecisionDetails,
   getEffectDetails,
+  getSnapshotMarkerDetails,
   getStateChangeDetails,
   getWaitDetails,
 } from '../utils/eventSemantics';
@@ -47,6 +48,7 @@ const SEMANTIC_EVENT_TYPES = new Set<TimelineEvent['event_type']>([
   'decision',
   'effect',
   'wait',
+  'snapshot_marker',
 ]);
 const EFFECT_WAIT_EVENT_TYPES = new Set<TimelineEvent['event_type']>([
   'effect',
@@ -168,6 +170,7 @@ function TimelineRow({
   const retrySafety =
     traceStatus === 'FAILED' ? classifyEffectEvent(event) : null;
   const waitDetails = getWaitDetails(event);
+  const snapshotMarker = getSnapshotMarkerDetails(event);
   const rowAccent = isError
     ? 'border-red-200 bg-red-50/70 dark:border-red-500/40 dark:bg-red-500/10'
     : event.source === 'synthetic'
@@ -222,6 +225,8 @@ function TimelineRow({
                 />
               ) : waitDetails ? (
                 <WaitPreview wait={waitDetails} />
+              ) : snapshotMarker ? (
+                <SnapshotMarkerPreview snapshotMarker={snapshotMarker} />
               ) : (
                 <p className="mt-3 text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
                   {summarizeTimelineEvent(event)}
@@ -452,6 +457,23 @@ function WaitPreview({
         {wait.resolution ? (
           <SemanticValuePill tone="accent">{wait.resolution}</SemanticValuePill>
         ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SnapshotMarkerPreview({
+  snapshotMarker,
+}: {
+  snapshotMarker: NonNullable<ReturnType<typeof getSnapshotMarkerDetails>>;
+}) {
+  return (
+    <div className="mt-3 space-y-2">
+      <p className="text-sm font-medium leading-6 text-slate-900 dark:text-slate-100">
+        {snapshotMarker.label}
+      </p>
+      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+        <SemanticValuePill tone="accent">{snapshotMarker.markerKind}</SemanticValuePill>
       </div>
     </div>
   );

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -3,7 +3,12 @@ import { focusManager, onlineManager } from '@tanstack/react-query';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearApiKey, setApiKey, type TraceDetail } from '../api/client';
+import {
+  clearApiKey,
+  setApiKey,
+  type TimelineEvent,
+  type TraceDetail,
+} from '../api/client';
 import { setMatchMediaMatches } from '../test/matchMedia';
 import { getAccessibleSummary, getReasonExplanation } from '../utils/retrySafety';
 import {
@@ -41,6 +46,50 @@ function countRequests(pathname: string): number {
     const url = new URL(readRequestUrl(input), 'http://localhost');
     return url.pathname === pathname;
   }).length;
+}
+
+function createWaitEvent({
+  waitKind = 'external',
+  phase = 'entered',
+  waitId,
+  resolution,
+  ...eventOverrides
+}: {
+  waitKind?: string;
+  phase?: string;
+  waitId?: string;
+  resolution?: string;
+} & Partial<TimelineEvent> = {}): TimelineEvent {
+  return createTimelineEvent({
+    ...eventOverrides,
+    event_type: 'wait',
+    payload: {
+      wait_kind: waitKind,
+      phase,
+      ...(waitId ? { wait_id: waitId } : {}),
+      ...(resolution ? { resolution } : {}),
+    },
+  });
+}
+
+function createRunningTimelineResponse(
+  events: TimelineEvent[],
+  pollCursor = 'cursor-running'
+) {
+  return jsonResponse({
+    events,
+    trace_status: 'RUNNING',
+    has_more: false,
+    poll_cursor: pollCursor,
+  });
+}
+
+function getRunningStatePanel(): HTMLElement {
+  const panel = screen.getByText('Running state').closest('section');
+  if (!panel) {
+    throw new Error('Running state panel not found');
+  }
+  return panel;
 }
 
 beforeEach(() => {
@@ -2058,16 +2107,294 @@ describe('TraceDetailPage', () => {
     renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
 
     expect(await screen.findByText('Declared wait')).toBeInTheDocument();
+    const runningStatePanel = within(getRunningStatePanel());
     expect(
       screen.getByText(
         'Execution declared a wait and has not yet recorded a matching resolution.'
       )
     ).toBeInTheDocument();
-    expect(screen.getByText('Current wait')).toBeInTheDocument();
-    expect(screen.getAllByText('model_response').length).toBeGreaterThan(0);
+    expect(runningStatePanel.getByText('Current wait')).toBeInTheDocument();
+    expect(runningStatePanel.getAllByText('model_response')).toHaveLength(2);
     expect(
-      screen.getByRole('button', { name: 'Jump to Waiting span' })
-    ).toBeInTheDocument();
+      runningStatePanel.getAllByRole('button', { name: 'Jump to Waiting span' })
+    ).toHaveLength(2);
+  });
+
+  it('renders a single unresolved wait row with metadata and jump action', async () => {
+    const waitingSpan = createSpan({
+      span_id: 'wait-row-span',
+      name: 'Wait row span',
+      status: 'STARTED',
+      started_at: '2026-03-14T10:00:30.000Z',
+    });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createRunningTraceDetail()),
+        spans: () => jsonResponse({ spans: [waitingSpan] }),
+        timeline: () =>
+          createRunningTimelineResponse([
+            createWaitEvent({
+              id: 'wait-row-event',
+              span_id: waitingSpan.span_id,
+              span_name: waitingSpan.name,
+              timestamp: '2026-03-14T10:01:30.000Z',
+              waitKind: 'external_api',
+              waitId: 'wait-123',
+              message: 'Awaiting webhook callback',
+            }),
+          ]),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await screen.findByText('Running state');
+    const runningStatePanel = within(getRunningStatePanel());
+    expect(runningStatePanel.getByText('Open waits')).toBeInTheDocument();
+    expect(runningStatePanel.getByText('Wait gate')).toBeInTheDocument();
+    expect(runningStatePanel.getAllByText('external_api')).toHaveLength(2);
+    expect(runningStatePanel.getByText('wait-123')).toBeInTheDocument();
+    expect(runningStatePanel.getByText('2026-03-14T10:01:30.000Z')).toBeInTheDocument();
+    expect(runningStatePanel.getByText('Open duration')).toBeInTheDocument();
+    expect(runningStatePanel.getByText('Awaiting webhook callback')).toBeInTheDocument();
+    expect(
+      runningStatePanel.getAllByRole('button', { name: 'Jump to Wait row span' })
+    ).toHaveLength(2);
+  });
+
+  it('renders unresolved waits newest-first', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createRunningTraceDetail()),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: () =>
+          createRunningTimelineResponse([
+            createWaitEvent({
+              id: 'oldest-wait',
+              timestamp: '2026-03-14T10:01:00.000Z',
+              waitKind: 'oldest_wait',
+              message: 'Oldest pending wait',
+            }),
+            createWaitEvent({
+              id: 'middle-wait',
+              timestamp: '2026-03-14T10:03:00.000Z',
+              waitKind: 'middle_wait',
+              message: 'Middle pending wait',
+            }),
+            createWaitEvent({
+              id: 'newest-wait',
+              timestamp: '2026-03-14T10:05:00.000Z',
+              waitKind: 'newest_wait',
+              message: 'Newest pending wait',
+            }),
+          ]),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await screen.findByText('Open waits');
+    const runningStatePanel = within(getRunningStatePanel());
+    expect(
+      runningStatePanel
+        .getAllByText(/pending wait$/)
+        .map((element) => element.textContent)
+    ).toEqual([
+      'Newest pending wait',
+      'Middle pending wait',
+      'Oldest pending wait',
+    ]);
+  });
+
+  it('uses the Approval gate title for human approval waits', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createRunningTraceDetail()),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: () =>
+          createRunningTimelineResponse([
+            createWaitEvent({
+              id: 'approval-wait',
+              timestamp: '2026-03-14T10:01:30.000Z',
+              waitKind: 'human_approval',
+              message: 'Awaiting manager sign-off',
+            }),
+          ]),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await screen.findByText('Approval gate');
+    const runningStatePanel = within(getRunningStatePanel());
+    expect(runningStatePanel.getByText('Approval gate')).toBeInTheDocument();
+    expect(runningStatePanel.getByText('Awaiting manager sign-off')).toBeInTheDocument();
+  });
+
+  it('does not render an open-wait jump button when the span is not resolvable', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createRunningTraceDetail()),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: () =>
+          createRunningTimelineResponse([
+            createWaitEvent({
+              id: 'orphaned-wait',
+              span_id: 'missing-span',
+              span_name: 'Missing span',
+              timestamp: '2026-03-14T10:01:30.000Z',
+              waitKind: 'external_api',
+              message: 'Awaiting orphaned callback',
+            }),
+          ]),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await screen.findByText('Running state');
+    const runningStatePanel = within(getRunningStatePanel());
+    expect(runningStatePanel.getByText('Awaiting orphaned callback')).toBeInTheDocument();
+    expect(
+      runningStatePanel.queryByRole('button', { name: 'Jump to Missing span' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('removes a resolved wait row on the next poll cycle', async () => {
+    const openWait = createWaitEvent({
+      id: 'open-wait',
+      timestamp: '2026-03-14T10:01:30.000Z',
+      waitKind: 'external_api',
+      waitId: 'wait-1',
+      message: 'Waiting on external API',
+    });
+    let currentPollEvents: TimelineEvent[] = [];
+    let currentPollCursor = 'cursor-poll-1';
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createRunningTraceDetail()),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: (url) => {
+          if (url.searchParams.get('after') === 'cursor-open-wait') {
+            return createRunningTimelineResponse(currentPollEvents, currentPollCursor);
+          }
+
+          return createRunningTimelineResponse([openWait], 'cursor-open-wait');
+        },
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    await screen.findByText('Running state');
+    const runningStatePanel = within(getRunningStatePanel());
+    expect(runningStatePanel.getByText('wait-1')).toBeInTheDocument();
+
+    currentPollEvents = [
+      createWaitEvent({
+        id: 'resolved-wait',
+        timestamp: '2026-03-14T10:02:00.000Z',
+        waitKind: 'external_api',
+        phase: 'resolved',
+        waitId: 'wait-1',
+        resolution: 'completed',
+      }),
+    ];
+    currentPollCursor = 'cursor-poll-2';
+
+    await act(async () => {
+      await view.queryClient.refetchQueries({
+        queryKey: ['timeline', TRACE_ONE.id, 'poll'],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('wait-1')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('Open waits')).not.toBeInTheDocument();
+  });
+
+  it('keeps anonymous waits visible as standalone rows', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createRunningTraceDetail()),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: () =>
+          createRunningTimelineResponse([
+            createWaitEvent({
+              id: 'anonymous-entered',
+              timestamp: '2026-03-14T10:01:30.000Z',
+              waitKind: 'custom',
+              message: 'Anonymous gate entered',
+            }),
+            createWaitEvent({
+              id: 'anonymous-resolved',
+              timestamp: '2026-03-14T10:02:00.000Z',
+              waitKind: 'custom',
+              phase: 'resolved',
+              resolution: 'ignored',
+              message: 'Anonymous gate resolved',
+            }),
+          ]),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await screen.findByText('Running state');
+    const runningStatePanel = within(getRunningStatePanel());
+    expect(runningStatePanel.getByText('Anonymous gate entered')).toBeInTheDocument();
+    expect(runningStatePanel.getAllByText('custom')).toHaveLength(2);
+    expect(screen.queryByText('wait-1')).not.toBeInTheDocument();
+  });
+
+  it('refreshes open wait durations only when the timeline poll re-renders the panel', async () => {
+    const baseNow = new Date('2026-03-14T10:02:00.000Z').getTime();
+    const traceStartedAt = new Date(baseNow - 2 * 60 * 1000).toISOString();
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(baseNow);
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse(createRunningTraceDetail({ started_at: traceStartedAt })),
+        spans: () => jsonResponse({ spans: [] }),
+        timeline: (url) => {
+          if (url.searchParams.get('after') === 'cursor-duration') {
+            return createRunningTimelineResponse([], 'cursor-duration');
+          }
+
+          return createRunningTimelineResponse(
+            [
+              createWaitEvent({
+                id: 'duration-wait',
+                timestamp: new Date(baseNow - 60 * 1000).toISOString(),
+                waitKind: 'timer',
+                message: 'Waiting on timer',
+              }),
+            ],
+            'cursor-duration'
+          );
+        },
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    expect(await screen.findByText('Waiting on timer')).toBeInTheDocument();
+    expect(screen.getByText('Open duration').parentElement).toHaveTextContent('1.0m');
+
+    dateNowSpy.mockReturnValue(baseNow + 30 * 1000);
+    expect(screen.getByText('Open duration').parentElement).toHaveTextContent('1.0m');
+
+    await act(async () => {
+      await view.queryClient.refetchQueries({
+        queryKey: ['timeline', TRACE_ONE.id, 'poll'],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Open duration').parentElement).toHaveTextContent('1.5m');
+    });
   });
 
   it.each([

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -67,7 +67,11 @@ import {
   type TraceCostSeries,
 } from '../utils/reasoning';
 import { serializeSpanParam } from '../utils/traceDetailSearchParams';
-import type { WaitStallAssessment } from '../utils/waitStallAnalysis';
+import {
+  computeOpenWaits,
+  type OpenWait,
+  type WaitStallAssessment,
+} from '../utils/waitStallAnalysis';
 import {
   buildSpanTree,
   collectExpandableSpanIds,
@@ -192,6 +196,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
     events: timeline.events,
     hasTimelineSnapshot: timeline.hasSnapshot,
   });
+  const openWaits = useMemo(() => computeOpenWaits(timeline.events), [timeline.events]);
   const retrySafetyAnalysis = useRetrySafetyAnalysis(spans, timeline.events);
   const showRetrySafety = timelineStatus === 'FAILED';
   const visibleRetrySafetyAssessments = showRetrySafety
@@ -280,6 +285,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
       failureAnalysis={failureAnalysis}
       retrySafetyAnalysis={showRetrySafety ? retrySafetyAnalysis : null}
       onSelectSpan={handleSelectSpanAndShowDetails}
+      openWaits={openWaits}
       selectedBreadcrumbPath={selectedBreadcrumbPath}
       selectedSpan={selectedSpan}
       spanIndex={spanIndex}
@@ -549,6 +555,7 @@ function TraceDetailsSurface({
   failureAnalysis,
   retrySafetyAnalysis,
   onSelectSpan,
+  openWaits,
   selectedBreadcrumbPath,
   selectedSpan,
   spanIndex,
@@ -560,6 +567,7 @@ function TraceDetailsSurface({
   failureAnalysis: ReturnType<typeof buildFailureAnalysis>;
   retrySafetyAnalysis: ReturnType<typeof useRetrySafetyAnalysis> | null;
   onSelectSpan: (spanId: string) => void;
+  openWaits: OpenWait[];
   selectedBreadcrumbPath: ReturnType<typeof buildBreadcrumbPath>;
   selectedSpan: Span | null;
   spanIndex: ReadonlyMap<string, Span>;
@@ -583,6 +591,8 @@ function TraceDetailsSurface({
           <RunningStatePanel
             assessment={runningStateAssessment}
             events={events}
+            openWaits={openWaits}
+            spanIndex={spanIndex}
             onSelectSpan={onSelectSpan}
           />
         ) : null}
@@ -769,15 +779,20 @@ function TracePayloadPanel({ title, data }: { title: string; data: unknown }) {
 function RunningStatePanel({
   assessment,
   events,
+  openWaits,
+  spanIndex,
   onSelectSpan,
 }: {
   assessment: WaitStallAssessment;
   events: TimelineEvent[];
+  openWaits: OpenWait[];
+  spanIndex: ReadonlyMap<string, Span>;
   onSelectSpan: (spanId: string) => void;
 }) {
   const waitKind = resolveDeclaredWaitKind(assessment, events);
   const panelTone = getRunningStatePanelTone(assessment.classification);
   const summary = getRunningStateSummary(assessment);
+  const orderedOpenWaits = [...openWaits].reverse();
 
   return (
     <section className={`rounded-xl border px-4 py-4 shadow-sm ${panelTone}`}>
@@ -847,7 +862,95 @@ function RunningStatePanel({
           </div>
         ) : null}
       </div>
+
+      {orderedOpenWaits.length > 0 ? (
+        <div className="mt-4 border-t border-current/15 pt-4">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] opacity-75">
+            Open waits
+          </div>
+          <div className="mt-3 space-y-3">
+            {orderedOpenWaits.map((openWait) => (
+              <OpenWaitRow
+                key={openWait.event.id}
+                openWait={openWait}
+                spanIndex={spanIndex}
+                onSelectSpan={onSelectSpan}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
     </section>
+  );
+}
+
+function OpenWaitRow({
+  openWait,
+  spanIndex,
+  onSelectSpan,
+}: {
+  openWait: OpenWait;
+  spanIndex: ReadonlyMap<string, Span>;
+  onSelectSpan: (spanId: string) => void;
+}) {
+  const waitTitle =
+    openWait.details.waitKind === 'human_approval' ? 'Approval gate' : 'Wait gate';
+  const openDurationMs = calculateDuration(openWait.event.timestamp, undefined);
+  const hasNavigableSpan = Boolean(
+    openWait.event.span_id && spanIndex.has(openWait.event.span_id)
+  );
+
+  return (
+    <div className="rounded-lg border border-current/15 bg-white/60 p-3 dark:bg-slate-950/30">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold">{waitTitle}</div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+            <span className="rounded-full border border-current/15 px-2.5 py-1 font-medium">
+              {openWait.details.waitKind}
+            </span>
+            {openWait.details.waitId ? (
+              <span className="rounded-full border border-current/15 px-2.5 py-1 font-mono">
+                {openWait.details.waitId}
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        {hasNavigableSpan ? (
+          <button
+            type="button"
+            className="rounded-full border border-current/20 bg-white/70 px-3 py-1.5 text-xs font-medium transition hover:bg-white dark:bg-slate-950/40 dark:hover:bg-slate-950/70"
+            onClick={() => onSelectSpan(openWait.event.span_id!)}
+          >
+            Jump to {openWait.event.span_name ?? openWait.event.span_id}
+          </button>
+        ) : null}
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-4 text-xs">
+        <div>
+          <div className="font-semibold uppercase tracking-[0.16em] opacity-75">
+            Entered
+          </div>
+          <div className="mt-1 text-sm font-medium">
+            {formatTimestamp(openWait.event.timestamp)}
+          </div>
+        </div>
+        <div>
+          <div className="font-semibold uppercase tracking-[0.16em] opacity-75">
+            Open duration
+          </div>
+          <div className="mt-1 text-sm font-medium">
+            {formatDuration(openDurationMs)}
+          </div>
+        </div>
+      </div>
+
+      {openWait.event.message ? (
+        <p className="mt-3 text-sm leading-6 opacity-90">{openWait.event.message}</p>
+      ) : null}
+    </div>
   );
 }
 

--- a/web/src/utils/eventSemantics.test.ts
+++ b/web/src/utils/eventSemantics.test.ts
@@ -1,6 +1,50 @@
 import { describe, expect, it } from 'vitest';
 import { createTimelineEvent } from '../test/traceFixtures';
-import { getEffectDetails, getWaitDetails } from './eventSemantics';
+import {
+  getEffectDetails,
+  getSnapshotMarkerDetails,
+  getWaitDetails,
+} from './eventSemantics';
+
+describe('getSnapshotMarkerDetails', () => {
+  it('extracts a well-formed snapshot marker payload', () => {
+    const event = createTimelineEvent({
+      event_type: 'snapshot_marker',
+      payload: {
+        marker_kind: 'milestone',
+        label: 'Pipeline ready',
+      },
+    });
+
+    expect(getSnapshotMarkerDetails(event)).toEqual({
+      markerKind: 'milestone',
+      label: 'Pipeline ready',
+    });
+  });
+
+  it('returns null for malformed snapshot markers', () => {
+    const event = createTimelineEvent({
+      event_type: 'snapshot_marker',
+      payload: {
+        marker_kind: 'milestone',
+      },
+    });
+
+    expect(getSnapshotMarkerDetails(event)).toBeNull();
+  });
+
+  it('returns null for non-snapshot-marker events', () => {
+    const event = createTimelineEvent({
+      event_type: 'custom',
+      payload: {
+        marker_kind: 'milestone',
+        label: 'Pipeline ready',
+      },
+    });
+
+    expect(getSnapshotMarkerDetails(event)).toBeNull();
+  });
+});
 
 describe('getEffectDetails', () => {
   it('extracts a well-formed effect payload with all fields', () => {

--- a/web/src/utils/eventSemantics.ts
+++ b/web/src/utils/eventSemantics.ts
@@ -29,6 +29,11 @@ export interface WaitDetails {
   resolution?: string;
 }
 
+export interface SnapshotMarkerDetails {
+  markerKind: string;
+  label: string;
+}
+
 export function getStateChangeDetails(
   event: TimelineEvent
 ): StateChangeDetails | null {
@@ -125,6 +130,26 @@ export function getWaitDetails(event: TimelineEvent): WaitDetails | null {
     phase,
     waitId,
     resolution,
+  };
+}
+
+export function getSnapshotMarkerDetails(
+  event: TimelineEvent
+): SnapshotMarkerDetails | null {
+  if (event.event_type !== 'snapshot_marker' || !event.payload) {
+    return null;
+  }
+
+  const markerKind = getNonEmptyString(event.payload, 'marker_kind');
+  const label = getNonEmptyString(event.payload, 'label');
+
+  if (!markerKind || !label) {
+    return null;
+  }
+
+  return {
+    markerKind,
+    label,
   };
 }
 

--- a/web/src/utils/timeline.test.ts
+++ b/web/src/utils/timeline.test.ts
@@ -100,6 +100,31 @@ describe('summarizeTimelineEvent', () => {
     expect(summarizeTimelineEvent(event)).toBe('effect');
   });
 
+  it('summarizes well-formed snapshot markers from semantic payload fields', () => {
+    const event = createTimelineEvent({
+      event_type: 'snapshot_marker',
+      message: 'fallback marker message',
+      payload: {
+        marker_kind: 'milestone',
+        label: 'Data ingestion complete',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('Data ingestion complete');
+  });
+
+  it('falls back to the message for malformed snapshot markers', () => {
+    const event = createTimelineEvent({
+      event_type: 'snapshot_marker',
+      message: 'fallback marker message',
+      payload: {
+        marker_kind: 'milestone',
+      },
+    });
+
+    expect(summarizeTimelineEvent(event)).toBe('fallback marker message');
+  });
+
   it('summarizes well-formed wait events', () => {
     const enteredEvent = createTimelineEvent({
       event_type: 'wait',

--- a/web/src/utils/timeline.ts
+++ b/web/src/utils/timeline.ts
@@ -3,6 +3,7 @@ import {
   formatInlineSemanticValue,
   getDecisionDetails,
   getEffectDetails,
+  getSnapshotMarkerDetails,
   getStateChangeDetails,
   getWaitDetails,
 } from './eventSemantics';
@@ -88,6 +89,13 @@ export function summarizeTimelineEvent(event: TimelineEvent): string {
         })`;
       }
       return event.message ?? 'effect';
+    }
+    case 'snapshot_marker': {
+      const details = getSnapshotMarkerDetails(event);
+      if (details) {
+        return details.label;
+      }
+      return event.message ?? 'snapshot marker';
     }
     case 'span_started':
       return `${event.span_name ?? event.span_id ?? 'Span'} started`;


### PR DESCRIPTION
## Summary

This PR implements the approved OpenSpec change for execution state enrichment across the contract, backend, Python SDK, timeline semantics, and trace detail UI.

It adds first-class `snapshot_marker` support end to end and enriches the running-state panel with unresolved wait rows, including guardrails so wait-row jump actions only render when span context is resolvable.

## Why

The approved change requires two debugger-facing improvements:

- milestone-style `snapshot_marker` events that stay semantically distinct from generic logs
- richer running-trace state so unresolved waits are visible directly in the existing running-state panel

This PR also fixes the local SDK verification path so `cd sdks/python && uv run pytest` is reproducible from the checkout.

## Impact

- `snapshot_marker` now flows through OpenAPI, generated types, API mapping, SDK helpers, and web timeline rendering
- running traces now show newest-first unresolved wait rows with entered time, open duration, wait metadata, and span jump actions when safe
- SDK development setup now installs the default dev toolchain needed for local test runs

## Validation

- `go test ./internal/api/...`
- `cd sdks/python && uv run pytest`
- `openspec validate add-execution-state-enrichment --strict`
- `CI=1 pnpm --filter web exec vitest run src/pages/TraceDetailPage.test.tsx -t 'renders declared waits with wait-specific text from the decisive event|renders a single unresolved wait row with metadata and jump action|keeps anonymous waits visible as standalone rows|does not render an open-wait jump button when the span is not resolvable' --reporter=verbose`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `snapshot_marker` event type for marking execution milestones in traces.
  * Enhanced running trace UI to display unresolved waits with duration tracking and jump-to-span actions.
  * Added `snapshot_marker()` method to Python SDK for emitting milestone markers.

* **Documentation**
  * Updated event conventions guide with `snapshot_marker` usage guidance and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->