### PR TITLE
redesign debugger ui

### DIFF
--- a/openspec/changes/update-debugger-ui-redesign/design.md
+++ b/openspec/changes/update-debugger-ui-redesign/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The current Continua debugger already exposes the right product primitives: overview-worthy trace/session counts, URL-backed list pages, failure-first trace detail, session narratives, comparison, and a desktop/mobile workspace split. The redesign should improve hierarchy and ergonomics without changing backend APIs or invalidating the route/state model that current tests depend on.
+
+## Goals
+
+- Make the app feel like an operator console rather than a generic SaaS dashboard
+- Improve scanability and actionability on traces, sessions, and detail pages
+- Preserve the existing URL-backed behavior and investigation workflows
+- Keep the redesign frontend-only and compatible with the current embedded SPA runtime
+
+## Non-Goals
+
+- Adding analytics APIs, dashboard time series, or new backend read models
+- Reworking compare semantics or trace/session URL contracts
+- Introducing agent graphs, eval workflows, or prompt playground features
+
+## Decisions
+
+### Decision: Shell-first information architecture
+
+Use a shared shell with a left navigation rail and compact utility bar instead of independent page headers. This gives the product a stable frame and aligns Continua with current observability tools that prioritize route switching between overview, request/trace triage, and session investigation.
+
+### Decision: Overview is a snapshot screen, not an analytics dashboard
+
+The new `/` route will summarize counts and recent work using the existing list endpoints only. This keeps the redesign frontend-only and avoids fake charting driven by underpowered data.
+
+### Decision: Utility-first visual language, not card mosaics
+
+The redesign will remove the default "rounded white card everywhere" look. Most product surfaces become structured sections, list rows, split panes, toolbars, metric strips, and drawers. Cards remain only when a contained comparison or metric group benefits from them.
+
+### Decision: Preserve current URL/state contracts
+
+`/traces`, `/sessions`, `/sessions/:id`, `/sessions/:id/compare`, and `/traces/:id?span=` keep their existing state semantics. The redesign may change component composition and screen hierarchy, but it must not move core state out of search params or invent new public params.
+
+### Decision: Desktop trace context becomes a drawer
+
+Trace context is useful but secondary during active debugging. On desktop it moves out of the main workspace into a toggleable drawer. On mobile it stays accessible from the summary flow to avoid oversized chrome.
+
+### Decision: Mobile trace detail reduces top-level tabs
+
+The current six-tab mobile model spreads related information too thinly. The redesign collapses this to four top-level tabs:
+- `Summary`: failure guidance, selected span detail, and reasoning
+- `Execution`: tree/waterfall sub-toggle
+- `Timeline`
+- `State`
+
+### Decision: Local quick filters only in the tree rail
+
+Tree-rail quick filters will derive from existing loaded span data only, such as failed-only or kind-based filters. This improves investigation speed without requiring server-side filtering or new query keys.
+
+## Implementation Notes
+
+- Favor shared CSS tokens and a small number of reusable primitives over one-off style rewrites on every component
+- Keep existing page labels and control names where tests or accessibility benefit from stability
+- Where possible, restyle and recompose existing components rather than replacing their underlying data flow
+- Keep desktop/mobile behavior deterministic for tests; avoid motion or viewport behavior that depends on timing

--- a/openspec/changes/update-debugger-ui-redesign/proposal.md
+++ b/openspec/changes/update-debugger-ui-redesign/proposal.md
@@ -1,0 +1,40 @@
+# Change: Update Debugger UI Redesign
+
+## Why
+
+Continua's debugger already has solid trace, session, and timeline behavior, but the current UI reads like a collection of generic Tailwind pages rather than a deliberate observability product. Operators need a calmer information hierarchy, stronger navigation, denser triage surfaces, and more intentional workspaces so they can move from overview to trace/session investigation without friction.
+
+## What Changes
+
+- Add a shared operator-first application shell with a left navigation rail, compact top utility bar, API-key status, and route-aware layout for overview, traces, sessions, settings, and deep detail pages.
+- Replace the placeholder `/` route with a real overview screen built only from existing trace and session endpoints, emphasizing snapshot counts, running/failing work, and recent investigation entry points.
+- Redesign traces and sessions into denser triage surfaces with sticky filter/search controls, quick filters, better row hierarchy, and shared loading/empty/error states while preserving existing URL-backed search state.
+- Redesign session detail and compare pages into clearer operator workspaces with stronger summary/header structure and more deliberate compare affordances, without changing compare URL semantics.
+- Redesign trace detail into a denser investigation workspace: stronger header, slimmer tree rail, refined waterfall/inspector presentation, desktop trace-context drawer, mobile four-tab composition, and local tree-rail quick filters using existing span data only.
+- Introduce a cohesive visual system across the web app using embedded IBM Plex fonts, graphite/ivory tokenized surfaces, restrained shadows, and semantic status color reserved for state and failures.
+- Add frontend coverage for the shell, overview, redesigned list layouts, mobile workspace composition, and trace/session navigation continuity.
+- Add Playwright screenshot smoke coverage scaffolding for the main routes against seeded demo data.
+
+## Scope Limits
+
+- Frontend-only redesign. No REST contract, database, backend behavior, or SDK changes.
+- Overview metrics are derived from existing list endpoints only. No new analytics or time-series APIs.
+- Existing routes remain intact; only `/` changes from placeholder landing page to real overview.
+- Existing URL params remain authoritative on traces, sessions, session detail, compare, and `?span=` trace selection.
+- No new public URL params in this phase.
+- No new product capabilities such as evals, annotations, agent graphs, prompt playgrounds, or replay flows.
+
+## Impact
+
+- Affected specs: `debugger-ui-redesign` (new capability)
+- Affected code:
+  - `web/src/App.tsx` and new shared shell/layout components
+  - `web/src/styles/globals.css` and related UI primitives
+  - `web/src/pages/TracesPage.tsx`
+  - `web/src/pages/SessionsPage.tsx`
+  - `web/src/pages/SessionDetailPage.tsx`
+  - `web/src/pages/SessionComparePage.tsx`
+  - `web/src/pages/TraceDetailPage.tsx`
+  - `web/src/pages/SettingsPage.tsx`
+  - targeted shared components under `web/src/components/`
+- New dependency: embedded IBM Plex font packages and Playwright test tooling

--- a/openspec/changes/update-debugger-ui-redesign/specs/debugger-ui-redesign/spec.md
+++ b/openspec/changes/update-debugger-ui-redesign/specs/debugger-ui-redesign/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Shared Operator App Shell
+
+The web debugger SHALL provide a shared application shell with stable navigation and route-aware utilities for the main product routes.
+
+#### Scenario: Desktop shell
+- **WHEN** the app renders on desktop-sized viewports
+- **THEN** a left navigation rail is visible with entries for `Overview`, `Traces`, `Sessions`, and `Settings`
+- **AND** a compact top utility bar exposes the command palette, theme control, and API-key state
+
+#### Scenario: Mobile shell
+- **WHEN** the app renders on narrow viewports
+- **THEN** navigation is accessible via a compact top bar and mobile drawer
+- **AND** the same route set remains reachable
+
+### Requirement: Overview Route
+
+The `/` route SHALL render a real overview screen using existing trace and session endpoints only.
+
+#### Scenario: Overview shows operator snapshot data
+- **WHEN** the overview route loads successfully
+- **THEN** it shows snapshot metrics and direct investigation entry points for recent failed traces, running traces, recent traces, and recent sessions
+
+#### Scenario: Overview remains frontend-only
+- **WHEN** the overview route is implemented
+- **THEN** it does not require new REST endpoints, database queries, or backend analytics APIs
+
+### Requirement: Traces and Sessions Triage Surfaces
+
+The traces and sessions routes SHALL support denser operator triage without regressing existing URL-backed list behavior.
+
+#### Scenario: Traces page preserves URL-driven filters
+- **WHEN** a user loads or updates `/traces` with existing supported search params
+- **THEN** the redesigned page rehydrates those filters and issues the same API requests as before
+- **AND** the visual layout emphasizes trace name and status before secondary metrics
+
+#### Scenario: Sessions page preserves URL-driven search, sort, and pagination
+- **WHEN** a user loads or updates `/sessions` with existing supported search params
+- **THEN** the redesigned page rehydrates those params and preserves existing search/sort/pagination semantics
+- **AND** the visual layout emphasizes external session identity before secondary metadata
+
+### Requirement: Session Investigation Workspace
+
+The session detail and compare routes SHALL present a clearer investigation workspace without changing compare URL behavior.
+
+#### Scenario: Session detail keeps compare selection state
+- **WHEN** a user selects baseline and candidate traces on session detail
+- **THEN** the redesigned session detail page preserves the existing compare URL params and action flow
+
+#### Scenario: Session compare improves top-level scanability
+- **WHEN** a user opens `/sessions/{id}/compare`
+- **THEN** the page presents persistent baseline/candidate context and clear diff grouping before row-level inspection
+
+### Requirement: Trace Investigation Workspace
+
+The trace detail route SHALL preserve the current polling and selection model while improving workspace ergonomics.
+
+#### Scenario: Desktop trace context uses a drawer
+- **WHEN** a user opens trace detail on desktop
+- **THEN** trace context is available via a toggleable side drawer rather than occupying prime workspace space by default
+
+#### Scenario: Mobile trace detail uses four top-level tabs
+- **WHEN** a user opens trace detail on a narrow viewport
+- **THEN** the top-level tabs are `Summary`, `Execution`, `Timeline`, and `State`
+- **AND** the execution tab provides access to both tree and waterfall views
+
+#### Scenario: Tree rail quick filters are local-only
+- **WHEN** a user uses trace detail tree-rail quick filters
+- **THEN** those filters operate only on already loaded span data
+- **AND** they do not add new public URL params or require new server requests

--- a/openspec/changes/update-debugger-ui-redesign/tasks.md
+++ b/openspec/changes/update-debugger-ui-redesign/tasks.md
@@ -1,0 +1,57 @@
+## 1. OpenSpec
+
+- [ ] 1.1 Add `proposal.md`, `tasks.md`, `design.md`, and `specs/debugger-ui-redesign/spec.md`
+- [ ] 1.2 Validate the change with `openspec validate update-debugger-ui-redesign --strict`
+
+## 2. Shared App Shell and Visual System
+
+- [ ] 2.1 Add embedded IBM Plex Sans and IBM Plex Mono to the web app
+- [ ] 2.2 Replace the current top-only navigation wrapper with a shell that provides a desktop left rail, compact top utility bar, and mobile drawer navigation
+- [ ] 2.3 Surface route-aware navigation items for `Overview`, `Traces`, `Sessions`, and `Settings`
+- [ ] 2.4 Add API-key presence status and keep theme + command palette actions in the shell
+- [ ] 2.5 Introduce shared operator-console tokens and reusable surface/button/input styles in `globals.css`
+
+## 3. Overview Route
+
+- [ ] 3.1 Replace the placeholder home page with a real overview page
+- [ ] 3.2 Build overview snapshot metrics using existing trace and session list endpoints only
+- [ ] 3.3 Add sections for recent failures, running traces, recent sessions, and direct jump actions
+- [ ] 3.4 Add empty/loading/error/auth states aligned with the new visual system
+
+## 4. Traces and Sessions Triage
+
+- [ ] 4.1 Redesign the traces page into a sticky-toolbar triage surface while preserving existing URL search-param behavior
+- [ ] 4.2 Add quick-filter affordances and denser trace rows with stronger name/status emphasis
+- [ ] 4.3 Redesign the sessions page into a workflow/session index while preserving existing search/sort/pagination behavior
+- [ ] 4.4 Replace the plain sessions table treatment with denser rows and clearer secondary scan data
+- [ ] 4.5 Update shared pagination and sortable controls to match the new system
+
+## 5. Session Workspaces
+
+- [ ] 5.1 Redesign the session detail header and summary surfaces
+- [ ] 5.2 Recompose narrative/storyline and trace table into a clearer operator workspace without changing compare URL semantics
+- [ ] 5.3 Redesign compare selection surfaces and action hierarchy
+- [ ] 5.4 Redesign the session compare page with a persistent baseline/candidate header and clearer diff grouping
+
+## 6. Trace Workspace
+
+- [ ] 6.1 Redesign the trace detail header and summary strip
+- [ ] 6.2 Move desktop trace context into a right-side drawer while keeping mobile expandable access
+- [ ] 6.3 Refine tree rail, waterfall, inspector tabs, and span detail presentation for denser operator use
+- [ ] 6.4 Add local tree-rail quick filters using existing span data only
+- [ ] 6.5 Reduce mobile workspace composition to `Summary`, `Execution`, `Timeline`, and `State`, with execution sub-toggle between tree and waterfall
+
+## 7. Settings and Auth Surface
+
+- [ ] 7.1 Redesign the settings page into the same shell/system language
+- [ ] 7.2 Redesign the API key prompt to match the operator-console visual system
+
+## 8. Tests and Validation
+
+- [ ] 8.1 Add or update Vitest coverage for the app shell and overview route
+- [ ] 8.2 Update traces and sessions page tests to cover the redesigned layouts without regressing URL-state behavior
+- [ ] 8.3 Update trace detail tests for the desktop context drawer and the new four-tab mobile composition
+- [ ] 8.4 Add coverage for session detail/compare layout continuity where the redesign changes semantics or visible controls
+- [ ] 8.5 Add Playwright screenshot smoke tests/config for overview, traces, trace detail, sessions, session detail, session compare, and settings using seeded demo data
+- [ ] 8.6 Run `pnpm --filter web test`
+- [ ] 8.7 Run targeted build/type-check validation for the web app

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,12 @@ importers:
       '@continua/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource/ibm-plex-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@tanstack/react-query':
         specifier: 5.59.20
         version: 5.59.20(react@18.3.1)
@@ -107,6 +113,9 @@ importers:
         specifier: 2.5.4
         version: 2.5.4
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@testing-library/jest-dom':
         specifier: 6.6.3
         version: 6.6.3
@@ -767,6 +776,12 @@ packages:
   '@exodus/schemasafe@1.3.0':
     resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
 
+  '@fontsource/ibm-plex-mono@5.2.7':
+    resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
+
+  '@fontsource/ibm-plex-sans@5.2.8':
+    resolution: {integrity: sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -807,6 +822,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@redocly/ajv@8.17.1':
     resolution: {integrity: sha512-EDtsGZS964mf9zAUXAl9Ew16eYbeyAFWhsPr0fX6oaJxgd8rApYlPBf0joyhnUHz88WxrigyFtTaqqzXNzPgqw==}
@@ -1708,6 +1728,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2412,6 +2437,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -3663,6 +3698,10 @@ snapshots:
 
   '@exodus/schemasafe@1.3.0': {}
 
+  '@fontsource/ibm-plex-mono@5.2.7': {}
+
+  '@fontsource/ibm-plex-sans@5.2.8': {}
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -3705,6 +3744,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@redocly/ajv@8.17.1':
     dependencies:
@@ -4846,6 +4889,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5529,6 +5575,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 

--- a/web/e2e/ui-smoke.spec.ts
+++ b/web/e2e/ui-smoke.spec.ts
@@ -1,0 +1,365 @@
+import { expect, test, type Page, type Route, type TestInfo } from '@playwright/test';
+import {
+  OTHER_SESSION_ID,
+  SESSION_COMPARE,
+  SESSION_ID,
+  SESSION_NARRATIVE,
+  SESSION_ONE,
+  SESSION_TWO,
+  TRACE_DETAIL,
+  TRACE_ONE,
+  TRACE_THREE,
+  TRACE_TWO,
+  RUNNING_SESSION_NARRATIVE,
+} from '../src/test/traceFixtures';
+
+const API_KEY = process.env.PLAYWRIGHT_API_KEY ?? 'test-key';
+
+const TRACE_DETAILS = new Map([
+  [TRACE_ONE.id, TRACE_DETAIL],
+  [
+    TRACE_TWO.id,
+    {
+      ...TRACE_DETAIL,
+      ...TRACE_TWO,
+      trace_id: 'external-trace-latency',
+      user_id: 'user-456',
+      tags: ['latency'],
+      input: { prompt: 'latency check' },
+      output: { answer: 'running' },
+    },
+  ],
+  [
+    TRACE_THREE.id,
+    {
+      ...TRACE_DETAIL,
+      ...TRACE_THREE,
+      trace_id: 'external-trace-alpha',
+      user_id: 'user-123',
+      tags: ['alpha'],
+      input: { prompt: 'alpha' },
+      output: { answer: 'complete' },
+    },
+  ],
+]);
+
+const ALL_TRACES = [TRACE_ONE, TRACE_TWO, TRACE_THREE];
+const TRACE_SPANS = {
+  spans: [
+    {
+      id: 'span-root',
+      trace_id: TRACE_ONE.id,
+      span_id: 'root',
+      name: 'Checkout root',
+      kind: 'CHAIN',
+      status: 'FAILED',
+      started_at: TRACE_ONE.started_at,
+      ended_at: TRACE_ONE.ended_at,
+      latency_ms: 2000,
+      tokens_in: 120,
+      tokens_out: 80,
+      cost_usd: 0.12,
+      metadata: { phase: 'checkout' },
+    },
+    {
+      id: 'span-tool',
+      trace_id: TRACE_ONE.id,
+      span_id: 'tool-call',
+      parent_span_id: 'root',
+      name: 'Checkout tool',
+      kind: 'TOOL',
+      status: 'FAILED',
+      started_at: '2026-03-14T10:00:01.000Z',
+      ended_at: '2026-03-14T10:00:02.000Z',
+      latency_ms: 1000,
+      error_message: 'Gateway timeout',
+      metadata: { tool: 'charge-card' },
+    },
+  ],
+};
+const TRACE_TIMELINE = {
+  events: [
+    {
+      id: 'timeline-error',
+      trace_id: TRACE_ONE.id,
+      span_id: 'tool-call',
+      span_name: 'Checkout tool',
+      event_type: 'error',
+      timestamp: '2026-03-14T10:00:02.000Z',
+      source: 'explicit',
+      level: 'error',
+      message: 'Gateway timeout',
+      payload: { code: 'gateway_timeout' },
+    },
+  ],
+  trace_status: 'FAILED',
+  has_more: false,
+};
+
+async function bootstrapOperatorSession(page: Page) {
+  await page.addInitScript((apiKey) => {
+    window.localStorage.setItem('continua_api_key', apiKey);
+    window.localStorage.setItem('continua_theme_mode', 'light');
+  }, API_KEY);
+}
+
+async function fulfillJson(route: Route, data: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(data),
+  });
+}
+
+function filterTraces(url: URL) {
+  let traces = [...ALL_TRACES];
+  const sessionId = url.searchParams.get('session_id');
+  const status = url.searchParams.get('status');
+  const q = url.searchParams.get('q')?.toLowerCase();
+  const userId = url.searchParams.get('user_id');
+  const hasErrors = url.searchParams.get('has_errors') === 'true';
+  const minDurationMs = Number(url.searchParams.get('min_duration_ms') ?? '');
+
+  if (sessionId) {
+    traces = traces.filter((trace) => trace.session_id === sessionId);
+  }
+
+  if (status) {
+    traces = traces.filter((trace) => trace.status.toLowerCase() === status);
+  }
+
+  if (q) {
+    traces = traces.filter((trace) => {
+      const detail = TRACE_DETAILS.get(trace.id);
+      return (
+        trace.name.toLowerCase().includes(q) ||
+        detail?.user_id?.toLowerCase().includes(q) ||
+        trace.session_external_id?.toLowerCase().includes(q)
+      );
+    });
+  }
+
+  if (userId) {
+    traces = traces.filter((trace) => TRACE_DETAILS.get(trace.id)?.user_id === userId);
+  }
+
+  if (hasErrors) {
+    traces = traces.filter((trace) => (trace.error_count ?? 0) > 0);
+  }
+
+  if (!Number.isNaN(minDurationMs) && minDurationMs > 0) {
+    traces = traces.filter((trace) => {
+      if (!trace.ended_at) {
+        return false;
+      }
+
+      return (
+        new Date(trace.ended_at).getTime() - new Date(trace.started_at).getTime() >=
+        minDurationMs
+      );
+    });
+  }
+
+  const offset = Number(url.searchParams.get('offset') ?? '0');
+  const limit = Number(url.searchParams.get('limit') ?? '20');
+
+  return {
+    total: traces.length,
+    traces: traces.slice(offset, offset + limit),
+  };
+}
+
+function filterSessions(url: URL) {
+  let sessions = [SESSION_ONE, SESSION_TWO];
+  const q = url.searchParams.get('q')?.toLowerCase();
+  const userId = url.searchParams.get('user_id');
+
+  if (q) {
+    sessions = sessions.filter(
+      (session) =>
+        session.external_id.toLowerCase().includes(q) ||
+        session.name?.toLowerCase().includes(q)
+    );
+  }
+
+  if (userId) {
+    sessions = sessions.filter((session) => session.user_id === userId);
+  }
+
+  const offset = Number(url.searchParams.get('offset') ?? '0');
+  const limit = Number(url.searchParams.get('limit') ?? '20');
+
+  return {
+    total: sessions.length,
+    sessions: sessions.slice(offset, offset + limit),
+  };
+}
+
+async function mockApiRoutes(page: Page) {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname === '/api/traces') {
+      return fulfillJson(route, filterTraces(url));
+    }
+
+    if (/^\/api\/traces\/[^/]+\/spans$/.test(url.pathname)) {
+      return fulfillJson(route, TRACE_SPANS);
+    }
+
+    if (/^\/api\/traces\/[^/]+\/events$/.test(url.pathname)) {
+      return fulfillJson(route, TRACE_TIMELINE);
+    }
+
+    if (/^\/api\/traces\/[^/]+$/.test(url.pathname)) {
+      const traceId = url.pathname.split('/').at(-1) ?? '';
+      return fulfillJson(
+        route,
+        TRACE_DETAILS.get(traceId) ?? { ...TRACE_DETAIL, id: traceId }
+      );
+    }
+
+    if (url.pathname === '/api/sessions') {
+      return fulfillJson(route, filterSessions(url));
+    }
+
+    if (/^\/api\/sessions\/[^/]+\/narrative$/.test(url.pathname)) {
+      const sessionId = url.pathname.split('/').at(-2);
+      return fulfillJson(
+        route,
+        sessionId === SESSION_ID ? SESSION_NARRATIVE : RUNNING_SESSION_NARRATIVE
+      );
+    }
+
+    if (/^\/api\/sessions\/[^/]+\/compare$/.test(url.pathname)) {
+      return fulfillJson(route, SESSION_COMPARE);
+    }
+
+    if (/^\/api\/sessions\/[^/]+$/.test(url.pathname)) {
+      const sessionId = url.pathname.split('/').at(-1);
+      if (sessionId === SESSION_ID) {
+        return fulfillJson(route, SESSION_ONE);
+      }
+      if (sessionId === OTHER_SESSION_ID) {
+        return fulfillJson(route, SESSION_TWO);
+      }
+      return fulfillJson(route, { code: 'not_found', message: 'Resource not found' }, 404);
+    }
+
+    return fulfillJson(route, { code: 'not_found', message: 'Resource not found' }, 404);
+  });
+}
+
+async function gotoAndCapture(
+  page: Page,
+  testInfo: TestInfo,
+  path: string,
+  waitFor: () => Promise<unknown>,
+  screenshotName: string
+) {
+  await page.goto(path);
+  await waitFor();
+  await page.evaluate(async () => {
+    if ('fonts' in document) {
+      await document.fonts.ready;
+    }
+  });
+  const screenshot = await page.screenshot({ fullPage: true, animations: 'disabled' });
+  await testInfo.attach(screenshotName, {
+    body: screenshot,
+    contentType: 'image/png',
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await bootstrapOperatorSession(page);
+  await mockApiRoutes(page);
+});
+
+test('captures overview, traces, sessions, and settings shells', async ({ page }, testInfo) => {
+  const prefix = testInfo.project.name;
+
+  await gotoAndCapture(
+    page,
+    testInfo,
+    '/',
+    () =>
+      expect(
+        page.getByRole('heading', {
+          name: /Trace the work that matters before it turns into support debt/i,
+        })
+      ).toBeVisible(),
+    `${prefix}-overview`
+  );
+
+  await gotoAndCapture(
+    page,
+    testInfo,
+    '/traces',
+    () =>
+      expect(
+        page.getByRole('heading', {
+          name: /Find the run, isolate the failure, and jump straight into the workspace/i,
+        })
+      ).toBeVisible(),
+    `${prefix}-traces`
+  );
+
+  await gotoAndCapture(
+    page,
+    testInfo,
+    '/sessions',
+    () =>
+      expect(
+        page.getByRole('heading', {
+          name: /Follow a user journey across multiple traces without losing narrative context/i,
+        })
+      ).toBeVisible(),
+    `${prefix}-sessions`
+  );
+
+  await gotoAndCapture(
+    page,
+    testInfo,
+    '/settings',
+    () =>
+      expect(
+        page.getByRole('heading', {
+          name: /Configure this browser as an operator workspace/i,
+        })
+      ).toBeVisible(),
+    `${prefix}-settings`
+  );
+});
+
+test('captures trace, session, and compare workspaces', async ({ page }, testInfo) => {
+  const prefix = testInfo.project.name;
+  const isMobile = testInfo.project.name === 'mobile-chromium';
+
+  await gotoAndCapture(
+    page,
+    testInfo,
+    `/traces/${TRACE_ONE.id}`,
+    () =>
+      isMobile
+        ? expect(page.getByRole('button', { name: 'Summary' })).toBeVisible()
+        : expect(page.getByRole('heading', { name: 'Execution Waterfall' })).toBeVisible(),
+    `${prefix}-trace-detail`
+  );
+
+  await gotoAndCapture(
+    page,
+    testInfo,
+    `/sessions/${SESSION_ID}`,
+    () => expect(page.getByRole('heading', { name: 'Traces' })).toBeVisible(),
+    `${prefix}-session-detail`
+  );
+
+  await gotoAndCapture(
+    page,
+    testInfo,
+    `/sessions/${SESSION_ID}/compare?baseline_trace_id=${SESSION_COMPARE.baseline.id}&candidate_trace_id=${SESSION_COMPARE.candidate.id}`,
+    () => expect(page.getByRole('heading', { name: 'Span Diff' })).toBeVisible(),
+    `${prefix}-session-compare`
+  );
+});

--- a/web/package.json
+++ b/web/package.json
@@ -11,11 +11,15 @@
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:update": "playwright test --update-snapshots",
     "profile:workspace": "node ./scripts/profile-visual-workspace.mjs",
     "clean": "rm -rf dist"
   },
   "dependencies": {
     "@continua/contracts": "workspace:*",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/ibm-plex-sans": "^5.2.8",
     "@tanstack/react-query": "5.59.20",
     "class-variance-authority": "0.7.0",
     "clsx": "2.1.1",
@@ -27,6 +31,7 @@
     "tailwind-merge": "2.5.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.0.1",
     "@testing-library/user-event": "14.5.2",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3000',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command:
+      'pnpm build && pnpm exec vite preview --host 127.0.0.1 --port 3000 --strictPort',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'desktop-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 1024 },
+      },
+    },
+    {
+      name: 'mobile-chromium',
+      use: {
+        ...devices['Pixel 5'],
+      },
+    },
+  ],
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,13 +1,14 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { TracesPage } from './pages/TracesPage';
 import { TraceDetailPage } from './pages/TraceDetailPage';
 import { SessionsPage } from './pages/SessionsPage';
 import { SessionDetailPage } from './pages/SessionDetailPage';
 import { SessionComparePage } from './pages/SessionComparePage';
-import { Navigation } from './components/Navigation';
 import { SettingsPage } from './pages/SettingsPage';
 import { ThemeProvider } from './hooks/ThemeProvider';
+import { AppShell } from './components/AppShell';
+import { OverviewPage } from './pages/OverviewPage';
 
 const queryClient = new QueryClient();
 
@@ -17,44 +18,18 @@ export function App() {
       <ThemeProvider>
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={<PageWithNav><HomePage /></PageWithNav>} />
-            <Route path="/traces" element={<PageWithNav><TracesPage /></PageWithNav>} />
-            <Route path="/traces/:id" element={<PageWithNav><TraceDetailPage /></PageWithNav>} />
-            <Route path="/sessions" element={<PageWithNav><SessionsPage /></PageWithNav>} />
-            <Route path="/sessions/:id" element={<PageWithNav><SessionDetailPage /></PageWithNav>} />
-            <Route path="/sessions/:id/compare" element={<PageWithNav><SessionComparePage /></PageWithNav>} />
-            <Route path="/settings" element={<PageWithNav><SettingsPage /></PageWithNav>} />
+            <Route element={<AppShell />}>
+              <Route path="/" element={<OverviewPage />} />
+              <Route path="/traces" element={<TracesPage />} />
+              <Route path="/traces/:id" element={<TraceDetailPage />} />
+              <Route path="/sessions" element={<SessionsPage />} />
+              <Route path="/sessions/:id" element={<SessionDetailPage />} />
+              <Route path="/sessions/:id/compare" element={<SessionComparePage />} />
+              <Route path="/settings" element={<SettingsPage />} />
+            </Route>
           </Routes>
         </BrowserRouter>
       </ThemeProvider>
     </QueryClientProvider>
-  );
-}
-
-function PageWithNav({ children }: { children: React.ReactNode }) {
-  return (
-    <>
-      <Navigation />
-      {children}
-    </>
-  );
-}
-
-function HomePage() {
-  return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold text-slate-900 dark:text-slate-100">Continua</h1>
-        <p className="mt-2 text-slate-600 dark:text-slate-400">AI Agent Observability Platform</p>
-        <div className="mt-4 space-x-4">
-          <Link to="/traces" className="inline-block text-blue-600 hover:underline dark:text-sky-400">
-            View Traces
-          </Link>
-          <Link to="/sessions" className="inline-block text-blue-600 hover:underline dark:text-sky-400">
-            View Sessions
-          </Link>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -13,6 +13,7 @@ import {
 } from '../utils/sessionsSearchParams';
 
 const API_KEY_STORAGE_KEY = 'continua_api_key';
+const API_KEY_EVENT_NAME = 'continua:api-key-change';
 
 export type { FetchTracesParams } from '../utils/tracesSearchParams';
 export type {
@@ -33,6 +34,7 @@ export function getApiKey(): string | null {
  */
 export function setApiKey(key: string): void {
   localStorage.setItem(API_KEY_STORAGE_KEY, key);
+  dispatchApiKeyChange();
 }
 
 /**
@@ -40,6 +42,7 @@ export function setApiKey(key: string): void {
  */
 export function clearApiKey(): void {
   localStorage.removeItem(API_KEY_STORAGE_KEY);
+  dispatchApiKeyChange();
 }
 
 /**
@@ -80,6 +83,14 @@ export function isComparisonTooLargeError(
     typeof error.detail === 'object' &&
     error.detail !== null
   );
+}
+
+function dispatchApiKeyChange() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(new Event(API_KEY_EVENT_NAME));
 }
 
 /**

--- a/web/src/components/ApiKeyPrompt.tsx
+++ b/web/src/components/ApiKeyPrompt.tsx
@@ -23,11 +23,15 @@ export function ApiKeyPrompt({ onSubmit }: ApiKeyPromptProps) {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center dark:bg-slate-950">
-      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-lg dark:bg-slate-900">
-        <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-slate-100">API Key Required</h2>
-        <p className="mb-6 text-slate-600 dark:text-slate-300">
-          Enter your Continua API key to view traces.
+    <div className="app-page min-h-full justify-center py-10">
+      <div className="app-surface mx-auto w-full max-w-2xl overflow-hidden p-8 sm:p-10">
+        <div className="app-overline">Access required</div>
+        <h2 className="mt-4 text-3xl font-semibold tracking-[-0.04em] text-[var(--continua-text-primary)]">
+          Connect this browser to the Continua debugger.
+        </h2>
+        <p className="mt-4 max-w-xl text-base leading-7 text-[var(--continua-text-secondary)]">
+          Enter your Continua API key to unlock traces, sessions, and the full
+          investigation workspace in this browser profile.
         </p>
         <form onSubmit={handleSubmit}>
           <input
@@ -38,14 +42,14 @@ export function ApiKeyPrompt({ onSubmit }: ApiKeyPromptProps) {
               setError('');
             }}
             placeholder="ck_live_..."
-            className="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-900 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+            className="app-input mt-8"
           />
           {error && (
-            <p className="mt-2 text-red-600 text-sm">{error}</p>
+            <p className="mt-3 text-sm text-red-600 dark:text-red-300">{error}</p>
           )}
           <button
             type="submit"
-            className="mt-4 w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors"
+            className="app-button-primary mt-5 w-full"
           >
             Connect
           </button>

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -1,0 +1,78 @@
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearApiKey, setApiKey } from '../api/client';
+import { ThemeProvider } from '../hooks/ThemeProvider';
+import { AppShell } from './AppShell';
+
+async function renderShell(initialEntry = '/') {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route path="/" element={<div>Overview content</div>} />
+            <Route path="/traces" element={<div>Trace list content</div>} />
+            <Route path="/sessions" element={<div>Session list content</div>} />
+            <Route path="/settings" element={<div>Settings content</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem('continua_api_key', 'test-key');
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe('AppShell', () => {
+  it('renders the operator shell, primary navigation, and active route content', async () => {
+    await renderShell('/sessions');
+
+    const primaryNav = screen.getByRole('navigation', { name: 'Primary' });
+    expect(screen.getByText('Operator Console')).toBeInTheDocument();
+    expect(within(primaryNav).getByText('Overview').closest('a')).toHaveAttribute('href', '/');
+    expect(within(primaryNav).getByText('Traces').closest('a')).toHaveAttribute('href', '/traces');
+    expect(within(primaryNav).getByText('Sessions').closest('a')).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+    expect(screen.getByText('Session list content')).toBeInTheDocument();
+    expect(screen.getByText('API key connected')).toBeInTheDocument();
+  });
+
+  it('updates the API key indicator when local auth state changes', async () => {
+    await renderShell('/');
+    expect(screen.getByText('API key connected')).toBeInTheDocument();
+
+    act(() => {
+      clearApiKey();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('API key required')).toBeInTheDocument();
+    });
+
+    act(() => {
+      setApiKey('restored-key');
+    });
+    await waitFor(() => {
+      expect(screen.getByText('API key connected')).toBeInTheDocument();
+    });
+  });
+
+  it('opens the command palette from the shell control', async () => {
+    const user = userEvent.setup();
+    await renderShell('/');
+
+    await user.click(screen.getByRole('button', { name: /Command Palette/i }));
+    expect(screen.getByRole('combobox', { name: 'Search commands' })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Activity,
+  Command,
+  LayoutDashboard,
+  Menu,
+  MoonStar,
+  PanelLeftClose,
+  Settings2,
+  SunMedium,
+  Waypoints,
+  X,
+} from 'lucide-react';
+import {
+  NavLink,
+  Outlet,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom';
+import { CommandPalette } from './CommandPalette';
+import { getApiKey } from '../api/client';
+import { useTheme } from '../hooks/useTheme';
+
+interface NavItem {
+  path: string;
+  label: string;
+  detail: string;
+  icon: typeof LayoutDashboard;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  {
+    path: '/',
+    label: 'Overview',
+    detail: 'Snapshot of active traces and sessions',
+    icon: LayoutDashboard,
+  },
+  {
+    path: '/traces',
+    label: 'Traces',
+    detail: 'Triage individual runs and failures',
+    icon: Activity,
+  },
+  {
+    path: '/sessions',
+    label: 'Sessions',
+    detail: 'Follow user workflows across traces',
+    icon: Waypoints,
+  },
+  {
+    path: '/settings',
+    label: 'Settings',
+    detail: 'Theme and local API-key controls',
+    icon: Settings2,
+  },
+];
+
+export function AppShell() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { resolvedTheme, toggleTheme } = useTheme();
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [hasApiKey, setHasApiKey] = useState(() => Boolean(getApiKey()));
+  const activeItem = useMemo(
+    () =>
+      NAV_ITEMS.find((item) =>
+        item.path === '/'
+          ? location.pathname === '/'
+          : location.pathname.startsWith(item.path)
+      ) ?? NAV_ITEMS[0],
+    [location.pathname]
+  );
+  const commands = useMemo(
+    () => [
+      {
+        id: 'go-overview',
+        title: 'Go to Overview',
+        keywords: ['home', 'overview', 'dashboard'],
+        action: () => navigate('/'),
+      },
+      {
+        id: 'go-traces',
+        title: 'Go to Traces',
+        keywords: ['navigate', 'traces'],
+        action: () => navigate('/traces'),
+      },
+      {
+        id: 'go-sessions',
+        title: 'Go to Sessions',
+        keywords: ['navigate', 'sessions'],
+        action: () => navigate('/sessions'),
+      },
+      {
+        id: 'go-settings',
+        title: 'Go to Settings',
+        keywords: ['navigate', 'settings', 'theme', 'api key'],
+        action: () => navigate('/settings'),
+      },
+      {
+        id: 'toggle-theme',
+        title: 'Toggle Theme',
+        keywords: ['appearance', 'theme', 'dark', 'light'],
+        action: () => toggleTheme(),
+      },
+    ],
+    [navigate, toggleTheme]
+  );
+
+  useEffect(() => {
+    if (mobileOpen) {
+      setMobileOpen(false);
+    }
+  }, [location.pathname, location.search, mobileOpen]);
+
+  useEffect(() => {
+    const syncApiKeyState = () => setHasApiKey(Boolean(getApiKey()));
+
+    window.addEventListener('storage', syncApiKeyState);
+    window.addEventListener('continua:api-key-change', syncApiKeyState);
+
+    return () => {
+      window.removeEventListener('storage', syncApiKeyState);
+      window.removeEventListener('continua:api-key-change', syncApiKeyState);
+    };
+  }, []);
+
+  return (
+    <div className="app-shell-enter min-h-screen bg-transparent text-[var(--continua-text-primary)]">
+      <div className="flex min-h-screen">
+        <aside className="hidden w-[17rem] shrink-0 border-r border-[var(--continua-border-strong)] bg-[var(--continua-shell-rail)] px-4 py-5 lg:flex lg:flex-col">
+          <ShellBrand />
+          <nav className="mt-8 flex flex-1 flex-col gap-2" aria-label="Primary">
+            {NAV_ITEMS.map((item) => (
+              <ShellNavLink key={item.path} item={item} />
+            ))}
+          </nav>
+          <div className="rounded-[1.25rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-4 shadow-[var(--continua-shadow-soft)]">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--continua-text-muted)]">
+              Investigation model
+            </div>
+            <p className="mt-3 text-sm leading-6 text-[var(--continua-text-secondary)]">
+              Triage recent work, then move directly into a trace or session workspace
+              without leaving the shared shell.
+            </p>
+          </div>
+        </aside>
+
+        {mobileOpen ? (
+          <div className="app-overlay-enter fixed inset-0 z-50 lg:hidden">
+            <button
+              type="button"
+              aria-label="Close navigation overlay"
+              className="absolute inset-0 bg-slate-950/45 backdrop-blur-sm"
+              onClick={() => setMobileOpen(false)}
+            />
+            <aside className="app-drawer-enter relative flex h-full w-[19rem] max-w-[88vw] flex-col border-r border-[var(--continua-border-strong)] bg-[var(--continua-shell-rail)] px-4 py-5 shadow-2xl">
+              <div className="flex items-center justify-between">
+                <ShellBrand />
+                <button
+                  type="button"
+                  aria-label="Close navigation"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)] transition hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-text-primary)]"
+                  onClick={() => setMobileOpen(false)}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              <nav className="mt-8 flex flex-1 flex-col gap-2" aria-label="Mobile primary">
+                {NAV_ITEMS.map((item) => (
+                  <ShellNavLink key={item.path} item={item} />
+                ))}
+              </nav>
+            </aside>
+          </div>
+        ) : null}
+
+        <div className="flex min-h-screen min-w-0 flex-1 flex-col">
+          <header className="sticky top-0 z-40 border-b border-[var(--continua-border-soft)] bg-[var(--continua-shell-topbar)] px-4 py-3 backdrop-blur-xl sm:px-6 lg:px-8">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex min-w-0 items-center gap-3">
+                <button
+                  type="button"
+                  aria-label="Open navigation"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)] transition hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-text-primary)] lg:hidden"
+                  onClick={() => setMobileOpen(true)}
+                >
+                  <Menu className="h-4 w-4" />
+                </button>
+
+                <div className="min-w-0">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--continua-text-muted)]">
+                    {activeItem.label}
+                  </div>
+                  <div className="mt-1 truncate text-sm text-[var(--continua-text-secondary)]">
+                    {activeItem.detail}
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="inline-flex items-center gap-2 rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-3 py-2 text-xs font-medium text-[var(--continua-text-secondary)] shadow-[var(--continua-shadow-soft)]">
+                  <Command className="h-3.5 w-3.5 text-[var(--continua-accent)]" />
+                  <span>{hasApiKey ? 'API key connected' : 'API key required'}</span>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={toggleTheme}
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-3 py-2 text-sm font-medium text-[var(--continua-text-secondary)] shadow-[var(--continua-shadow-soft)] transition hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
+                  aria-label="Toggle theme"
+                >
+                  {resolvedTheme === 'dark' ? (
+                    <MoonStar className="h-4 w-4 text-[var(--continua-accent)]" />
+                  ) : (
+                    <SunMedium className="h-4 w-4 text-[var(--continua-accent)]" />
+                  )}
+                  <span className="capitalize">{resolvedTheme}</span>
+                </button>
+
+                <CommandPalette commands={commands} />
+              </div>
+            </div>
+          </header>
+
+          <main className="min-w-0 flex-1 overflow-x-hidden px-4 py-5 sm:px-6 lg:px-8">
+            <Outlet />
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ShellBrand() {
+  return (
+    <div className="rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface-elevated)] p-4 shadow-[var(--continua-shadow-soft)]">
+      <div className="flex items-center gap-3">
+        <div className="inline-flex h-11 w-11 items-center justify-center rounded-[1rem] bg-[var(--continua-accent-strong)] text-[var(--continua-accent-contrast)] shadow-[var(--continua-shadow-soft)]">
+          <PanelLeftClose className="h-5 w-5" />
+        </div>
+        <div className="min-w-0">
+          <div className="truncate text-lg font-semibold tracking-[-0.02em] text-[var(--continua-text-primary)]">
+            Continua
+          </div>
+          <div className="mt-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
+            Operator Console
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ShellNavLink({ item }: { item: NavItem }) {
+  const Icon = item.icon;
+
+  return (
+    <NavLink
+      to={item.path}
+      end={item.path === '/'}
+      className={({ isActive }) =>
+        `group flex items-start gap-3 rounded-[1.15rem] border px-3 py-3 transition ${
+          isActive
+            ? 'border-[var(--continua-border-strong)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-primary)] shadow-[var(--continua-shadow-soft)]'
+            : 'border-transparent bg-transparent text-[var(--continua-text-secondary)] hover:border-[var(--continua-border-soft)] hover:bg-[var(--continua-surface-muted)] hover:text-[var(--continua-text-primary)]'
+        }`
+      }
+    >
+      {({ isActive }) => (
+        <>
+          <span
+            className={`mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${
+              isActive
+                ? 'bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
+                : 'bg-[var(--continua-surface-muted)] text-[var(--continua-text-muted)] group-hover:text-[var(--continua-accent)]'
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+          </span>
+          <span className="min-w-0">
+            <span className="block text-sm font-semibold">{item.label}</span>
+            <span className="mt-1 block text-xs leading-5 text-[var(--continua-text-muted)]">
+              {item.detail}
+            </span>
+          </span>
+        </>
+      )}
+    </NavLink>
+  );
+}

--- a/web/src/components/ExecutionWaterfall.tsx
+++ b/web/src/components/ExecutionWaterfall.tsx
@@ -102,29 +102,29 @@ export function ExecutionWaterfall({
 
   if (rows.length === 0 || !window) {
     return (
-      <section className="flex h-full items-center justify-center rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-        <div className="text-sm text-slate-500 dark:text-slate-400">No spans available for execution timing.</div>
+      <section className="flex h-full items-center justify-center rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface)] shadow-[var(--continua-shadow-soft)]">
+        <div className="text-sm text-[var(--continua-text-muted)]">No spans available for execution timing.</div>
       </section>
     );
   }
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
-        <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface)] shadow-[var(--continua-shadow-soft)]">
+      <div className="border-b border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-4 py-3">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-[var(--continua-text-secondary)]">
           Execution Waterfall
         </h2>
-        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+        <p className="mt-1 text-sm text-[var(--continua-text-muted)]">
           Timing bars follow the visible tree order and selection state.
         </p>
       </div>
 
-      <div className="grid grid-cols-[minmax(0,13rem)_minmax(0,1fr)] border-b border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
-        <div className="border-r border-slate-200 px-4 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:border-slate-800 dark:text-slate-400">
+      <div className="grid grid-cols-[minmax(0,13rem)_minmax(0,1fr)] border-b border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)]">
+        <div className="border-r border-[var(--continua-border-soft)] px-4 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
           Visible spans
         </div>
         <div className="relative px-4 py-3">
-          <div className="relative flex h-full items-start justify-between gap-2 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+          <div className="relative flex h-full items-start justify-between gap-2 text-[11px] font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
             {ticks.map((tick) => (
               <span
                 key={tick.leftPercent}
@@ -146,7 +146,7 @@ export function ExecutionWaterfall({
         onScroll={onScroll}
       >
         <div
-          className="divide-y divide-slate-100 dark:divide-slate-800"
+          className="divide-y divide-[var(--continua-border-soft)]"
           style={{
             paddingBottom: `${paddingBottom}px`,
             paddingTop: `${paddingTop}px`,
@@ -176,10 +176,10 @@ export function ExecutionWaterfall({
               >
                 <button
                   type="button"
-                  className={`flex h-full min-w-0 items-center border-r border-slate-200 px-4 py-3 text-left transition dark:border-slate-800 ${
+                  className={`flex h-full min-w-0 items-center border-r border-[var(--continua-border-soft)] px-4 py-3 text-left transition ${
                     isSelected
-                      ? 'bg-blue-50 dark:bg-sky-500/10'
-                      : 'bg-white hover:bg-slate-50 dark:bg-slate-900 dark:hover:bg-slate-800/60'
+                      ? 'bg-[var(--continua-accent-faint)]'
+                      : 'bg-[var(--continua-surface-elevated)] hover:bg-[var(--continua-surface-muted)]'
                   }`}
                   onClick={() => onSelectSpanAndShowDetails(row.span.span_id)}
                 >
@@ -188,7 +188,7 @@ export function ExecutionWaterfall({
                     style={{ paddingLeft: `${row.depth * 12}px` }}
                   >
                     <div className="flex items-center gap-2">
-                      <div className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                      <div className="min-w-0 flex-1 truncate text-sm font-medium text-[var(--continua-text-primary)]">
                         {row.span.name}
                       </div>
                       {row.span.status === 'FAILED' && retrySafety ? (
@@ -200,7 +200,7 @@ export function ExecutionWaterfall({
                       ) : null}
                     </div>
 
-                    <div className="mt-1 flex items-center gap-1 overflow-hidden whitespace-nowrap text-xs text-slate-500 dark:text-slate-400">
+                    <div className="mt-1 flex items-center gap-1 overflow-hidden whitespace-nowrap text-xs text-[var(--continua-text-muted)]">
                       <span className="shrink-0">{row.span.status}</span>
                       <span aria-hidden="true">·</span>
                       <span className="shrink-0">{formatDuration(row.span.latency_ms)}</span>
@@ -234,7 +234,7 @@ export function ExecutionWaterfall({
                   >
                     <button
                       type="button"
-                      className={`absolute top-1/2 flex h-6 -translate-y-1/2 items-center rounded-full border px-2 text-xs font-medium text-slate-900 transition focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-slate-50`}
+                      className={`absolute top-1/2 flex h-6 -translate-y-1/2 items-center rounded-full border px-2 text-xs font-medium text-slate-900 transition focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] dark:text-slate-50`}
                       style={{
                         left: `${bar.leftPercent}%`,
                         width: `${Math.max(bar.widthPercent, 0.35)}%`,

--- a/web/src/components/InspectorTabs.tsx
+++ b/web/src/components/InspectorTabs.tsx
@@ -42,8 +42,8 @@ export function InspectorTabs({
   }, [switchToDetailsRef]);
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface)] shadow-[var(--continua-shadow-soft)]">
+      <div className="border-b border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-4 py-3">
         <div className="flex items-center gap-2">
           <InspectorTabButton
             active={activeTab === 'details'}
@@ -114,10 +114,10 @@ function InspectorTabButton({
     <button
       type="button"
       aria-label={label}
-      className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
+      className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] ${
         active
-          ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
-          : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800'
+          ? 'border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
+          : 'border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)] hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-text-primary)]'
       }`}
       aria-pressed={active}
       onClick={onClick}
@@ -128,8 +128,8 @@ function InspectorTabButton({
           aria-hidden="true"
           className={`ml-2 rounded-full px-2 py-0.5 text-xs font-semibold ${
             active
-              ? 'bg-white/20 text-white dark:bg-slate-200/30 dark:text-slate-950'
-              : 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
+              ? 'bg-[var(--continua-accent)] text-[var(--continua-accent-contrast)]'
+              : 'bg-[var(--continua-text-primary)] text-[var(--continua-surface-elevated)]'
           }`}
         >
           {badgeCount}

--- a/web/src/components/PaginationControls.tsx
+++ b/web/src/components/PaginationControls.tsx
@@ -18,8 +18,8 @@ interface PaginationControlsProps {
 
 function buttonClassName(enabled: boolean): string {
   return enabled
-    ? 'rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200'
-    : 'cursor-not-allowed rounded-lg bg-slate-200 px-3 py-2 text-sm font-medium text-slate-400 dark:bg-slate-800 dark:text-slate-500';
+    ? 'app-button-secondary'
+    : 'cursor-not-allowed rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-4 py-2 text-sm font-medium text-[var(--continua-text-muted)] opacity-55';
 }
 
 export function PaginationControls({
@@ -54,7 +54,7 @@ export function PaginationControls({
   }, [currentItemCount, lastValidOffset, offset, onRepairOffset]);
 
   return (
-    <div className="mt-4 flex flex-col gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-slate-800 dark:bg-slate-900 md:flex-row md:items-center md:justify-between">
+    <div className="app-surface mt-4 flex flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:justify-between">
       <div className="flex flex-wrap items-center gap-2">
         <button
           type="button"
@@ -94,7 +94,7 @@ export function PaginationControls({
         </button>
       </div>
 
-      <div className="flex flex-col gap-2 text-sm text-slate-600 dark:text-slate-300 md:items-end">
+      <div className="flex flex-col gap-2 text-sm text-[var(--continua-text-secondary)] md:items-end">
         <span>
           Showing {showingFrom}-{showingTo} of {total}
         </span>
@@ -106,7 +106,7 @@ export function PaginationControls({
               aria-label="Rows per page"
               value={pageSize}
               onChange={(event) => onPageSizeChange(Number(event.target.value) || DEFAULT_PAGE_SIZE)}
-              className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+              className="app-select min-w-[5rem] px-2 py-1.5"
             >
               {pageSizeOptions.map((option) => (
                 <option key={option} value={option}>

--- a/web/src/components/SortableHeader.tsx
+++ b/web/src/components/SortableHeader.tsx
@@ -25,7 +25,7 @@ export function SortableHeader({
 
   if (isDisabled) {
     return (
-      <span className="inline-flex items-center gap-1 text-slate-300 dark:text-slate-600">
+      <span className="inline-flex items-center gap-1 text-[var(--continua-text-muted)] opacity-55">
         <span>{label}</span>
         <span aria-hidden="true">{indicator}</span>
       </span>
@@ -36,7 +36,7 @@ export function SortableHeader({
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1 text-slate-500 transition hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-slate-400 dark:hover:text-slate-200"
+      className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[var(--continua-text-secondary)] transition hover:bg-[var(--continua-surface-muted)] hover:text-[var(--continua-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
     >
       <span>{label}</span>
       <span aria-hidden="true">{indicator}</span>

--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -46,7 +46,7 @@ export function SpanDetail({
 }: SpanDetailProps) {
   if (!span) {
     return (
-      <div className="h-full flex items-center justify-center text-slate-500 dark:text-slate-400">
+      <div className="flex h-full items-center justify-center text-[var(--continua-text-muted)]">
         Select a span to view details
       </div>
     );
@@ -77,9 +77,13 @@ export function SpanDetail({
           onSelectSpan={onSelectSpan}
           className="mb-3"
         />
-        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{span.name}</h2>
-        <div className="flex items-center gap-2 mt-1">
-          <span className="text-sm text-slate-500 dark:text-slate-400">{span.kind}</span>
+        <h2 className="text-xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+          {span.name}
+        </h2>
+        <div className="mt-2 flex items-center gap-2">
+          <span className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--continua-text-secondary)]">
+            {span.kind}
+          </span>
           <StatusBadge status={span.status} />
         </div>
       </div>
@@ -94,14 +98,14 @@ export function SpanDetail({
       {/* Token breakdown */}
       {(span.tokens_in || span.tokens_out) && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Token Breakdown</h3>
-          <div className="rounded bg-slate-50 p-3 text-sm dark:bg-slate-950/70">
+          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Token Breakdown</h3>
+          <div className="app-surface-muted p-3 text-sm">
             <div className="flex justify-between">
-              <span className="text-slate-600 dark:text-slate-300">Input tokens:</span>
+              <span className="text-[var(--continua-text-secondary)]">Input tokens:</span>
               <span className="font-mono">{span.tokens_in ?? 0}</span>
             </div>
             <div className="flex justify-between mt-1">
-              <span className="text-slate-600 dark:text-slate-300">Output tokens:</span>
+              <span className="text-[var(--continua-text-secondary)]">Output tokens:</span>
               <span className="font-mono">{span.tokens_out ?? 0}</span>
             </div>
           </div>
@@ -112,7 +116,7 @@ export function SpanDetail({
       {span.error_message && (
         <div className="mb-6">
           <h3 className="text-sm font-medium text-red-700 mb-2">Error</h3>
-          <div className="bg-red-50 border border-red-200 rounded p-3 text-sm text-red-800 font-mono whitespace-pre-wrap">
+          <div className="rounded border border-red-300/40 bg-red-50/80 p-3 font-mono text-sm text-red-800 whitespace-pre-wrap dark:border-red-400/25 dark:bg-red-400/10 dark:text-red-100">
             {span.error_message}
           </div>
         </div>
@@ -121,8 +125,8 @@ export function SpanDetail({
       {/* LLM context */}
       {showLLMContext && (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">LLM Context</h3>
-          <div className="rounded bg-slate-50 p-3 text-sm dark:bg-slate-950/70">
+          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">LLM Context</h3>
+          <div className="app-surface-muted p-3 text-sm">
             <DetailRow label="Model" value={span.model} />
             <DetailRow label="Provider" value={span.provider} className="mt-1" />
           </div>
@@ -132,7 +136,7 @@ export function SpanDetail({
       {/* Input */}
       {span.input !== undefined && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Input</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Input</h3>
           <TruncationBanner
             title="Input payload"
             truncated={span.input_truncated}
@@ -146,7 +150,7 @@ export function SpanDetail({
       {/* Output */}
       {span.output !== undefined && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Output</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Output</h3>
           <TruncationBanner
             title="Output payload"
             truncated={span.output_truncated}
@@ -160,34 +164,34 @@ export function SpanDetail({
       {/* Metadata */}
       {span.metadata && Object.keys(span.metadata).length > 0 && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Metadata</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Metadata</h3>
           <JsonViewer data={span.metadata} />
         </div>
       )}
 
       {decisions.length > 0 && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Decisions</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Decisions</h3>
           <div className="space-y-3">
             {decisions.map((decision) => (
               <div
                 key={decision.event.id}
-                className="rounded border border-blue-100 bg-blue-50/70 p-3 dark:border-sky-500/30 dark:bg-sky-500/10"
+                className="rounded-xl border border-[var(--continua-border-strong)] bg-[var(--continua-surface-muted)] p-3"
               >
-                <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                <div className="text-sm font-semibold text-[var(--continua-text-primary)]">
                   {decision.question}
                 </div>
-                <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-[var(--continua-text-secondary)]">
                   <span>Chosen</span>
                   <DecisionValuePill tone="accent">
                     {formatInlineSemanticValue(decision.chosen)}
                   </DecisionValuePill>
                 </div>
                 {decision.reasoning ? (
-                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{decision.reasoning}</p>
+                  <p className="mt-2 text-sm text-[var(--continua-text-secondary)]">{decision.reasoning}</p>
                 ) : null}
                 {decision.alternatives && decision.alternatives.length > 0 ? (
-                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--continua-text-muted)]">
                     <span>Alternatives</span>
                     {decision.alternatives.map((alternative, index) => (
                       <DecisionValuePill
@@ -206,28 +210,28 @@ export function SpanDetail({
 
       {span.status === 'FAILED' && retrySafety ? (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">
             Retry Safety
           </h3>
-          <div className="rounded border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/70">
+          <div className="app-surface-muted p-4">
             <div className="flex flex-wrap items-center gap-3">
               <RetrySafetyBadge
                 classification={retrySafety.classification}
                 variant="full"
                 aria-label={getAccessibleSummary(retrySafety.classification)}
               />
-              <span className="text-sm text-slate-700 dark:text-slate-200">
+              <span className="text-sm text-[var(--continua-text-secondary)]">
                 Advisory only. Retry safety is inferred from recorded effect metadata.
               </span>
             </div>
-            <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
+            <p className="mt-3 text-sm text-[var(--continua-text-secondary)]">
               {getReasonExplanation(retrySafety.reason)}
             </p>
             {(retrySafety.effectKind !== undefined ||
               retrySafety.hasExternalSideEffect !== undefined ||
               retrySafety.idempotent !== undefined ||
               retrySafety.idempotencyKey !== undefined) ? (
-              <div className="mt-4 rounded border border-slate-200 bg-white p-3 text-sm dark:border-slate-700 dark:bg-slate-900">
+              <div className="mt-4 rounded-xl border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] p-3 text-sm">
                 <DetailRow label="effect_kind" value={retrySafety.effectKind} mono />
                 {retrySafety.hasExternalSideEffect !== undefined ? (
                   <DetailRow
@@ -261,8 +265,8 @@ export function SpanDetail({
 
       {/* IDs */}
       <div className="mb-6">
-          <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Identifiers</h3>
-          <div className="rounded bg-slate-50 p-3 text-sm dark:bg-slate-950/70">
+          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Identifiers</h3>
+          <div className="app-surface-muted p-3 text-sm">
           <DetailRow label="Span UUID" value={span.id} mono />
           <DetailRow
             label="Span ID"
@@ -285,7 +289,7 @@ export function SpanDetail({
                   <button
                     type="button"
                     aria-label={`Select parent span ${span.parent_span_id}`}
-                    className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+                    className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-2.5 py-1 text-xs font-medium text-[var(--continua-text-secondary)] transition hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
                     onClick={() => onSelectSpan(parentSpan.span_id)}
                   >
                     {span.parent_span_id}
@@ -309,8 +313,8 @@ export function SpanDetail({
 
       {/* Timestamps */}
       <div>
-        <h3 className="text-sm font-medium text-slate-700 mb-2 dark:text-slate-200">Timestamps</h3>
-        <div className="rounded bg-slate-50 p-3 text-sm dark:bg-slate-950/70">
+        <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Timestamps</h3>
+        <div className="app-surface-muted p-3 text-sm">
           <DetailRow
             label="Started"
             value={formatTimestamp(span.started_at)}
@@ -337,9 +341,9 @@ interface MetricCardProps {
 
 function MetricCard({ label, value }: MetricCardProps) {
   return (
-    <div className="rounded p-3 text-center bg-slate-50 dark:bg-slate-950/70">
-      <div className="text-xl font-semibold text-slate-900 dark:text-slate-100">{value}</div>
-      <div className="text-xs text-slate-500 mt-1 dark:text-slate-400">{label}</div>
+    <div className="app-surface-muted p-3 text-center">
+      <div className="text-xl font-semibold text-[var(--continua-text-primary)]">{value}</div>
+      <div className="mt-1 text-xs text-[var(--continua-text-muted)]">{label}</div>
     </div>
   );
 }
@@ -363,7 +367,7 @@ function DetailRow({
 
   return (
     <div className={`flex justify-between gap-4 ${className}`.trim()}>
-      <span className="text-slate-600 dark:text-slate-300">{label}:</span>
+      <span className="text-[var(--continua-text-secondary)]">{label}:</span>
       {hasValue ? (
         <span className="flex min-w-0 items-center justify-end gap-2">
           <span className={mono ? 'font-mono text-xs text-right' : 'text-right'}>
@@ -372,7 +376,7 @@ function DetailRow({
           {action}
         </span>
       ) : (
-        <span className="text-slate-400 dark:text-slate-500">-</span>
+        <span className="text-[var(--continua-text-muted)]">-</span>
       )}
     </div>
   );

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -7,16 +7,21 @@ interface StatusBadgeProps {
  */
 export function StatusBadge({ status }: StatusBadgeProps) {
   const colors = {
-    RUNNING: 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-200',
-    STARTED: 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-200',
-    COMPLETED: 'bg-green-100 text-green-800 dark:bg-emerald-500/15 dark:text-emerald-200',
-    FAILED: 'bg-red-100 text-red-800 dark:bg-red-500/15 dark:text-red-200',
-    SCHEDULED: 'bg-gray-100 text-gray-800 dark:bg-slate-800 dark:text-slate-200',
+    RUNNING:
+      'border border-sky-300/60 bg-sky-100/80 text-sky-900 dark:border-sky-400/25 dark:bg-sky-400/10 dark:text-sky-100',
+    STARTED:
+      'border border-sky-300/60 bg-sky-100/80 text-sky-900 dark:border-sky-400/25 dark:bg-sky-400/10 dark:text-sky-100',
+    COMPLETED:
+      'border border-emerald-300/60 bg-emerald-100/80 text-emerald-900 dark:border-emerald-400/20 dark:bg-emerald-400/10 dark:text-emerald-100',
+    FAILED:
+      'border border-red-300/60 bg-red-100/80 text-red-900 dark:border-red-400/25 dark:bg-red-400/10 dark:text-red-100',
+    SCHEDULED:
+      'border border-slate-300/70 bg-slate-100/80 text-slate-700 dark:border-slate-600 dark:bg-slate-800/80 dark:text-slate-200',
   };
 
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors[status]}`}
+      className={`inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] ${colors[status]}`}
     >
       {status}
     </span>

--- a/web/src/components/TreeRail.tsx
+++ b/web/src/components/TreeRail.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useMemo,
+  useState,
   type Dispatch,
   type SetStateAction,
 } from 'react';
@@ -52,6 +53,8 @@ export function TreeRail({
   onVisibleRowsChange,
   spanAssessments = EMPTY_SPAN_ASSESSMENTS,
 }: TreeRailProps) {
+  const [failedOnly, setFailedOnly] = useState(false);
+  const [kindFilter, setKindFilter] = useState<'ALL' | Span['kind']>('ALL');
   const {
     effectiveExpandedSpanIds,
     handleCollapseAll,
@@ -71,12 +74,31 @@ export function TreeRail({
     spanTree,
     spans,
   });
+  const availableKinds = useMemo(
+    () => Array.from(new Set(spans.map((span) => span.kind))),
+    [spans]
+  );
+  const filteredRows = useMemo(
+    () =>
+      visibleRows.filter((row) => {
+        if (failedOnly && !failedSpanIds.has(row.span.span_id)) {
+          return false;
+        }
+
+        if (kindFilter !== 'ALL' && row.span.kind !== kindFilter) {
+          return false;
+        }
+
+        return true;
+      }),
+    [failedOnly, failedSpanIds, kindFilter, visibleRows]
+  );
   const visibleRowIndexBySpanId = useMemo(
     () =>
       new Map(
-        visibleRows.map((row, index) => [row.span.span_id, index] as const)
+        filteredRows.map((row, index) => [row.span.span_id, index] as const)
       ),
-    [visibleRows]
+    [filteredRows]
   );
   const {
     containerRef,
@@ -87,12 +109,12 @@ export function TreeRail({
     virtualRows,
   } = useVirtualRows({
     estimatedRowHeight: showMetrics ? TREE_ROW_HEIGHT_WITH_METRICS : TREE_ROW_HEIGHT,
-    rows: visibleRows,
+    rows: filteredRows,
   });
 
   useEffect(() => {
-    onVisibleRowsChange(visibleRows);
-  }, [onVisibleRowsChange, visibleRows]);
+    onVisibleRowsChange(filteredRows);
+  }, [filteredRows, onVisibleRowsChange]);
 
   useEffect(() => {
     if (!selectedSpanId || !revealPath.has(selectedSpanId)) {
@@ -114,14 +136,14 @@ export function TreeRail({
   ]);
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface)] shadow-[var(--continua-shadow-soft)]">
+      <div className="border-b border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-4 py-3">
         <div className="flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-[var(--continua-text-secondary)]">
               Spans ({spans.length})
             </h2>
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            <p className="mt-1 text-sm text-[var(--continua-text-muted)]">
               Search, expand, and inspect the visible span hierarchy.
             </p>
           </div>
@@ -135,31 +157,31 @@ export function TreeRail({
               value={searchQueryInput}
               onChange={(event) => setSearchQueryInput(event.target.value)}
               placeholder="Search name, kind, span ID, status, model, provider, errors"
-              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-blue-300 focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+              className="app-input"
             />
           </label>
 
           <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              className="rounded-full bg-white px-3 py-1.5 text-sm font-medium text-slate-600 ring-1 ring-slate-200 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800"
+              className="app-button-ghost"
               onClick={handleExpandAll}
             >
               Expand all
             </button>
             <button
               type="button"
-              className="rounded-full bg-white px-3 py-1.5 text-sm font-medium text-slate-600 ring-1 ring-slate-200 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800"
+              className="app-button-ghost"
               onClick={handleCollapseAll}
             >
               Collapse all
             </button>
             <button
               type="button"
-              className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
+              className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] ${
                 showMetrics
-                  ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
-                  : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800'
+                  ? 'border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
+                  : 'border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)]'
               }`}
               aria-pressed={showMetrics}
               onClick={() => setShowMetrics((current) => !current)}
@@ -167,10 +189,52 @@ export function TreeRail({
               Show metrics
             </button>
             {matchedSpanIds !== null ? (
-              <span className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+              <span className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
                 {matchedSpanIds.size} match{matchedSpanIds.size === 1 ? '' : 'es'}
               </span>
             ) : null}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              aria-pressed={failedOnly}
+              onClick={() => setFailedOnly((current) => !current)}
+              className={`rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] transition focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] ${
+                failedOnly
+                  ? 'border border-red-400/50 bg-red-100/80 text-red-900 dark:border-red-400/25 dark:bg-red-400/10 dark:text-red-100'
+                  : 'border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)]'
+              }`}
+            >
+              Failed only
+            </button>
+            <button
+              type="button"
+              aria-pressed={kindFilter === 'ALL'}
+              onClick={() => setKindFilter('ALL')}
+              className={`rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] transition ${
+                kindFilter === 'ALL'
+                  ? 'border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
+                  : 'border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)]'
+              }`}
+            >
+              All kinds
+            </button>
+            {availableKinds.map((kind) => (
+              <button
+                key={kind}
+                type="button"
+                aria-pressed={kindFilter === kind}
+                onClick={() => setKindFilter((current) => (current === kind ? 'ALL' : kind))}
+                className={`rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] transition ${
+                  kindFilter === kind
+                    ? 'border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
+                    : 'border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)]'
+                }`}
+              >
+                {kind}
+              </button>
+            ))}
           </div>
         </div>
       </div>
@@ -178,7 +242,7 @@ export function TreeRail({
       <div
         ref={containerRef}
         className="min-h-0 flex-1 overflow-y-auto"
-        data-visible-row-count={visibleRows.length}
+        data-visible-row-count={filteredRows.length}
         onScroll={onScroll}
       >
         <div

--- a/web/src/components/WorkspaceShell.tsx
+++ b/web/src/components/WorkspaceShell.tsx
@@ -1,11 +1,9 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Group, Panel, Separator } from 'react-resizable-panels';
 
 export type MobileWorkspaceTabId =
-  | 'details'
-  | 'waterfall'
-  | 'tree'
-  | 'reasoning'
+  | 'summary'
+  | 'execution'
   | 'timeline'
   | 'state';
 
@@ -14,8 +12,7 @@ interface WorkspaceShellProps {
   treeRail: ReactNode;
   waterfall: ReactNode;
   inspector: ReactNode;
-  mobileDetails: ReactNode;
-  mobileReasoning: ReactNode;
+  mobileSummary: ReactNode;
   mobileTimeline: ReactNode;
   mobileState: ReactNode;
   activeMobileTab: MobileWorkspaceTabId;
@@ -23,11 +20,9 @@ interface WorkspaceShellProps {
 }
 
 const MOBILE_TABS: Array<{ id: MobileWorkspaceTabId; label: string }> = [
-  { id: 'details', label: 'Details' },
-  { id: 'waterfall', label: 'Waterfall' },
-  { id: 'tree', label: 'Tree' },
+  { id: 'summary', label: 'Summary' },
+  { id: 'execution', label: 'Execution' },
   { id: 'timeline', label: 'Timeline' },
-  { id: 'reasoning', label: 'Reasoning' },
   { id: 'state', label: 'State' },
 ];
 const USE_STATIC_DESKTOP_LAYOUT =
@@ -38,8 +33,7 @@ export function WorkspaceShell({
   treeRail,
   waterfall,
   inspector,
-  mobileDetails,
-  mobileReasoning,
+  mobileSummary,
   mobileTimeline,
   mobileState,
   activeMobileTab,
@@ -82,17 +76,17 @@ export function WorkspaceShell({
   }
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div className="border-b border-slate-200 bg-slate-50 px-3 py-3 dark:border-slate-800 dark:bg-slate-950/70">
+    <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface)] shadow-[var(--continua-shadow-soft)]">
+      <div className="border-b border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-3 py-3">
         <div className="flex flex-wrap items-center gap-2">
           {MOBILE_TABS.map((tab) => (
             <button
               key={tab.id}
               type="button"
-              className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
+              className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] ${
                 activeMobileTab === tab.id
-                  ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
-                  : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800'
+                  ? 'border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
+                  : 'border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)] hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-text-primary)]'
               }`}
               aria-pressed={activeMobileTab === tab.id}
               onClick={() => onMobileTabChange(tab.id)}
@@ -106,33 +100,20 @@ export function WorkspaceShell({
       <div className="min-h-0 flex-1">
         <div
           className="h-full"
-          style={{ display: activeMobileTab === 'details' ? 'block' : 'none' }}
+          style={{ display: activeMobileTab === 'summary' ? 'block' : 'none' }}
         >
-          {mobileDetails}
+          {mobileSummary}
         </div>
-        <div
-          className="h-full"
-          style={{ display: activeMobileTab === 'waterfall' ? 'block' : 'none' }}
-        >
-          {waterfall}
-        </div>
-        <div
-          className="h-full"
-          style={{ display: activeMobileTab === 'tree' ? 'block' : 'none' }}
-        >
-          {treeRail}
-        </div>
+        <MobileExecutionPane
+          active={activeMobileTab === 'execution'}
+          treeRail={treeRail}
+          waterfall={waterfall}
+        />
         <div
           className="h-full"
           style={{ display: activeMobileTab === 'timeline' ? 'block' : 'none' }}
         >
           {mobileTimeline}
-        </div>
-        <div
-          className="h-full"
-          style={{ display: activeMobileTab === 'reasoning' ? 'block' : 'none' }}
-        >
-          {mobileReasoning}
         </div>
         <div
           className="h-full"
@@ -142,6 +123,51 @@ export function WorkspaceShell({
         </div>
       </div>
     </section>
+  );
+}
+
+function MobileExecutionPane({
+  active,
+  treeRail,
+  waterfall,
+}: {
+  active: boolean;
+  treeRail: ReactNode;
+  waterfall: ReactNode;
+}) {
+  const [mode, setMode] = useState<'waterfall' | 'tree'>('waterfall');
+
+  return (
+    <div className="h-full" style={{ display: active ? 'block' : 'none' }}>
+      <div className="border-b border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-3 py-2">
+        <div className="flex flex-wrap items-center gap-2">
+          {(['waterfall', 'tree'] as const).map((nextMode) => (
+            <button
+              key={nextMode}
+              type="button"
+              aria-pressed={mode === nextMode}
+              onClick={() => setMode(nextMode)}
+              className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] ${
+                mode === nextMode
+                  ? 'border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
+                  : 'border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)]'
+              }`}
+            >
+              {nextMode === 'waterfall' ? 'Waterfall' : 'Tree'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="h-[calc(100%-3.5rem)]">
+        <div className="h-full" style={{ display: mode === 'waterfall' ? 'block' : 'none' }}>
+          {waterfall}
+        </div>
+        <div className="h-full" style={{ display: mode === 'tree' ? 'block' : 'none' }}>
+          {treeRail}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/web/src/hooks/ThemeProvider.tsx
+++ b/web/src/hooks/ThemeProvider.tsx
@@ -24,7 +24,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       setSystemPrefersDark(event.matches);
     };
 
-    setSystemPrefersDark(mediaQuery.matches);
     mediaQuery.addEventListener('change', handleChange);
 
     return () => {

--- a/web/src/pages/OverviewPage.test.tsx
+++ b/web/src/pages/OverviewPage.test.tsx
@@ -1,0 +1,57 @@
+import { screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearApiKey, setApiKey } from '../api/client';
+import { buildFetchHandler, jsonResponse, renderTraceRoutes } from './testUtils';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  localStorage.clear();
+  setApiKey('test-key');
+});
+
+afterEach(() => {
+  clearApiKey();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('OverviewPage', () => {
+  it('renders snapshot metrics and operator jump actions from existing trace/session endpoints', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes(['/']);
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /Trace the work that matters before it turns into support debt/i,
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Tracked traces')).toBeInTheDocument();
+    expect(screen.getByText('Running now')).toBeInTheDocument();
+    expect(screen.getByText('Failed traces')).toBeInTheDocument();
+    expect(screen.getByText('Sessions')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open traces' })).toHaveAttribute('href', '/traces');
+    expect(screen.getByRole('link', { name: 'Open sessions' })).toHaveAttribute('href', '/sessions');
+    expect(screen.getByRole('heading', { name: 'Recent failed traces' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Recent sessions' })).toBeInTheDocument();
+  });
+
+  it('keeps overview content visible when one supporting query fails', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        sessionsList: () => jsonResponse({ message: 'Session list unavailable' }, 500),
+      })
+    );
+
+    renderTraceRoutes(['/']);
+
+    expect(await screen.findByText(/Overview data is partially unavailable/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Recent failed traces' })).toBeInTheDocument();
+    expect(screen.getAllByText('Checkout Trace').length).toBeGreaterThan(0);
+    expect(screen.getByText('Could not load sessions: Session list unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('No sessions yet')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -1,0 +1,413 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { Link, useLocation } from 'react-router-dom';
+import {
+  fetchSessions,
+  fetchTraces,
+  isAuthError,
+  type Session,
+  type Trace,
+} from '../api/client';
+import { AuthErrorBanner } from '../components/AuthErrorBanner';
+import { StatusBadge } from '../components/StatusBadge';
+import { useRequireApiKey } from '../hooks/useRequireApiKey';
+import {
+  formatCost,
+  formatRelativeTime,
+  formatTokens,
+} from '../utils/format';
+
+const OVERVIEW_TRACE_LIMIT = 6;
+const OVERVIEW_SESSION_LIMIT = 6;
+
+export function OverviewPage() {
+  const { hasApiKey, prompt } = useRequireApiKey();
+
+  if (!hasApiKey) {
+    return prompt;
+  }
+
+  return <OverviewContent />;
+}
+
+function OverviewContent() {
+  const location = useLocation();
+  const returnTo = `${location.pathname}${location.search}`;
+  const recentTracesQuery = useQuery({
+    queryKey: ['overview', 'recent-traces'],
+    queryFn: () => fetchTraces({ limit: OVERVIEW_TRACE_LIMIT }),
+    placeholderData: keepPreviousData,
+  });
+  const failedTracesQuery = useQuery({
+    queryKey: ['overview', 'failed-traces'],
+    queryFn: () => fetchTraces({ limit: OVERVIEW_TRACE_LIMIT, status: 'failed' }),
+    placeholderData: keepPreviousData,
+  });
+  const runningTracesQuery = useQuery({
+    queryKey: ['overview', 'running-traces'],
+    queryFn: () => fetchTraces({ limit: OVERVIEW_TRACE_LIMIT, status: 'running' }),
+    placeholderData: keepPreviousData,
+  });
+  const sessionsQuery = useQuery({
+    queryKey: ['overview', 'sessions'],
+    queryFn: () => fetchSessions({ limit: OVERVIEW_SESSION_LIMIT }),
+    placeholderData: keepPreviousData,
+  });
+
+  const authError = [
+    recentTracesQuery.error,
+    failedTracesQuery.error,
+    runningTracesQuery.error,
+    sessionsQuery.error,
+  ].find(isAuthError);
+  const recentTracesError = getOverviewQueryError(recentTracesQuery.error, recentTracesQuery.data);
+  const failedTracesError = getOverviewQueryError(failedTracesQuery.error, failedTracesQuery.data);
+  const runningTracesError = getOverviewQueryError(runningTracesQuery.error, runningTracesQuery.data);
+  const sessionsError = getOverviewQueryError(sessionsQuery.error, sessionsQuery.data);
+  const otherErrors = [
+    recentTracesQuery.error,
+    failedTracesQuery.error,
+    runningTracesQuery.error,
+    sessionsQuery.error,
+  ].filter((error): error is Error => error instanceof Error && !isAuthError(error));
+
+  if (authError) {
+    return <AuthErrorBanner message={authError.message} />;
+  }
+
+  const recentTraces = recentTracesQuery.data?.traces ?? [];
+  const failedTraces = failedTracesQuery.data?.traces ?? [];
+  const runningTraces = runningTracesQuery.data?.traces ?? [];
+  const sessions = sessionsQuery.data?.sessions ?? [];
+  const totalTraces = recentTracesQuery.data?.total ?? 0;
+  const totalFailedTraces = failedTracesQuery.data?.total ?? 0;
+  const totalRunningTraces = runningTracesQuery.data?.total ?? 0;
+  const totalSessions = sessionsQuery.data?.total ?? 0;
+  const activeLoadState = [
+    recentTracesQuery.isFetching,
+    failedTracesQuery.isFetching,
+    runningTracesQuery.isFetching,
+    sessionsQuery.isFetching,
+  ].some(Boolean);
+  return (
+    <div className="app-page">
+      <section className="app-surface relative overflow-hidden p-6 sm:p-8">
+        <div className="absolute inset-y-0 right-0 hidden w-[28rem] bg-[radial-gradient(circle_at_top,rgba(47,131,204,0.18),transparent_62%)] lg:block" />
+        <div className="relative flex flex-col gap-8 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-3xl">
+            <div className="app-overline">Operator Overview</div>
+            <h1 className="mt-4 max-w-2xl text-4xl font-semibold tracking-[-0.04em] text-[var(--continua-text-primary)] sm:text-5xl">
+              Trace the work that matters before it turns into support debt.
+            </h1>
+            <p className="mt-4 max-w-2xl text-base leading-7 text-[var(--continua-text-secondary)] sm:text-lg">
+              Recent failures, live executions, and session workflows stay in one
+              operator surface so you can move from signal to root cause quickly.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Link to="/traces" className="app-button-primary">
+              Open traces
+            </Link>
+            <Link to="/sessions" className="app-button-secondary">
+              Open sessions
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {otherErrors.length > 0 ? (
+        <div className="app-alert-error">
+          Overview data is partially unavailable. {otherErrors[0].message}
+        </div>
+      ) : null}
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <OverviewMetric
+          label="Tracked traces"
+          value={formatOverviewMetricValue(totalTraces, recentTracesError)}
+          hint="Recent request inventory"
+        />
+        <OverviewMetric
+          label="Running now"
+          value={formatOverviewMetricValue(totalRunningTraces, runningTracesError)}
+          hint="Currently polling for progress"
+        />
+        <OverviewMetric
+          label="Failed traces"
+          value={formatOverviewMetricValue(totalFailedTraces, failedTracesError)}
+          hint="Failure queue in scope"
+        />
+        <OverviewMetric
+          label="Sessions"
+          value={formatOverviewMetricValue(totalSessions, sessionsError)}
+          hint="Workflow groups in scope"
+        />
+      </section>
+
+      <section className="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        <div className="app-surface p-5">
+          <div className="app-section-header">
+            <div>
+              <div className="app-overline">Failures</div>
+              <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+                Recent failed traces
+              </h2>
+            </div>
+            <Link to="/traces?status=failed" className="app-inline-link">
+              View all failed traces
+            </Link>
+          </div>
+
+            <TraceActivityList
+              traces={failedTraces}
+              emptyTitle="No failed traces"
+              emptyBody="Failures will surface here as soon as they happen."
+              errorMessage={failedTracesError}
+              isLoading={failedTracesQuery.isPending && !failedTracesQuery.data}
+              returnTo={returnTo}
+            />
+        </div>
+
+        <div className="space-y-5">
+          <div className="app-surface p-5">
+            <div className="app-section-header">
+              <div>
+                <div className="app-overline">Live work</div>
+                <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+                  Running traces
+                </h2>
+              </div>
+              <Link to="/traces?status=running" className="app-inline-link">
+                Open live triage
+              </Link>
+            </div>
+
+            <TraceActivityList
+              traces={runningTraces}
+              emptyTitle="No running traces"
+              emptyBody="When executions are in flight they show up here."
+              errorMessage={runningTracesError}
+              isLoading={runningTracesQuery.isPending && !runningTracesQuery.data}
+              returnTo={returnTo}
+            />
+          </div>
+
+          <div className="app-surface p-5">
+            <div className="app-section-header">
+              <div>
+                <div className="app-overline">Session workflows</div>
+                <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+                  Recent sessions
+                </h2>
+              </div>
+              <Link to="/sessions" className="app-inline-link">
+                Open session index
+              </Link>
+            </div>
+
+            <SessionActivityList
+              sessions={sessions}
+              emptyTitle="No sessions yet"
+              emptyBody="Sessions appear when traces are grouped under a shared session identifier."
+              errorMessage={sessionsError}
+              isLoading={sessionsQuery.isPending && !sessionsQuery.data}
+              returnTo={returnTo}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="app-surface p-5">
+        <div className="app-section-header">
+          <div>
+            <div className="app-overline">Recent activity</div>
+            <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+              Latest traces
+            </h2>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-sm text-[var(--continua-text-muted)]">
+            <span>{totalTraces} total traces</span>
+            {activeLoadState ? <span>Refreshing…</span> : null}
+          </div>
+        </div>
+
+        <TraceActivityList
+          traces={recentTraces}
+          emptyTitle="No traces yet"
+          emptyBody="Start ingesting spans or run the demo flow to populate the debugger."
+          errorMessage={recentTracesError}
+          isLoading={recentTracesQuery.isPending && !recentTracesQuery.data}
+          returnTo={returnTo}
+        />
+      </section>
+    </div>
+  );
+}
+
+function OverviewMetric({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint: string;
+}) {
+  return (
+    <article className="app-metric-panel">
+      <div className="app-overline">{label}</div>
+      <div className="mt-3 text-3xl font-semibold tracking-[-0.04em] text-[var(--continua-text-primary)]">
+        {value}
+      </div>
+      <p className="mt-2 text-sm text-[var(--continua-text-muted)]">{hint}</p>
+    </article>
+  );
+}
+
+function TraceActivityList({
+  traces,
+  emptyTitle,
+  emptyBody,
+  errorMessage,
+  isLoading,
+  returnTo,
+}: {
+  traces: Trace[];
+  emptyTitle: string;
+  emptyBody: string;
+  errorMessage: string | null;
+  isLoading: boolean;
+  returnTo: string;
+}) {
+  if (isLoading) {
+    return <div className="app-empty-state">Loading traces…</div>;
+  }
+
+  if (errorMessage) {
+    return <div className="app-alert-error mt-5">Could not load traces: {errorMessage}</div>;
+  }
+
+  if (traces.length === 0) {
+    return (
+      <div className="app-empty-state">
+        <h3 className="text-base font-semibold text-[var(--continua-text-primary)]">{emptyTitle}</h3>
+        <p className="mt-2">{emptyBody}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-5 space-y-3">
+      {traces.map((trace) => {
+        const totalTokens = (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
+
+        return (
+          <Link
+            key={trace.id}
+            to={`/traces/${trace.id}`}
+            state={{ returnTo }}
+            className="app-list-row group"
+          >
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="truncate text-sm font-semibold text-[var(--continua-text-primary)] transition group-hover:text-[var(--continua-accent)]">
+                  {trace.name}
+                </div>
+                <StatusBadge status={trace.status} />
+              </div>
+
+              <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--continua-text-muted)]">
+                <span>{formatRelativeTime(trace.started_at)}</span>
+                <span>{trace.status === 'RUNNING' ? 'Live now' : 'Trace complete'}</span>
+                {trace.session_external_id ? <span>{trace.session_external_id}</span> : null}
+                {trace.error_count && trace.error_count > 0 ? (
+                  <span className="text-red-600 dark:text-red-300">{trace.error_count} errors</span>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="flex shrink-0 flex-col items-end gap-1 text-right text-xs text-[var(--continua-text-muted)]">
+              <span>{formatTokens(totalTokens)}</span>
+              <span>{formatCost(trace.total_cost_usd)}</span>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+function SessionActivityList({
+  sessions,
+  emptyTitle,
+  emptyBody,
+  errorMessage,
+  isLoading,
+  returnTo,
+}: {
+  sessions: Session[];
+  emptyTitle: string;
+  emptyBody: string;
+  errorMessage: string | null;
+  isLoading: boolean;
+  returnTo: string;
+}) {
+  if (isLoading) {
+    return <div className="app-empty-state">Loading sessions…</div>;
+  }
+
+  if (errorMessage) {
+    return <div className="app-alert-error mt-5">Could not load sessions: {errorMessage}</div>;
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <div className="app-empty-state">
+        <h3 className="text-base font-semibold text-[var(--continua-text-primary)]">{emptyTitle}</h3>
+        <p className="mt-2">{emptyBody}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-5 space-y-3">
+      {sessions.map((session) => (
+        <Link
+          key={session.id}
+          to={`/sessions/${session.id}`}
+          state={{ returnTo }}
+          className="app-list-row group"
+        >
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-[var(--continua-text-primary)] transition group-hover:text-[var(--continua-accent)]">
+              {session.external_id}
+            </div>
+            <div className="mt-1 text-xs text-[var(--continua-text-muted)]">
+              {session.name || 'Unnamed session'}
+            </div>
+          </div>
+
+          <div className="flex shrink-0 flex-col items-end gap-1 text-right text-xs text-[var(--continua-text-muted)]">
+            <span>{session.trace_count ?? 0} traces</span>
+            <span>{formatRelativeTime(session.created_at)}</span>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function getOverviewQueryError(
+  error: unknown,
+  data: unknown
+): string | null {
+  if (!error || data || isAuthError(error)) {
+    return null;
+  }
+
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
+function formatOverviewMetricValue(value: number, errorMessage: string | null): string {
+  return errorMessage ? 'Unavailable' : String(value);
+}

--- a/web/src/pages/SessionComparePage.test.tsx
+++ b/web/src/pages/SessionComparePage.test.tsx
@@ -198,7 +198,9 @@ describe('SessionComparePage', () => {
     expect(await screen.findByRole('link', { name: SESSION_COMPARE.baseline.name })).toBeInTheDocument();
     await user.click(screen.getByRole('link', { name: SESSION_COMPARE.baseline.name }));
 
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '← Session' })).toHaveAttribute(
       'href',
       `/sessions/${SESSION_ID}/compare?baseline_trace_id=${SESSION_COMPARE.baseline.id}&candidate_trace_id=${SESSION_COMPARE.candidate.id}`
@@ -242,7 +244,9 @@ describe('SessionComparePage', () => {
       expect(router.state.location.pathname).toBe(`/traces/${SESSION_COMPARE.baseline.id}`);
     });
 
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '← Session' })).toHaveAttribute(
       'href',
       `/sessions/${SESSION_ID}/compare?baseline_trace_id=${SESSION_COMPARE.baseline.id}&candidate_trace_id=${SESSION_COMPARE.candidate.id}`

--- a/web/src/pages/SessionComparePage.tsx
+++ b/web/src/pages/SessionComparePage.tsx
@@ -36,7 +36,7 @@ export function SessionComparePage() {
 
   if (!id) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-slate-950">
+      <div className="flex min-h-full items-center justify-center">
         <div className="text-red-600 dark:text-red-300">Session ID is required</div>
       </div>
     );
@@ -75,7 +75,7 @@ function SessionCompareContent({ sessionId }: { sessionId: string }) {
   if (!baselineTraceId || !candidateTraceId) {
     return (
       <ComparePageShell returnTo={returnTo}>
-        <section className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100">
+        <section className="rounded-[1.5rem] border border-amber-300/40 bg-amber-50/80 p-6 text-amber-900 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-100">
           <h1 className="text-lg font-semibold">Comparison needs two traces</h1>
           <p className="mt-2 text-sm">
             Open this page from a session with both a baseline and candidate trace selected.
@@ -88,7 +88,7 @@ function SessionCompareContent({ sessionId }: { sessionId: string }) {
   if (comparisonQuery.isLoading) {
     return (
       <ComparePageShell returnTo={returnTo}>
-        <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+        <div className="app-empty-state">
           Loading comparison...
         </div>
       </ComparePageShell>
@@ -103,7 +103,7 @@ function SessionCompareContent({ sessionId }: { sessionId: string }) {
         ) : isComparisonTooLargeError(comparisonQuery.error) ? (
           <ComparisonTooLargePanel error={comparisonQuery.error} />
         ) : (
-          <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+          <div className="app-alert-error">
             Error loading comparison: {queryErrorMessage(comparisonQuery.error)}
           </div>
         )}
@@ -114,7 +114,7 @@ function SessionCompareContent({ sessionId }: { sessionId: string }) {
   if (!comparisonQuery.data) {
     return (
       <ComparePageShell returnTo={returnTo}>
-        <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+        <div className="app-empty-state">
           Comparison not found.
         </div>
       </ComparePageShell>
@@ -125,21 +125,22 @@ function SessionCompareContent({ sessionId }: { sessionId: string }) {
     <ComparePageShell returnTo={returnTo}>
       <CompareOverview comparison={comparisonQuery.data} currentCompareUrl={currentCompareUrl} />
 
-      <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <section className="app-surface p-6">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Span Diff</h2>
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            <div className="app-overline">Diff workspace</div>
+            <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">Span Diff</h2>
+            <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">
               Ordered baseline-first diff with inline semantic event comparison.
             </p>
           </div>
-          <div className="text-sm text-slate-500 dark:text-slate-400">
+          <div className="text-sm text-[var(--continua-text-muted)]">
             {comparisonQuery.data.span_diffs.length} rows
           </div>
         </div>
 
         {comparisonQuery.data.span_diffs.length === 0 ? (
-          <div className="mt-6 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-5 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-300">
+          <div className="app-empty-state mt-6">
             No span rows were returned for this comparison. Both traces may be empty.
           </div>
         ) : (
@@ -158,7 +159,7 @@ function SessionCompareContent({ sessionId }: { sessionId: string }) {
               return (
                 <div key={rowKey}>
                   {showCandidateOnlyDivider ? (
-                    <div className="mb-3 rounded-lg border border-sky-200 bg-sky-50 px-3 py-2 text-sm font-medium text-sky-900 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-100">
+                    <div className="mb-3 rounded-xl border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] px-3 py-2 text-sm font-medium text-[var(--continua-accent)]">
                       Candidate-only branches
                     </div>
                   ) : null}
@@ -193,16 +194,14 @@ function ComparePageShell({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <Link
-          to={returnTo}
-          className="mb-4 inline-block text-sm text-blue-600 hover:text-blue-800 dark:text-sky-400 dark:hover:text-sky-300"
-        >
-          &larr; Back to Session
-        </Link>
-        <div className="space-y-6">{children}</div>
-      </div>
+    <div className="app-page">
+      <Link
+        to={returnTo}
+        className="inline-flex text-sm font-medium text-[var(--continua-accent)] transition hover:opacity-80"
+      >
+        &larr; Back to Session
+      </Link>
+      <div className="space-y-6">{children}</div>
     </div>
   );
 }
@@ -215,19 +214,19 @@ function CompareOverview({
   currentCompareUrl: string;
 }) {
   return (
-    <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <section className="app-surface sticky top-[4.9rem] z-10 p-6">
       <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:justify-between">
         <div>
-          <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+          <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
             Session Compare
           </p>
-          <h1 className="mt-2 text-2xl font-bold text-slate-900 dark:text-slate-100">
+          <h1 className="mt-2 text-3xl font-semibold tracking-[-0.04em] text-[var(--continua-text-primary)]">
             {comparison.session.external_id}
           </h1>
           {comparison.session.name ? (
-            <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{comparison.session.name}</p>
+            <p className="mt-2 text-sm text-[var(--continua-text-secondary)]">{comparison.session.name}</p>
           ) : null}
-          <p className="mt-2 font-mono text-xs text-slate-500 dark:text-slate-400">
+          <p className="mt-2 font-mono text-xs text-[var(--continua-text-muted)]">
             {comparison.session.id}
           </p>
         </div>
@@ -295,20 +294,20 @@ function CompareTraceCard({
   currentCompareUrl: string;
 }) {
   return (
-    <article className="rounded-xl border border-slate-200 bg-slate-50/80 p-4 dark:border-slate-800 dark:bg-slate-950/50">
+    <article className="app-surface-muted p-4">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+          <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
             {label}
           </p>
           <Link
             to={`/traces/${trace.id}`}
             state={{ returnTo: currentCompareUrl }}
-            className="mt-2 inline-block text-sm font-semibold text-blue-700 hover:text-blue-900 dark:text-sky-400 dark:hover:text-sky-300"
+            className="mt-2 inline-block text-sm font-semibold text-[var(--continua-accent)] hover:opacity-80"
           >
             {trace.name}
           </Link>
-          <p className="mt-2 font-mono text-xs text-slate-500 dark:text-slate-400">{trace.trace_id}</p>
+          <p className="mt-2 font-mono text-xs text-[var(--continua-text-muted)]">{trace.trace_id}</p>
         </div>
         <StatusBadge status={trace.status} />
       </div>
@@ -345,17 +344,18 @@ function CompareSpanRow({
   onToggleExpanded: () => void;
   currentCompareUrl: string;
 }) {
+  const rowToneClass =
+    row.diff_status === 'changed'
+      ? 'border-amber-300/35 bg-amber-50/60 dark:border-amber-400/20 dark:bg-amber-400/10'
+      : row.diff_status === 'baseline_only'
+        ? 'border-rose-300/35 bg-rose-50/60 dark:border-rose-400/20 dark:bg-rose-400/10'
+        : row.diff_status === 'candidate_only'
+          ? 'border-sky-300/35 bg-sky-50/60 dark:border-sky-400/20 dark:bg-sky-400/10'
+          : 'border-[var(--continua-border-strong)] bg-[var(--continua-surface-elevated)]';
+
   return (
     <article
-      className={`rounded-xl border p-4 shadow-sm ${
-        row.diff_status === 'changed'
-          ? 'border-amber-200 bg-amber-50/70 dark:border-amber-500/30 dark:bg-amber-500/10'
-          : row.diff_status === 'baseline_only'
-            ? 'border-rose-200 bg-rose-50/70 dark:border-rose-500/30 dark:bg-rose-500/10'
-            : row.diff_status === 'candidate_only'
-              ? 'border-sky-200 bg-sky-50/70 dark:border-sky-500/30 dark:bg-sky-500/10'
-              : 'border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900'
-      }`}
+      className={`rounded-[1.35rem] border p-4 shadow-[var(--continua-shadow-soft)] ${rowToneClass}`}
       style={{ marginLeft: `${row.depth * 12}px` }}
     >
       <div className="flex flex-col gap-4">
@@ -365,7 +365,7 @@ function CompareSpanRow({
           {row.changed_fields.map((field) => (
             <span
               key={field}
-              className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+              className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2 py-0.5 text-xs font-medium text-[var(--continua-text-secondary)]"
             >
               {field}
             </span>
@@ -374,7 +374,7 @@ function CompareSpanRow({
             <button
               type="button"
               onClick={onToggleExpanded}
-              className="ml-auto rounded-md border border-slate-300 px-2.5 py-1 text-xs font-medium text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-slate-100"
+              className="ml-auto rounded-full border border-[var(--continua-border-strong)] bg-[var(--continua-surface-elevated)] px-3 py-1.5 text-xs font-medium text-[var(--continua-text-secondary)] transition hover:border-[var(--continua-accent)] hover:text-[var(--continua-accent)]"
             >
               {expanded ? 'Hide semantic details' : 'Show semantic details'}
             </button>
@@ -397,7 +397,7 @@ function CompareSpanRow({
         </div>
 
         {expanded && hasSemanticContent ? (
-          <div className="rounded-lg border border-slate-200 bg-slate-50/70 p-3 dark:border-slate-800 dark:bg-slate-950/40">
+          <div className="rounded-[1.1rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-3">
             <div className="space-y-3">
               {row.semantic_groups.map((group, index) => (
                 <CompareSemanticGroupRow
@@ -426,27 +426,27 @@ function CompareSpanSide({
 }) {
   if (!span) {
     return (
-      <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-400">
+      <div className="rounded-[1.05rem] border border-dashed border-[var(--continua-border-strong)] bg-[var(--continua-surface-muted)] px-3 py-4 text-sm text-[var(--continua-text-muted)]">
         {label}: no matching span
       </div>
     );
   }
 
   return (
-    <div className="rounded-lg border border-slate-200 bg-slate-50/80 p-3 dark:border-slate-800 dark:bg-slate-950/50">
+    <div className="rounded-[1.05rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-3">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+          <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
             {label}
           </p>
           <Link
             to={`/traces/${traceId}?span=${encodeURIComponent(span.span_id)}`}
             state={{ returnTo: currentCompareUrl }}
-            className="mt-2 inline-block text-sm font-semibold text-blue-700 hover:text-blue-900 dark:text-sky-400 dark:hover:text-sky-300"
+            className="mt-2 inline-block text-sm font-semibold text-[var(--continua-accent)] hover:opacity-80"
           >
             {span.name}
           </Link>
-          <p className="mt-1 font-mono text-xs text-slate-500 dark:text-slate-400">{span.span_id}</p>
+          <p className="mt-1 font-mono text-xs text-[var(--continua-text-muted)]">{span.span_id}</p>
         </div>
         <StatusBadge status={span.status} />
       </div>
@@ -472,9 +472,9 @@ function CompareSemanticGroupRow({
   group: SpanDiffRow['semantic_groups'][number];
 }) {
   return (
-    <div className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900">
+    <div className="rounded-[1.05rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] p-3">
       <div className="flex flex-wrap items-center gap-2">
-        <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+        <span className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-[var(--continua-text-secondary)]">
           {group.event_type}
         </span>
         <DiffStatusPill diffStatus={group.diff_status} small />
@@ -506,25 +506,25 @@ function CompareSemanticSide({
 }) {
   if (!event) {
     return (
-      <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-400">
+      <div className="rounded-[1.05rem] border border-dashed border-[var(--continua-border-strong)] bg-[var(--continua-surface-muted)] px-3 py-4 text-sm text-[var(--continua-text-muted)]">
         {label}: no matching event
       </div>
     );
   }
 
   return (
-    <div className="rounded-lg border border-slate-200 bg-slate-50/70 p-3 dark:border-slate-800 dark:bg-slate-950/40">
-      <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+    <div className="rounded-[1.05rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-3">
+      <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
         {label}
       </p>
-      <p className="mt-2 text-sm font-medium text-slate-900 dark:text-slate-100">
+      <p className="mt-2 text-sm font-medium text-[var(--continua-text-primary)]">
         {event.message ?? '(no message)'}
       </p>
-      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+      <p className="mt-1 text-xs text-[var(--continua-text-muted)]">
         {formatRelativeTime(event.timestamp)}
       </p>
       {event.payload ? (
-        <pre className="mt-3 overflow-x-auto rounded-md bg-slate-950 px-3 py-2 text-xs text-slate-100">
+        <pre className="mt-3 overflow-x-auto rounded-[0.95rem] bg-slate-950 px-3 py-2 text-xs text-slate-100">
           {JSON.stringify(event.payload, null, 2)}
         </pre>
       ) : null}
@@ -538,7 +538,7 @@ function ComparisonTooLargePanel({
   error: ApiError & { detail: ComparisonTooLargeErrorDetail };
 }) {
   return (
-    <section className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100">
+    <section className="rounded-[1.5rem] border border-amber-300/40 bg-amber-50/80 p-6 text-amber-900 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-100">
       <h1 className="text-lg font-semibold">Comparison exceeds the v1 ceiling</h1>
       <p className="mt-2 text-sm">{error.message}</p>
       <dl className="mt-4 grid gap-3 md:grid-cols-2">
@@ -579,12 +579,18 @@ function OverviewMetric({
   compact?: boolean;
 }) {
   return (
-    <div className={compact ? '' : 'rounded-lg border border-slate-200 p-4 dark:border-slate-800'}>
-      <dt className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+    <div
+      className={
+        compact
+          ? 'rounded-[1rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] p-3'
+          : 'app-metric-panel'
+      }
+    >
+      <dt className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
         {label}
       </dt>
-      <dd className="mt-2 text-sm font-semibold text-slate-900 dark:text-slate-100">{value}</dd>
-      {hint ? <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{hint}</p> : null}
+      <dd className="mt-2 text-sm font-semibold text-[var(--continua-text-primary)]">{value}</dd>
+      {hint ? <p className="mt-1 text-xs text-[var(--continua-text-secondary)]">{hint}</p> : null}
     </div>
   );
 }
@@ -625,7 +631,7 @@ function MatchSourcePill({
 }) {
   return (
     <span
-      className={`rounded-full bg-slate-200 px-2 py-0.5 font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200 ${
+      className={`rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2 py-0.5 font-medium text-[var(--continua-text-secondary)] ${
         small ? 'text-[11px]' : 'text-xs'
       }`}
       title={matchReason ?? undefined}

--- a/web/src/pages/SessionDetailPage.test.tsx
+++ b/web/src/pages/SessionDetailPage.test.tsx
@@ -135,7 +135,9 @@ describe('SessionDetailPage', () => {
     expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
     await user.click(screen.getByRole('link', { name: 'Checkout Trace' }));
 
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '← Session' })).toHaveAttribute(
       'href',
       `/sessions/${SESSION_ID}?offset=20&sort_by=started_at&sort_dir=asc`
@@ -365,7 +367,9 @@ describe('SessionDetailPage', () => {
     expect(await screen.findByRole('link', { name: 'Storyline Route Trace' })).toBeInTheDocument();
     await user.click(screen.getByRole('link', { name: 'Storyline Route Trace' }));
 
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '← Session' })).toHaveAttribute(
       'href',
       `/sessions/${SESSION_ID}?offset=20&sort_by=started_at&sort_dir=asc`

--- a/web/src/pages/SessionDetailPage.tsx
+++ b/web/src/pages/SessionDetailPage.tsx
@@ -517,24 +517,22 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
 
   if (sessionQuery.error) {
     return (
-      <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
-        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="app-page max-w-4xl">
           {isAuthError(sessionQuery.error) ? (
             <AuthErrorBanner message={queryErrorMessage(sessionQuery.error)} />
           ) : (
-            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+            <div className="app-alert-error">
               Error loading session: {queryErrorMessage(sessionQuery.error)}
             </div>
           )}
-        </div>
       </div>
     );
   }
 
   if (!sessionQuery.data) {
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center dark:bg-slate-950">
-        <div className="text-slate-500 dark:text-slate-400">Session not found</div>
+      <div className="flex min-h-full items-center justify-center">
+        <div className="text-[var(--continua-text-muted)]">Session not found</div>
       </div>
     );
   }
@@ -542,20 +540,19 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
   const session = sessionQuery.data;
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+    <div className="app-page">
         <Link
           to={returnTo}
-          className="mb-4 inline-block text-sm text-blue-600 hover:text-blue-800 dark:text-sky-400 dark:hover:text-sky-300"
+          className="inline-flex text-sm font-medium text-[var(--continua-accent)] transition hover:opacity-80"
         >
           &larr; Back to Sessions
         </Link>
 
-        <section className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <section className="app-surface p-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
               <div className="flex flex-wrap items-center gap-3">
-                <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{session.external_id}</h1>
+                <h1 className="text-3xl font-semibold tracking-[-0.04em] text-[var(--continua-text-primary)]">{session.external_id}</h1>
                 <CopyButton
                   aria-label="Copy session external ID"
                   value={session.external_id}
@@ -564,7 +561,7 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
                 />
               </div>
               <div className="mt-2 flex flex-wrap items-center gap-3">
-                <span className="font-mono text-sm text-slate-500 dark:text-slate-400">{session.id}</span>
+                <span className="font-mono text-sm text-[var(--continua-text-muted)]">{session.id}</span>
                 <CopyButton
                   aria-label="Copy session UUID"
                   value={session.id}
@@ -573,28 +570,28 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
                 />
               </div>
               {session.name ? (
-                <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{session.name}</p>
+                <p className="mt-3 text-sm text-[var(--continua-text-secondary)]">{session.name}</p>
               ) : null}
             </div>
 
             <dl className="grid gap-4 sm:grid-cols-3">
               <div>
-                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
                   User ID
                 </dt>
-                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">{session.user_id || '-'}</dd>
+                <dd className="mt-1 text-sm text-[var(--continua-text-primary)]">{session.user_id || '-'}</dd>
               </div>
               <div>
-                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
                   Trace Count
                 </dt>
-                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">{session.trace_count ?? 0}</dd>
+                <dd className="mt-1 text-sm text-[var(--continua-text-primary)]">{session.trace_count ?? 0}</dd>
               </div>
               <div>
-                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                <dt className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
                   Created
                 </dt>
-                <dd className="mt-1 text-sm text-slate-900 dark:text-slate-100">
+                <dd className="mt-1 text-sm text-[var(--continua-text-primary)]">
                   {formatRelativeTime(session.created_at)}
                 </dd>
               </div>
@@ -629,15 +626,16 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
 
         <div className="mb-4 flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Traces</h2>
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            <div className="app-overline">Trace browser</div>
+            <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">Traces</h2>
+            <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">
               Sort by started time and preserve table state in the URL.
             </p>
           </div>
-          <div className="text-sm text-slate-500 dark:text-slate-400">
+          <div className="text-sm text-[var(--continua-text-muted)]">
             <span>{total} traces</span>
             {tracesQuery.isFetching && !tracesQuery.isPending && (
-              <span className="ml-2 text-blue-600 dark:text-sky-400">Updating...</span>
+              <span className="ml-2">Updating...</span>
             )}
           </div>
         </div>
@@ -648,26 +646,26 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
               <AuthErrorBanner message={queryErrorMessage(tracesQuery.error)} />
             </div>
           ) : (
-            <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+            <div className="app-alert-error mb-4">
               Error loading traces: {queryErrorMessage(tracesQuery.error)}
             </div>
           )
         )}
 
         {tracesQuery.isPending && !tracesQuery.data ? (
-          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+          <div className="app-empty-state">
             Loading traces...
           </div>
         ) : traces.length === 0 ? (
-          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No traces in this session</h2>
-            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          <div className="app-empty-state">
+            <h2 className="text-lg font-semibold text-[var(--continua-text-primary)]">No traces in this session</h2>
+            <p className="mt-2">
               Traces will appear here as they are ingested for this session.
             </p>
           </div>
         ) : (
           <>
-            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <div className="app-surface overflow-x-auto">
               <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
                 <thead className="bg-slate-50 dark:bg-slate-950/70">
                   <tr>
@@ -721,7 +719,6 @@ function SessionDetailContent({ sessionId }: { sessionId: string }) {
             />
           </>
         )}
-      </div>
     </div>
   );
 }
@@ -751,7 +748,7 @@ function SessionNarrativeSections({
         {isAuthError(error) ? (
           <AuthErrorBanner message={queryErrorMessage(error)} />
         ) : (
-          <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+          <div className="app-alert-error">
             Error loading narrative: {queryErrorMessage(error)}
           </div>
         )}
@@ -763,18 +760,18 @@ function SessionNarrativeSections({
     return (
       <section
         aria-label="Session narrative loading"
-        className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+        className="app-surface mb-6 p-6"
       >
         <div className="animate-pulse">
-          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          <h2 className="text-lg font-semibold text-[var(--continua-text-primary)]">
             Session Narrative
           </h2>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Loading narrative...</p>
+          <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">Loading narrative...</p>
           <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {Array.from({ length: 6 }).map((_, index) => (
               <div
                 key={index}
-                className="h-20 rounded-lg bg-slate-100 dark:bg-slate-800"
+                className="h-20 rounded-[1.1rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)]"
               />
             ))}
           </div>
@@ -794,24 +791,25 @@ function SessionNarrativeSections({
     return (
       <section
         aria-label="Session narrative placeholder"
-        className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+        className="app-surface mb-6 p-6"
       >
         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            <div className="app-overline">Narrative</div>
+            <h2 className="mt-2 text-lg font-semibold text-[var(--continua-text-primary)]">
               Session Narrative
             </h2>
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">
               A compact session storyline will appear here as traces are ingested for this session.
             </p>
           </div>
           {isFetching ? (
-            <div className="text-sm text-blue-600 dark:text-sky-400">Updating narrative...</div>
+            <div className="text-sm text-[var(--continua-accent)]">Updating narrative...</div>
           ) : null}
         </div>
 
-        <div className="mt-4 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-5 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-950/50 dark:text-slate-300">
-          <p className="font-medium text-slate-900 dark:text-slate-100">No narrative yet</p>
+        <div className="app-empty-state mt-4 text-left">
+          <p className="font-medium text-[var(--continua-text-primary)]">No narrative yet</p>
           <p className="mt-1">
             This placeholder stays compact until the session has at least one ingested trace.
           </p>
@@ -824,19 +822,20 @@ function SessionNarrativeSections({
     <>
       <section
         aria-label="Session narrative summary"
-        className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+        className="app-surface mb-6 p-6"
       >
         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            <div className="app-overline">Narrative</div>
+            <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
               Session Narrative
             </h2>
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">
               Chronological summary for the returned storyline above the full trace browser.
             </p>
           </div>
           {isFetching && (
-            <div className="text-sm text-blue-600 dark:text-sky-400">Updating narrative...</div>
+            <div className="text-sm text-[var(--continua-accent)]">Updating narrative...</div>
           )}
         </div>
 
@@ -875,27 +874,28 @@ function SessionNarrativeSections({
 
       <section
         aria-label="Session narrative storyline"
-        className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+        className="app-surface mb-6 p-6"
       >
         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Storyline</h2>
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            <div className="app-overline">Lineage</div>
+            <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">Storyline</h2>
+            <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">
               Oldest-first trace flow for the narrative that was returned.
             </p>
           </div>
         </div>
 
         {narrative.summary.truncated && (
-          <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100">
+          <div className="mt-4 rounded-[1.15rem] border border-amber-300/40 bg-amber-50/80 px-4 py-3 text-sm text-amber-900 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-100">
             Narrative limited to the first {narrative.summary.returned_trace_count} traces. The
             table below remains the full browser.
           </div>
         )}
 
         {narrative.traces.length === 0 ? (
-          <div className="mt-4 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-5 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-950/50 dark:text-slate-300">
-            <p className="font-medium text-slate-900 dark:text-slate-100">No narrative yet</p>
+          <div className="app-empty-state mt-4 text-left">
+            <p className="font-medium text-[var(--continua-text-primary)]">No narrative yet</p>
             <p className="mt-1">
               A compact session storyline will appear here as traces are ingested for this session.
             </p>
@@ -947,14 +947,14 @@ function StorylineTraceCard({
     isTerminalTraceStatus(parentTrace.status);
 
   return (
-    <article className="rounded-xl border border-slate-200 bg-slate-50/80 p-5 dark:border-slate-800 dark:bg-slate-950/60">
+    <article className="app-surface-muted overflow-hidden p-5">
       <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <Link
               to={`/traces/${trace.id}`}
               state={{ returnTo }}
-              className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-sky-400 dark:hover:text-sky-300"
+              className="text-sm font-semibold text-[var(--continua-accent)] transition hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
             >
               {trace.name}
             </Link>
@@ -962,13 +962,13 @@ function StorylineTraceCard({
             <NarrativeLineageBadge lineage={trace.lineage} />
           </div>
 
-          <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--continua-text-muted)]">
             <span className="font-mono">{trace.trace_id}</span>
             {trace.user_id ? <span>User {trace.user_id}</span> : null}
           </div>
 
           {semanticSnippet ? (
-            <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{semanticSnippet}</p>
+            <p className="mt-3 text-sm text-[var(--continua-text-secondary)]">{semanticSnippet}</p>
           ) : null}
 
           <div className="mt-4 flex flex-wrap gap-2">
@@ -997,7 +997,7 @@ function StorylineTraceCard({
           </div>
         </div>
 
-        <dl className="grid gap-3 sm:grid-cols-2 xl:w-[28rem] xl:grid-cols-3">
+        <dl className="grid gap-3 sm:grid-cols-2 xl:w-[30rem] xl:grid-cols-3">
           <MetricBlock label="Started" value={formatRelativeTime(trace.started_at)} compact />
           <MetricBlock label="Ended" value={formatRelativeTime(trace.ended_at)} compact />
           <MetricBlock
@@ -1054,7 +1054,7 @@ function CompareBar({
     (candidate && !isTerminalTraceStatus(candidate.status));
 
   return (
-    <section className="mb-6 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <section className="app-surface sticky top-[5rem] z-20 mb-6 p-4">
       <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
         <div className="grid gap-3 sm:grid-cols-2 xl:w-[40rem]">
           <CompareSelectionCard
@@ -1073,14 +1073,14 @@ function CompareBar({
           <button
             type="button"
             onClick={() => swapCompare()}
-            className="rounded-md border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-slate-100"
+            className="app-button-ghost"
           >
             Swap
           </button>
           <button
             type="button"
             onClick={() => clearCompare()}
-            className="rounded-md border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-slate-100"
+            className="app-button-ghost"
           >
             Clear
           </button>
@@ -1088,7 +1088,7 @@ function CompareBar({
             <Link
               to={compareHref}
               state={{ returnTo: currentSessionDetailUrl }}
-              className="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:bg-sky-500 dark:hover:bg-sky-400"
+              className="app-button-primary"
             >
               Open comparison
             </Link>
@@ -1096,7 +1096,7 @@ function CompareBar({
             <button
               type="button"
               disabled
-              className="cursor-not-allowed rounded-md bg-slate-200 px-3 py-2 text-sm font-medium text-slate-500 dark:bg-slate-800 dark:text-slate-400"
+              className="cursor-not-allowed rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-4 py-2.5 text-sm font-medium text-[var(--continua-text-muted)]"
               title={
                 hasRunningSelection
                   ? 'Both selected traces must be terminal before comparison can open'
@@ -1110,7 +1110,7 @@ function CompareBar({
       </div>
 
       {(isBaselineLookupPending || isCandidateLookupPending || hasRunningSelection) ? (
-        <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+        <p className="mt-3 text-sm text-[var(--continua-text-secondary)]">
           {isBaselineLookupPending || isCandidateLookupPending
             ? 'Resolving selected trace details...'
             : 'Running traces stay visible here, but comparison remains disabled until they finish.'}
@@ -1130,24 +1130,24 @@ function CompareSelectionCard({
   isPending: boolean;
 }) {
   return (
-    <div className="rounded-lg border border-slate-200 bg-slate-50/80 p-3 dark:border-slate-800 dark:bg-slate-950/50">
-      <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+    <div className="rounded-[1.15rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-4">
+      <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
         {label}
       </p>
       {isPending ? (
-        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">Loading trace…</p>
+        <p className="mt-2 text-sm text-[var(--continua-text-secondary)]">Loading trace…</p>
       ) : trace ? (
         <div className="mt-2">
           <div className="flex flex-wrap items-center gap-2">
-            <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{trace.name}</p>
+            <p className="text-sm font-semibold text-[var(--continua-text-primary)]">{trace.name}</p>
             <StatusBadge status={trace.status} />
           </div>
           {trace.trace_id ? (
-            <p className="mt-1 font-mono text-xs text-slate-500 dark:text-slate-400">{trace.trace_id}</p>
+            <p className="mt-1 font-mono text-xs text-[var(--continua-text-muted)]">{trace.trace_id}</p>
           ) : null}
         </div>
       ) : (
-        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">No trace selected</p>
+        <p className="mt-2 text-sm text-[var(--continua-text-secondary)]">No trace selected</p>
       )}
     </div>
   );
@@ -1172,12 +1172,12 @@ function CompareRoleButton({
       disabled={disabled}
       onClick={onClick}
       title={title}
-      className={`rounded-md border px-2.5 py-1 text-xs font-medium ${
+      className={`rounded-full border px-3 py-1.5 text-xs font-medium transition ${
         disabled
-          ? 'cursor-not-allowed border-slate-200 text-slate-400 dark:border-slate-800 dark:text-slate-500'
+          ? 'cursor-not-allowed border-[var(--continua-border-soft)] text-[var(--continua-text-muted)]'
           : isSelected
-            ? 'border-blue-300 bg-blue-50 text-blue-800 dark:border-sky-500/40 dark:bg-sky-500/10 dark:text-sky-100'
-            : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-slate-100'
+            ? 'border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
+            : 'border-[var(--continua-border-strong)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)] hover:border-[var(--continua-accent)] hover:text-[var(--continua-accent)]'
       }`}
     >
       {label}
@@ -1197,13 +1197,19 @@ function MetricBlock({
   compact?: boolean;
 }) {
   return (
-    <div className={compact ? '' : 'rounded-lg border border-slate-200 p-4 dark:border-slate-800'}>
-      <dt className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+    <div
+      className={
+        compact
+          ? 'rounded-[1rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] p-3'
+          : 'app-metric-panel'
+      }
+    >
+      <dt className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
         {label}
       </dt>
-      <dd className="mt-2 text-sm font-semibold text-slate-900 dark:text-slate-100">{value}</dd>
+      <dd className="mt-2 text-sm font-semibold text-[var(--continua-text-primary)]">{value}</dd>
       {hint ? (
-        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{hint}</p>
+        <p className="mt-1 text-xs text-[var(--continua-text-secondary)]">{hint}</p>
       ) : null}
     </div>
   );
@@ -1215,8 +1221,8 @@ function NarrativeLineageBadge({ lineage }: { lineage: SessionNarrativeLineage }
     lineage.type === 'explicit'
       ? 'bg-amber-100 text-amber-900 dark:bg-amber-500/15 dark:text-amber-100'
       : lineage.type === 'inferred'
-        ? 'bg-indigo-100 text-indigo-900 dark:bg-indigo-500/15 dark:text-indigo-100'
-        : 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-200';
+        ? 'bg-sky-100 text-sky-900 dark:bg-sky-500/15 dark:text-sky-100'
+        : 'bg-[var(--continua-surface-muted)] text-[var(--continua-text-secondary)]';
 
   return (
     <span
@@ -1259,12 +1265,12 @@ function SessionTraceRow({
   const isSelectable = isTerminalTraceStatus(trace.status);
 
   return (
-    <tr className="transition hover:bg-slate-50 dark:hover:bg-slate-800/60">
+    <tr className="border-b border-[var(--continua-border-soft)] transition hover:bg-[var(--continua-surface-muted)]">
       <td className="px-6 py-4 align-top">
         <Link
           to={`/traces/${trace.id}`}
           state={{ returnTo }}
-          className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-sky-400 dark:hover:text-sky-300"
+          className="text-sm font-semibold text-[var(--continua-accent)] transition hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
         >
           {trace.name}
         </Link>
@@ -1288,16 +1294,16 @@ function SessionTraceRow({
       <td className="px-6 py-4 whitespace-nowrap align-top">
         <StatusBadge status={trace.status} />
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-[var(--continua-text-primary)] align-top">
         {formatDuration(duration)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-[var(--continua-text-primary)] align-top">
         {formatTokens(totalTokens)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-[var(--continua-text-primary)] align-top">
         {formatCost(trace.total_cost_usd)}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-500 align-top dark:text-slate-400">
+      <td className="px-6 py-4 whitespace-nowrap text-sm text-[var(--continua-text-muted)] align-top">
         {formatRelativeTime(trace.started_at)}
       </td>
     </tr>

--- a/web/src/pages/SessionsPage.test.tsx
+++ b/web/src/pages/SessionsPage.test.tsx
@@ -9,6 +9,7 @@ import {
   buildFetchHandler,
   getRequests,
   jsonResponse,
+  readRequestUrl,
   renderTraceRoutes,
 } from './testUtils';
 
@@ -16,6 +17,13 @@ let fetchMock: ReturnType<typeof vi.fn>;
 
 function getSessionListRequests(): URL[] {
   return getRequests(fetchMock, '/api/sessions');
+}
+
+function countNarrativeRequests(): number {
+  return fetchMock.mock.calls.filter(([input]) => {
+    const url = new URL(readRequestUrl(input), 'http://localhost');
+    return /^\/api\/sessions\/[^/]+\/narrative$/.test(url.pathname);
+  }).length;
 }
 
 async function waitForSessionListFetch(search: string) {
@@ -34,6 +42,7 @@ beforeEach(() => {
 afterEach(() => {
   clearApiKey();
   localStorage.clear();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -131,6 +140,17 @@ describe('SessionsPage', () => {
     expect(router.state.location.search).toBe('?offset=20');
     expect(screen.getByText('conv-latency-456')).toBeInTheDocument();
     expect(screen.getByText(OTHER_SESSION_ID)).toBeInTheDocument();
+  });
+
+  it('does not fan out narrative requests while rendering the session index', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes(['/sessions']);
+
+    expect(await screen.findByText('conv-checkout-123')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(countNarrativeRequests()).toBe(0);
+    });
   });
 
   it('resets offset when sort and page size change', async () => {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -1,7 +1,11 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { fetchSessions, isAuthError, type Session } from '../api/client';
+import {
+  fetchSessions,
+  isAuthError,
+  type Session,
+} from '../api/client';
 import { AuthErrorBanner } from '../components/AuthErrorBanner';
 import { PaginationControls } from '../components/PaginationControls';
 import { SortableHeader } from '../components/SortableHeader';
@@ -12,6 +16,7 @@ import { buildSessionsQueryString } from '../utils/sessionsSearchParams';
 import { formatRelativeTime } from '../utils/format';
 
 const DEBOUNCE_MS = 300;
+const EMPTY_SESSIONS: Session[] = [];
 
 function normalizeDraft(value: string): string {
   return value.trim();
@@ -123,7 +128,7 @@ function SessionsContent() {
     placeholderData: keepPreviousData,
   });
 
-  const sessions = sessionsQuery.data?.sessions ?? [];
+  const sessions = sessionsQuery.data?.sessions ?? EMPTY_SESSIONS;
   const total = sessionsQuery.data?.total ?? 0;
   const hasFilters = Boolean(filters.q || filters.user_id);
 
@@ -139,29 +144,60 @@ function SessionsContent() {
   }, [filters.limit, filters.offset, sessions.length, setFilters, total]);
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Sessions</h1>
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+    <div className="app-page">
+      <section className="app-surface p-6 sm:p-7">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-3xl">
+            <div className="app-overline">Session workflows</div>
+            <h1 className="mt-3 text-3xl font-semibold tracking-[-0.04em] text-[var(--continua-text-primary)] sm:text-4xl">
+              Follow a user journey across multiple traces without losing narrative context.
+            </h1>
+            <p className="mt-3 text-sm leading-7 text-[var(--continua-text-secondary)] sm:text-base">
               Search sessions by external ID, filter by user, and sort for scale.
             </p>
           </div>
-          <div className="text-sm text-slate-500 dark:text-slate-400">
-            <span>{total} total</span>
-            {sessionsQuery.isFetching && !sessionsQuery.isPending && (
-              <span className="ml-2 text-blue-600 dark:text-sky-400">Updating...</span>
-            )}
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <SessionStat label="Sessions" value={String(total)} />
+            <SessionStat
+              label="Loaded"
+              value={String(sessions.length)}
+            />
+            <SessionStat
+              label="Scoped user"
+              value={filters.user_id ? '1' : 'All'}
+            />
           </div>
         </div>
+      </section>
 
-        <section className="mb-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <section className="app-surface sticky top-[4.9rem] z-20 p-4 sm:p-5">
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            <QuickFilterButton
+              active={!filters.user_id}
+              label="All users"
+              onClick={() => setFilters({ user_id: undefined }, 'push')}
+            />
+            <QuickFilterButton
+              active={Boolean(filters.q)}
+              label="Search active"
+              onClick={() => {
+                if (filters.q) {
+                  setFilters({ q: undefined }, 'push');
+                }
+              }}
+            />
+            <div className="ml-auto text-sm text-[var(--continua-text-muted)]">
+              <span>{total} total</span>
+              {sessionsQuery.isFetching && !sessionsQuery.isPending ? <span className="ml-2">Refreshing…</span> : null}
+            </div>
+          </div>
+
           <div className="grid gap-4 md:grid-cols-2">
             <div>
               <label
                 htmlFor="session-search"
-                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
               >
                 Search
               </label>
@@ -171,14 +207,14 @@ function SessionsContent() {
                 value={searchDraft}
                 onChange={(event) => setSearchDraft(event.target.value)}
                 placeholder="Search external ID or name"
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+                className="app-input"
               />
             </div>
 
             <div>
               <label
                 htmlFor="session-user-id"
-                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
               >
                 User ID
               </label>
@@ -188,7 +224,7 @@ function SessionsContent() {
                 value={userIdDraft}
                 onChange={(event) => setUserIdDraft(event.target.value)}
                 placeholder="Filter by exact user"
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+                className="app-input"
               />
             </div>
           </div>
@@ -198,109 +234,95 @@ function SessionsContent() {
               <button
                 type="button"
                 onClick={clearAll}
-                className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900 dark:hover:text-slate-100"
+                className="app-button-secondary"
               >
                 Clear filters
               </button>
             </div>
           )}
-        </section>
+      </section>
 
-        {sessionsQuery.error && (
-          isAuthError(sessionsQuery.error) ? (
-            <div className="mb-4">
-              <AuthErrorBanner
-                message={
-                  sessionsQuery.error instanceof Error
-                    ? sessionsQuery.error.message
-                    : 'Invalid or missing API key'
-                }
-              />
-            </div>
-          ) : (
-            <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
-              Error loading sessions:{' '}
-              {sessionsQuery.error instanceof Error
+      {sessionsQuery.error && (
+        isAuthError(sessionsQuery.error) ? (
+          <AuthErrorBanner
+            message={
+              sessionsQuery.error instanceof Error
                 ? sessionsQuery.error.message
-                : 'Unknown error'}
-            </div>
-          )
-        )}
-
-        {sessionsQuery.isPending && !sessionsQuery.data ? (
-          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
-            Loading sessions...
-          </div>
-        ) : sessions.length === 0 ? (
-          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-              {hasFilters ? 'No matching sessions' : 'No sessions yet'}
-            </h2>
-            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-              {hasFilters
-                ? 'Try broadening the filters or clearing them.'
-                : 'Sessions are created when traces include a session identifier.'}
-            </p>
-          </div>
+                : 'Invalid or missing API key'
+            }
+          />
         ) : (
-          <>
-            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
-                <thead className="bg-slate-50 dark:bg-slate-950/70">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      Session
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      Name
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      User ID
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      <SortableHeader
-                        label="Traces"
-                        isActive={filters.sort_by === 'trace_count'}
-                        isAscending={filters.sort_dir === 'asc'}
-                        isDisabled={isSearchActive}
-                        onClick={handleTraceCountSortToggle}
-                      />
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      <SortableHeader
-                        label="Created"
-                        isActive={filters.sort_by === 'created_at'}
-                        isAscending={filters.sort_dir === 'asc'}
-                        isDisabled={isSearchActive}
-                        onClick={handleCreatedSortToggle}
-                      />
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-900">
-                  {sessions.map((session) => (
-                    <SessionRow
-                      key={session.id}
-                      returnTo={currentListUrl}
-                      session={session}
-                    />
-                  ))}
-                </tbody>
-              </table>
+          <div className="app-alert-error">
+            Error loading sessions:{' '}
+            {sessionsQuery.error instanceof Error
+              ? sessionsQuery.error.message
+              : 'Unknown error'}
+          </div>
+        )
+      )}
+
+      {sessionsQuery.isPending && !sessionsQuery.data ? (
+        <div className="app-empty-state">Loading sessions...</div>
+      ) : sessions.length === 0 ? (
+        <div className="app-empty-state">
+          <h2 className="text-lg font-semibold text-[var(--continua-text-primary)]">
+            {hasFilters ? 'No matching sessions' : 'No sessions yet'}
+          </h2>
+          <p className="mt-2">
+            {hasFilters
+              ? 'Try broadening the filters or clearing them.'
+              : 'Sessions are created when traces include a session identifier.'}
+          </p>
+        </div>
+      ) : (
+        <>
+          <section className="app-surface overflow-hidden">
+            <div className="flex items-center justify-between border-b border-[var(--continua-border-soft)] px-4 py-3 sm:px-5">
+              <div className="flex items-center gap-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
+                <span>Session</span>
+                <span>User</span>
+                <span>Name</span>
+              </div>
+              <div className="flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
+                <SortableHeader
+                  label="Traces"
+                  isActive={filters.sort_by === 'trace_count'}
+                  isAscending={filters.sort_dir === 'asc'}
+                  isDisabled={isSearchActive}
+                  onClick={handleTraceCountSortToggle}
+                />
+                <SortableHeader
+                  label="Created"
+                  isActive={filters.sort_by === 'created_at'}
+                  isAscending={filters.sort_dir === 'asc'}
+                  isDisabled={isSearchActive}
+                  onClick={handleCreatedSortToggle}
+                />
+              </div>
             </div>
 
-            <PaginationControls
-              offset={filters.offset}
-              pageSize={filters.limit ?? DEFAULT_PAGE_SIZE}
-              total={total}
-              currentItemCount={sessions.length}
-              onOffsetChange={(offset) => setFilters({ offset }, 'push')}
-              onPageSizeChange={(limit) => setFilters({ limit }, 'push')}
-              onRepairOffset={(offset) => setFilters({ offset }, 'replace')}
-            />
-          </>
-        )}
-      </div>
+            <div className="space-y-3 p-4 sm:p-5">
+              {sessions.map((session) => (
+                <SessionRow
+                  key={session.id}
+                  returnTo={currentListUrl}
+                  session={session}
+                />
+              ))}
+            </div>
+          </section>
+
+          <PaginationControls
+            offset={filters.offset}
+            pageSize={filters.limit ?? DEFAULT_PAGE_SIZE}
+            total={total}
+            currentItemCount={sessions.length}
+            onOffsetChange={(offset) => setFilters({ offset }, 'push')}
+            onPageSizeChange={(limit) => setFilters({ limit }, 'push')}
+            onRepairOffset={(offset) => setFilters({ offset }, 'replace')}
+          />
+        </>
+      )}
     </div>
   );
 }
@@ -313,31 +335,82 @@ function SessionRow({
   returnTo: string;
 }) {
   return (
-    <tr className="transition hover:bg-slate-50 dark:hover:bg-slate-800/60">
-      <td className="px-6 py-4 align-top">
-        <div className="min-w-[14rem]">
+    <article className="app-list-row">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-3">
           <Link
             to={`/sessions/${session.id}`}
             state={{ returnTo }}
-            className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-sky-400 dark:hover:text-sky-300"
+            className="truncate text-sm font-semibold text-[var(--continua-text-primary)] transition hover:text-[var(--continua-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
           >
             {session.external_id}
           </Link>
-          <div className="mt-1 font-mono text-xs text-slate-400 dark:text-slate-500">{session.id}</div>
+          <span className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2.5 py-1 text-[11px] font-medium text-[var(--continua-text-secondary)]">
+            {session.trace_count ?? 0} traces
+          </span>
         </div>
-      </td>
-      <td className="px-6 py-4 text-sm text-slate-900 align-top dark:text-slate-100">
-        {session.name || '-'}
-      </td>
-      <td className="px-6 py-4 text-sm text-slate-500 align-top dark:text-slate-400">
-        {session.user_id || '-'}
-      </td>
-      <td className="px-6 py-4 text-sm text-slate-900 align-top dark:text-slate-100">
-        {session.trace_count ?? 0}
-      </td>
-      <td className="px-6 py-4 text-sm text-slate-500 align-top dark:text-slate-400">
-        {formatRelativeTime(session.created_at)}
-      </td>
-    </tr>
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--continua-text-muted)]">
+          <span>{session.user_id || 'No user ID'}</span>
+          <span>{session.name || 'Unnamed session'}</span>
+          <span>Created {formatRelativeTime(session.created_at)}</span>
+          <span className="font-mono">{session.id}</span>
+        </div>
+      </div>
+
+      <div className="grid shrink-0 gap-3 text-right text-xs sm:grid-cols-2 sm:text-sm">
+        <MetricColumn label="Traces" value={String(session.trace_count ?? 0)} />
+        <MetricColumn label="Created" value={formatRelativeTime(session.created_at)} />
+      </div>
+    </article>
+  );
+}
+
+function MetricColumn({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-[5.25rem]">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--continua-text-muted)]">
+        {label}
+      </div>
+      <div className="mt-1 text-xs font-medium text-[var(--continua-text-primary)] sm:text-sm">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function SessionStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="app-surface-muted px-4 py-3">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function QuickFilterButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        active
+          ? 'inline-flex items-center rounded-full border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] px-3 py-1.5 text-sm font-medium text-[var(--continua-accent)]'
+          : 'app-button-ghost'
+      }
+    >
+      {label}
+    </button>
   );
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -45,111 +45,110 @@ export function SettingsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
-      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
-            Settings
-          </h1>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-            Manage the debugger API key and local UI preferences for this browser.
-          </p>
-        </div>
+    <div className="app-page max-w-5xl">
+      <section className="app-surface p-6 sm:p-7">
+        <div className="app-overline">Local settings</div>
+        <h1 className="mt-3 text-3xl font-semibold tracking-[-0.04em] text-[var(--continua-text-primary)] sm:text-4xl">
+          Configure this browser as an operator workspace.
+        </h1>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-[var(--continua-text-secondary)] sm:text-base">
+          Manage the debugger API key and local UI preferences for this browser.
+        </p>
+      </section>
 
-        <div className="grid gap-6">
-          <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-            <div className="mb-4">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-                API Key
-              </h2>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                The key is stored locally and sent as `X-API-Key` on API requests.
-              </p>
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        <section className="app-surface p-6">
+          <div className="mb-4">
+            <h2 className="text-xl font-semibold text-[var(--continua-text-primary)]">
+              API key
+            </h2>
+            <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">
+              The key is stored locally and sent as `X-API-Key` on API requests.
+            </p>
+          </div>
+
+          <dl className="app-surface-muted p-4">
+            <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
+              Current key
+            </dt>
+            <dd className="mt-2 font-mono text-sm text-[var(--continua-text-primary)]">
+              {storedKey ? maskApiKey(storedKey) : 'Not configured'}
+            </dd>
+          </dl>
+
+          <form className="mt-5 space-y-4" onSubmit={handleSave}>
+            <div>
+              <label
+                htmlFor="settings-api-key"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
+              >
+                New API key
+              </label>
+              <input
+                id="settings-api-key"
+                type="password"
+                value={draftKey}
+                onChange={(event) => setDraftKey(event.target.value)}
+                placeholder="ck_live_..."
+                className="app-input"
+              />
             </div>
 
-            <dl className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/60">
-              <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                Current key
-              </dt>
-              <dd className="mt-2 font-mono text-sm text-slate-900 dark:text-slate-100">
-                {storedKey ? maskApiKey(storedKey) : 'Not configured'}
-              </dd>
-            </dl>
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="submit"
+                className="app-button-primary"
+              >
+                Save key
+              </button>
+              <button
+                type="button"
+                onClick={handleClear}
+                className="app-button-secondary"
+              >
+                Clear key
+              </button>
+              {statusMessage ? (
+                <span className="text-sm text-[var(--continua-text-muted)]">
+                  {statusMessage}
+                </span>
+              ) : null}
+            </div>
+          </form>
+        </section>
 
-            <form className="mt-4 space-y-4" onSubmit={handleSave}>
-              <div>
-                <label
-                  htmlFor="settings-api-key"
-                  className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
-                >
-                  New API key
-                </label>
-                <input
-                  id="settings-api-key"
-                  type="password"
-                  value={draftKey}
-                  onChange={(event) => setDraftKey(event.target.value)}
-                  placeholder="ck_live_..."
-                  className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
-                />
-              </div>
+        <section className="app-surface p-6">
+          <div className="mb-4">
+            <h2 className="text-xl font-semibold text-[var(--continua-text-primary)]">
+              Theme
+            </h2>
+            <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">
+              Current rendering: {resolvedTheme}. System mode follows the OS preference.
+            </p>
+          </div>
 
-              <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-wrap gap-3">
+            {(['system', 'light', 'dark'] as ThemeMode[]).map((themeMode) => {
+              const isActive = themeMode === mode;
+
+              return (
                 <button
-                  type="submit"
-                  className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                >
-                  Save key
-                </button>
-                <button
+                  key={themeMode}
                   type="button"
-                  onClick={handleClear}
-                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900"
+                  aria-pressed={isActive}
+                  onClick={() => setMode(themeMode)}
+                  className={`rounded-full px-4 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] ${
+                    isActive
+                      ? 'border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
+                      : 'border border-[var(--continua-border-strong)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)] hover:border-[var(--continua-accent)] hover:text-[var(--continua-accent)]'
+                  }`}
                 >
-                  Clear key
+                  {formatThemeMode(themeMode)}
                 </button>
-                {statusMessage ? (
-                  <span className="text-sm text-slate-500 dark:text-slate-400">
-                    {statusMessage}
-                  </span>
-                ) : null}
-              </div>
-            </form>
-          </section>
-
-          <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-            <div className="mb-4">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-                Theme
-              </h2>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                Current rendering: {resolvedTheme}. System mode follows the OS preference.
-              </p>
-            </div>
-
-            <div className="flex flex-wrap gap-3">
-              {(['system', 'light', 'dark'] as ThemeMode[]).map((themeMode) => {
-                const isActive = themeMode === mode;
-
-                return (
-                  <button
-                    key={themeMode}
-                    type="button"
-                    aria-pressed={isActive}
-                    onClick={() => setMode(themeMode)}
-                    className={`rounded-full px-4 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-200 ${
-                      isActive
-                        ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-950'
-                        : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900'
-                    }`}
-                  >
-                    {formatThemeMode(themeMode)}
-                  </button>
-                );
-              })}
-            </div>
-          </section>
-        </div>
+              );
+            })}
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -185,7 +185,7 @@ describe('TraceDetailPage', () => {
     expect(screen.getByRole('heading', { name: 'Execution Waterfall' })).toBeInTheDocument();
   });
 
-  it('renders the non-desktop stacked layout with Details active by default', async () => {
+  it('renders the non-desktop stacked layout with Summary active by default', async () => {
     setMatchMediaMatches(false);
     const rootSpan = createSpan({ span_id: 'mobile-root', name: 'Mobile root' });
 
@@ -204,18 +204,54 @@ describe('TraceDetailPage', () => {
 
     renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
 
-    expect(await screen.findByRole('button', { name: 'Details' })).toHaveAttribute(
+    expect(await screen.findByRole('button', { name: 'Summary' })).toHaveAttribute(
       'aria-pressed',
       'true'
     );
-    expect(screen.getByRole('button', { name: 'Waterfall' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Tree' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Execution' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Timeline' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Reasoning' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Trace Context/i })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: 'State' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Trace Context')).toHaveAttribute(
       'aria-expanded',
       'false'
     );
+  });
+
+  it('opens the trace context sheet from a non-summary mobile tab', async () => {
+    setMatchMediaMatches(false);
+    const user = userEvent.setup();
+    const rootSpan = createSpan({ span_id: 'mobile-context-root', name: 'Mobile context root' });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse({ ...TRACE_DETAIL, status: 'COMPLETED', error_count: 0 }),
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await screen.findByRole('button', { name: 'Timeline' });
+    await user.click(screen.getByRole('button', { name: 'Timeline' }));
+    expect(screen.getByLabelText('Trace Context')).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(screen.getByRole('button', { name: /Trace Context/i }));
+
+    expect(await screen.findByText('External Trace ID')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close trace context sheet' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Trace Context')).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(screen.getByRole('button', { name: 'Close trace context sheet' }));
+    await waitFor(() => {
+      expect(screen.queryByText('External Trace ID')).not.toBeInTheDocument();
+    });
+    expect(screen.getByLabelText('Trace Context')).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('renders the state tab with a badge and shows span decisions in details', async () => {
@@ -378,7 +414,7 @@ describe('TraceDetailPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('selects a span from the reasoning tab and switches back to details on mobile', async () => {
+  it('selects a span from the summary workspace and keeps summary active on mobile', async () => {
     setMatchMediaMatches(false);
     const user = userEvent.setup();
     const rootSpan = createSpan({
@@ -421,11 +457,10 @@ describe('TraceDetailPage', () => {
     const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
 
     expect(
-      await screen.findByRole('button', { name: 'Reasoning' })
+      await screen.findByRole('button', { name: 'Summary' })
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Reasoning' }));
-    expect(screen.getByRole('button', { name: 'Reasoning' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: 'Summary' })).toHaveAttribute(
       'aria-pressed',
       'true'
     );
@@ -437,13 +472,9 @@ describe('TraceDetailPage', () => {
     );
 
     expect(view.router.state.location.search).toBe('?span=mobile-reasoning-child');
-    expect(screen.getByRole('button', { name: 'Details' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: 'Summary' })).toHaveAttribute(
       'aria-pressed',
       'true'
-    );
-    expect(screen.getByRole('button', { name: 'Reasoning' })).toHaveAttribute(
-      'aria-pressed',
-      'false'
     );
     expect(
       within(screen.getByLabelText('Span breadcrumb')).getByText(
@@ -1082,7 +1113,9 @@ describe('TraceDetailPage', () => {
     );
 
     const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
 
     fetchMock.mockClear();
     await user.click(screen.getByRole('button', { name: 'Select span Query child' }));
@@ -2014,7 +2047,9 @@ describe('TraceDetailPage', () => {
     );
 
     renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
     expect(screen.queryByText('Running state')).not.toBeInTheDocument();
 
     await act(async () => {
@@ -2768,7 +2803,9 @@ describe('TraceDetailPage', () => {
       },
     ]);
 
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '← Session' })).toHaveAttribute(
       'href',
       `/sessions/${SESSION_ID}?sort_by=started_at&offset=20`
@@ -2780,11 +2817,14 @@ describe('TraceDetailPage', () => {
     fetchMock.mockImplementation(buildFetchHandler());
 
     renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
-    await screen.findByText('Trace Context');
+    await screen.findByRole('button', { name: /Trace Context/i });
 
     await user.click(screen.getByRole('button', { name: /Trace Context/i }));
 
-    expect(screen.getByText(SESSION_EXTERNAL_ID)).toBeInTheDocument();
-    expect(screen.getByText(SESSION_ID)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: new RegExp(`${SESSION_EXTERNAL_ID}\\s*${SESSION_ID}`),
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -96,11 +96,7 @@ export function TraceDetailPage() {
   }
 
   if (!id) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
-        <div className="text-red-600">Trace ID is required</div>
-      </div>
-    );
+    return <TraceDetailEmptyState>Trace ID is required.</TraceDetailEmptyState>;
   }
 
   return (
@@ -120,7 +116,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
   const location = useLocation();
   const { spanParam, setSpanParam } = useTraceDetailSearchParams();
   const [activeMobileTab, setActiveMobileTab] =
-    useState<MobileWorkspaceTabId>('details');
+    useState<MobileWorkspaceTabId>('summary');
   const [isTraceContextOpen, setIsTraceContextOpen] = useState(false);
   const switchToInspectorDetailsRef = useRef<(() => void) | null>(null);
   const traceQuery = useQuery({
@@ -214,7 +210,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
   const handleSelectSpanAndShowDetails = useCallback((spanId: string) => {
     selectSpan(spanId);
     switchToInspectorDetailsRef.current?.();
-    setActiveMobileTab('details');
+    setActiveMobileTab('summary');
   }, [selectSpan]);
 
   const buildCopyTraceUrl = useCallback(() => {
@@ -231,51 +227,35 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
   }, [location.pathname, location.search, selectedSpanExternalId]);
 
   if (traceQuery.isLoading || spansQuery.isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
-        <div className="text-slate-500 dark:text-slate-400">Loading trace...</div>
-      </div>
-    );
+    return <TraceDetailEmptyState>Loading trace...</TraceDetailEmptyState>;
   }
 
   if (traceQuery.error) {
-    return (
-      <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
-        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-          {isAuthError(traceQuery.error) ? (
-            <AuthErrorBanner message={queryErrorMessage(traceQuery.error)} />
-          ) : (
-            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
-              Error loading trace: {queryErrorMessage(traceQuery.error)}
-            </div>
-          )}
-        </div>
+    return isAuthError(traceQuery.error) ? (
+      <div className="app-page">
+        <AuthErrorBanner message={queryErrorMessage(traceQuery.error)} />
       </div>
+    ) : (
+      <TraceDetailErrorState>
+        Error loading trace: {queryErrorMessage(traceQuery.error)}
+      </TraceDetailErrorState>
     );
   }
 
   if (spansQuery.error) {
-    return (
-      <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
-        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-          {isAuthError(spansQuery.error) ? (
-            <AuthErrorBanner message={queryErrorMessage(spansQuery.error)} />
-          ) : (
-            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
-              Error loading spans: {queryErrorMessage(spansQuery.error)}
-            </div>
-          )}
-        </div>
+    return isAuthError(spansQuery.error) ? (
+      <div className="app-page">
+        <AuthErrorBanner message={queryErrorMessage(spansQuery.error)} />
       </div>
+    ) : (
+      <TraceDetailErrorState>
+        Error loading spans: {queryErrorMessage(spansQuery.error)}
+      </TraceDetailErrorState>
     );
   }
 
   if (!trace) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
-        <div className="text-red-600">Trace not found</div>
-      </div>
-    );
+    return <TraceDetailEmptyState>Trace not found.</TraceDetailEmptyState>;
   }
 
   const detailsContent = (
@@ -290,14 +270,6 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
       selectedSpan={selectedSpan}
       spanIndex={spanIndex}
       events={timeline.events}
-      traceContext={isDesktop ? null : (
-        <TraceContextSection
-          buildCopyTraceUrl={buildCopyTraceUrl}
-          onToggle={() => setIsTraceContextOpen((open) => !open)}
-          open={isTraceContextOpen}
-          trace={trace}
-        />
-      )}
     />
   );
 
@@ -320,82 +292,131 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
     />
   );
   const stateContent = <StateDiffViewer changes={stateChanges} />;
+  const mobileSummaryContent = (
+    <div className="grid h-full gap-4 overflow-y-auto p-4">
+      {detailsContent}
+      {reasoningContent}
+    </div>
+  );
 
   return (
-    <div className="flex min-h-screen flex-col bg-slate-50 dark:bg-slate-950">
-      <header className="border-b border-slate-200 bg-white px-6 py-4 dark:border-slate-800 dark:bg-slate-900">
-        <div className="flex items-center gap-4">
-          <Link to={returnTo} className="text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200">
-            {returnTo.startsWith('/sessions/') ? '← Session' : '← Traces'}
-          </Link>
+    <div className="relative flex min-h-full flex-col gap-4">
+      <header className="app-surface p-5 sm:p-6">
+        <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
           <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-3">
-              <h1 className="truncate text-xl font-semibold text-slate-900 dark:text-slate-100">
+            <Link
+              to={returnTo}
+              className="inline-flex items-center text-sm font-medium text-[var(--continua-accent)] transition hover:opacity-80"
+            >
+              {returnTo.startsWith('/sessions/') ? '← Session' : '← Traces'}
+            </Link>
+
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <h1 className="truncate text-3xl font-semibold tracking-[-0.04em] text-[var(--continua-text-primary)]">
                 {trace.name}
               </h1>
               <StatusBadge status={timelineStatus ?? trace.status} />
             </div>
-            <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-slate-500 dark:text-slate-400">
-              <span>{formatDuration(duration)}</span>
-              <span>{formatTokens(totalTokens)} tokens</span>
-              <span>{formatCost(trace.total_cost_usd)}</span>
-              {trace.error_count && trace.error_count > 0 ? (
-                <span className="text-red-600 dark:text-red-300">{trace.error_count} errors</span>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-[var(--continua-text-muted)]">
+              <span className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2.5 py-1 font-mono">
+                {trace.trace_id ?? trace.id}
+              </span>
+              {trace.session_external_id ? (
+                <span className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2.5 py-1">
+                  {trace.session_external_id}
+                </span>
               ) : null}
             </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <TraceHeaderMetric label="Duration" value={formatDuration(duration)} />
+              <TraceHeaderMetric label="Tokens" value={formatTokens(totalTokens)} />
+              <TraceHeaderMetric label="Cost" value={formatCost(trace.total_cost_usd)} />
+              <TraceHeaderMetric
+                label="Errors"
+                value={trace.error_count && trace.error_count > 0 ? String(trace.error_count) : '0'}
+                danger={Boolean(trace.error_count && trace.error_count > 0)}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2 xl:justify-end">
+            <CopyButton
+              aria-label="Copy Trace URL"
+              getValue={buildCopyTraceUrl}
+              idleLabel="Copy trace URL"
+              successLabel="Copied URL"
+              className="border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)] hover:border-[var(--continua-border-strong)] hover:bg-[var(--continua-surface-muted)] hover:text-[var(--continua-text-primary)]"
+            />
+            <button
+              type="button"
+              aria-expanded={isTraceContextOpen}
+              aria-label="Trace Context"
+              onClick={() => setIsTraceContextOpen((open) => !open)}
+              className="app-button-secondary"
+            >
+              {isTraceContextOpen ? 'Hide context' : 'Trace context'}
+            </button>
           </div>
         </div>
       </header>
 
-      <div className="min-h-0 flex-1 overflow-hidden p-4">
-        <div className="mx-auto flex h-full max-w-[96rem] flex-col gap-4">
-          {timelineAuthError ? (
-            <AuthErrorBanner message={queryErrorMessage(timeline.rawError)} />
-          ) : null}
+      {timelineAuthError ? (
+        <AuthErrorBanner message={queryErrorMessage(timeline.rawError)} />
+      ) : null}
 
-          {isDesktop ? (
-            <TraceContextSection
-              buildCopyTraceUrl={buildCopyTraceUrl}
-              onToggle={() => setIsTraceContextOpen((open) => !open)}
-              open={isTraceContextOpen}
-              trace={trace}
-            />
-          ) : null}
-
-          <TraceWorkspace
-            activeMobileTab={activeMobileTab}
-            detailsContent={detailsContent}
-            events={timeline.events}
-            expandableSpanIds={expandableSpanIds}
-            expandedSpanIds={expandedSpanIds}
-            failedSpanIds={failureAnalysis.failedSpanIds}
-            inlineErrorPreviews={failureAnalysis.inlineErrorPreviews}
-            inspectorSwitchToDetailsRef={switchToInspectorDetailsRef}
-            isDesktop={isDesktop}
-            onMobileTabChange={setActiveMobileTab}
-            onSelectSpan={handleSelectSpan}
-            onSelectSpanAndShowDetails={handleSelectSpanAndShowDetails}
-            onToggleExpand={toggleExpandedSpan}
-            primaryAncestorPath={failureAnalysis.primaryAncestorPath}
-            revealKey={revealVersion}
-            revealPath={revealPath}
-            revealTarget={waterfallRevealTarget}
-            reasoningContent={reasoningContent}
-            selectedSpanId={selectedSpanExternalId}
-            setExpandedSpanIds={setExpandedSpanIds}
-            spanAssessments={visibleRetrySafetyAssessments}
-            spanIndex={spanIndex}
-            spanTree={spanTree}
-            spans={spans}
-            stateChangeCount={stateChanges.length}
-            stateContent={stateContent}
-            traceCostSeries={traceCostSeries}
-            timelineContent={timelineContent}
-            traceEndedAt={trace.ended_at}
-            traceStartedAt={trace.started_at}
-          />
-        </div>
+      <div className="min-h-[42rem] flex-1">
+        <TraceWorkspace
+          activeMobileTab={activeMobileTab}
+          detailsContent={detailsContent}
+          events={timeline.events}
+          expandableSpanIds={expandableSpanIds}
+          expandedSpanIds={expandedSpanIds}
+          failedSpanIds={failureAnalysis.failedSpanIds}
+          inlineErrorPreviews={failureAnalysis.inlineErrorPreviews}
+          inspectorSwitchToDetailsRef={switchToInspectorDetailsRef}
+          isDesktop={isDesktop}
+          mobileSummaryContent={mobileSummaryContent}
+          onMobileTabChange={setActiveMobileTab}
+          onSelectSpan={handleSelectSpan}
+          onSelectSpanAndShowDetails={handleSelectSpanAndShowDetails}
+          onToggleExpand={toggleExpandedSpan}
+          primaryAncestorPath={failureAnalysis.primaryAncestorPath}
+          revealKey={revealVersion}
+          revealPath={revealPath}
+          revealTarget={waterfallRevealTarget}
+          reasoningContent={reasoningContent}
+          selectedSpanId={selectedSpanExternalId}
+          setExpandedSpanIds={setExpandedSpanIds}
+          spanAssessments={visibleRetrySafetyAssessments}
+          spanIndex={spanIndex}
+          spanTree={spanTree}
+          spans={spans}
+          stateChangeCount={stateChanges.length}
+          stateContent={stateContent}
+          traceCostSeries={traceCostSeries}
+          timelineContent={timelineContent}
+          traceEndedAt={trace.ended_at}
+          traceStartedAt={trace.started_at}
+        />
       </div>
+
+      {isDesktop && isTraceContextOpen ? (
+        <TraceContextDrawer
+          buildCopyTraceUrl={buildCopyTraceUrl}
+          onClose={() => setIsTraceContextOpen(false)}
+          trace={trace}
+        />
+      ) : null}
+
+      {!isDesktop && isTraceContextOpen ? (
+        <TraceContextSheet
+          buildCopyTraceUrl={buildCopyTraceUrl}
+          onClose={() => setIsTraceContextOpen(false)}
+          trace={trace}
+        />
+      ) : null}
     </div>
   );
 }
@@ -410,6 +431,7 @@ interface TraceWorkspaceProps {
   inlineErrorPreviews: ReadonlyMap<string, string>;
   inspectorSwitchToDetailsRef: MutableRefObject<(() => void) | null>;
   isDesktop: boolean;
+  mobileSummaryContent: ReactNode;
   onMobileTabChange: (tab: MobileWorkspaceTabId) => void;
   onSelectSpan: (spanId: string) => void;
   onSelectSpanAndShowDetails: (spanId: string) => void;
@@ -443,6 +465,7 @@ function TraceWorkspace({
   inlineErrorPreviews,
   inspectorSwitchToDetailsRef,
   isDesktop,
+  mobileSummaryContent,
   onMobileTabChange,
   onSelectSpan,
   onSelectSpanAndShowDetails,
@@ -521,8 +544,7 @@ function TraceWorkspace({
           switchToDetailsRef={inspectorSwitchToDetailsRef}
         />
       }
-      mobileDetails={detailsContent}
-      mobileReasoning={reasoningContent}
+      mobileSummary={mobileSummaryContent}
       mobileTimeline={timelineContent}
       mobileState={stateContent}
       activeMobileTab={activeMobileTab}
@@ -560,7 +582,6 @@ function TraceDetailsSurface({
   selectedSpan,
   spanIndex,
   events,
-  traceContext,
 }: {
   runningStateAssessment: WaitStallAssessment | null;
   timelineStatus: 'RUNNING' | 'COMPLETED' | 'FAILED' | null;
@@ -572,13 +593,10 @@ function TraceDetailsSurface({
   selectedSpan: Span | null;
   spanIndex: ReadonlyMap<string, Span>;
   events: TimelineEvent[];
-  traceContext: ReactNode;
 }) {
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-slate-50 p-4 dark:bg-slate-950">
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-transparent p-4">
       <div className="space-y-4">
-        {traceContext}
-
         {timelineStatus === 'FAILED' ? (
           <FailureSummary
             summary={failureAnalysis.summary}
@@ -597,7 +615,7 @@ function TraceDetailsSurface({
           />
         ) : null}
 
-        <div className="min-h-[22rem] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="min-h-[22rem] overflow-hidden rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface)] shadow-[var(--continua-shadow-soft)]">
           <SpanDetail
             span={selectedSpan}
             breadcrumbPath={selectedBreadcrumbPath}
@@ -616,6 +634,99 @@ function TraceDetailsSurface({
   );
 }
 
+function TraceHeaderMetric({
+  label,
+  value,
+  danger = false,
+}: {
+  label: string;
+  value: string;
+  danger?: boolean;
+}) {
+  return (
+    <div className="app-surface-muted px-4 py-3">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
+        {label}
+      </div>
+      <div
+        className={`mt-2 text-xl font-semibold tracking-[-0.03em] ${
+          danger ? 'text-red-600 dark:text-red-300' : 'text-[var(--continua-text-primary)]'
+        }`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function TraceContextDrawer({
+  buildCopyTraceUrl,
+  onClose,
+  trace,
+}: {
+  buildCopyTraceUrl: () => string;
+  onClose: () => void;
+  trace: TraceDetail;
+}) {
+  return (
+    <div className="app-overlay-enter fixed inset-0 z-50 hidden bg-slate-950/35 backdrop-blur-sm lg:block">
+      <button
+        type="button"
+        aria-label="Close trace context drawer"
+        className="absolute inset-0"
+        onClick={onClose}
+      />
+      <aside
+        className="app-drawer-enter absolute inset-y-4 right-4 w-[32rem] max-w-[calc(100vw-2rem)] overflow-y-auto"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Trace context"
+      >
+        <TraceContextSection
+          buildCopyTraceUrl={buildCopyTraceUrl}
+          onToggle={onClose}
+          open
+          trace={trace}
+        />
+      </aside>
+    </div>
+  );
+}
+
+function TraceContextSheet({
+  buildCopyTraceUrl,
+  onClose,
+  trace,
+}: {
+  buildCopyTraceUrl: () => string;
+  onClose: () => void;
+  trace: TraceDetail;
+}) {
+  return (
+    <div className="app-overlay-enter fixed inset-0 z-50 flex items-end bg-slate-950/45 backdrop-blur-sm lg:hidden">
+      <button
+        type="button"
+        aria-label="Close trace context sheet"
+        className="absolute inset-0"
+        onClick={onClose}
+      />
+      <aside
+        className="app-sheet-enter relative z-10 max-h-[82vh] w-full overflow-y-auto px-3 pb-3"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Trace context"
+      >
+        <TraceContextSection
+          buildCopyTraceUrl={buildCopyTraceUrl}
+          onToggle={onClose}
+          open
+          trace={trace}
+        />
+      </aside>
+    </div>
+  );
+}
+
 function TraceContextSection({
   buildCopyTraceUrl,
   onToggle,
@@ -628,18 +739,18 @@ function TraceContextSection({
   trace: TraceDetail;
 }) {
   return (
-    <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/70">
+    <section className="overflow-hidden rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface)] shadow-[var(--continua-shadow-soft)]">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-4 py-3">
         <button
           type="button"
           className="flex items-center gap-3 text-left"
           aria-expanded={open}
           onClick={onToggle}
         >
-          <span className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">
+          <span className="text-sm font-semibold uppercase tracking-[0.2em] text-[var(--continua-text-secondary)]">
             Trace Context
           </span>
-          <span className="rounded-full bg-white px-2 py-1 text-xs font-medium text-slate-500 ring-1 ring-slate-200 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700">
+          <span className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-2 py-1 text-xs font-medium text-[var(--continua-text-muted)]">
             {open ? 'Hide' : 'Show'}
           </span>
         </button>
@@ -672,12 +783,12 @@ function TraceContextSection({
               value={trace.session_id ? (
                 <Link
                   to={`/sessions/${trace.session_id}`}
-                  className="inline-flex flex-col text-left text-blue-600 hover:text-blue-800 dark:text-sky-400 dark:hover:text-sky-300"
+                  className="inline-flex flex-col text-left text-[var(--continua-accent)] hover:opacity-80"
                 >
-                  <span className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                  <span className="text-sm font-medium text-[var(--continua-text-primary)]">
                     {trace.session_external_id ?? trace.session_id}
                   </span>
-                  <span className="font-mono text-xs text-slate-500 dark:text-slate-400">
+                  <span className="font-mono text-xs text-[var(--continua-text-muted)]">
                     {trace.session_id}
                   </span>
                 </Link>
@@ -707,7 +818,7 @@ function TraceContextSection({
                   {trace.tags.map((tag) => (
                     <span
                       key={tag}
-                      className="rounded-full border border-slate-200 bg-white px-3 py-1 font-mono text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+                      className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-3 py-1 font-mono text-xs text-[var(--continua-text-secondary)]"
                     >
                       {tag}
                     </span>
@@ -749,12 +860,12 @@ function TraceContextField({
   copyButtonLabel?: string;
 }) {
   return (
-    <div className={`rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/70 ${className}`.trim()}>
-      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+    <div className={`rounded-xl border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-4 ${className}`.trim()}>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--continua-text-muted)]">
         {label}
       </div>
       <div className="mt-2 flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1 text-sm text-slate-900 dark:text-slate-100">{value}</div>
+        <div className="min-w-0 flex-1 text-sm text-[var(--continua-text-primary)]">{value}</div>
         {copyValue && copyButtonLabel ? (
           <CopyButton
             aria-label={copyButtonLabel}
@@ -769,9 +880,27 @@ function TraceContextField({
 
 function TracePayloadPanel({ title, data }: { title: string; data: unknown }) {
   return (
-    <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/70">
-      <h3 className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">{title}</h3>
-      <JsonViewer data={data} className="max-h-80 overflow-y-auto bg-white dark:bg-slate-900" />
+    <div className="rounded-xl border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-4">
+      <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">{title}</h3>
+      <JsonViewer data={data} className="max-h-80 overflow-y-auto bg-[var(--continua-surface-elevated)]" />
+    </div>
+  );
+}
+
+function TraceDetailEmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div className="app-page">
+      <div className="app-empty-state mt-0 flex min-h-[24rem] items-center justify-center px-6">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function TraceDetailErrorState({ children }: { children: ReactNode }) {
+  return (
+    <div className="app-page">
+      <div className="app-alert-error">{children}</div>
     </div>
   );
 }

--- a/web/src/pages/TracesPage.test.tsx
+++ b/web/src/pages/TracesPage.test.tsx
@@ -3,7 +3,6 @@ import {
   fireEvent,
   screen,
   waitFor,
-  within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -22,6 +21,7 @@ import {
   createDeferredResponse,
   getRequests,
   jsonResponse,
+  readRequestUrl,
   renderTraceRoutes,
   resetTestEntityCounter,
 } from './testUtils';
@@ -30,6 +30,13 @@ let fetchMock: ReturnType<typeof vi.fn>;
 
 function getTraceListRequests(): URL[] {
   return getRequests(fetchMock, '/api/traces');
+}
+
+function countTraceDetailRequests(): number {
+  return fetchMock.mock.calls.filter(([input]) => {
+    const url = new URL(readRequestUrl(input), 'http://localhost');
+    return /^\/api\/traces\/[^/]+$/.test(url.pathname);
+  }).length;
 }
 
 async function waitForListFetch(search: string) {
@@ -72,9 +79,12 @@ describe('TracesPage', () => {
 
     expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
     expect(
-      screen.getByText('Search names, user IDs, and matching span names.')
-    ).toBeInTheDocument();
+      screen.getAllByText('Search names, user IDs, and matching span names.').length
+    ).toBeGreaterThan(0);
     await waitForListFetch('?limit=20');
+    await waitFor(() => {
+      expect(countTraceDetailRequests()).toBe(0);
+    });
     expect(screen.queryByRole('button', { name: 'Clear all' })).not.toBeInTheDocument();
   });
 
@@ -359,7 +369,7 @@ describe('TracesPage', () => {
     await user.selectOptions(screen.getByLabelText('Status'), 'running');
 
     expect(screen.getByText('Checkout Trace')).toBeInTheDocument();
-    expect(screen.getByText('Updating...')).toBeInTheDocument();
+    expect(screen.getByText('Refreshing…')).toBeInTheDocument();
 
     deferred.resolve(jsonResponse({ traces: [TRACE_TWO], total: 1 }));
 
@@ -399,7 +409,7 @@ describe('TracesPage', () => {
     renderTraceRoutes(['/traces?q=trace']);
     expect(await screen.findByText('Zeta Trace')).toBeInTheDocument();
 
-    const links = within(screen.getByRole('table')).getAllByRole('link', {
+    const links = screen.getAllByRole('link', {
       name: /(Zeta|Alpha) Trace/,
     });
     expect(links.map((link) => link.textContent)).toEqual([
@@ -418,7 +428,9 @@ describe('TracesPage', () => {
       },
     ]);
 
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '← Traces' })).toHaveAttribute(
       'href',
       '/traces?q=checkout&status=failed'
@@ -431,7 +443,9 @@ describe('TracesPage', () => {
         state: { returnTo: '/sessions' },
       },
     ]);
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '← Traces' })).toHaveAttribute(
       'href',
       '/traces'
@@ -439,7 +453,9 @@ describe('TracesPage', () => {
     unrelatedState.unmount();
 
     renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
-    expect(await screen.findByText('Trace Context')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Trace Context/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '← Traces' })).toHaveAttribute(
       'href',
       '/traces'
@@ -466,7 +482,19 @@ describe('TracesPage', () => {
     const clearErrors = screen.getByRole('button', { name: 'Clear Errors filter' });
     const clearSession = screen.getByRole('button', { name: 'Clear Session filter' });
     const clearAll = screen.getByRole('button', { name: 'Clear all' });
+    const allTracesQuickFilter = screen.getByRole('button', { name: 'All traces' });
+    const failedQuickFilter = screen.getByRole('button', { name: 'Failed' });
+    const runningQuickFilter = screen.getByRole('button', { name: 'Running' });
+    const hasErrorsQuickFilter = screen.getByRole('button', { name: 'Has errors' });
 
+    await user.tab();
+    expect(allTracesQuickFilter).toHaveFocus();
+    await user.tab();
+    expect(failedQuickFilter).toHaveFocus();
+    await user.tab();
+    expect(runningQuickFilter).toHaveFocus();
+    await user.tab();
+    expect(hasErrorsQuickFilter).toHaveFocus();
     await user.tab();
     expect(searchInput).toHaveFocus();
     await user.tab();
@@ -490,9 +518,9 @@ describe('TracesPage', () => {
     await user.tab();
     expect(clearAll).toHaveFocus();
 
-    expect(searchInput.className).toContain('focus:ring-2');
+    expect(searchInput).toHaveClass('app-input');
     expect(clearSearch.className).toContain('focus:ring-2');
-    expect(clearAll.className).toContain('focus:ring-2');
+    expect(clearAll).toHaveClass('app-button-secondary');
   });
 
   it('rehydrates draft text inputs on back and forward navigation', async () => {
@@ -589,7 +617,7 @@ describe('TracesPage', () => {
     expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
 
     expect(screen.queryByRole('button', { name: 'Started' })).not.toBeInTheDocument();
-    expect(screen.getByText('Started')).toBeInTheDocument();
+    expect(screen.getAllByText('Started').length).toBeGreaterThan(0);
   });
 
   it('renders session external ID first on trace rows', async () => {
@@ -599,6 +627,6 @@ describe('TracesPage', () => {
     expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
 
     expect(screen.getByText('conv-checkout-123')).toBeInTheDocument();
-    expect(screen.getByText(SESSION_ID)).toBeInTheDocument();
+    expect(screen.queryByText(SESSION_ID)).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/TracesPage.tsx
+++ b/web/src/pages/TracesPage.tsx
@@ -25,6 +25,7 @@ import {
 } from '../utils/format';
 
 const DEBOUNCE_MS = 300;
+const EMPTY_TRACES: Trace[] = [];
 
 function normalizeTrimmedDraft(value: string): string {
   return value.trim();
@@ -213,7 +214,7 @@ function TracesContent() {
     placeholderData: keepPreviousData,
   });
 
-  const traces = tracesQuery.data?.traces ?? [];
+  const traces = tracesQuery.data?.traces ?? EMPTY_TRACES;
   const total = tracesQuery.data?.total ?? 0;
   const currentListUrl = `${location.pathname}${location.search}`;
 
@@ -246,29 +247,69 @@ function TracesContent() {
   }, [filters.sort_by, filters.sort_dir, isSearchActive, setFilters]);
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Traces</h1>
-            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-              Find traces by name, owner, time window, or error signals.
+    <div className="app-page">
+      <section className="app-surface p-6 sm:p-7">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-3xl">
+            <div className="app-overline">Trace triage</div>
+            <h1 className="mt-3 text-3xl font-semibold tracking-[-0.04em] text-[var(--continua-text-primary)] sm:text-4xl">
+              Find the run, isolate the failure, and jump straight into the workspace.
+            </h1>
+            <p className="mt-3 text-sm leading-7 text-[var(--continua-text-secondary)] sm:text-base">
+              Search names, user IDs, and matching span names.
             </p>
           </div>
-          <div className="text-sm text-slate-500 dark:text-slate-400">
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <TraceStat label="Tracked" value={String(total)} />
+            <TraceStat label="Live" value={String(runningTracesCount(filters.status, traces, tracesQuery.data?.total))} />
+            <TraceStat
+              label="Failures"
+              value={
+                filters.status === 'failed'
+                  ? String(total)
+                  : String(traces.filter((trace) => (trace.error_count ?? 0) > 0).length)
+              }
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="app-surface sticky top-[4.9rem] z-20 p-4 sm:p-5">
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <QuickFilterButton
+            active={!filters.status}
+            label="All traces"
+            onClick={() => setFilters({ status: undefined }, 'push')}
+          />
+          <QuickFilterButton
+            active={filters.status === 'failed'}
+            label="Failed"
+            onClick={() => setFilters({ status: filters.status === 'failed' ? undefined : 'failed' }, 'push')}
+          />
+          <QuickFilterButton
+            active={filters.status === 'running'}
+            label="Running"
+            onClick={() => setFilters({ status: filters.status === 'running' ? undefined : 'running' }, 'push')}
+          />
+          <QuickFilterButton
+            active={Boolean(filters.has_errors)}
+            label="Has errors"
+            onClick={() =>
+              setFilters({ has_errors: filters.has_errors ? undefined : true }, 'push')
+            }
+          />
+          <div className="ml-auto text-sm text-[var(--continua-text-muted)]">
             <span>{total} total</span>
-            {tracesQuery.isFetching && !tracesQuery.isPending && (
-              <span className="ml-2 text-blue-600 dark:text-sky-400">Updating...</span>
-            )}
+            {tracesQuery.isFetching && !tracesQuery.isPending ? <span className="ml-2">Refreshing…</span> : null}
           </div>
         </div>
 
-        <section className="mb-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
             <div className="xl:col-span-2">
               <label
                 htmlFor="trace-search"
-                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
               >
                 Search
               </label>
@@ -284,9 +325,9 @@ function TracesContent() {
                 }
                 aria-describedby="trace-search-hint"
                 placeholder="Search traces"
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+                className="app-input"
               />
-              <p id="trace-search-hint" className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              <p id="trace-search-hint" className="mt-1 text-xs text-[var(--continua-text-muted)]">
                 Search names, user IDs, and matching span names.
               </p>
             </div>
@@ -294,7 +335,7 @@ function TracesContent() {
             <div>
               <label
                 htmlFor="trace-status"
-                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
               >
                 Status
               </label>
@@ -311,7 +352,7 @@ function TracesContent() {
                     'push'
                   )
                 }
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+                className="app-select"
               >
                 <option value="">All statuses</option>
                 <option value="running">Running</option>
@@ -323,7 +364,7 @@ function TracesContent() {
             <div>
               <label
                 htmlFor="trace-start-date"
-                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
               >
                 Start Date
               </label>
@@ -341,14 +382,14 @@ function TracesContent() {
                     'push'
                   )
                 }
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+                className="app-input"
               />
             </div>
 
             <div>
               <label
                 htmlFor="trace-end-date"
-                className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
               >
                 End Date
               </label>
@@ -366,14 +407,14 @@ function TracesContent() {
                     'push'
                   )
                 }
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+                className="app-input"
               />
             </div>
 
             <div>
               <label
                 htmlFor="trace-user-id"
-                className="mb-1 block text-sm font-medium text-gray-700"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
               >
                 User ID
               </label>
@@ -388,7 +429,7 @@ function TracesContent() {
                   handleEnterCommit(event, commitUserId, userIdDraft)
                 }
                 placeholder="Filter by user"
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                className="app-input"
               />
             </div>
 
@@ -396,7 +437,7 @@ function TracesContent() {
               <div>
                 <label
                   htmlFor="trace-min-duration"
-                  className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                  className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
                 >
                   Min Duration (ms)
                 </label>
@@ -413,11 +454,11 @@ function TracesContent() {
                     handleEnterCommit(event, commitMinDuration, minDurationDraft)
                   }
                   placeholder="e.g. 1500"
-                  className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-900"
+                  className="app-input"
                 />
               </div>
 
-              <label className="flex items-end gap-2 text-sm font-medium text-slate-700 xl:pt-0 dark:text-slate-200">
+              <label className="flex items-end gap-2 text-sm font-medium text-[var(--continua-text-secondary)] xl:pt-0">
                 <input
                   type="checkbox"
                   checked={Boolean(filters.has_errors)}
@@ -430,7 +471,7 @@ function TracesContent() {
                     )
                   }
                   aria-label="Only show traces with errors"
-                  className="mt-0 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950"
+                  className="mt-0 h-4 w-4 rounded border-[var(--continua-border-strong)] text-[var(--continua-accent)] focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
                 />
                 <span>Has errors</span>
               </label>
@@ -438,146 +479,121 @@ function TracesContent() {
           </div>
 
           {dateRangeError && (
-            <p className="mt-3 text-sm font-medium text-red-600">{dateRangeError}</p>
+            <p className="mt-3 text-sm font-medium text-red-600 dark:text-red-300">{dateRangeError}</p>
           )}
-        </section>
+      </section>
 
-        {hasActiveFilters && (
-          <div className="mb-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-            <div className="flex flex-wrap items-center gap-2">
-              {activeChips.map((chip) => (
-                <span
-                  key={chip.key}
-                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200"
+      {hasActiveFilters && (
+        <div className="app-surface p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {activeChips.map((chip) => (
+              <span
+                key={chip.key}
+                className="inline-flex items-center gap-2 rounded-full border border-[var(--continua-border-strong)] bg-[var(--continua-surface-muted)] px-3 py-1.5 text-sm text-[var(--continua-text-secondary)]"
+              >
+                <span className="font-medium">{chip.label}:</span>
+                <span>{chip.value}</span>
+                <button
+                  type="button"
+                  onClick={() => clearChip(chip.key)}
+                  aria-label={`Clear ${chip.label} filter`}
+                  className="rounded-full p-0.5 text-[var(--continua-text-muted)] transition hover:bg-[var(--continua-surface-elevated)] hover:text-[var(--continua-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
                 >
-                  <span className="font-medium">{chip.label}:</span>
-                  <span>{chip.value}</span>
-                  <button
-                    type="button"
-                    onClick={() => clearChip(chip.key)}
-                    aria-label={`Clear ${chip.label} filter`}
-                    className="rounded-full p-0.5 text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
-                  >
-                    ×
-                  </button>
-                </span>
-              ))}
-              <button
-                type="button"
-                onClick={clearAll}
-                className="ml-auto rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900 dark:hover:text-slate-100"
-              >
-                Clear all
-              </button>
-            </div>
+                  ×
+                </button>
+              </span>
+            ))}
+            <button
+              type="button"
+              onClick={clearAll}
+              className="app-button-secondary ml-auto"
+            >
+              Clear all
+            </button>
           </div>
-        )}
+        </div>
+      )}
 
-        {tracesQuery.error && (
-          isAuthError(tracesQuery.error) ? (
-            <div className="mb-4">
-              <AuthErrorBanner message={getErrorMessage(tracesQuery.error)} />
-            </div>
-          ) : (
-            <div className="mb-4 flex flex-col gap-3 rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <p className="font-semibold">Could not load traces</p>
-                <p className="text-sm">{getErrorMessage(tracesQuery.error)}</p>
-              </div>
-              <button
-                type="button"
-                onClick={() => void tracesQuery.refetch()}
-                className="rounded-lg bg-red-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-200"
-              >
-                Retry
-              </button>
-            </div>
-          )
-        )}
-
-        {dateRangeError ? (
-          <div className="rounded-xl border border-dashed border-red-200 bg-white p-8 text-center text-sm text-slate-600 shadow-sm dark:border-red-500/40 dark:bg-slate-900 dark:text-slate-300">
-            Fix the date range to load traces.
-          </div>
-        ) : tracesQuery.isPending && !tracesQuery.data ? (
-          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
-            Loading traces...
-          </div>
-        ) : tracesQuery.error && !tracesQuery.data ? (
-          <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-600 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
-            Retry the request or adjust your filters to continue.
-          </div>
-        ) : traces.length === 0 ? (
-          hasActiveFilters ? (
-            <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No matching traces</h2>
-              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-                Try broadening the filters or clearing them entirely.
-              </p>
-            </div>
-          ) : (
-            <div className="rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No traces yet</h2>
-              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-                Start sending traces from your application to see them here.
-              </p>
-            </div>
-          )
+      {tracesQuery.error && (
+        isAuthError(tracesQuery.error) ? (
+          <AuthErrorBanner message={getErrorMessage(tracesQuery.error)} />
         ) : (
-          <>
-            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-              <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
-                <thead className="bg-slate-50 dark:bg-slate-950/70">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      Name
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      Status
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      Duration
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      Tokens
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      Cost
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                      <SortableHeader
-                        label="Started"
-                        isActive={filters.sort_by === 'started_at'}
-                        isAscending={filters.sort_dir === 'asc'}
-                        isDisabled={isSearchActive}
-                        onClick={handleStartedSortToggle}
-                      />
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-900">
-                  {traces.map((trace) => (
-                    <TraceRow
-                      key={trace.id}
-                      trace={trace}
-                      returnTo={currentListUrl}
-                    />
-                  ))}
-                </tbody>
-              </table>
+          <div className="app-alert-error flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-semibold">Could not load traces</p>
+              <p className="text-sm">{getErrorMessage(tracesQuery.error)}</p>
             </div>
-            <PaginationControls
-              offset={filters.offset}
-              pageSize={filters.limit ?? DEFAULT_PAGE_SIZE}
-              total={total}
-              currentItemCount={traces.length}
-              onOffsetChange={(offset) => setFilters({ offset }, 'push')}
-              onPageSizeChange={(limit) => setFilters({ limit }, 'push')}
-              onRepairOffset={(offset) => setFilters({ offset }, 'replace')}
-            />
-          </>
-        )}
-      </div>
+            <button
+              type="button"
+              onClick={() => void tracesQuery.refetch()}
+              className="app-button-primary"
+            >
+              Retry
+            </button>
+          </div>
+        )
+      )}
+
+      {dateRangeError ? (
+        <div className="app-empty-state">Fix the date range to load traces.</div>
+      ) : tracesQuery.isPending && !tracesQuery.data ? (
+        <div className="app-empty-state">Loading traces...</div>
+      ) : tracesQuery.error && !tracesQuery.data ? (
+        <div className="app-empty-state">Retry the request or adjust your filters to continue.</div>
+      ) : traces.length === 0 ? (
+        hasActiveFilters ? (
+          <div className="app-empty-state">
+            <h2 className="text-lg font-semibold text-[var(--continua-text-primary)]">No matching traces</h2>
+            <p className="mt-2">Try broadening the filters or clearing them entirely.</p>
+          </div>
+        ) : (
+          <div className="app-empty-state">
+            <h2 className="text-lg font-semibold text-[var(--continua-text-primary)]">No traces yet</h2>
+            <p className="mt-2">Start sending traces from your application to see them here.</p>
+          </div>
+        )
+      ) : (
+        <>
+          <section className="app-surface overflow-hidden">
+            <div className="flex items-center justify-between border-b border-[var(--continua-border-soft)] px-4 py-3 sm:px-5">
+              <div className="flex items-center gap-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
+                <span>Name</span>
+                <span>Status</span>
+                <span>Duration</span>
+                <span>Tokens</span>
+                <span>Cost</span>
+              </div>
+              <SortableHeader
+                label="Started"
+                isActive={filters.sort_by === 'started_at'}
+                isAscending={filters.sort_dir === 'asc'}
+                isDisabled={isSearchActive}
+                onClick={handleStartedSortToggle}
+              />
+            </div>
+
+            <div className="space-y-3 p-4 sm:p-5">
+              {traces.map((trace) => (
+                <TraceRow
+                  key={trace.id}
+                  trace={trace}
+                  returnTo={currentListUrl}
+                />
+              ))}
+            </div>
+          </section>
+
+          <PaginationControls
+            offset={filters.offset}
+            pageSize={filters.limit ?? DEFAULT_PAGE_SIZE}
+            total={total}
+            currentItemCount={traces.length}
+            onOffsetChange={(offset) => setFilters({ offset }, 'push')}
+            onPageSizeChange={(limit) => setFilters({ limit }, 'push')}
+            onRepairOffset={(offset) => setFilters({ offset }, 'replace')}
+          />
+        </>
+      )}
     </div>
   );
 }
@@ -592,51 +608,108 @@ function TraceRow({ trace, returnTo }: TraceRowProps) {
   const totalTokens = (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0);
 
   return (
-    <tr className="transition hover:bg-slate-50 dark:hover:bg-slate-800/60">
-      <td className="px-6 py-4 align-top">
-        <div className="min-w-[16rem]">
-          <div className="flex flex-wrap items-center gap-2">
-            <Link
-              to={`/traces/${trace.id}`}
-              state={{ returnTo }}
-              className="text-sm font-semibold text-blue-700 transition hover:text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:text-sky-400 dark:hover:text-sky-300"
-            >
-              {trace.name}
-            </Link>
-            {trace.error_count && trace.error_count > 0 && (
-              <span className="inline-flex rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-500/15 dark:text-red-200">
-                {trace.error_count} error{trace.error_count === 1 ? '' : 's'}
-              </span>
-            )}
-          </div>
-          {trace.session_id && (
+    <article className="app-list-row">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            to={`/traces/${trace.id}`}
+            state={{ returnTo }}
+            className="truncate text-sm font-semibold text-[var(--continua-text-primary)] transition hover:text-[var(--continua-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
+          >
+            {trace.name}
+          </Link>
+          <StatusBadge status={trace.status} />
+          {trace.error_count && trace.error_count > 0 ? (
+            <span className="inline-flex rounded-full border border-red-300/60 bg-red-100/80 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-red-900 dark:border-red-400/25 dark:bg-red-400/10 dark:text-red-100">
+              {trace.error_count} error{trace.error_count === 1 ? '' : 's'}
+            </span>
+          ) : null}
+        </div>
+
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--continua-text-muted)]">
+          <span>{formatRelativeTime(trace.started_at)}</span>
+          {trace.session_id ? (
             <Link
               to={`/sessions/${trace.session_id}`}
-              className="mt-1 inline-flex flex-col text-left text-xs transition hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:hover:text-sky-300"
+              className="inline-flex items-center gap-2 rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2.5 py-1 text-[11px] font-medium text-[var(--continua-text-secondary)] transition hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-accent)]"
             >
-              <span className="font-medium text-slate-600 dark:text-slate-300">
-                {trace.session_external_id ?? trace.session_id}
-              </span>
-              <span className="font-mono text-slate-400 dark:text-slate-500">{trace.session_id}</span>
+              <span>{trace.session_external_id ?? trace.session_id}</span>
             </Link>
-          )}
+          ) : null}
         </div>
-      </td>
-      <td className="px-6 py-4 whitespace-nowrap align-top">
-        <StatusBadge status={trace.status} />
-      </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
-        {formatDuration(duration)}
-      </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
-        {formatTokens(totalTokens)}
-      </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 align-top dark:text-slate-100">
-        {formatCost(trace.total_cost_usd)}
-      </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-500 align-top dark:text-slate-400">
-        {formatRelativeTime(trace.started_at)}
-      </td>
-    </tr>
+      </div>
+
+      <div className="grid shrink-0 gap-3 text-right text-xs sm:grid-cols-4 sm:text-sm">
+        <MetricColumn label="Duration" value={formatDuration(duration)} />
+        <MetricColumn label="Tokens" value={formatTokens(totalTokens)} />
+        <MetricColumn label="Cost" value={formatCost(trace.total_cost_usd)} />
+        <MetricColumn
+          label="Errors"
+          value={trace.error_count && trace.error_count > 0 ? String(trace.error_count) : '0'}
+        />
+      </div>
+    </article>
   );
+}
+
+function MetricColumn({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-[5.25rem]">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--continua-text-muted)]">
+        {label}
+      </div>
+      <div className="mt-1 text-xs font-medium text-[var(--continua-text-primary)] sm:text-sm">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function TraceStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="app-surface-muted px-4 py-3">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function QuickFilterButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        active
+          ? 'inline-flex items-center rounded-full border border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] px-3 py-1.5 text-sm font-medium text-[var(--continua-accent)]'
+          : 'app-button-ghost'
+      }
+    >
+      {label}
+    </button>
+  );
+}
+
+function runningTracesCount(
+  status: 'running' | 'completed' | 'failed' | undefined,
+  traces: Trace[],
+  total?: number
+) {
+  if (status === 'running') {
+    return total ?? traces.length;
+  }
+
+  return traces.filter((trace) => trace.status === 'RUNNING').length;
 }

--- a/web/src/pages/testUtils.tsx
+++ b/web/src/pages/testUtils.tsx
@@ -31,6 +31,7 @@ import { SessionDetailPage } from './SessionDetailPage';
 import { SessionsPage } from './SessionsPage';
 import { SettingsPage } from './SettingsPage';
 import { TracesPage } from './TracesPage';
+import { OverviewPage } from './OverviewPage';
 export {
   EMPTY_SESSION_NARRATIVE,
   OTHER_SESSION_EXTERNAL_ID,
@@ -115,7 +116,34 @@ export function buildFetchHandler({
     }
 
     if (/^\/api\/traces\/[^/]+$/.test(url.pathname)) {
-      return detail?.(url) ?? jsonResponse(TRACE_DETAIL);
+      if (detail) {
+        return detail(url);
+      }
+
+      const traceId = url.pathname.split('/').at(-1);
+      if (traceId === TRACE_ONE.id) {
+        return jsonResponse(TRACE_DETAIL);
+      }
+      if (traceId === TRACE_TWO.id) {
+        return jsonResponse({
+          ...TRACE_DETAIL,
+          ...TRACE_TWO,
+          trace_id: 'external-trace-latency',
+          user_id: 'user-456',
+          tags: ['latency'],
+        });
+      }
+      if (traceId === TRACE_THREE.id) {
+        return jsonResponse({
+          ...TRACE_DETAIL,
+          ...TRACE_THREE,
+          trace_id: 'external-trace-alpha',
+          user_id: 'user-123',
+          tags: ['alpha'],
+        });
+      }
+
+      return jsonResponse(TRACE_DETAIL);
     }
 
     if (url.pathname === '/api/sessions') {
@@ -208,6 +236,7 @@ export function renderTraceRoutes(
   const queryClient = createQueryClient();
   const router = createMemoryRouter(
     [
+      { path: '/', element: <OverviewPage /> },
       { path: '/traces', element: <TracesPage /> },
       { path: '/traces/:id', element: <TraceDetailPage /> },
       { path: '/sessions', element: <SessionsPage /> },

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1,3 +1,9 @@
+@import '@fontsource/ibm-plex-sans/400.css';
+@import '@fontsource/ibm-plex-sans/500.css';
+@import '@fontsource/ibm-plex-sans/600.css';
+@import '@fontsource/ibm-plex-mono/400.css';
+@import '@fontsource/ibm-plex-mono/500.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -5,32 +11,66 @@
 @layer base {
   :root {
     color-scheme: light;
-    --continua-panel-separator: rgba(203, 213, 225, 0.95);
-    --continua-waterfall-failed-bg: #fee2e2;
-    --continua-waterfall-failed-border: #fca5a5;
-    --continua-waterfall-running-bg: #dbeafe;
-    --continua-waterfall-running-border: #93c5fd;
+    --continua-font-sans: 'IBM Plex Sans', 'Segoe UI', sans-serif;
+    --continua-font-mono: 'IBM Plex Mono', 'SFMono-Regular', monospace;
+    --continua-app-bg: #f5f0e7;
+    --continua-shell-rail: rgba(249, 245, 238, 0.9);
+    --continua-shell-topbar: rgba(245, 240, 231, 0.84);
+    --continua-surface: rgba(255, 253, 248, 0.84);
+    --continua-surface-elevated: rgba(255, 255, 255, 0.94);
+    --continua-surface-muted: rgba(245, 240, 231, 0.84);
+    --continua-border-soft: rgba(73, 84, 102, 0.1);
+    --continua-border-strong: rgba(73, 84, 102, 0.16);
+    --continua-text-primary: #1f2733;
+    --continua-text-secondary: #435161;
+    --continua-text-muted: #66768a;
+    --continua-accent: #2563eb;
+    --continua-accent-strong: #1d4ed8;
+    --continua-accent-contrast: #f8fbff;
+    --continua-accent-faint: rgba(37, 99, 235, 0.12);
+    --continua-shadow-soft: 0 18px 40px rgba(15, 23, 42, 0.07);
+    --continua-panel-separator: rgba(148, 163, 184, 0.9);
+    --continua-waterfall-failed-bg: rgba(255, 232, 232, 0.95);
+    --continua-waterfall-failed-border: rgba(248, 113, 113, 0.45);
+    --continua-waterfall-running-bg: rgba(219, 234, 254, 0.95);
+    --continua-waterfall-running-border: rgba(59, 130, 246, 0.4);
     --continua-waterfall-running-dot: #2563eb;
-    --continua-waterfall-success-bg: #dcfce7;
-    --continua-waterfall-success-border: #86efac;
-    --continua-waterfall-success-selected-bg: #bfdbfe;
-    --continua-waterfall-success-selected-border: #60a5fa;
-    --continua-waterfall-tick-color: rgba(148, 163, 184, 0.3);
+    --continua-waterfall-success-bg: rgba(232, 244, 238, 0.95);
+    --continua-waterfall-success-border: rgba(52, 211, 153, 0.38);
+    --continua-waterfall-success-selected-bg: rgba(219, 234, 254, 0.95);
+    --continua-waterfall-success-selected-border: rgba(37, 99, 235, 0.45);
+    --continua-waterfall-tick-color: rgba(100, 116, 139, 0.18);
   }
 
   html.dark {
     color-scheme: dark;
-    --continua-panel-separator: rgba(51, 65, 85, 0.95);
-    --continua-waterfall-failed-bg: rgba(127, 29, 29, 0.5);
-    --continua-waterfall-failed-border: rgba(248, 113, 113, 0.55);
-    --continua-waterfall-running-bg: rgba(30, 64, 175, 0.45);
-    --continua-waterfall-running-border: rgba(96, 165, 250, 0.65);
+    --continua-app-bg: #0d141b;
+    --continua-shell-rail: rgba(14, 22, 31, 0.96);
+    --continua-shell-topbar: rgba(13, 20, 27, 0.86);
+    --continua-surface: rgba(21, 32, 45, 0.82);
+    --continua-surface-elevated: rgba(24, 37, 51, 0.95);
+    --continua-surface-muted: rgba(16, 25, 34, 0.88);
+    --continua-border-soft: rgba(148, 163, 184, 0.12);
+    --continua-border-strong: rgba(148, 163, 184, 0.18);
+    --continua-text-primary: #eef4fb;
+    --continua-text-secondary: #b8c7d7;
+    --continua-text-muted: #7f91a5;
+    --continua-accent: #7dd3fc;
+    --continua-accent-strong: #38bdf8;
+    --continua-accent-contrast: #041018;
+    --continua-accent-faint: rgba(125, 211, 252, 0.14);
+    --continua-shadow-soft: 0 20px 45px rgba(2, 8, 23, 0.38);
+    --continua-panel-separator: rgba(71, 85, 105, 0.95);
+    --continua-waterfall-failed-bg: rgba(127, 29, 29, 0.4);
+    --continua-waterfall-failed-border: rgba(248, 113, 113, 0.4);
+    --continua-waterfall-running-bg: rgba(15, 23, 42, 0.95);
+    --continua-waterfall-running-border: rgba(125, 211, 252, 0.28);
     --continua-waterfall-running-dot: #93c5fd;
-    --continua-waterfall-success-bg: rgba(6, 95, 70, 0.5);
-    --continua-waterfall-success-border: rgba(52, 211, 153, 0.6);
-    --continua-waterfall-success-selected-bg: rgba(37, 99, 235, 0.6);
-    --continua-waterfall-success-selected-border: rgba(125, 211, 252, 0.7);
-    --continua-waterfall-tick-color: rgba(71, 85, 105, 0.45);
+    --continua-waterfall-success-bg: rgba(6, 78, 59, 0.38);
+    --continua-waterfall-success-border: rgba(110, 231, 183, 0.26);
+    --continua-waterfall-success-selected-bg: rgba(12, 74, 110, 0.54);
+    --continua-waterfall-success-selected-border: rgba(125, 211, 252, 0.38);
+    --continua-waterfall-tick-color: rgba(148, 163, 184, 0.14);
   }
 
   html,
@@ -40,6 +80,175 @@
   }
 
   body {
-    @apply bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100;
+    background-color: var(--continua-app-bg);
+    background-image:
+      radial-gradient(circle at top left, rgba(37, 99, 235, 0.08), transparent 24rem),
+      radial-gradient(circle at bottom right, rgba(15, 23, 42, 0.07), transparent 22rem);
+    color: var(--continua-text-primary);
+    font-family: var(--continua-font-sans);
+    @apply antialiased;
+  }
+
+  code,
+  kbd,
+  pre,
+  samp {
+    font-family: var(--continua-font-mono);
+  }
+
+  ::selection {
+    background: var(--continua-accent-faint);
+  }
+}
+
+@keyframes continua-shell-enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes continua-overlay-enter {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes continua-drawer-enter {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes continua-sheet-enter {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@layer components {
+  .app-shell-enter {
+    animation: continua-shell-enter 240ms ease-out;
+  }
+
+  .app-overlay-enter {
+    animation: continua-overlay-enter 180ms ease-out;
+  }
+
+  .app-drawer-enter {
+    animation: continua-drawer-enter 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .app-sheet-enter {
+    animation: continua-sheet-enter 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .app-page {
+    @apply mx-auto flex max-w-[92rem] flex-col gap-6;
+  }
+
+  .app-surface {
+    background: var(--continua-surface);
+    border: 1px solid var(--continua-border-strong);
+    box-shadow: var(--continua-shadow-soft);
+    backdrop-filter: blur(18px);
+    @apply rounded-[1.5rem];
+  }
+
+  .app-surface-muted {
+    background: var(--continua-surface-muted);
+    border: 1px solid var(--continua-border-soft);
+    @apply rounded-[1.25rem];
+  }
+
+  .app-metric-panel {
+    background: var(--continua-surface);
+    border: 1px solid var(--continua-border-strong);
+    box-shadow: var(--continua-shadow-soft);
+    @apply rounded-[1.35rem] p-5;
+  }
+
+  .app-overline {
+    color: var(--continua-text-muted);
+    @apply text-[11px] font-semibold uppercase tracking-[0.22em];
+  }
+
+  .app-section-header {
+    @apply flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between;
+  }
+
+  .app-inline-link {
+    color: var(--continua-accent);
+    @apply text-sm font-medium transition hover:opacity-80;
+  }
+
+  .app-button-primary {
+    background: var(--continua-accent-strong);
+    color: var(--continua-accent-contrast);
+    @apply inline-flex items-center justify-center rounded-full px-4 py-2.5 text-sm font-medium transition hover:brightness-110 focus:outline-none focus:ring-2;
+    box-shadow: var(--continua-shadow-soft);
+  }
+
+  .app-button-secondary {
+    background: var(--continua-surface-elevated);
+    border: 1px solid var(--continua-border-strong);
+    color: var(--continua-text-primary);
+    @apply inline-flex items-center justify-center rounded-full px-4 py-2.5 text-sm font-medium transition hover:border-[var(--continua-accent)] hover:text-[var(--continua-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)];
+  }
+
+  .app-button-ghost {
+    background: transparent;
+    border: 1px solid var(--continua-border-soft);
+    color: var(--continua-text-secondary);
+    @apply inline-flex items-center justify-center rounded-full px-3 py-2 text-sm font-medium transition hover:border-[var(--continua-border-strong)] hover:bg-[var(--continua-surface-muted)] hover:text-[var(--continua-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)];
+  }
+
+  .app-input,
+  .app-select {
+    background: var(--continua-surface-elevated);
+    border: 1px solid var(--continua-border-strong);
+    color: var(--continua-text-primary);
+    @apply w-full rounded-[1rem] px-3 py-2.5 text-sm outline-none transition focus:border-[var(--continua-accent)] focus:ring-2 focus:ring-[var(--continua-accent-faint)];
+  }
+
+  .app-list-row {
+    background: var(--continua-surface-elevated);
+    border: 1px solid var(--continua-border-soft);
+    @apply flex items-start justify-between gap-3 rounded-[1.2rem] px-4 py-4 transition hover:-translate-y-0.5 hover:border-[var(--continua-border-strong)] hover:bg-[var(--continua-surface)];
+  }
+
+  .app-empty-state {
+    background: var(--continua-surface-muted);
+    border: 1px dashed var(--continua-border-strong);
+    color: var(--continua-text-muted);
+    @apply mt-5 rounded-[1.25rem] px-5 py-10 text-center text-sm;
+  }
+
+  .app-alert-error {
+    @apply rounded-[1.25rem] border px-4 py-3 text-sm;
+    background: rgba(239, 68, 68, 0.08);
+    border-color: rgba(239, 68, 68, 0.24);
+    color: #b91c1c;
   }
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -25,5 +25,6 @@ export default defineConfig({
     globals: true,
     passWithNoTests: true,
     setupFiles: ['./src/test/setup.ts'],
+    exclude: ['e2e/**', 'node_modules/**'],
   },
 });


### PR DESCRIPTION
## Summary
- redesign the Continua debugger into an operator-first shell with Overview, Traces, Sessions, and Settings surfaces
- add the new overview dashboard, shared design-token system, trace/session workspace refresh, and mobile trace-detail restructuring
- add Vitest coverage for the new shell and overview plus Playwright desktop/mobile smoke coverage for the redesigned UI

## Why
- the existing UI looked generic and did not support fast operator triage across traces and sessions
- this change makes the debugger denser, more navigable, and more consistent without changing backend contracts or URL behavior

## Validation
- pnpm --filter web lint
- pnpm --filter web type-check
- pnpm --filter web test
- pnpm --filter web test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned operator shell with improved left navigation rail and top toolbar
  * New Overview page displaying trace and session snapshots, running work, and recent activity
  * Improved Traces and Sessions pages with refined layout, sticky filter controls, and quick status filters
  * Updated mobile workspace with new tabs: Summary, Execution, Timeline, State
  * Added trace context panel (desktop drawer, mobile sheet) for investigation context
  * New visual design system with improved typography and color palette

* **Documentation**
  * Added comprehensive UI redesign specifications and implementation guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->