### PR TITLE
docs: refresh living docs and Codex skills

### DIFF
--- a/.codex/references/commands.md
+++ b/.codex/references/commands.md
@@ -7,6 +7,7 @@ Claude's `/project:*` commands do not exist in Codex, but the underlying workflo
 - `check-todos`: review and pick from outstanding tasks
 - `whats-next`: create a handoff note before context resets
 - `dev-docs-update`: refresh docs or implementation notes before stopping
+- `docs-status-audit`: verify living docs vs historical docs and fix drift before stopping
 
 ## Development workflows
 - `dev`: start or stop the local database, server, or web app
@@ -25,9 +26,12 @@ Claude's `/project:*` commands do not exist in Codex, but the underlying workflo
 - `review`: perform a code review focused on bugs, regressions, and missing tests
 - `review-pr`: inspect a pull request or diff with review findings first
 - `test`: plan and implement the smallest relevant test coverage for the change
+- `test:e2e`: run or update the Playwright UI smoke coverage in `web/`
 
 ## Suggested Codex phrasing
 - "Review this diff for regressions and missing tests."
 - "Run the pre-PR checks relevant to these files."
 - "Create a migration for X and wire the generated code."
 - "Update the OpenAPI contract, regenerate, and implement the handler."
+- "Refresh the living docs and mark older docs as historical."
+- "Run the frontend Vitest suites and the Playwright smoke checks."

--- a/.codex/references/decisions.md
+++ b/.codex/references/decisions.md
@@ -49,9 +49,11 @@ Important caveat: `openspec/specs/` is currently empty, so OpenSpec is not a com
   - `internal/web`
 - Active frontend/UI runtime: `web/src`
 - Current user-facing frontend focus:
+  - shared `AppShell` and `/` overview
   - traces list + sessions list URL state
-  - failure-first trace detail workspace
-  - payload inspection + state diff
+  - session detail + session compare workspaces
+  - failure-first trace detail workspace with desktop drawer and mobile four-tab composition
+  - payload inspection + state diff + semantic reasoning surfaces
   - settings, auth recovery, command palette, theming
 - Real SDK: `sdks/python`
 - Stubbed or placeholder-heavy areas:
@@ -79,7 +81,14 @@ Important caveat: `openspec/specs/` is currently empty, so OpenSpec is not a com
 - `config.example.yaml` is not the implementation contract and currently contains future-state drift.
 
 ## Useful reference docs
+- `docs/README.md`
 - `docs/DEBUGGER_PLATFORM_BASELINE.md`
 - `docs/PHASE5_CURRENT_STATE_REPORT.md`
 - `docs/architecture/RULES.md`
 - `docs/architecture/data-model.md`
+
+## Current validation surfaces
+- `pnpm --filter web test`
+- `pnpm --filter web test:e2e`
+- `web/playwright.config.ts`
+- `web/e2e/ui-smoke.spec.ts`

--- a/.codex/skills/continua-backend-dev/SKILL.md
+++ b/.codex/skills/continua-backend-dev/SKILL.md
@@ -17,6 +17,7 @@ description: Backend development guide for Continua's current Go platform server
 ## Current backend shape
 - `cmd/continua/main.go` wires the Fx app.
 - `internal/api` is feature-split and owns auth, handler wiring, mapping, and timeline pagination.
+- `internal/api/sessions_handlers.go` owns session list, detail, and compare endpoints.
 - `internal/ingest/service.go` owns sync vs async accept/orchestrate behavior.
 - `internal/ingest/processor.go` owns validation and the shared trace/span/event write path.
 - `internal/jobs` owns River workers for async ingest, rollups, and cleanup.
@@ -31,6 +32,11 @@ description: Backend development guide for Continua's current Go platform server
 - Add or update store/query code if required
 - Map DB rows to API types in `internal/api/mapper.go`
 - Add tests in the touched backend package
+
+Current read APIs already include:
+- traces list/detail/spans/events
+- sessions list/detail
+- session compare at `GET /api/sessions/{id}/compare`
 
 ### Store/query change
 - Edit `db/platform/queries/*.sql`

--- a/.codex/skills/continua-backend-dev/resources/api-patterns.md
+++ b/.codex/skills/continua-backend-dev/resources/api-patterns.md
@@ -3,7 +3,7 @@
 ## Current endpoint families
 - ingest: `POST /v1/ingest`, `GET /v1/ingest/batches/{id}`
 - traces: list, detail, spans, events
-- sessions: list and detail
+- sessions: list, detail, compare
 - health: `GET /api/health` is routed directly in Chi and stays outside OpenAPI auth handling
 
 ## Contract-first flow
@@ -42,11 +42,18 @@ Do not add handler-only fields without first updating OpenAPI.
   - synthetic span lifecycle events derived from spans
 - timeline pagination is cursor-based and implemented in `internal/api/timeline.go`
 
+## Session compare specifics
+- compare is exposed at `GET /api/sessions/{id}/compare`
+- requests are project-scoped and validate that both traces belong to the session
+- both traces must be terminal before compare runs
+- large comparisons fail with a structured `422` detail rather than timing out or streaming partial results
+
 ## Error and auth conventions
 - missing/invalid API key -> `401`
 - project-scoped misses -> `404`
 - validation errors for ingest -> `400`
 - unsupported async-version header -> `400 unsupported_async_version`
+- invalid session compare request -> `400 invalid_compare_request`
 
 ## Good boundaries
 - auth logic in middleware

--- a/.codex/skills/continua-backend-dev/resources/architecture.md
+++ b/.codex/skills/continua-backend-dev/resources/architecture.md
@@ -11,6 +11,11 @@
 
 The Go server is the current platform runtime. `engine/` is a separate module but is not part of the active product path.
 
+Current frontend consumers of these backend reads include:
+- the shared shell and overview route at `/`
+- trace triage and detail
+- session detail and session compare
+
 ## Request and job flow
 
 ### Protected REST request
@@ -26,6 +31,12 @@ The Go server is the current platform runtime. `engine/` is a separate module bu
 2. project-scoped accept logic in `internal/ingest/service.go`
 3. shared validation/write path in `internal/ingest/processor.go`
 4. async batches and rollups through River workers in `internal/jobs`
+
+### Session compare flow
+1. `GET /api/sessions/{id}/compare` in `internal/api/sessions_handlers.go`
+2. project scoping + request validation
+3. compare store/query path over session traces, spans, and semantic events
+4. mapper conversion into compare response types
 
 ## Active vs scaffolded packages
 

--- a/.codex/skills/continua-backend-dev/resources/database.md
+++ b/.codex/skills/continua-backend-dev/resources/database.md
@@ -30,6 +30,7 @@ Use sqlc for fixed queries first. The notable exception is `internal/store/searc
 - `spans.sql`: span upsert, list-by-trace, token/status updates
 - `events.sql`: explicit event insert and timeline reads
 - `sessions.sql`: session counts and `GetOrCreateSessionByExternalID`
+- `session_compare.sql`: compare validation, span diffs, semantic event diff inputs
 - `rollups.sql`: trace aggregate computation
 
 ## Migration rules

--- a/.codex/skills/continua-backend-dev/resources/testing.md
+++ b/.codex/skills/continua-backend-dev/resources/testing.md
@@ -28,6 +28,7 @@
 - project-scoped `404` behavior
 - mapper-visible fields from OpenAPI changes
 - pagination and cursor behavior for timeline endpoints
+- session compare validation, scoping, and too-large responses
 
 ### Ingest
 - batch validation
@@ -52,3 +53,7 @@
 - if you touched ingest logic, run `go test ./internal/ingest/... ./internal/jobs/...`
 - if you touched SQL or store wrappers, run `go test ./internal/store/...`
 - if the change crosses multiple layers, run `make test`
+
+Notable current backend coverage includes:
+- `internal/api/session_compare_integration_test.go`
+- timeline unit coverage in `internal/api/timeline_unit_test.go`

--- a/.codex/skills/continua-debugger-ui/SKILL.md
+++ b/.codex/skills/continua-debugger-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: continua-debugger-ui
-description: Guide for Continua's current debugger frontend. Use when changing trace detail workspace behavior, traces or sessions pages, payload inspection, state diff, settings, command palette, theming, or other debugger UX in web/src.
+description: Guide for Continua's current debugger frontend. Use when changing the shared shell, overview, traces, sessions, session compare, trace detail workspace behavior, payload inspection, state diff, settings, command palette, theming, or other debugger UX in web/src.
 ---
 
 # Continua Debugger UI
@@ -11,27 +11,35 @@ description: Guide for Continua's current debugger frontend. Use when changing t
 
 ## Use this skill when
 - editing `web/src/pages`, `web/src/components`, `web/src/hooks`, or `web/src/utils`
+- changing the shared shell, overview route, or session compare workspace
 - changing trace detail workspace layout or selection behavior
 - changing traces or sessions list URL state, sorting, filters, or pagination
 - changing payload inspection, truncation banners, state diff, or timeline rendering
 - changing settings, auth recovery, command palette, or theme behavior
 
 ## Current debugger shape
-- `App.tsx` routes to `/traces`, `/traces/:id`, `/sessions`, `/sessions/:id`, and `/settings`
+- `App.tsx` routes through a shared `AppShell` to `/`, `/traces`, `/traces/:id`, `/sessions`, `/sessions/:id`, `/sessions/:id/compare`, and `/settings`
+- `OverviewPage.tsx` is a real operator snapshot screen built from existing trace/session endpoints
+- `SessionComparePage.tsx` is part of the implemented product surface
 - `TraceDetailPage.tsx` is the main debugger workspace coordinator
-- desktop trace detail uses `WorkspaceShell` with `TreeRail`, `ExecutionWaterfall`, and `InspectorTabs`
-- mobile trace detail keeps the same surfaces behind tab switches
+- desktop trace detail uses `WorkspaceShell` for the tree/waterfall/inspector layout and a separate trace-context drawer
+- mobile trace detail uses `Summary`, `Execution`, `Timeline`, and `State` top-level tabs
+- the execution tab keeps a local `Waterfall` / `Tree` sub-toggle on mobile
 - `InspectorTabs` keeps `details`, `timeline`, and `state` mounted while hidden
 - `SpanDetail` owns the detailed selected-span surface; `Timeline` and waterfall selection should route back into the same shared span-selection path
 
 ## State and routing rules
 - Preserve URL-driven state for list pages and trace detail.
+- preserve the current route set and shell structure instead of reintroducing route-local headers everywhere
 - `/traces` and `/sessions` state belongs in search params, not local-only `useState`.
+- `/sessions/:id` compare selection lives in search params and drives `/sessions/:id/compare`
 - selected span state belongs in `?span=` via `useTraceDetailSearchParams`
 - do not include UI-only URL params in React Query keys unless the server request depends on them
 - keep back-link continuity working from traces or sessions into trace detail and back
+- keep session-detail and session-compare return navigation compatible with current `returnTo` behavior
 
 ## Implementation guardrails
+- reuse the shell/system language in `globals.css`, `AppShell`, and current page primitives instead of falling back to generic card dashboards
 - keep complex view-model logic in pure utilities or small hooks:
   - `useWorkspaceState`
   - `useTraceDetailSearchParams`
@@ -42,6 +50,7 @@ description: Guide for Continua's current debugger frontend. Use when changing t
   - `failureAnalysis.ts`
   - `stateChanges.ts`
 - keep tree, waterfall, breadcrumb, and timeline selection synchronized through shared callbacks
+- keep tree-rail quick filters local to already loaded span data
 - preserve polling-based running-trace behavior; do not design around a live WebSocket runtime that does not exist
 - reuse `PayloadInspector`, `TruncationBanner`, `CopyButton`, and `AuthErrorBanner` instead of creating duplicate patterns
 

--- a/.codex/skills/continua-debugger-ui/resources/list-pages.md
+++ b/.codex/skills/continua-debugger-ui/resources/list-pages.md
@@ -1,14 +1,21 @@
-# Traces And Sessions Pages
+# Overview, Traces, And Sessions Pages
 
 ## Current state pattern
 
-The list pages are URL-driven.
+The operator console keeps overview shell navigation static while traces, sessions, session detail, and compare state stay URL-driven where it matters.
 
 Use existing hooks and utilities instead of re-inventing parsing logic:
 - `useTracesSearchParams`
 - `useSessionsSearchParams`
 - `tracesSearchParams.ts`
 - `sessionsSearchParams.ts`
+
+## Overview route
+
+The `/` route is implemented and should stay frontend-only:
+- it uses existing trace and session list endpoints
+- it does not require new analytics APIs
+- it acts as a snapshot/jump surface, not a chart-heavy dashboard
 
 ## Traces page
 
@@ -18,6 +25,7 @@ Implemented behavior includes:
 - sort state
 - page size and pagination state
 - back-link continuity into trace detail
+- denser row rendering with trace name/status emphasized ahead of secondary metrics
 
 ## Sessions page
 
@@ -26,6 +34,7 @@ Implemented behavior includes:
 - sort by created time or trace count
 - pagination and stale-offset repair
 - external-ID-first rendering
+- row-level navigation back into session detail with `returnTo`
 
 ## Session detail page
 
@@ -36,3 +45,16 @@ The trace table under `/sessions/:id` also uses URL-driven table state:
 - `offset`
 
 Keep trace-detail return navigation compatible with session-detail URLs.
+
+Compare state on session detail is also URL-backed:
+- `baseline_trace_id`
+- `candidate_trace_id`
+
+## Session compare page
+
+`/sessions/:id/compare` is a first-class route.
+
+Important current behavior:
+- it reuses the compare query params from session detail
+- it preserves `returnTo` navigation back into session detail
+- it is sticky-header oriented and optimized for baseline/candidate scanability before row-level diff inspection

--- a/.codex/skills/continua-debugger-ui/resources/trace-workspace.md
+++ b/.codex/skills/continua-debugger-ui/resources/trace-workspace.md
@@ -8,13 +8,16 @@
 - selection and reveal behavior
 - return navigation
 - desktop vs mobile workspace composition
+- trace-context drawer state
 
 ## Desktop layout
 
-`WorkspaceShell` renders:
+`WorkspaceShell` renders the main investigation panes:
 - left: `TreeRail`
 - top-right: `ExecutionWaterfall`
 - bottom-right: `InspectorTabs`
+
+Desktop trace context is no longer a permanently visible panel in that grid. It is opened separately as a right-side drawer from trace detail.
 
 `InspectorTabs` renders:
 - `Details`
@@ -22,6 +25,16 @@
 - `State`
 
 The tabs stay mounted while hidden so local UI state survives tab switches.
+
+## Mobile layout
+
+Top-level mobile tabs are:
+- `Summary`
+- `Execution`
+- `Timeline`
+- `State`
+
+Inside `Execution`, mobile keeps a local `Waterfall` / `Tree` sub-toggle.
 
 ## Shared selection model
 
@@ -42,16 +55,19 @@ Current selection state is coordinated through:
 ## Data surfaces already implemented
 
 - failure-first summary
+- running-state / wait-stall summary
 - stale-trace signal
 - payload inspection with truncation banners
 - decision rendering in span detail
 - state diff extracted from `state_change` timeline events
 - semantic timeline summaries for `state_change` and `decision`
+- local quick filters in `TreeRail` using already loaded span data only
 
 ## Test anchors
 
 When changing this area, the most useful frontend coverage usually lives in:
 - `web/src/pages/TraceDetailPage.test.tsx`
+- `web/src/components/AppShell.test.tsx`
 - `web/src/components/InspectorTabs.test.tsx`
 - `web/src/components/PayloadInspector.test.tsx`
 - `web/src/components/StateDiffViewer.test.tsx`

--- a/.codex/skills/continua-integrations/SKILL.md
+++ b/.codex/skills/continua-integrations/SKILL.md
@@ -16,6 +16,7 @@ description: Guide for Continua's integration surfaces as they exist today. Use 
 
 ## Current integration reality
 - The Python SDK is real and actively usable.
+- Generated SDK types now include current debugger/read-model surfaces such as session compare response shapes.
 - The TypeScript SDK is only a stub package.
 - `internal/proxy/` is a placeholder directory, not a live proxy implementation.
 - Framework adapters are not implemented in this repo today.

--- a/.codex/skills/continua-integrations/resources/python-sdk.md
+++ b/.codex/skills/continua-integrations/resources/python-sdk.md
@@ -27,9 +27,15 @@ sdks/python/
   - `error`
   - `exception`
   - `metric`
+  - `state_change`
+  - `decision`
+  - `effect`
+  - `wait`
+  - `snapshot_marker`
 - async ingest support exists through:
   - `ingest_mode`
   - `wait_for_batch()`
+- `set_llm_response(...)` and `set_tool_call(...)` emit one implicit `effect` event per helper type per span unless disabled
 
 ## Important behavior
 - the client sends batches to `/v1/ingest`
@@ -37,6 +43,7 @@ sdks/python/
 - traces/spans/events accumulate in the batch queue and flush automatically
 - if the global client is not initialized, trace/span helpers quietly skip emission instead of failing user code
 - `session_id` is an external session key, not a server-side UUID the client has to create
+- the generated `types.py` includes current compare/read models from OpenAPI, but there is not a higher-level Python compare client surface yet
 
 ## Current ingest modes
 - `sync`

--- a/.codex/skills/continua-observability/SKILL.md
+++ b/.codex/skills/continua-observability/SKILL.md
@@ -20,6 +20,7 @@ description: Domain-specific guide for Continua's current observability core. Us
 - Continua's active observability core is REST + Postgres + River + debugger UI.
 - The important persisted entities are `projects`, `ingest_batches`, `ingest_batch_payloads`, `sessions`, `traces`, `spans`, and `span_events`.
 - The debugger timeline is polling-based and merges explicit events with synthetic span lifecycle events.
+- The current debugger also exposes overview, session narrative/detail, and session compare surfaces on top of the same read model.
 - Replay and WebSocket runtime are not implemented product features today.
 
 ## Key domain rules
@@ -29,6 +30,7 @@ description: Domain-specific guide for Continua's current observability core. Us
 - rollups compute trace totals from spans asynchronously
 - explicit events are separate from synthetic timeline events derived from spans
 - payload truncation metadata is part of the active trace/span model
+- `state_change` drives the State view, while `decision`, `effect`, and `wait` power semantic debugger surfaces and compare summaries
 
 ## Useful references
 - [trace-lifecycle.md](resources/trace-lifecycle.md)

--- a/.codex/skills/continua-observability/resources/trace-lifecycle.md
+++ b/.codex/skills/continua-observability/resources/trace-lifecycle.md
@@ -56,6 +56,11 @@ There is no active payload table for span request/response bodies. Trace and spa
 - synthetic lifecycle events are derived from span start/end/status data
 - `/api/traces/{id}/events` merges both and returns cursor-based pages
 - the frontend polls this endpoint every 3 seconds for running traces
+- semantic event types such as `state_change`, `decision`, `effect`, `wait`, and `snapshot_marker` are debugger-facing observability events, not replay primitives
+
+## Additional read surfaces
+- `/api/sessions/{id}` groups traces into a workflow/session view
+- `/api/sessions/{id}/compare` compares two terminal traces within a session using span and semantic-event diffs
 
 ## Rollups
 - trace totals are computed from spans

--- a/.codex/skills/continua-testing/SKILL.md
+++ b/.codex/skills/continua-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: continua-testing
-description: Testing strategy for Continua (Go, engine, web, SDKs). Use when adding features, fixing bugs, or changing API/DB behavior; triggers on go test, make test, integration tests, pnpm test, or SDK test updates.
+description: Testing strategy for Continua (Go, engine, web, SDKs). Use when adding features, fixing bugs, or changing API/DB behavior; covers go test, make test, Vitest, Playwright smoke coverage, integration tests, and SDK test updates.
 ---
 
 # Continua Testing
@@ -22,9 +22,11 @@ description: Testing strategy for Continua (Go, engine, web, SDKs). Use when add
   - `ingest_handlers_test.go`
   - `traces_handlers_test.go`
   - `sessions_handlers_test.go`
+  - `session_compare_integration_test.go`
   - `server_helpers_test.go`
   - `timeline_unit_test.go`
 - Web UI uses Vitest and Testing Library under `web/src`.
+- Web UI also has Playwright smoke coverage under `web/e2e/` with config in `web/playwright.config.ts`.
 - Python SDK uses pytest under `sdks/python/tests`.
 - The TypeScript SDK currently has only minimal stub coverage.
 
@@ -33,5 +35,6 @@ description: Testing strategy for Continua (Go, engine, web, SDKs). Use when add
 - ingest or job change -> `go test ./internal/ingest/... ./internal/jobs/...`
 - SQL/store change -> `go test ./internal/store/...`
 - web UI change -> `pnpm --filter web test`
+- route/shell/layout smoke change -> `pnpm --filter web test:e2e`
 - Python SDK change -> `cd sdks/python && uv run pytest`
 - cross-layer change -> `make test`

--- a/.codex/skills/continua-testing/references/commands.md
+++ b/.codex/skills/continua-testing/references/commands.md
@@ -10,6 +10,8 @@
 
 ## SDKs
 - Web UI: `pnpm --filter web test`
+- Web UI smoke: `pnpm --filter web test:e2e`
+- Web UI type-check: `pnpm --filter web type-check`
 - TypeScript SDK: `pnpm --filter @continua/sdk test`
 - Python: `cd sdks/python && uv run pytest`
 

--- a/.codex/skills/continua-testing/references/strategy.md
+++ b/.codex/skills/continua-testing/references/strategy.md
@@ -3,7 +3,8 @@
 ## Scope
 - Prefer the smallest relevant suite first, but cover the real behavior you changed.
 - Use DB-backed tests for store, auth, ingest, and API behavior when the logic depends on Postgres semantics.
-- Use web Vitest coverage for URL state, payload inspector behavior, failure analysis, and component rendering logic.
+- Use web Vitest coverage for shell/route composition, overview metrics, URL state, payload inspector behavior, failure analysis, and component rendering logic.
+- Use Playwright smoke coverage when the change affects the shared shell, route wiring, major page layouts, or responsive page composition.
 - Use SDK tests when changing contract handling, batching, retry behavior, or helper APIs.
 
 ## Placement

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,14 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 ## Current Repo Baseline
 - Treat the checked-in code as the primary truth. Historical phase docs and some older architecture docs drift from the current implementation.
-- The live product path today is: authenticated REST ingest -> Postgres persistence -> River background jobs -> trace/session/timeline debugger UI.
+- The live product path today is: authenticated REST ingest -> Postgres persistence -> River background jobs -> REST read APIs -> embedded React debugger operator console.
 - The current repo handoff doc is `docs/DEBUGGER_PLATFORM_BASELINE.md`. Use `docs/PHASE5_CURRENT_STATE_REPORT.md` as deeper historical context, not the shortest current-state baseline.
 - `openspec/specs/` is currently empty. That means OpenSpec is useful for active proposals and archived work, but not as a complete source of current-state specs.
+
+## Documentation Status Convention
+- `Current`: authoritative, repo-verified guidance for the current checkout.
+- `Historical`: preserved context or archaeology; do not treat it as the current architecture contract.
+- `Active change`: material under `openspec/changes/`; useful for intent/history, but not current-state truth by itself.
 
 ## Implemented Vs Scaffolded
 - Active backend packages: `internal/api`, `internal/ingest`, `internal/jobs`, `internal/store`, `internal/config`, `internal/web`.
@@ -97,9 +102,14 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 ## Frontend Reality
 - The web UI is a Vite SPA embedded into the Go binary through `internal/web/static`.
+- Current routes are `/`, `/traces`, `/traces/:id`, `/sessions`, `/sessions/:id`, `/sessions/:id/compare`, and `/settings`.
+- The app uses a shared `AppShell` with primary navigation, route-aware shell chrome, API-key status, theme controls, and command palette access.
+- The overview route is frontend-only and derives its snapshot from existing trace and session list endpoints.
 - The traces page is URL-driven and exposes current backend filters.
 - Trace detail is failure-first and uses polling of `/api/traces/{id}/events`, not a live WebSocket subscription.
-- Payload inspection, truncation banners, breadcrumb navigation, and session drill-down are implemented in `web/src`.
+- Desktop trace detail uses a drawer for trace context; mobile trace detail uses `Summary`, `Execution`, `Timeline`, and `State` top-level tabs.
+- Session detail and session compare preserve URL-driven state and return navigation.
+- Payload inspection, truncation banners, breadcrumb navigation, local tree-rail quick filters, and session drill-down are implemented in `web/src`.
 
 ## Testing Expectations
 - Add tests for new behavior.
@@ -110,6 +120,7 @@ Keep this managed block so 'openspec update' can refresh the instructions.
   - `go test ./internal/store/...`
   - `go test ./internal/jobs/...`
   - `pnpm --filter web test`
+  - `pnpm --filter web test:e2e`
   - `cd sdks/python && uv run pytest`
 - Full validation:
   - `make generate`
@@ -131,10 +142,10 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 ### Repo-local skills
 - `continua-backend-dev`: current Go platform server, REST/API, sqlc/store, migrations, and River-backed backend workflows.
-- `continua-debugger-ui`: current React debugger UI, trace workspace, URL-state patterns, payload inspection, settings, command palette, and theming.
+- `continua-debugger-ui`: current React debugger UI, app shell, overview, trace workspace, session compare, URL-state patterns, payload inspection, settings, command palette, and theming.
 - `continua-observability`: trace/span/session/event model, async ingest lifecycle, rollups, timeline semantics, and debugger data surfaces.
 - `continua-integrations`: Python SDK, contract-driven SDK generation, TypeScript SDK stub status, and integration-boundary planning.
-- `continua-testing`: suite selection, real-DB test patterns, web Vitest coverage, and SDK verification.
+- `continua-testing`: suite selection, real-DB test patterns, web Vitest coverage, Playwright smoke coverage, and SDK verification.
 
 ### How to use repo-local skills
 - Open the matching `.codex/skills/<skill>/SKILL.md` when the task fits the skill.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 # Continua
 
-AI Agent Observability Debugger
+> **Status: Current**
+> This README is the repo-verified entrypoint for the current checkout. For the short architecture handoff, use [docs/DEBUGGER_PLATFORM_BASELINE.md](./docs/DEBUGGER_PLATFORM_BASELINE.md). For the doc map and status convention, use [docs/README.md](./docs/README.md).
+
+AI agent observability debugger and operator console.
+
+## Current Product Surface
+
+Continua's implemented product path today is:
+
+```text
+Python SDK / custom client
+  -> authenticated REST ingest
+  -> Postgres persistence
+  -> River background jobs
+  -> REST read APIs
+  -> embedded React debugger operator console
+```
+
+The current web surface includes:
+- `/` overview built from existing trace and session endpoints
+- `/traces` and `/traces/:id` for trace triage and investigation
+- `/sessions`, `/sessions/:id`, and `/sessions/:id/compare` for workflow-level investigation
+- `/settings` for local API-key and theme controls
 
 ## Quick Start
 
@@ -9,55 +31,59 @@ AI Agent Observability Debugger
 ./scripts/setup.sh
 
 # Start development
-make dev           # Start database
-make dev-server    # Start Go backend (in new terminal)
-make dev-web       # Start web UI (in new terminal)
+make dev           # Start Postgres via docker compose
+make dev-server    # Start the Go server
+make dev-web       # Start the Vite web app
 
-# Open http://localhost:3000
+# Open the operator console
+# http://localhost:3000
 ```
 
 ## Architecture
 
-- **Backend**: Go 1.22+ with Chi router
-- **Frontend**: Vite + React + TypeScript
-- **Database**: PostgreSQL / SQLite
+- **Backend**: Go 1.22+, Chi router, Fx wiring
+- **Frontend**: Vite + React + TypeScript SPA embedded into the Go binary for production
+- **Database**: PostgreSQL is the real runtime database
+- **Queueing**: River workers run inside the platform server
+- **SDKs**: Python is real; TypeScript is still a stub package
 
-Current repo-state baseline: [docs/DEBUGGER_PLATFORM_BASELINE.md](./docs/DEBUGGER_PLATFORM_BASELINE.md)
+Important runtime boundaries:
+- `db/platform/migrations/sqlite/` is bootstrap-only scaffolding, not a peer runtime target
+- runtime config is env-only via `internal/config/config.go`
+- WebSocket runtime, proxy capture, replay runtime, and durable engine execution are not implemented product features today
 
 ## Commands
 
 ```bash
-make generate      # Generate all code
-make build         # Build everything
-make test          # Run tests
-make lint          # Run linters
-make help          # Show all commands
+make generate                  # Contracts, sqlc, copied server types, Python SDK types
+make build                     # Go server + web UI
+make test                      # Go + JS tests
+make lint                      # Go + JS lint
+pnpm --filter web test         # Frontend Vitest suites
+pnpm --filter web test:e2e     # Playwright UI smoke coverage
+make help                      # Show all make targets
 ```
 
 ## Project Structure
 
-```
+```text
 continua/
-├── cmd/continua/           # Server binary
-├── contracts/              # API contracts (source of truth)
-├── db/platform/            # Platform database
-├── deploy/                 # Docker, K8s, Helm
-├── docs/                   # Documentation
-├── engine/                 # Isolated engine module
-├── internal/               # Server internals
-├── pkg/                    # Shared packages
-├── scripts/                # Build scripts
-├── sdks/                   # Python & TypeScript SDKs
-├── web/                    # Vite React SPA
-├── go.mod                  # Root module
-├── go.work                 # Workspace (links engine)
-├── Makefile                # Build system
+├── cmd/continua/           # Go server binary and CLI
+├── contracts/              # OpenAPI and WebSocket contract sources
+├── db/platform/            # Postgres migrations and sqlc inputs
+├── docs/                   # Current and historical documentation
+├── engine/                 # Future durable execution module
+├── internal/               # Active platform runtime
+├── sdks/python/            # Primary usable SDK
+├── sdks/typescript/        # Stub SDK package
+├── web/                    # Vite React debugger app
+├── Makefile                # Build/test/dev entrypoints
 └── pnpm-workspace.yaml     # JS workspace
 ```
 
 ## Architecture Rules
 
-See [docs/architecture/RULES.md](./docs/architecture/RULES.md) for the 10 rules that prevent drift.
+See [docs/architecture/RULES.md](./docs/architecture/RULES.md) for the current anti-drift rules.
 
 ## License
 

--- a/docs/CONTINUA_ARCHITECTURE_PLAN_v1.md
+++ b/docs/CONTINUA_ARCHITECTURE_PLAN_v1.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](./README.md) and [DEBUGGER_PLATFORM_BASELINE.md](./DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Continua Architecture Plan v1.0
 
 > **AI Agent Observability & Debugging Platform**

--- a/docs/CONTINUA_DESIGN_DECISIONS_v1.md
+++ b/docs/CONTINUA_DESIGN_DECISIONS_v1.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](./README.md) and [DEBUGGER_PLATFORM_BASELINE.md](./DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Continua v1 Schema & Design Decisions
 
 > **Summary of changes from initial architecture to final v1 design**

--- a/docs/CONTINUA_IMPLEMENTATION_CHECKLIST_v1.md
+++ b/docs/CONTINUA_IMPLEMENTATION_CHECKLIST_v1.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](./README.md) and [DEBUGGER_PLATFORM_BASELINE.md](./DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Continua Implementation Checklist v1.0
 
 > **Detailed task breakdown for implementing the Continua observability platform**

--- a/docs/DEBUGGER_PLATFORM_BASELINE.md
+++ b/docs/DEBUGGER_PLATFORM_BASELINE.md
@@ -1,8 +1,11 @@
 # Continua Debugger Platform Baseline
 
-Status date: 2026-03-22
+> **Status: Current**
+> This is the shortest repo-verified handoff for the current checkout. Use [README.md](../README.md) for setup, [docs/README.md](./README.md) for doc status, and [PHASE5_CURRENT_STATE_REPORT.md](./PHASE5_CURRENT_STATE_REPORT.md) only as deeper historical context.
 
-Purpose: give future agents a short, repo-verified baseline for the current product state after the observability buildout and before new debugger-platform work begins.
+Status date: 2026-04-02
+
+Purpose: give future agents a short, repo-verified baseline for the current product state after the debugger shell/overview/session-compare redesign landed in the working tree.
 
 ## Summary
 
@@ -14,7 +17,7 @@ Python SDK / custom client
   -> Postgres persistence
   -> River background jobs
   -> REST read APIs
-  -> embedded React debugger UI
+  -> embedded React debugger operator console
 ```
 
 The observability core is already real:
@@ -23,16 +26,21 @@ The observability core is already real:
 - true async ingest infrastructure
 - trace rollups
 - trace, session, and timeline read APIs
+- session compare API
 - Python SDK helpers for traces, spans, sessions, and async batch polling
 
 The debugger surface is also real:
+- shared `AppShell` with route-aware shell navigation
+- overview route at `/` built from existing trace and session endpoints only
 - traces list with URL-driven filter, sort, and pagination state
 - sessions list and session detail with URL-driven state
+- session compare workspace at `/sessions/:id/compare`
 - failure-first trace detail flow
-- trace workspace with tree rail, execution waterfall, and inspector tabs
+- trace workspace with tree rail, execution waterfall, inspector tabs, and desktop trace-context drawer
 - payload inspection, truncation banners, breadcrumb navigation, and span deep links
 - state-change and decision event semantics
-- settings page, auth recovery, command palette, and theming
+- settings page, auth recovery, command palette, theming, and operator-console styling
+- Playwright smoke-test scaffolding for the major routes
 
 ## Implemented Vs Future
 
@@ -62,17 +70,24 @@ Do not describe replay, live WebSocket runtime, proxy capture, score APIs, or Ty
 ## Debugger Frontend Shape
 
 Current routes:
+- `/`
 - `/traces`
 - `/traces/:id`
 - `/sessions`
 - `/sessions/:id`
+- `/sessions/:id/compare`
 - `/settings`
 
 Important frontend patterns:
+- the app is wrapped in a shared `AppShell` that owns primary navigation, shell chrome, API-key state, theme toggle, and command palette access
+- overview remains frontend-only and uses existing list endpoints rather than new analytics APIs
 - list-page state lives in URL params, not local-only component state
+- session compare state lives in `baseline_trace_id` / `candidate_trace_id` query params
 - trace detail span selection is URL-backed via `?span=`
 - running traces poll `/api/traces/{id}/events`; there is no live WebSocket runtime
-- `TraceDetailPage` coordinates `TreeRail`, `ExecutionWaterfall`, `InspectorTabs`, `SpanDetail`, `Timeline`, and `StateDiffViewer`
+- desktop trace detail keeps the main workspace in `WorkspaceShell` and moves trace context into a toggleable drawer
+- mobile trace detail uses `Summary`, `Execution`, `Timeline`, and `State` top-level tabs, with a tree/waterfall sub-toggle inside `Execution`
+- `TreeRail` now supports local quick filters that work only on already loaded span data
 - complex UI logic is factored into pure helpers and small hooks such as `useWorkspaceState`, `useTraceDetailSearchParams`, `spanTree.ts`, and `waterfallTime.ts`
 
 ## Backend And Data Model Reality
@@ -96,7 +111,16 @@ Important semantics:
 - `sessions.external_id` is the user-facing session identifier
 - `traces.trace_id` is the external trace identifier
 - `spans.span_id` and `spans.parent_span_id` are external span identifiers
+- session compare reads terminal traces within a session through `GET /api/sessions/{id}/compare`
 - timeline responses merge explicit events with synthetic lifecycle markers
+
+## Validation Surfaces
+
+Current web validation surfaces include:
+- `pnpm --filter web test`
+- `pnpm --filter web test:e2e`
+- `web/playwright.config.ts`
+- `web/e2e/ui-smoke.spec.ts`
 
 ## OpenSpec State
 
@@ -105,22 +129,13 @@ Repo convention:
 - completed change history belongs in `openspec/implemented/`
 - `openspec/specs/` is still empty, so OpenSpec is not the complete current-state source of truth
 
-Debugger-oriented implemented history now lives in:
-- `openspec/implemented/add-trace-discovery-triage`
-- `openspec/implemented/add-failure-first-trace-detail`
-- `openspec/implemented/add-payload-inspection-deep-navigation`
-- `openspec/implemented/add-visual-execution-workspace`
-- `openspec/implemented/add-session-scale-ux`
-- `openspec/implemented/add-debugger-semantics-polish`
-
-Still active:
-- `openspec/changes/add-true-async-ingest`
-  - feature implementation is largely present, but metrics and some validation items are still open in its task list
+Active change material may describe the debugger redesign as in flight, but the current checkout already contains the relevant shell/overview/session-compare UI code. For current-state truth, prefer live code plus this baseline.
 
 ## Planning Guidance
 
 Use this baseline when starting new debugger work:
-- extend the debugger UI from the existing trace workspace rather than rebuilding trace detail from scratch
+- extend the debugger UI from the existing shell, overview, session, compare, and trace workspaces rather than rebuilding them from scratch
 - preserve the current URL-driven state patterns on traces, sessions, and trace detail
+- preserve current session compare URL semantics and trace-detail return navigation
 - treat the React debugger as the active product surface and the Python SDK as the active ingestion surface
 - treat `docs/PHASE5_CURRENT_STATE_REPORT.md` as deep historical context, not the shortest current-state handoff

--- a/docs/INGESTION_FLOW.mermaid.md
+++ b/docs/INGESTION_FLOW.mermaid.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](./README.md) and [DEBUGGER_PLATFORM_BASELINE.md](./DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Continua Ingestion & Query Flows
 
 > **Version Note**: This document describes the complete ingestion architecture.

--- a/docs/PHASE5_CURRENT_STATE_REPORT.md
+++ b/docs/PHASE5_CURRENT_STATE_REPORT.md
@@ -1,6 +1,7 @@
 # Continua Current State Report
 
-Superseded note (2026-03-22): use [DEBUGGER_PLATFORM_BASELINE.md](./DEBUGGER_PLATFORM_BASELINE.md) for the current repo-state handoff. This report remains useful as a deeper Phase 5 archaeology snapshot.
+> **Status: Historical**
+> This report is preserved as a Phase 5 archaeology snapshot. It does not define the full current checkout, which now includes later debugger shell, overview, and session-compare work. Use [docs/README.md](./README.md) and [DEBUGGER_PLATFORM_BASELINE.md](./DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
 
 Status date: 2026-03-12
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,57 @@
 # Continua Documentation
 
-## Overview
+> **Status: Current**
+> This page is the documentation index for the current checkout. It also defines the status labels used across `docs/`.
 
-Continua is currently an AI agent observability debugger with a live REST + Postgres + River + React product path.
+## Status Convention
 
-## Quick Links
+- **Current**: authoritative, repo-verified guidance for the current checkout
+- **Historical**: preserved context, rollout notes, plans, or reports that do not define today's architecture
+- **Active change**: proposal material under `openspec/changes/`; useful for intent/history, but not the current-state source of truth
 
+## Current Docs
+
+Use these first:
 - [Debugger Platform Baseline](./DEBUGGER_PLATFORM_BASELINE.md)
-- [Architecture Rules](./architecture/RULES.md)
 - [Architecture Overview](./architecture/overview.md)
+- [Architecture Rules](./architecture/RULES.md)
 - [Data Model](./architecture/data-model.md)
-- [Phase 3 Verified Report](./phase3/report_phase3.md)
-- [Phase 4 Design Doc](./phase4/design_doc.md)
+- [Event Conventions](./event-conventions.md)
+- [Repo Root README](../README.md)
+
+## Historical Docs
+
+These remain in place for provenance and archaeology:
 - [Phase 5 Current State Report](./PHASE5_CURRENT_STATE_REPORT.md)
+- `docs/phase2/`, `docs/phase3/`, `docs/phase4/`
+- `docs/guides/`
+- `docs/reviews/`
+- `docs/plans/`
+- `docs/*_v1.md`, rollout notes, and scratch docs such as `docs/temp.md`
 
-## Getting Started
+Historical docs should not be treated as the current architecture contract unless a newer current doc points back to them for context.
 
-See the main [README.md](../README.md) for quick start instructions.
+## Active Change Docs
+
+OpenSpec change proposals live under:
+- `openspec/changes/`
+
+Implemented OpenSpec history lives under:
+- `openspec/implemented/`
+
+Because `openspec/specs/` is still empty, OpenSpec is not a complete current-state spec set for this repo.
+
+## Current Runtime Snapshot
+
+Continua is currently an AI agent observability debugger with one implemented path:
+
+```text
+Python SDK / custom client
+  -> authenticated REST ingest
+  -> Postgres persistence
+  -> River background jobs
+  -> REST read APIs
+  -> embedded React debugger operator console
+```
+
+The current web surface includes the shared shell, `/` overview, traces, sessions, session compare, and settings.

--- a/docs/architecture/RULES.md
+++ b/docs/architecture/RULES.md
@@ -1,28 +1,66 @@
 # Continua Architecture Rules
 
-## 10 Rules That Prevent Drift and Coupling
+> **Status: Current**
+> These are the current anti-drift rules for the active product path.
 
-### 1. ONE generation command
+## 10 Rules That Prevent Drift
+
+### 1. Live runtime beats old docs
+
+When docs disagree, prefer the current code in `cmd/`, `internal/`, `web/`, and `sdks/python/`.
+
+### 2. ONE generation command
+
 ```bash
-make generate  # CI runs this and fails on any diff.
+make generate
 ```
 
-### 2. Contracts are source of truth
-- `contracts/openapi/openapi.yaml` → REST API
-- `contracts/websocket/events.ts` → WebSocket events
+This is the repo-level generation entrypoint for OpenAPI outputs, sqlc, copied Go server types, and Python SDK types.
 
-### 3. Generated Go files use `_gen.go` suffix (except sqlc)
+### 3. Contracts are source of truth
 
-### 4. Track generated code, not build artifacts
+- `contracts/openapi/openapi.yaml` -> REST API
+- `contracts/websocket/events.ts` -> WebSocket schema history
 
-### 5. Module boundaries enforced by Go
+The runtime uses the REST contract heavily. The WebSocket schema exists, but there is no fully implemented WebSocket runtime today.
 
-### 6. Platform and Engine have separate schemas
+### 4. Generated files are tracked, not edited
 
-### 7. Web UI is static-only
+Change the source inputs, not:
+- `contracts/generated/`
+- `internal/api/server_gen.go`
+- `db/gen/go/platform/`
+- `contracts/websocket/events.schema.json`
 
-### 8. One lockfile at root
+### 5. Postgres is the runtime database
 
-### 9. CI drift check is the gatekeeper
+`db/platform/migrations/postgres/` is the real platform schema. SQLite under `db/platform/migrations/sqlite/` is bootstrap-only scaffolding.
 
-### 10. Domain types never leak into API responses
+### 6. Runtime config is env-only
+
+`internal/config/config.go` is the live config contract. `config.example.yaml` is future-state drift, not runtime truth.
+
+### 7. Keep backend responsibilities split
+
+- handlers in `internal/api/*_handlers.go`
+- ingest orchestration in `internal/ingest`
+- River work in `internal/jobs`
+- thin persistence wrappers in `internal/store`
+- DB rows mapped to API types in `internal/api/mapper.go`
+
+### 8. Preserve current web state contracts
+
+- list-page state belongs in URL params
+- trace selection belongs in `?span=`
+- session compare stays in `baseline_trace_id` / `candidate_trace_id`
+- trace detail remains polling-based; do not assume live push
+
+### 9. Future-looking directories are not product proof
+
+Do not describe `engine/`, `internal/proxy`, `internal/ws`, `internal/replay`, `internal/alerts`, `internal/export`, `internal/state`, `internal/telemetry`, or `sdks/typescript` as implemented product surfaces unless the code in the current task makes that true.
+
+### 10. Use the doc status labels consistently
+
+- **Current** -> authoritative repo-verified guidance
+- **Historical** -> preserved context, not the current architecture contract
+- **Active change** -> proposal material under `openspec/changes/`, not current-state truth by itself

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,23 +1,89 @@
 # Data Model
 
-## Core Entities
+> **Status: Current**
+> This is the current platform data model used by the Go server, Postgres schema, and debugger UI.
+
+## Core Persisted Entities
+
+### Project
+
+`projects` scope all protected data access. API-key auth resolves a request into a project before reading or writing platform data.
+
+### Ingest Batch
+
+`ingest_batches` store durable idempotency and async lifecycle state for `POST /v1/ingest`.
+
+Important semantics:
+- one batch is identified externally by `batch_key`
+- async acceptance and polling are backed by persisted batch rows
+- legacy compatibility may exist in status handling, but the active async path uses the true-async batch model
+
+### Ingest Batch Payload
+
+`ingest_batch_payloads` store compressed request payloads for accepted async batches until the worker processes and cleans them up.
 
 ### Session
-A session groups related traces together.
+
+`sessions` group related traces. Each row has:
+- an internal UUID primary key
+- a user-facing `external_id`
+- optional narrative and workflow-facing metadata used by the debugger
 
 ### Trace
-A trace represents a single execution of an AI agent.
+
+`traces` represent individual executions within a session or standalone context. Each row has:
+- an internal UUID primary key
+- an external `trace_id`
+- aggregate rollup fields such as duration, status, cost, token counts, and error counts
+- trace-level input/output payload fields
 
 ### Span
-A span represents a single operation within a trace (LLM call, tool invocation, etc.).
 
-### Payload
-Stores request/response bodies for spans.
+`spans` represent operations within a trace. Each row has:
+- an internal UUID primary key
+- an external `span_id`
+- an external `parent_span_id` for tree reconstruction
+- kind, status, timing, cost/token fields, model/provider fields, metadata, and span-level payloads
 
-## Relationships
+### Span Event
 
+`span_events` store explicit append-only events such as logs, errors, exceptions, metrics, and semantic debugger events.
+
+Important semantics:
+- explicit events are stored separately from spans
+- trace timelines merge explicit events with synthetic lifecycle events derived from spans
+- session compare currently focuses on semantic event types such as `decision`, `effect`, and `wait`
+
+## Relationship Shape
+
+```text
+projects
+  1-* ingest_batches
+  1-* sessions
+  1-* traces
+
+sessions
+  1-* traces
+
+traces
+  1-* spans
+
+spans
+  1-* span_events
+  0..1 parent_span_id -> spans.span_id (external ID relationship)
 ```
-Session 1-* Trace 1-* Span 1-* Payload
-                      |
-                      └── parent_span_id (self-referential)
-```
+
+## Identity And Mapping Rules
+
+- `sessions.external_id` is the user-facing session identifier
+- `traces.trace_id` is the external trace identifier
+- `spans.span_id` and `spans.parent_span_id` are external span identifiers
+- internal UUIDs are the persistence identity used inside the database and server code
+
+## Payload And Timeline Notes
+
+- there is no active standalone runtime `payloads` table for trace/span request and response bodies
+- trace payloads live on `traces`
+- span payloads live on `spans`
+- accepted async payload blobs live temporarily in `ingest_batch_payloads`
+- the timeline API returns explicit `span_events` plus synthetic lifecycle markers

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,8 +1,11 @@
 # Architecture Overview
 
+> **Status: Current**
+> This document summarizes the current runtime shape. For the shortest handoff, use [../DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md).
+
 ## Current Runtime
 
-Continua's implemented platform is a single Go server plus an embedded React debugger UI.
+Continua's implemented platform is a single Go server plus an embedded React debugger operator console.
 
 The active request path today is:
 
@@ -12,34 +15,35 @@ Python SDK / custom client
   -> Postgres persistence
   -> River background jobs
   -> REST read APIs
-  -> React debugger UI
+  -> React debugger operator console
 ```
 
 ## Runtime Components
 
 ### Platform Server
 
-The Go server in `cmd/continua` is the real product runtime today. It provides:
+The Go server in `cmd/continua` is the real product runtime today. It is wired with Fx in `cmd/continua/main.go` and provides:
 - authenticated REST APIs from `contracts/openapi/openapi.yaml`
 - ingest handling in `internal/api` + `internal/ingest`
 - River worker startup in `internal/jobs`
 - Postgres-backed store/query access in `internal/store`
 - the embedded web UI from `internal/web`
 
+The HTTP router is Chi-based in `internal/api/router.go`.
+
 ### Web UI
 
 The frontend in `web/` is a Vite React SPA built into `internal/web/static/` and embedded into the Go binary.
 
 Implemented UI areas include:
-- traces list with URL-driven filtering
-- trace detail with failure-first triage
-- trace detail workspace with tree rail, execution waterfall, and inspector tabs
-- span tree and span detail surfaces
-- payload inspection and truncation banners
-- state diff and semantic state/decision events
-- merged timeline view backed by polling
-- sessions list and session detail views
-- settings, auth recovery, command palette, and theming
+- shared `AppShell` with primary navigation and route-aware utility chrome
+- `/` overview built from existing trace and session list endpoints only
+- traces list with URL-driven filtering and return navigation
+- trace detail with failure-first triage, a desktop trace-context drawer, and mobile `Summary` / `Execution` / `Timeline` / `State` tabs
+- local tree-rail quick filters that operate only on already loaded span data
+- payload inspection, truncation banners, reasoning/state surfaces, and merged polling-based timeline
+- sessions list, session detail, and session compare workspaces
+- settings, auth recovery, command palette, theming, and operator-console visual styling
 
 ### Background Jobs
 
@@ -86,7 +90,7 @@ POST /v1/ingest
   -> trace rollup jobs
 ```
 
-### Trace Debugging
+### Debugger Reads
 
 ```text
 GET /api/traces
@@ -95,6 +99,7 @@ GET /api/traces/{id}/spans
 GET /api/traces/{id}/events
 GET /api/sessions
 GET /api/sessions/{id}
+GET /api/sessions/{id}/compare
 ```
 
 The trace detail UI does not use a live WebSocket runtime today. It polls the timeline API for running traces and merges explicit stored events with synthetic lifecycle events derived from spans.
@@ -111,10 +116,12 @@ The important persisted entities today are:
 - `span_events`
 
 Important semantics:
-- sessions expose internal UUIDs plus `external_id`
+- sessions expose internal UUIDs plus user-facing `external_id`
 - traces expose internal UUIDs plus external `trace_id`
 - spans expose internal UUIDs plus external `span_id`
 - span tree parent links use external `parent_span_id`
+- trace and span payloads live on `traces` / `spans`; there is no active standalone runtime payload table
+- timeline responses merge explicit events with synthetic lifecycle entries
 
 ## Contracts And Generation
 
@@ -145,5 +152,12 @@ These exist as plans, contracts, or scaffolding, but not as full runtime capabil
 - proxy capture runtime in `internal/proxy`
 - replay execution runtime in `internal/replay`
 - feature-complete TypeScript SDK
+
+## Current Validation Surfaces
+
+- `pnpm --filter web test`
+- `pnpm --filter web test:e2e`
+- `web/playwright.config.ts`
+- `web/e2e/ui-smoke.spec.ts`
 
 For the shortest current repo-verified handoff, see `docs/DEBUGGER_PLATFORM_BASELINE.md`.

--- a/docs/async_ingest_rollout.md
+++ b/docs/async_ingest_rollout.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](./README.md) and [DEBUGGER_PLATFORM_BASELINE.md](./DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Async Ingest Rollout
 
 This runbook covers the compatibility-first rollout for `add-true-async-ingest`.

--- a/docs/event-conventions.md
+++ b/docs/event-conventions.md
@@ -1,5 +1,8 @@
 # Event Conventions
 
+> **Status: Current**
+> These are the current debugger-facing event semantics used by the timeline, state diff surfaces, reasoning summaries, and semantic compare flows.
+
 Continua events are debugger-facing observability signals.
 
 These are debugger semantics, not replay primitives.

--- a/docs/guides/ingestion_codebase_guide.md
+++ b/docs/guides/ingestion_codebase_guide.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Continua Ingestion Pipeline - Codebase Guide
 
 This guide documents the batch ingestion pipeline implementation in Continua, covering the complete flow from HTTP request to database writes.

--- a/docs/guides/ingestion_line_by_line_guide.md
+++ b/docs/guides/ingestion_line_by_line_guide.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Ingestion Line-By-Line Guide
 
 This guide walks the ingestion pipeline in the exact order the code executes, with line-level references for every step. It focuses on the synchronous ingest path implemented in Go.

--- a/docs/guides/phase2_e2e_usability_codebase_guide.md
+++ b/docs/guides/phase2_e2e_usability_codebase_guide.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 2: End-to-End Usability Codebase Guide
 
 This guide documents what was implemented for Continua Phase 2, how the platform is now runnable end-to-end, and how requests flow through the codebase.

--- a/docs/phase2/spec-0-discovery.md
+++ b/docs/phase2/spec-0-discovery.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Spec 0: Repository Discovery
 
 ## Summary

--- a/docs/phase3/report_phase3.md
+++ b/docs/phase3/report_phase3.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Continua: AI Agent Observability Platform
 ## Comprehensive Project Report (Corrected)
 

--- a/docs/phase3/spec-0-discovery.md
+++ b/docs/phase3/spec-0-discovery.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Spec 0: Discovery Report
 
 ## Summary

--- a/docs/phase3/spec-1-async-rollups.md
+++ b/docs/phase3/spec-1-async-rollups.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Spec 1: Async Rollups via River
 
 ## Summary

--- a/docs/phase3/spec-2-idempotency.md
+++ b/docs/phase3/spec-2-idempotency.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Spec 2: Idempotency Hardening
 
 ## Summary

--- a/docs/phase3/spec-3-search.md
+++ b/docs/phase3/spec-3-search.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Spec 3: Search & Filtering
 
 ## Summary

--- a/docs/phase3/spec-4-performance.md
+++ b/docs/phase3/spec-4-performance.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Spec 4: Query Performance
 
 ## Summary

--- a/docs/phase3/spec-5-sessions-ui.md
+++ b/docs/phase3/spec-5-sessions-ui.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Spec 5: Sessions UI
 
 ## Summary

--- a/docs/phase3/spec-6-python-sdk.md
+++ b/docs/phase3/spec-6-python-sdk.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Spec 6: Python SDK Polish
 
 ## Overview

--- a/docs/phase4/REPORT.md
+++ b/docs/phase4/REPORT.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 4 Report
 
 ## Summary

--- a/docs/phase4/design_doc.md
+++ b/docs/phase4/design_doc.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Continua Phase 4 Design Doc
 
 ## Document Metadata

--- a/docs/phase4/spec-0-discovery.md
+++ b/docs/phase4/spec-0-discovery.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 4 Discovery
 
 ## Scope Reviewed

--- a/docs/phase4/spec-1-timeline-api.md
+++ b/docs/phase4/spec-1-timeline-api.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 4 Spec 1: Timeline API
 
 ## Implemented Surface

--- a/docs/phase4/spec-2-timeline-ui.md
+++ b/docs/phase4/spec-2-timeline-ui.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 4 Spec 2: Timeline UI
 
 ## Implemented Surface

--- a/docs/phase4/spec-3-long-polling.md
+++ b/docs/phase4/spec-3-long-polling.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 4 Spec 3: Long Polling
 
 ## Implemented Polling Model

--- a/docs/phase4/spec-4-python-sdk.md
+++ b/docs/phase4/spec-4-python-sdk.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 4 Spec 4: Python SDK Event Helpers
 
 ## Implemented Surface

--- a/docs/phase4/spec-5-alignment.md
+++ b/docs/phase4/spec-5-alignment.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 4 Spec 5: Contract Alignment
 
 ## Generated Artifacts

--- a/docs/reviews/enable-e2e-usability.md
+++ b/docs/reviews/enable-e2e-usability.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 2 Review: Enable End-to-End Usability
 
 Date: 2026-01-13

--- a/docs/reviews/phase3-add-reliability-search-sessions-spec-review.md
+++ b/docs/reviews/phase3-add-reliability-search-sessions-spec-review.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 3 OpenSpec Review: add-reliability-search-sessions (Post-Update)
 
 ## Repo Findings

--- a/docs/reviews/phase3-testcases-existing-review.md
+++ b/docs/reviews/phase3-testcases-existing-review.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 3 - Existing Tests Review (Pre-existing Tests)
 
 Scope (files reviewed)

--- a/docs/reviews/phase3-testcases-review.md
+++ b/docs/reviews/phase3-testcases-review.md
@@ -1,3 +1,6 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](../README.md) and [DEBUGGER_PLATFORM_BASELINE.md](../DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 # Phase 3 Testcases Review (Deep Analysis)
 
 ## Scope Reviewed

--- a/docs/temp.md
+++ b/docs/temp.md
@@ -1,1 +1,4 @@
+> **Status: Historical**
+> This document is preserved for historical context and does not define the current repo state. Use [docs/README.md](./README.md) and [DEBUGGER_PLATFORM_BASELINE.md](./DEBUGGER_PLATFORM_BASELINE.md) for current guidance.
+
 Lets complete all the requirements in Must, Should, and Do later before starting with debugger. I want my debugger to be complete before starting on teh replay stuff. Can u please divide the requirements in multiple phases, divide them properly and in a smart manner it should not be that all teh heavyy requirements are in one phase and that the agent struggles in completing them. Keep them distributed smartly such that the agent is able to effectively complete all the requirements listed in each phaes.


### PR DESCRIPTION
## Summary
- refresh the living repo docs to match the current checkout and debugger operator console
- update repo-local Codex references and skills for the shared shell, overview, session compare, Playwright smoke coverage, and current runtime boundaries
- mark older phase/v1/runbook docs as historical and point them back to the current baseline

## Verification
- `git diff --check -- README.md AGENTS.md docs .codex/references .codex/skills`
- targeted grep audit for stale route/runtime wording in the living docs and skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session compare workspace for analyzing differences between two traces within a session
  * Overview page providing snapshot view of traces and sessions
  * Shared app shell with consistent navigation across routes

* **Documentation**
  * Reorganized documentation with current/historical/active-change status convention
  * Updated architecture guidance, baseline, and anti-drift rules
  * Clarified testing scope to include Playwright e2e smoke coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->