### PR TITLE
Add engine dark-launch core

### DIFF
--- a/engine/cmd/continua-engine/internal/darklaunch/activities.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/activities.go
@@ -1,0 +1,48 @@
+package darklaunch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/continua-ai/continua/engine/internal/activity"
+)
+
+const DemoActivityType = "darklaunch.compose-greeting"
+
+type ActivityInput struct {
+	Name string `json:"name"`
+}
+
+type ActivityOutput struct {
+	Greeting string `json:"greeting"`
+}
+
+func Handlers() map[string]activity.Handler {
+	return map[string]activity.Handler{
+		DemoActivityType: composeGreetingActivity,
+	}
+}
+
+func composeGreetingActivity(ctx context.Context, payload json.RawMessage) (json.RawMessage, error) {
+	var input ActivityInput
+	if len(payload) > 0 {
+		if err := json.Unmarshal(payload, &input); err != nil {
+			return nil, fmt.Errorf("decode activity input: %w", err)
+		}
+	}
+	if input.Name == "" {
+		input.Name = "world"
+	}
+	if err := applyTestActivityHooks(ctx, input.Name); err != nil {
+		return nil, err
+	}
+
+	output, err := json.Marshal(ActivityOutput{
+		Greeting: "hello, " + input.Name,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}

--- a/engine/cmd/continua-engine/internal/darklaunch/testhooks.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/testhooks.go
@@ -1,0 +1,47 @@
+package darklaunch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	enginetesthooks "github.com/continua-ai/continua/engine/internal/testhooks"
+)
+
+const (
+	TestActivityAttemptsFileEnv = "CONTINUA_ENGINE_TEST_ACTIVITY_ATTEMPTS_FILE"
+	TestActivityReleaseFileEnv  = "CONTINUA_ENGINE_TEST_ACTIVITY_RELEASE_FILE"
+)
+
+func applyTestActivityHooks(ctx context.Context, activityName string) error {
+	if err := appendTestActivityAttempt(activityName); err != nil {
+		return err
+	}
+	return waitForTestActivityRelease(ctx)
+}
+
+func appendTestActivityAttempt(activityName string) error {
+	attemptsFile := os.Getenv(TestActivityAttemptsFileEnv)
+	if attemptsFile == "" {
+		return nil
+	}
+
+	line := []byte(fmt.Sprintf("%s %s\n", time.Now().UTC().Format(time.RFC3339Nano), activityName))
+	file, err := os.OpenFile(attemptsFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.Write(line)
+	return err
+}
+
+func waitForTestActivityRelease(ctx context.Context) error {
+	releaseFile := os.Getenv(TestActivityReleaseFileEnv)
+	if releaseFile == "" {
+		return nil
+	}
+	return enginetesthooks.WaitForReleaseFile(ctx, releaseFile)
+}

--- a/engine/cmd/continua-engine/internal/darklaunch/workflow.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/workflow.go
@@ -1,0 +1,95 @@
+package darklaunch
+
+import (
+	"time"
+
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+const (
+	DemoDefinitionName    = "darklaunch.demo"
+	DemoDefinitionVersion = "v1"
+)
+
+type WorkflowInput struct {
+	Name    string `json:"name"`
+	TimerAt string `json:"timer_at"`
+}
+
+type SignalPayload struct {
+	Approval string `json:"approval"`
+}
+
+type WorkflowResult struct {
+	Greeting string `json:"greeting"`
+	Approval string `json:"approval"`
+}
+
+func Definitions() []workflow.Definition {
+	return []workflow.Definition{
+		{
+			Name:    DemoDefinitionName,
+			Version: DemoDefinitionVersion,
+			Run:     runDemoWorkflow,
+		},
+	}
+}
+
+func runDemoWorkflow(ctx workflow.Context) error {
+	var input WorkflowInput
+	if err := ctx.Input(&input); err != nil {
+		return err
+	}
+	if input.Name == "" {
+		input.Name = "world"
+	}
+
+	if err := ctx.SetCustomStatus(map[string]string{"phase": "activity"}); err != nil {
+		return err
+	}
+
+	var activityOutput ActivityOutput
+	if err := ctx.Activity("compose-greeting", DemoActivityType, ActivityInput{Name: input.Name}, &activityOutput); err != nil {
+		return err
+	}
+
+	if err := ctx.SetCustomStatus(map[string]string{"phase": "timer"}); err != nil {
+		return err
+	}
+	if err := ctx.SleepUntil("demo-timer", timerDeadline(input)); err != nil {
+		return err
+	}
+
+	if err := ctx.SetCustomStatus(map[string]string{"phase": "signal"}); err != nil {
+		return err
+	}
+
+	var signal SignalPayload
+	if err := ctx.ReceiveSignal("approval", &signal); err != nil {
+		return err
+	}
+
+	result := WorkflowResult{
+		Greeting: activityOutput.Greeting,
+		Approval: signal.Approval,
+	}
+	if err := ctx.SetCustomStatus(map[string]string{"phase": "completed", "approval": signal.Approval}); err != nil {
+		return err
+	}
+	if err := ctx.SetResult(result); err != nil {
+		return err
+	}
+	return nil
+}
+
+func timerDeadline(input WorkflowInput) time.Time {
+	if input.TimerAt == "" {
+		return time.Unix(0, 0).UTC()
+	}
+
+	parsed, err := time.Parse(time.RFC3339, input.TimerAt)
+	if err != nil {
+		return time.Unix(0, 0).UTC()
+	}
+	return parsed.UTC()
+}

--- a/engine/cmd/continua-engine/internal/darklaunch/workflow.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/workflow.go
@@ -87,9 +87,11 @@ func timerDeadline(input WorkflowInput) time.Time {
 		return time.Unix(0, 0).UTC()
 	}
 
-	parsed, err := time.Parse(time.RFC3339, input.TimerAt)
-	if err != nil {
-		return time.Unix(0, 0).UTC()
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		parsed, err := time.Parse(layout, input.TimerAt)
+		if err == nil {
+			return parsed.UTC()
+		}
 	}
-	return parsed.UTC()
+	return time.Unix(0, 0).UTC()
 }

--- a/engine/cmd/continua-engine/main.go
+++ b/engine/cmd/continua-engine/main.go
@@ -24,6 +24,10 @@ var (
 func main() {
 	rootCmd := newRootCmd()
 	if err := rootCmd.Execute(); err != nil {
+		var exitErr commandExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -31,9 +35,11 @@ func main() {
 
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "continua-engine",
-		Short: "Continua durable execution engine",
-		Long:  "Continua Engine manages the durable execution engine schema and runtime foundations.",
+		Use:           "continua-engine",
+		Short:         "Continua durable execution engine",
+		Long:          "Continua Engine manages the durable execution engine schema and runtime foundations.",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -41,6 +47,11 @@ func newRootCmd() *cobra.Command {
 
 	rootCmd.AddCommand(versionCmd())
 	rootCmd.AddCommand(migrateCmd())
+	rootCmd.AddCommand(serveCmd())
+	rootCmd.AddCommand(startCmd())
+	rootCmd.AddCommand(signalCmd())
+	rootCmd.AddCommand(cancelCmd())
+	rootCmd.AddCommand(inspectCmd())
 	return rootCmd
 }
 

--- a/engine/cmd/continua-engine/main_test.go
+++ b/engine/cmd/continua-engine/main_test.go
@@ -5,9 +5,13 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
 	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
 )
 
@@ -51,8 +55,16 @@ func TestMigrateCommandsRoundTrip(t *testing.T) {
 		t.Fatalf("unexpected migrate down output: %q", stdout)
 	}
 
-	if schemaExists(t, db.DatabaseURL, "engine") {
-		t.Fatal("expected engine schema to be removed after migrate down")
+	if !schemaExists(t, db.DatabaseURL, "engine") {
+		t.Fatal("expected engine schema to remain after rolling back only the runtime migration")
+	}
+	for _, column := range []string{"result", "custom_status", "waiting_for", "completed_at"} {
+		if columnExists(t, db.DatabaseURL, "engine", "runs", column) {
+			t.Fatalf("expected engine.runs.%s to be removed after migrate down 1", column)
+		}
+	}
+	if enumLabelExists(t, db.DatabaseURL, "engine", "run_lifecycle_status", "waiting") {
+		t.Fatal("expected waiting enum label to be removed after migrate down 1")
 	}
 
 	stdout, stderr, err = executeCommand(t, "migrate", "up")
@@ -69,6 +81,14 @@ func TestMigrateCommandsRoundTrip(t *testing.T) {
 	if !schemaExists(t, db.DatabaseURL, "engine") {
 		t.Fatal("expected engine schema to exist after migrate up")
 	}
+	for _, column := range []string{"result", "custom_status", "waiting_for", "completed_at"} {
+		if !columnExists(t, db.DatabaseURL, "engine", "runs", column) {
+			t.Fatalf("expected engine.runs.%s to exist after migrate up", column)
+		}
+	}
+	if !enumLabelExists(t, db.DatabaseURL, "engine", "run_lifecycle_status", "waiting") {
+		t.Fatal("expected waiting enum label to exist after migrate up")
+	}
 
 	stdout, stderr, err = executeCommand(t, "migrate", "up")
 	if err != nil {
@@ -79,6 +99,75 @@ func TestMigrateCommandsRoundTrip(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "Engine migrations applied successfully") {
 		t.Fatalf("unexpected second migrate up output: %q", stdout)
+	}
+}
+
+func TestMigrateDownRejectsWaitingRuns(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+
+	t.Setenv("ENGINE_DATABASE_URL", db.DatabaseURL)
+	t.Setenv("DATABASE_URL", "")
+
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "migration-waiting-guard",
+		DefinitionName: "demo",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+	if _, err := store.TransitionRunToWaiting(ctx, enginedb.TransitionRunToWaitingParams{
+		ID:           claimed.ID,
+		ClaimedBy:    claimed.ClaimedBy,
+		WaitingFor:   []byte(`{"kind":"signal","signal_name":"approval"}`),
+		CustomStatus: []byte(`{"phase":"signal"}`),
+	}); err != nil {
+		t.Fatalf("TransitionRunToWaiting() error = %v", err)
+	}
+
+	stdout, stderr, err := executeCommand(t, "migrate", "down", "1")
+	if err == nil {
+		t.Fatal("expected migrate down 1 to fail when waiting rows exist")
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout on failed rollback, got %q", stdout)
+	}
+	if !strings.Contains(err.Error(), "cannot roll back engine runtime columns while engine.runs still contains waiting rows") &&
+		!strings.Contains(stderr, "cannot roll back engine runtime columns while engine.runs still contains waiting rows") {
+		t.Fatalf("expected waiting-row rollback guard, err=%q stderr=%q", err, stderr)
+	}
+
+	if !columnExists(t, db.DatabaseURL, "engine", "runs", "waiting_for") {
+		t.Fatal("expected waiting_for column to remain after failed rollback")
+	}
+	if !enumLabelExists(t, db.DatabaseURL, "engine", "run_lifecycle_status", "waiting") {
+		t.Fatal("expected waiting enum label to remain after failed rollback")
+	}
+
+	updatedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if updatedRun.Status != enginedb.EngineRunLifecycleStatusWaiting {
+		t.Fatalf("expected waiting run to remain unchanged after failed rollback, got %+v", updatedRun)
 	}
 }
 
@@ -115,6 +204,60 @@ func schemaExists(t *testing.T, databaseURL string, schemaName string) bool {
 		)
 	`, schemaName).Scan(&exists); err != nil {
 		t.Fatalf("check schema existence: %v", err)
+	}
+
+	return exists
+}
+
+func columnExists(t *testing.T, databaseURL string, schemaName string, tableName string, columnName string) bool {
+	t.Helper()
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("open direct pool: %v", err)
+	}
+	defer pool.Close()
+
+	var exists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = $1
+			  AND table_name = $2
+			  AND column_name = $3
+		)
+	`, schemaName, tableName, columnName).Scan(&exists); err != nil {
+		t.Fatalf("check column existence: %v", err)
+	}
+
+	return exists
+}
+
+func enumLabelExists(t *testing.T, databaseURL string, schemaName string, typeName string, label string) bool {
+	t.Helper()
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("open direct pool: %v", err)
+	}
+	defer pool.Close()
+
+	var exists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_type t
+			JOIN pg_namespace n ON n.oid = t.typnamespace
+			JOIN pg_enum e ON e.enumtypid = t.oid
+			WHERE n.nspname = $1
+			  AND t.typname = $2
+			  AND e.enumlabel = $3
+		)
+	`, schemaName, typeName, label).Scan(&exists); err != nil {
+		t.Fatalf("check enum label existence: %v", err)
 	}
 
 	return exists

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -186,15 +186,27 @@ func startCmd() *cobra.Command {
 					return writeJSONError(cmd.OutOrStdout(), "request_in_progress", "a start request with this request key is still in progress")
 				}
 
+				if _, err := tx.Tx().Exec(ctx, "SAVEPOINT start_create_instance"); err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
 				instance, err := tx.CreateInstance(ctx, enginedb.CreateInstanceParams{
 					ProjectID:      darkLaunchProjectID,
 					InstanceKey:    instanceKey,
 					DefinitionName: definitionName,
 				})
 				if err != nil {
+					if _, rollbackErr := tx.Tx().Exec(ctx, "ROLLBACK TO SAVEPOINT start_create_instance"); rollbackErr != nil {
+						return writeJSONError(cmd.OutOrStdout(), "internal_error", rollbackErr.Error())
+					}
+					if _, releaseErr := tx.Tx().Exec(ctx, "RELEASE SAVEPOINT start_create_instance"); releaseErr != nil {
+						return writeJSONError(cmd.OutOrStdout(), "internal_error", releaseErr.Error())
+					}
 					if errors.Is(err, enginestore.ErrAlreadyExists) {
 						return finalizeStartFailure(ctx, tx, claim.Row.ID, cmd.OutOrStdout(), "instance_conflict", "an instance with this key already exists")
 					}
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				if _, err := tx.Tx().Exec(ctx, "RELEASE SAVEPOINT start_create_instance"); err != nil {
 					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
 				}
 

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -1,0 +1,732 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	"github.com/continua-ai/continua/engine/internal/activity"
+	"github.com/continua-ai/continua/engine/internal/config"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	engineworker "github.com/continua-ai/continua/engine/internal/worker"
+	engineworkflow "github.com/continua-ai/continua/engine/internal/workflow"
+
+	"github.com/continua-ai/continua/engine/cmd/continua-engine/internal/darklaunch"
+)
+
+var darkLaunchProjectID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+type commandExitError struct {
+	code int
+}
+
+func (e commandExitError) Error() string {
+	return fmt.Sprintf("command exited with code %d", e.code)
+}
+
+type jsonCommandError struct {
+	Error jsonErrorPayload `json:"error"`
+}
+
+type jsonErrorPayload struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type startResponse struct {
+	InstanceID  string `json:"instance_id"`
+	InstanceKey string `json:"instance_key"`
+	RunID       string `json:"run_id"`
+	RunNumber   int32  `json:"run_number"`
+	Status      string `json:"status"`
+}
+
+type controlResponse struct {
+	InstanceID  string `json:"instance_id"`
+	RunID       string `json:"run_id"`
+	Accepted    bool   `json:"accepted"`
+	WakeApplied bool   `json:"wake_applied"`
+}
+
+type inspectHistoryEvent struct {
+	SequenceNo int32           `json:"sequence_no"`
+	EventType  string          `json:"event_type"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
+	CreatedAt  time.Time       `json:"created_at"`
+}
+
+type inspectResponse struct {
+	InstanceID        string                `json:"instance_id"`
+	InstanceKey       string                `json:"instance_key"`
+	DefinitionName    string                `json:"definition_name"`
+	DefinitionVersion string                `json:"definition_version"`
+	RunID             string                `json:"run_id"`
+	RunNumber         int32                 `json:"run_number"`
+	Status            string                `json:"status"`
+	Result            json.RawMessage       `json:"result,omitempty"`
+	CustomStatus      json.RawMessage       `json:"custom_status,omitempty"`
+	WaitingFor        json.RawMessage       `json:"waiting_for,omitempty"`
+	History           []inspectHistoryEvent `json:"history"`
+}
+
+func serveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "serve",
+		Short: "Run the dark-launch engine runtime",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
+			return withRuntime(ctx, func(ctx context.Context, cfg *config.Config, store *enginestore.Store, definitions *engineworkflow.Registry, activities *activity.Registry) error {
+				workflowWorker := engineworkflow.NewWorker(store, definitions, cfg.Runtime.RunLeaseTTL)
+				activityWorker := activity.NewWorker(store, activities, cfg.Runtime.ActivityLeaseTTL)
+				maintenanceWorker := engineworker.NewMaintenanceWorker(store)
+
+				log.Printf("starting continua-engine serve")
+
+				group, groupCtx := errgroup.WithContext(ctx)
+				group.Go(func() error {
+					return engineworker.RunLoop(groupCtx, cfg.Runtime.WorkflowPollInterval, "workflow", workflowWorker.PollOnce)
+				})
+				group.Go(func() error {
+					return engineworker.RunLoop(groupCtx, cfg.Runtime.ActivityPollInterval, "activity", activityWorker.PollOnce)
+				})
+				group.Go(func() error {
+					return engineworker.RunLoop(groupCtx, cfg.Runtime.MaintenancePollInterval, "maintenance", maintenanceWorker.PollOnce)
+				})
+
+				err := group.Wait()
+				if err == nil {
+					log.Printf("continua-engine serve stopped")
+				}
+				return err
+			})
+		},
+	}
+}
+
+func startCmd() *cobra.Command {
+	var instanceKey string
+	var definitionName string
+	var definitionVersion string
+	var requestKey string
+	var input string
+
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start a dark-launch workflow instance",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if instanceKey == "" || definitionName == "" || definitionVersion == "" || requestKey == "" {
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", "start requires --instance-key, --definition, --version, and --request-key")
+			}
+
+			inputPayload, err := parseOptionalJSON(input)
+			if err != nil {
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+			}
+
+			err = withRuntime(cmd.Context(), func(ctx context.Context, cfg *config.Config, store *enginestore.Store, definitions *engineworkflow.Registry, _ *activity.Registry) error {
+				if _, ok := definitions.Get(definitionName, definitionVersion); !ok {
+					return writeJSONError(cmd.OutOrStdout(), "definition_not_registered", fmt.Sprintf("definition %s@%s is not registered", definitionName, definitionVersion))
+				}
+
+				tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				defer func() {
+					_ = tx.Rollback(ctx)
+				}()
+
+				claim, err := tx.ClaimStartRequestDedupe(ctx, enginestore.ClaimStartRequestDedupeParams{
+					ProjectID:    darkLaunchProjectID,
+					RequestScope: "engine.start",
+					RequestKey:   requestKey,
+					ExpiresAt:    time.Now().Add(cfg.Runtime.RequestDedupeTTL),
+				})
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+
+				switch claim.State {
+				case enginestore.StartRequestDedupeClaimStateExistingFinalized:
+					payload := claim.Row.ResponsePayload
+					exitCode := 0
+					if claim.Row.Status == enginedb.EngineRequestDedupeStatusFailed {
+						payload, err = json.Marshal(jsonCommandError{
+							Error: jsonErrorPayload{
+								Code:    derefString(claim.Row.ErrorCode),
+								Message: derefString(claim.Row.ErrorMessage),
+							},
+						})
+						if err != nil {
+							return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+						}
+						exitCode = 1
+					}
+					if err := tx.Commit(ctx); err != nil {
+						return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+					}
+					return writeRawJSON(cmd.OutOrStdout(), payload, exitCode)
+				case enginestore.StartRequestDedupeClaimStateExistingInProgress:
+					return writeJSONError(cmd.OutOrStdout(), "request_in_progress", "a start request with this request key is still in progress")
+				}
+
+				instance, err := tx.CreateInstance(ctx, enginedb.CreateInstanceParams{
+					ProjectID:      darkLaunchProjectID,
+					InstanceKey:    instanceKey,
+					DefinitionName: definitionName,
+				})
+				if err != nil {
+					if errors.Is(err, enginestore.ErrAlreadyExists) {
+						return finalizeStartFailure(ctx, tx, claim.Row.ID, cmd.OutOrStdout(), "instance_conflict", "an instance with this key already exists")
+					}
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+
+				run, err := tx.CreateRun(ctx, enginedb.CreateRunParams{
+					ProjectID:         darkLaunchProjectID,
+					InstanceID:        instance.ID,
+					RunNumber:         1,
+					DefinitionVersion: definitionVersion,
+					ReadyAt:           time.Now(),
+				})
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+
+				startedPayload := enginehistory.WorkflowStartedPayload{
+					DefinitionName:    definitionName,
+					DefinitionVersion: definitionVersion,
+					InstanceKey:       instanceKey,
+					Input:             inputPayload,
+				}
+				startedRaw, err := enginehistory.MarshalPayload(startedPayload)
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				if _, err := tx.AppendHistory(ctx, enginedb.AppendHistoryParams{
+					ProjectID:  darkLaunchProjectID,
+					InstanceID: instance.ID,
+					RunID:      run.ID,
+					SequenceNo: 1,
+					EventType:  enginehistory.EventWorkflowStarted,
+					Payload:    startedRaw,
+				}); err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+
+				response := startResponse{
+					InstanceID:  instance.ID.String(),
+					InstanceKey: instance.InstanceKey,
+					RunID:       run.ID.String(),
+					RunNumber:   run.RunNumber,
+					Status:      string(run.Status),
+				}
+				responsePayload, err := json.Marshal(response)
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				if _, err := tx.FinalizeRequestDedupeWithResponse(ctx, enginedb.FinalizeRequestDedupeWithResponseParams{
+					ID:              claim.Row.ID,
+					ResponsePayload: responsePayload,
+				}); err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+
+				if err := tx.Commit(ctx); err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				return writeRawJSON(cmd.OutOrStdout(), responsePayload)
+			})
+			if err != nil {
+				var exitErr commandExitError
+				if errors.As(err, &exitErr) {
+					return err
+				}
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&instanceKey, "instance-key", "", "Durable instance key")
+	cmd.Flags().StringVar(&definitionName, "definition", "", "Compiled workflow definition name")
+	cmd.Flags().StringVar(&definitionVersion, "version", "", "Compiled workflow definition version")
+	cmd.Flags().StringVar(&requestKey, "request-key", "", "Durable request dedupe key")
+	cmd.Flags().StringVar(&input, "input", "", "Optional workflow input as JSON")
+	return cmd
+}
+
+func signalCmd() *cobra.Command {
+	var instanceKey string
+	var signalName string
+	var payload string
+	var dedupeKey string
+
+	cmd := &cobra.Command{
+		Use:   "signal",
+		Short: "Deliver a durable signal to the active run",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if instanceKey == "" || signalName == "" {
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", "signal requires --instance-key and --signal-name")
+			}
+
+			payloadRaw, err := parseOptionalJSON(payload)
+			if err != nil {
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+			}
+
+			err = withRuntime(cmd.Context(), func(ctx context.Context, _ *config.Config, store *enginestore.Store, _ *engineworkflow.Registry, _ *activity.Registry) error {
+				tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				defer func() { _ = tx.Rollback(ctx) }()
+
+				instance, run, err := loadLatestRunForUpdate(ctx, tx, instanceKey)
+				if err != nil {
+					return commandErrorFromStore(cmd.OutOrStdout(), err)
+				}
+				if isTerminalRun(run.Status) {
+					return writeJSONError(cmd.OutOrStdout(), "run_terminal", "cannot signal a terminal run")
+				}
+
+				signalPayload := enginehistory.SignalReceivedPayload{
+					SignalName: signalName,
+					Payload:    payloadRaw,
+				}
+				signalRaw, err := enginehistory.MarshalPayload(signalPayload)
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+
+				createErr := func() error {
+					_, createErr := tx.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+						ProjectID:   run.ProjectID,
+						InstanceID:  run.InstanceID,
+						RunID:       pgtype.UUID{Bytes: run.ID, Valid: true},
+						Kind:        "signal",
+						Payload:     signalRaw,
+						AvailableAt: time.Now(),
+						DedupeKey:   stringPtrOrNil(dedupeKey),
+					})
+					return createErr
+				}()
+				if createErr != nil && !(errors.Is(createErr, enginestore.ErrAlreadyExists) && dedupeKey != "") {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", createErr.Error())
+				}
+
+				wake, err := tx.WakeWaitingRun(ctx, run.ID)
+				if err != nil && !errors.Is(err, enginestore.ErrNotFound) {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+
+				response := controlResponse{
+					InstanceID:  instance.ID.String(),
+					RunID:       run.ID.String(),
+					Accepted:    true,
+					WakeApplied: err == nil && wake.Applied,
+				}
+
+				if err := tx.Commit(ctx); err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				return writeJSON(cmd.OutOrStdout(), response)
+			})
+			if err != nil {
+				var exitErr commandExitError
+				if errors.As(err, &exitErr) {
+					return err
+				}
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&instanceKey, "instance-key", "", "Durable instance key")
+	cmd.Flags().StringVar(&signalName, "signal-name", "", "Signal name")
+	cmd.Flags().StringVar(&payload, "payload", "", "Optional JSON signal payload")
+	cmd.Flags().StringVar(&dedupeKey, "dedupe-key", "", "Optional inbox dedupe key")
+	return cmd
+}
+
+func cancelCmd() *cobra.Command {
+	var instanceKey string
+
+	cmd := &cobra.Command{
+		Use:   "cancel",
+		Short: "Deliver a durable cancellation request to the active run",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if instanceKey == "" {
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", "cancel requires --instance-key")
+			}
+
+			err := withRuntime(cmd.Context(), func(ctx context.Context, _ *config.Config, store *enginestore.Store, _ *engineworkflow.Registry, _ *activity.Registry) error {
+				tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				defer func() { _ = tx.Rollback(ctx) }()
+
+				instance, run, err := loadLatestRunForUpdate(ctx, tx, instanceKey)
+				if err != nil {
+					return commandErrorFromStore(cmd.OutOrStdout(), err)
+				}
+				if isTerminalRun(run.Status) {
+					return writeJSONError(cmd.OutOrStdout(), "run_terminal", "cannot cancel a terminal run")
+				}
+
+				cancelRaw, err := enginehistory.MarshalPayload(enginehistory.CancelRequestedPayload{})
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+
+				cancelDedupe := "cancel:" + run.ID.String()
+				_, createErr := tx.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+					ProjectID:   run.ProjectID,
+					InstanceID:  run.InstanceID,
+					RunID:       pgtype.UUID{Bytes: run.ID, Valid: true},
+					Kind:        "cancel",
+					Payload:     cancelRaw,
+					AvailableAt: time.Now(),
+					DedupeKey:   &cancelDedupe,
+				})
+				if createErr != nil && !errors.Is(createErr, enginestore.ErrAlreadyExists) {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", createErr.Error())
+				}
+
+				wake, err := tx.WakeWaitingRun(ctx, run.ID)
+				if err != nil && !errors.Is(err, enginestore.ErrNotFound) {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+
+				response := controlResponse{
+					InstanceID:  instance.ID.String(),
+					RunID:       run.ID.String(),
+					Accepted:    true,
+					WakeApplied: err == nil && wake.Applied,
+				}
+
+				if err := tx.Commit(ctx); err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				return writeJSON(cmd.OutOrStdout(), response)
+			})
+			if err != nil {
+				var exitErr commandExitError
+				if errors.As(err, &exitErr) {
+					return err
+				}
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&instanceKey, "instance-key", "", "Durable instance key")
+	return cmd
+}
+
+func inspectCmd() *cobra.Command {
+	var instanceKey string
+
+	cmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect the current state of a dark-launch workflow instance",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if instanceKey == "" {
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", "inspect requires --instance-key")
+			}
+
+			err := withRuntime(cmd.Context(), func(ctx context.Context, _ *config.Config, store *enginestore.Store, _ *engineworkflow.Registry, _ *activity.Registry) error {
+				instance, run, historyRows, err := loadInstanceState(ctx, store, instanceKey)
+				if err != nil {
+					return commandErrorFromStore(cmd.OutOrStdout(), err)
+				}
+
+				response := inspectResponse{
+					InstanceID:        instance.ID.String(),
+					InstanceKey:       instance.InstanceKey,
+					DefinitionName:    instance.DefinitionName,
+					DefinitionVersion: run.DefinitionVersion,
+					RunID:             run.ID.String(),
+					RunNumber:         run.RunNumber,
+					Status:            string(run.Status),
+					Result:            cloneRaw(run.Result),
+					CustomStatus:      cloneRaw(run.CustomStatus),
+					WaitingFor:        cloneRaw(run.WaitingFor),
+					History:           make([]inspectHistoryEvent, 0, len(historyRows)),
+				}
+
+				for _, historyRow := range historyRows {
+					response.History = append(response.History, inspectHistoryEvent{
+						SequenceNo: historyRow.SequenceNo,
+						EventType:  historyRow.EventType,
+						Payload:    cloneRaw(historyRow.Payload),
+						CreatedAt:  historyRow.CreatedAt,
+					})
+				}
+
+				return writeJSON(cmd.OutOrStdout(), response)
+			})
+			if err != nil {
+				var exitErr commandExitError
+				if errors.As(err, &exitErr) {
+					return err
+				}
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&instanceKey, "instance-key", "", "Durable instance key")
+	return cmd
+}
+
+func withRuntime(
+	ctx context.Context,
+	fn func(context.Context, *config.Config, *enginestore.Store, *engineworkflow.Registry, *activity.Registry) error,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	pool, err := enginestore.NewPool(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	store := enginestore.New(pool)
+	defer store.Close()
+
+	definitions, activities, err := buildRegistries()
+	if err != nil {
+		return err
+	}
+
+	return fn(ctx, cfg, store, definitions, activities)
+}
+
+func buildRegistries() (*engineworkflow.Registry, *activity.Registry, error) {
+	definitions, err := engineworkflow.NewRegistry(darklaunch.Definitions()...)
+	if err != nil {
+		return nil, nil, err
+	}
+	activities, err := activity.NewRegistry(darklaunch.Handlers())
+	if err != nil {
+		return nil, nil, err
+	}
+	return definitions, activities, nil
+}
+
+func loadInstanceState(
+	ctx context.Context,
+	store *enginestore.Store,
+	instanceKey string,
+) (enginedb.EngineInstance, enginedb.EngineRun, []enginedb.EngineHistory, error) {
+	instance, err := store.GetInstanceByProjectAndKey(ctx, enginedb.GetInstanceByProjectAndKeyParams{
+		ProjectID:   darkLaunchProjectID,
+		InstanceKey: instanceKey,
+	})
+	if err != nil {
+		return enginedb.EngineInstance{}, enginedb.EngineRun{}, nil, err
+	}
+
+	runs, err := store.ListRunsByInstance(ctx, enginedb.ListRunsByInstanceParams{
+		InstanceID: instance.ID,
+		Limit:      1,
+	})
+	if err != nil {
+		return enginedb.EngineInstance{}, enginedb.EngineRun{}, nil, err
+	}
+	if len(runs) == 0 {
+		return enginedb.EngineInstance{}, enginedb.EngineRun{}, nil, enginestore.ErrNotFound
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, runs[0].ID)
+	if err != nil {
+		return enginedb.EngineInstance{}, enginedb.EngineRun{}, nil, err
+	}
+
+	return instance, runs[0], historyRows, nil
+}
+
+func loadLatestRun(
+	ctx context.Context,
+	store interface {
+		GetInstanceByProjectAndKey(context.Context, enginedb.GetInstanceByProjectAndKeyParams) (enginedb.EngineInstance, error)
+		ListRunsByInstance(context.Context, enginedb.ListRunsByInstanceParams) ([]enginedb.EngineRun, error)
+	},
+	instanceKey string,
+) (enginedb.EngineInstance, enginedb.EngineRun, error) {
+	instance, err := store.GetInstanceByProjectAndKey(ctx, enginedb.GetInstanceByProjectAndKeyParams{
+		ProjectID:   darkLaunchProjectID,
+		InstanceKey: instanceKey,
+	})
+	if err != nil {
+		return enginedb.EngineInstance{}, enginedb.EngineRun{}, err
+	}
+
+	runs, err := store.ListRunsByInstance(ctx, enginedb.ListRunsByInstanceParams{
+		InstanceID: instance.ID,
+		Limit:      1,
+	})
+	if err != nil {
+		return enginedb.EngineInstance{}, enginedb.EngineRun{}, err
+	}
+	if len(runs) == 0 {
+		return enginedb.EngineInstance{}, enginedb.EngineRun{}, enginestore.ErrNotFound
+	}
+
+	return instance, runs[0], nil
+}
+
+func loadLatestRunForUpdate(
+	ctx context.Context,
+	store interface {
+		GetInstanceByProjectAndKey(context.Context, enginedb.GetInstanceByProjectAndKeyParams) (enginedb.EngineInstance, error)
+		ListRunsByInstance(context.Context, enginedb.ListRunsByInstanceParams) ([]enginedb.EngineRun, error)
+		GetRunForUpdate(context.Context, uuid.UUID) (enginedb.EngineRun, error)
+	},
+	instanceKey string,
+) (enginedb.EngineInstance, enginedb.EngineRun, error) {
+	instance, run, err := loadLatestRun(ctx, store, instanceKey)
+	if err != nil {
+		return enginedb.EngineInstance{}, enginedb.EngineRun{}, err
+	}
+
+	lockedRun, err := store.GetRunForUpdate(ctx, run.ID)
+	if err != nil {
+		return enginedb.EngineInstance{}, enginedb.EngineRun{}, err
+	}
+
+	return instance, lockedRun, nil
+}
+
+func finalizeStartFailure(
+	ctx context.Context,
+	tx *enginestore.Tx,
+	dedupeID uuid.UUID,
+	writer io.Writer,
+	code string,
+	message string,
+) error {
+	payload, err := json.Marshal(jsonCommandError{
+		Error: jsonErrorPayload{
+			Code:    code,
+			Message: message,
+		},
+	})
+	if err != nil {
+		return writeJSONError(writer, "internal_error", err.Error())
+	}
+	if _, err := tx.FinalizeRequestDedupeWithError(ctx, enginedb.FinalizeRequestDedupeWithErrorParams{
+		ID:           dedupeID,
+		ErrorCode:    stringPtrOrNil(code),
+		ErrorMessage: stringPtrOrNil(message),
+	}); err != nil {
+		return writeJSONError(writer, "internal_error", err.Error())
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return writeJSONError(writer, "internal_error", err.Error())
+	}
+	return writeRawJSON(writer, payload, 1)
+}
+
+func writeJSON(writer io.Writer, value any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(writer, string(payload))
+	return err
+}
+
+func writeRawJSON(writer io.Writer, payload []byte, exitCode ...int) error {
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	if _, err := fmt.Fprintln(writer, string(payload)); err != nil {
+		return err
+	}
+	if len(exitCode) > 0 && exitCode[0] != 0 {
+		return commandExitError{code: exitCode[0]}
+	}
+	return nil
+}
+
+func writeJSONError(writer io.Writer, code string, message string) error {
+	if err := writeJSON(writer, jsonCommandError{
+		Error: jsonErrorPayload{
+			Code:    code,
+			Message: message,
+		},
+	}); err != nil {
+		return err
+	}
+	return commandExitError{code: 1}
+}
+
+func commandErrorFromStore(writer io.Writer, err error) error {
+	if errors.Is(err, enginestore.ErrNotFound) {
+		return writeJSONError(writer, "not_found", "workflow instance not found")
+	}
+	return writeJSONError(writer, "internal_error", err.Error())
+}
+
+func parseOptionalJSON(value string) (json.RawMessage, error) {
+	if value == "" {
+		return nil, nil
+	}
+	if !json.Valid([]byte(value)) {
+		return nil, fmt.Errorf("invalid JSON payload")
+	}
+	return json.RawMessage(value), nil
+}
+
+func isTerminalRun(status enginedb.EngineRunLifecycleStatus) bool {
+	return status == enginedb.EngineRunLifecycleStatusCompleted ||
+		status == enginedb.EngineRunLifecycleStatusFailed ||
+		status == enginedb.EngineRunLifecycleStatusCancelled
+}
+
+func stringPtrOrNil(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func cloneRaw(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -474,7 +474,8 @@ func inspectCmd() *cobra.Command {
 					History:           make([]inspectHistoryEvent, 0, len(historyRows)),
 				}
 
-				for _, historyRow := range historyRows {
+				for i := range historyRows {
+					historyRow := historyRows[i]
 					response.History = append(response.History, inspectHistoryEvent{
 						SequenceNo: historyRow.SequenceNo,
 						EventType:  historyRow.EventType,
@@ -527,12 +528,12 @@ func withRuntime(
 	return fn(ctx, cfg, store, definitions, activities)
 }
 
-func buildRegistries() (*engineworkflow.Registry, *activity.Registry, error) {
-	definitions, err := engineworkflow.NewRegistry(darklaunch.Definitions()...)
+func buildRegistries() (definitions *engineworkflow.Registry, activities *activity.Registry, err error) {
+	definitions, err = engineworkflow.NewRegistry(darklaunch.Definitions()...)
 	if err != nil {
 		return nil, nil, err
 	}
-	activities, err := activity.NewRegistry(darklaunch.Handlers())
+	activities, err = activity.NewRegistry(darklaunch.Handlers())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -578,13 +579,13 @@ func loadLatestRun(
 		ListRunsByInstance(context.Context, enginedb.ListRunsByInstanceParams) ([]enginedb.EngineRun, error)
 	},
 	instanceKey string,
-) (enginedb.EngineInstance, enginedb.EngineRun, error) {
-	instance, err := store.GetInstanceByProjectAndKey(ctx, enginedb.GetInstanceByProjectAndKeyParams{
+) (instance enginedb.EngineInstance, run enginedb.EngineRun, err error) {
+	instance, err = store.GetInstanceByProjectAndKey(ctx, enginedb.GetInstanceByProjectAndKeyParams{
 		ProjectID:   darkLaunchProjectID,
 		InstanceKey: instanceKey,
 	})
 	if err != nil {
-		return enginedb.EngineInstance{}, enginedb.EngineRun{}, err
+		return instance, run, err
 	}
 
 	runs, err := store.ListRunsByInstance(ctx, enginedb.ListRunsByInstanceParams{
@@ -592,13 +593,14 @@ func loadLatestRun(
 		Limit:      1,
 	})
 	if err != nil {
-		return enginedb.EngineInstance{}, enginedb.EngineRun{}, err
+		return instance, run, err
 	}
 	if len(runs) == 0 {
-		return enginedb.EngineInstance{}, enginedb.EngineRun{}, enginestore.ErrNotFound
+		return instance, run, enginestore.ErrNotFound
 	}
 
-	return instance, runs[0], nil
+	run = runs[0]
+	return instance, run, nil
 }
 
 func loadLatestRunForUpdate(
@@ -609,18 +611,19 @@ func loadLatestRunForUpdate(
 		GetRunForUpdate(context.Context, uuid.UUID) (enginedb.EngineRun, error)
 	},
 	instanceKey string,
-) (enginedb.EngineInstance, enginedb.EngineRun, error) {
-	instance, run, err := loadLatestRun(ctx, store, instanceKey)
+) (instance enginedb.EngineInstance, run enginedb.EngineRun, err error) {
+	instance, run, err = loadLatestRun(ctx, store, instanceKey)
 	if err != nil {
-		return enginedb.EngineInstance{}, enginedb.EngineRun{}, err
+		return instance, run, err
 	}
 
 	lockedRun, err := store.GetRunForUpdate(ctx, run.ID)
 	if err != nil {
-		return enginedb.EngineInstance{}, enginedb.EngineRun{}, err
+		return instance, run, err
 	}
 
-	return instance, lockedRun, nil
+	run = lockedRun
+	return instance, run, nil
 }
 
 func finalizeStartFailure(
@@ -675,7 +678,7 @@ func writeRawJSON(writer io.Writer, payload []byte, exitCode ...int) error {
 	return nil
 }
 
-func writeJSONError(writer io.Writer, code string, message string) error {
+func writeJSONError(writer io.Writer, code, message string) error {
 	if err := writeJSON(writer, jsonCommandError{
 		Error: jsonErrorPayload{
 			Code:    code,

--- a/engine/cmd/continua-engine/runtime_e2e_test.go
+++ b/engine/cmd/continua-engine/runtime_e2e_test.go
@@ -157,7 +157,10 @@ func TestStartCommandDedupeAndRegistrationErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initial start error = %v", err)
 	}
-	firstResponse := stdout
+	var firstResponse startResponse
+	if err := json.Unmarshal([]byte(stdout), &firstResponse); err != nil {
+		t.Fatalf("Unmarshal(initial start stdout) error = %v", err)
+	}
 
 	stdout, _, err = executeCommand(t,
 		"start",
@@ -170,8 +173,12 @@ func TestStartCommandDedupeAndRegistrationErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("duplicate request key start error = %v", err)
 	}
-	if stdout != firstResponse {
-		t.Fatalf("expected duplicate request key to replay cached response, got %q want %q", stdout, firstResponse)
+	var duplicateResponse startResponse
+	if err := json.Unmarshal([]byte(stdout), &duplicateResponse); err != nil {
+		t.Fatalf("Unmarshal(duplicate start stdout) error = %v", err)
+	}
+	if duplicateResponse != firstResponse {
+		t.Fatalf("expected duplicate request key to replay cached response, got %+v want %+v", duplicateResponse, firstResponse)
 	}
 
 	stdout, _, err = executeCommand(t,
@@ -808,7 +815,7 @@ func fileLineCount(t *testing.T, path string) int {
 
 func darklaunchTestEnv(key, value string) string { return key + "=" + value }
 
-func TestHelperProcessServe(t *testing.T) {
+func TestHelperProcessServe(_ *testing.T) {
 	if os.Getenv("GO_WANT_ENGINE_SERVE_HELPER") != "1" {
 		return
 	}
@@ -823,7 +830,8 @@ func TestHelperProcessServe(t *testing.T) {
 
 func filterEventTypes(history []inspectHistoryEvent) []string {
 	result := make([]string, 0, len(history))
-	for _, event := range history {
+	for i := range history {
+		event := history[i]
 		switch event.EventType {
 		case "custom_status.updated", "cancel.requested":
 			continue

--- a/engine/cmd/continua-engine/runtime_e2e_test.go
+++ b/engine/cmd/continua-engine/runtime_e2e_test.go
@@ -32,7 +32,7 @@ func TestEngineRuntimeHappyPathAndTerminalRejection(t *testing.T) {
 	instanceKey := "runtime-happy-path"
 	input := map[string]any{
 		"name":     "Ada",
-		"timer_at": time.Now().Add(300 * time.Millisecond).UTC().Format(time.RFC3339),
+		"timer_at": time.Now().Add(300 * time.Millisecond).UTC().Format(time.RFC3339Nano),
 	}
 	inputJSON, err := json.Marshal(input)
 	if err != nil {
@@ -215,7 +215,7 @@ func TestEngineRuntimeTimerAndSignalPersistenceAcrossRestart(t *testing.T) {
 	timerInstanceKey := "runtime-restart-timer"
 	timerInput, _ := json.Marshal(map[string]any{
 		"name":     "Timer",
-		"timer_at": time.Now().Add(750 * time.Millisecond).UTC().Format(time.RFC3339),
+		"timer_at": time.Now().Add(750 * time.Millisecond).UTC().Format(time.RFC3339Nano),
 	})
 	if _, _, err := executeCommand(t,
 		"start",

--- a/engine/cmd/continua-engine/runtime_e2e_test.go
+++ b/engine/cmd/continua-engine/runtime_e2e_test.go
@@ -1,0 +1,867 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	engineworkflow "github.com/continua-ai/continua/engine/internal/workflow"
+
+	"github.com/continua-ai/continua/engine/cmd/continua-engine/internal/darklaunch"
+)
+
+func TestEngineRuntimeHappyPathAndTerminalRejection(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+
+	serve := startServe(t)
+	defer serve.stop(t)
+
+	instanceKey := "runtime-happy-path"
+	input := map[string]any{
+		"name":     "Ada",
+		"timer_at": time.Now().Add(300 * time.Millisecond).UTC().Format(time.RFC3339),
+	}
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("Marshal(input) error = %v", err)
+	}
+
+	stdout, stderr, err := executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-happy-path",
+		"--input", string(inputJSON),
+	)
+	if err != nil {
+		t.Fatalf("start command error = %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var started startResponse
+	if err := json.Unmarshal([]byte(stdout), &started); err != nil {
+		t.Fatalf("Unmarshal(start stdout) error = %v", err)
+	}
+
+	state := waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "signal")
+	})
+	if state.InstanceID != started.InstanceID || state.RunID != started.RunID {
+		t.Fatalf("inspect returned unexpected identity: %+v vs %+v", state, started)
+	}
+
+	stdout, stderr, err = executeCommand(t,
+		"signal",
+		"--instance-key", instanceKey,
+		"--signal-name", "approval",
+		"--payload", `{"approval":"yes"}`,
+	)
+	if err != nil {
+		t.Fatalf("signal command error = %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var signaled controlResponse
+	if err := json.Unmarshal([]byte(stdout), &signaled); err != nil {
+		t.Fatalf("Unmarshal(signal stdout) error = %v", err)
+	}
+	if !signaled.Accepted {
+		t.Fatalf("expected signal accepted response, got %+v", signaled)
+	}
+
+	state = waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusCompleted)
+	})
+
+	var result darklaunch.WorkflowResult
+	if err := json.Unmarshal(state.Result, &result); err != nil {
+		t.Fatalf("Unmarshal(result) error = %v", err)
+	}
+	if result.Greeting != "hello, Ada" || result.Approval != "yes" {
+		t.Fatalf("unexpected workflow result: %+v", result)
+	}
+
+	var startedPayload map[string]any
+	if err := json.Unmarshal(state.History[0].Payload, &startedPayload); err != nil {
+		t.Fatalf("Unmarshal(started payload) error = %v", err)
+	}
+	if startedPayload["instance_key"] != instanceKey {
+		t.Fatalf("expected workflow.started instance_key %q, got %+v", instanceKey, startedPayload)
+	}
+
+	eventTypes := filterEventTypes(state.History)
+	expectedOrder := []string{
+		"workflow.started",
+		"activity.scheduled",
+		"activity.completed",
+		"timer.scheduled",
+		"timer.fired",
+		"signal.received",
+		"workflow.completed",
+	}
+	if !equalStrings(eventTypes, expectedOrder) {
+		t.Fatalf("unexpected history order: got %v want %v", eventTypes, expectedOrder)
+	}
+
+	stdout, _, err = executeCommand(t,
+		"signal",
+		"--instance-key", instanceKey,
+		"--signal-name", "approval",
+	)
+	if err == nil {
+		t.Fatal("expected signal on terminal run to fail")
+	}
+	assertJSONErrorCode(t, stdout, "run_terminal")
+
+	stdout, _, err = executeCommand(t, "cancel", "--instance-key", instanceKey)
+	if err == nil {
+		t.Fatal("expected cancel on terminal run to fail")
+	}
+	assertJSONErrorCode(t, stdout, "run_terminal")
+}
+
+func TestStartCommandDedupeAndRegistrationErrors(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+
+	inputJSON := `{"name":"Grace"}`
+	instanceKey := "runtime-start-dedupe"
+
+	stdout, _, err := executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-1",
+		"--input", inputJSON,
+	)
+	if err != nil {
+		t.Fatalf("initial start error = %v", err)
+	}
+	firstResponse := stdout
+
+	stdout, _, err = executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-1",
+		"--input", `{"name":"Ignored"}`,
+	)
+	if err != nil {
+		t.Fatalf("duplicate request key start error = %v", err)
+	}
+	if stdout != firstResponse {
+		t.Fatalf("expected duplicate request key to replay cached response, got %q want %q", stdout, firstResponse)
+	}
+
+	stdout, _, err = executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-2",
+	)
+	if err == nil {
+		t.Fatal("expected instance conflict start to fail")
+	}
+	assertJSONErrorCode(t, stdout, "instance_conflict")
+
+	stdout, _, err = executeCommand(t,
+		"start",
+		"--instance-key", "runtime-unknown-definition",
+		"--definition", "missing",
+		"--version", "v0",
+		"--request-key", "req-unknown",
+	)
+	if err == nil {
+		t.Fatal("expected unknown definition start to fail")
+	}
+	assertJSONErrorCode(t, stdout, "definition_not_registered")
+}
+
+func TestEngineRuntimeTimerAndSignalPersistenceAcrossRestart(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+
+	serve := startServe(t)
+
+	timerInstanceKey := "runtime-restart-timer"
+	timerInput, _ := json.Marshal(map[string]any{
+		"name":     "Timer",
+		"timer_at": time.Now().Add(750 * time.Millisecond).UTC().Format(time.RFC3339),
+	})
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", timerInstanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-timer-restart",
+		"--input", string(timerInput),
+	); err != nil {
+		t.Fatalf("start timer restart workflow: %v", err)
+	}
+
+	waitForInspect(t, timerInstanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "timer")
+	})
+	serve.stop(t)
+
+	time.Sleep(time.Second)
+
+	serve = startServe(t)
+	waitForInspect(t, timerInstanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "signal")
+	})
+	serve.stop(t)
+
+	serve = startServe(t)
+	signalInstanceKey := "runtime-restart-signal"
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", signalInstanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-signal-restart",
+		"--input", `{"name":"Signal","timer_at":"1970-01-01T00:00:00Z"}`,
+	); err != nil {
+		t.Fatalf("start signal restart workflow: %v", err)
+	}
+
+	waitForInspect(t, signalInstanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "signal")
+	})
+	serve.stop(t)
+
+	if _, _, err := executeCommand(t,
+		"signal",
+		"--instance-key", signalInstanceKey,
+		"--signal-name", "approval",
+		"--payload", `{"approval":"restarted"}`,
+	); err != nil {
+		t.Fatalf("signal while serve stopped: %v", err)
+	}
+
+	serve = startServe(t)
+	defer serve.stop(t)
+
+	state := waitForInspect(t, signalInstanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusCompleted)
+	})
+
+	var result darklaunch.WorkflowResult
+	if err := json.Unmarshal(state.Result, &result); err != nil {
+		t.Fatalf("Unmarshal(result) error = %v", err)
+	}
+	if result.Approval != "restarted" {
+		t.Fatalf("expected persisted signal payload after restart, got %+v", result)
+	}
+}
+
+func TestEngineRuntimeActivityPickupAfterRestart(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+	t.Setenv("ENGINE_ACTIVITY_POLL_INTERVAL", "5s")
+
+	serve := startServe(t)
+
+	instanceKey := "runtime-restart-activity-pickup"
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-activity-pickup",
+		"--input", `{"name":"Pickup","timer_at":"1970-01-01T00:00:00Z"}`,
+	); err != nil {
+		t.Fatalf("start activity pickup workflow: %v", err)
+	}
+
+	waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "activity")
+	})
+	serve.stop(t)
+
+	t.Setenv("ENGINE_ACTIVITY_POLL_INTERVAL", "50ms")
+	serve = startServe(t)
+	defer serve.stop(t)
+
+	waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "signal")
+	})
+}
+
+func TestSignalAndCancelRejectConcurrentTerminalization(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+	store := enginestore.New(db.Pool)
+
+	assertConcurrentTerminalizationRejectsControlCommand(t, store, db, "signal-terminal-race", "signal",
+		"--signal-name", "approval", "--payload", `{"approval":"late"}`,
+	)
+	assertConcurrentTerminalizationRejectsControlCommand(t, store, db, "cancel-terminal-race", "cancel")
+}
+
+func TestEngineRuntimeRunReclaimedAfterRestartBeforeActivationCompletes(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+	t.Setenv("ENGINE_RUN_LEASE_TTL", "250ms")
+
+	tempDir := t.TempDir()
+	claimMarker := filepath.Join(tempDir, "workflow-claim.marker")
+	claimRelease := filepath.Join(tempDir, "workflow-claim.release")
+
+	serve := startServeProcess(t,
+		darklaunchTestEnv(engineworkflow.TestWorkflowClaimMarkerEnv, claimMarker),
+		darklaunchTestEnv(engineworkflow.TestWorkflowClaimReleaseEnv, claimRelease),
+	)
+
+	instanceKey := "runtime-restart-before-activation-completes"
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-before-activation-completes",
+		"--input", `{"name":"ClaimRestart","timer_at":"1970-01-01T00:00:00Z"}`,
+	); err != nil {
+		t.Fatalf("start workflow: %v", err)
+	}
+
+	waitForFileExists(t, claimMarker)
+	serve.kill(t)
+
+	serve = startServeProcess(t)
+	defer serve.kill(t)
+
+	waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "signal")
+	})
+
+	if _, _, err := executeCommand(t,
+		"signal",
+		"--instance-key", instanceKey,
+		"--signal-name", "approval",
+		"--payload", `{"approval":"claimed"}`,
+	); err != nil {
+		t.Fatalf("signal reclaimed workflow: %v", err)
+	}
+
+	waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusCompleted)
+	})
+}
+
+func TestEngineRuntimeMidActivityRestartRecovery(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+	t.Setenv("ENGINE_ACTIVITY_LEASE_TTL", "250ms")
+
+	tempDir := t.TempDir()
+	attemptsFile := filepath.Join(tempDir, "activity-attempts.log")
+	releaseFile := filepath.Join(tempDir, "activity-release")
+
+	serve := startServeProcess(t,
+		darklaunchTestEnv(darklaunch.TestActivityAttemptsFileEnv, attemptsFile),
+		darklaunchTestEnv(darklaunch.TestActivityReleaseFileEnv, releaseFile),
+	)
+
+	instanceKey := "runtime-restart-activity-mid-flight"
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-activity-mid-flight",
+		"--input", `{"name":"MidFlight","timer_at":"1970-01-01T00:00:00Z"}`,
+	); err != nil {
+		t.Fatalf("start activity recovery workflow: %v", err)
+	}
+
+	waitForFileLineCount(t, attemptsFile, 1)
+	serve.kill(t)
+
+	serve = startServeProcess(t,
+		darklaunchTestEnv(darklaunch.TestActivityAttemptsFileEnv, attemptsFile),
+		darklaunchTestEnv(darklaunch.TestActivityReleaseFileEnv, releaseFile),
+	)
+	defer serve.kill(t)
+
+	waitForFileLineCount(t, attemptsFile, 2)
+	if err := os.WriteFile(releaseFile, []byte("release"), 0o644); err != nil {
+		t.Fatalf("WriteFile(release) error = %v", err)
+	}
+
+	waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "signal")
+	})
+
+	if count := fileLineCount(t, attemptsFile); count < 2 {
+		t.Fatalf("expected duplicate activity execution after restart, got %d attempt(s)", count)
+	}
+
+	if _, _, err := executeCommand(t,
+		"signal",
+		"--instance-key", instanceKey,
+		"--signal-name", "approval",
+		"--payload", `{"approval":"recovered"}`,
+	); err != nil {
+		t.Fatalf("signal recovered workflow: %v", err)
+	}
+
+	state := waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusCompleted)
+	})
+
+	var result darklaunch.WorkflowResult
+	if err := json.Unmarshal(state.Result, &result); err != nil {
+		t.Fatalf("Unmarshal(result) error = %v", err)
+	}
+	if result.Greeting != "hello, MidFlight" || result.Approval != "recovered" {
+		t.Fatalf("unexpected recovered workflow result: %+v", result)
+	}
+}
+
+func TestEngineRuntimeRunReclaimedBeforeFinalCommit(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+	t.Setenv("ENGINE_RUN_LEASE_TTL", "250ms")
+
+	tempDir := t.TempDir()
+	finalMarker := filepath.Join(tempDir, "workflow-final.marker")
+	finalRelease := filepath.Join(tempDir, "workflow-final.release")
+
+	serve := startServeProcess(t,
+		darklaunchTestEnv(engineworkflow.TestWorkflowFinalMarkerEnv, finalMarker),
+		darklaunchTestEnv(engineworkflow.TestWorkflowFinalReleaseEnv, finalRelease),
+	)
+
+	instanceKey := "runtime-restart-before-final-commit"
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-before-final-commit",
+		"--input", `{"name":"FinalRestart","timer_at":"1970-01-01T00:00:00Z"}`,
+	); err != nil {
+		t.Fatalf("start workflow: %v", err)
+	}
+
+	waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "signal")
+	})
+
+	if _, _, err := executeCommand(t,
+		"signal",
+		"--instance-key", instanceKey,
+		"--signal-name", "approval",
+		"--payload", `{"approval":"final"}`,
+	); err != nil {
+		t.Fatalf("signal workflow: %v", err)
+	}
+
+	waitForFileExists(t, finalMarker)
+	serve.kill(t)
+
+	serve = startServeProcess(t)
+	defer serve.kill(t)
+
+	state := waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusCompleted)
+	})
+
+	var result darklaunch.WorkflowResult
+	if err := json.Unmarshal(state.Result, &result); err != nil {
+		t.Fatalf("Unmarshal(result) error = %v", err)
+	}
+	if result.Greeting != "hello, FinalRestart" || result.Approval != "final" {
+		t.Fatalf("unexpected final restart result: %+v", result)
+	}
+}
+
+type serveHandle struct {
+	cancel context.CancelFunc
+	done   chan error
+}
+
+type serveProcess struct {
+	cmd    *exec.Cmd
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+	done   chan error
+}
+
+type commandResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func startServe(t *testing.T) serveHandle {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := newRootCmd()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"serve"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Execute()
+	}()
+
+	return serveHandle{
+		cancel: cancel,
+		done:   done,
+	}
+}
+
+func (s serveHandle) stop(t *testing.T) {
+	t.Helper()
+
+	s.cancel()
+	select {
+	case err := <-s.done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("serve command returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve command did not stop")
+	}
+}
+
+func startServeProcess(t *testing.T, extraEnv ...string) *serveProcess {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperProcessServe$")
+	cmd.Env = append(os.Environ(), "GO_WANT_ENGINE_SERVE_HELPER=1")
+	cmd.Env = append(cmd.Env, extraEnv...)
+
+	process := &serveProcess{
+		cmd:  cmd,
+		done: make(chan error, 1),
+	}
+	cmd.Stdout = &process.stdout
+	cmd.Stderr = &process.stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper serve process: %v", err)
+	}
+	go func() {
+		process.done <- cmd.Wait()
+	}()
+
+	return process
+}
+
+func (s *serveProcess) kill(t *testing.T) {
+	t.Helper()
+
+	if s == nil || s.cmd == nil || s.cmd.Process == nil {
+		return
+	}
+
+	if err := s.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("kill helper serve process: %v", err)
+	}
+
+	select {
+	case <-s.done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("helper serve process did not exit\nstdout=%s\nstderr=%s", s.stdout.String(), s.stderr.String())
+	}
+}
+
+func configureRuntimeEnv(t *testing.T, databaseURL string) {
+	t.Helper()
+
+	t.Setenv("ENGINE_DATABASE_URL", databaseURL)
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("ENGINE_WORKFLOW_POLL_INTERVAL", "50ms")
+	t.Setenv("ENGINE_ACTIVITY_POLL_INTERVAL", "50ms")
+	t.Setenv("ENGINE_MAINTENANCE_POLL_INTERVAL", "50ms")
+	t.Setenv("ENGINE_RUN_LEASE_TTL", "500ms")
+	t.Setenv("ENGINE_ACTIVITY_LEASE_TTL", "500ms")
+	t.Setenv("ENGINE_REQUEST_DEDUPE_TTL", "2s")
+}
+
+func inspectInstance(t *testing.T, instanceKey string) inspectResponse {
+	t.Helper()
+
+	stdout, stderr, err := executeCommand(t, "inspect", "--instance-key", instanceKey)
+	if err != nil {
+		t.Fatalf("inspect command error = %v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var state inspectResponse
+	if err := json.Unmarshal([]byte(stdout), &state); err != nil {
+		t.Fatalf("Unmarshal(inspect stdout) error = %v", err)
+	}
+	return state
+}
+
+func waitForInspect(t *testing.T, instanceKey string, predicate func(inspectResponse) bool) inspectResponse {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	var last inspectResponse
+	for time.Now().Before(deadline) {
+		last = inspectInstance(t, instanceKey)
+		if predicate(last) {
+			return last
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for inspect predicate, last state = %+v", last)
+	return inspectResponse{}
+}
+
+func assertConcurrentTerminalizationRejectsControlCommand(
+	t *testing.T,
+	store *enginestore.Store,
+	db *enginetest.TestDatabase,
+	instanceKey string,
+	command string,
+	extraArgs ...string,
+) {
+	t.Helper()
+
+	startArgs := []string{
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.DemoDefinitionName,
+		"--version", darklaunch.DemoDefinitionVersion,
+		"--request-key", "req-" + instanceKey,
+		"--input", `{"name":"TerminalRace","timer_at":"1970-01-01T00:00:00Z"}`,
+	}
+	stdout, stderr, err := executeCommand(t, startArgs...)
+	if err != nil {
+		t.Fatalf("start command error = %v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+
+	ctx := context.Background()
+	_, run, err := loadLatestRun(ctx, store, instanceKey)
+	if err != nil {
+		t.Fatalf("loadLatestRun() error = %v", err)
+	}
+	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+	if claimed.ID != run.ID {
+		t.Fatalf("claimed wrong run: got %s want %s", claimed.ID, run.ID)
+	}
+
+	tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	lockedRun, err := tx.GetRunForUpdate(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRunForUpdate() error = %v", err)
+	}
+
+	commandDone := make(chan commandResult, 1)
+	go func() {
+		args := append([]string{command, "--instance-key", instanceKey}, extraArgs...)
+		stdout, stderr, err := executeCommand(t, args...)
+		commandDone <- commandResult{stdout: stdout, stderr: stderr, err: err}
+	}()
+
+	waitForRunLockWaiter(t, db)
+
+	if _, err := tx.TransitionRunToCompleted(ctx, enginedb.TransitionRunToCompletedParams{
+		ID:           lockedRun.ID,
+		ClaimedBy:    lockedRun.ClaimedBy,
+		Result:       []byte(`{"done":true}`),
+		CustomStatus: nil,
+	}); err != nil {
+		t.Fatalf("TransitionRunToCompleted() error = %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	var result commandResult
+	select {
+	case result = <-commandDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s command did not finish", command)
+	}
+	if result.err == nil {
+		t.Fatalf("expected %s command to fail once run terminalized, stdout=%q stderr=%q", command, result.stdout, result.stderr)
+	}
+	assertJSONErrorCode(t, result.stdout, "run_terminal")
+
+	inboxRows, err := store.ListPendingInboxByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("ListPendingInboxByRun() error = %v", err)
+	}
+	if len(inboxRows) != 0 {
+		t.Fatalf("expected no pending inbox rows after rejected %s, got %+v", command, inboxRows)
+	}
+}
+
+func waitForRunLockWaiter(t *testing.T, db *enginetest.TestDatabase) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var waiting bool
+		if err := db.Pool.QueryRow(context.Background(), `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity
+				WHERE datname = current_database()
+				  AND wait_event_type = 'Lock'
+				  AND query LIKE '%FROM engine.runs%'
+				  AND query LIKE '%FOR UPDATE%'
+			)
+		`).Scan(&waiting); err != nil {
+			t.Fatalf("check pg_stat_activity: %v", err)
+		}
+		if waiting {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for command transaction to block on run row lock")
+}
+
+func waitForFileLineCount(t *testing.T, path string, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if fileLineCount(t, path) >= want {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d activity attempts in %s", want, path)
+}
+
+func waitForFileExists(t *testing.T, path string) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("Stat(%s) error = %v", path, err)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for file %s", path)
+}
+
+func fileLineCount(t *testing.T, path string) int {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	return len(strings.FieldsFunc(string(data), func(r rune) bool { return r == '\n' }))
+}
+
+func darklaunchTestEnv(key, value string) string { return key + "=" + value }
+
+func TestHelperProcessServe(t *testing.T) {
+	if os.Getenv("GO_WANT_ENGINE_SERVE_HELPER") != "1" {
+		return
+	}
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"serve"})
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func filterEventTypes(history []inspectHistoryEvent) []string {
+	result := make([]string, 0, len(history))
+	for _, event := range history {
+		switch event.EventType {
+		case "custom_status.updated", "cancel.requested":
+			continue
+		default:
+			result = append(result, event.EventType)
+		}
+	}
+	return result
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func assertJSONErrorCode(t *testing.T, stdout string, code string) {
+	t.Helper()
+
+	var response jsonCommandError
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("Unmarshal(error stdout) error = %v", err)
+	}
+	if response.Error.Code != code {
+		t.Fatalf("expected error code %q, got %+v", code, response)
+	}
+}
+
+func jsonContainsKind(raw json.RawMessage, kind string) bool {
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return false
+	}
+	return payload["kind"] == kind
+}

--- a/engine/db/gen/go/activity_tasks.sql.go
+++ b/engine/db/gen/go/activity_tasks.sql.go
@@ -68,23 +68,26 @@ func (q *Queries) ClaimNextActivityTask(ctx context.Context, arg ClaimNextActivi
 const completeActivityTask = `-- name: CompleteActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'completed',
-    output = $2,
+    output = $3,
     completed_at = NOW(),
     claimed_by = NULL,
     claimed_at = NULL,
     lease_expires_at = NULL,
     updated_at = NOW()
 WHERE id = $1
+  AND status = 'claimed'
+  AND claimed_by = $2
 RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at
 `
 
 type CompleteActivityTaskParams struct {
-	ID     uuid.UUID `json:"id"`
-	Output []byte    `json:"output"`
+	ID        uuid.UUID `json:"id"`
+	ClaimedBy *string   `json:"claimed_by"`
+	Output    []byte    `json:"output"`
 }
 
 func (q *Queries) CompleteActivityTask(ctx context.Context, arg CompleteActivityTaskParams) (EngineActivityTask, error) {
-	row := q.db.QueryRow(ctx, completeActivityTask, arg.ID, arg.Output)
+	row := q.db.QueryRow(ctx, completeActivityTask, arg.ID, arg.ClaimedBy, arg.Output)
 	var i EngineActivityTask
 	err := row.Scan(
 		&i.ID,
@@ -177,25 +180,67 @@ func (q *Queries) CreateActivityTask(ctx context.Context, arg CreateActivityTask
 const failActivityTask = `-- name: FailActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'failed',
-    last_error_code = $2,
-    last_error_message = $3,
+    last_error_code = $3,
+    last_error_message = $4,
     completed_at = NOW(),
     claimed_by = NULL,
     claimed_at = NULL,
     lease_expires_at = NULL,
     updated_at = NOW()
 WHERE id = $1
+  AND status = 'claimed'
+  AND claimed_by = $2
 RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at
 `
 
 type FailActivityTaskParams struct {
 	ID               uuid.UUID `json:"id"`
+	ClaimedBy        *string   `json:"claimed_by"`
 	LastErrorCode    *string   `json:"last_error_code"`
 	LastErrorMessage *string   `json:"last_error_message"`
 }
 
 func (q *Queries) FailActivityTask(ctx context.Context, arg FailActivityTaskParams) (EngineActivityTask, error) {
-	row := q.db.QueryRow(ctx, failActivityTask, arg.ID, arg.LastErrorCode, arg.LastErrorMessage)
+	row := q.db.QueryRow(ctx, failActivityTask,
+		arg.ID,
+		arg.ClaimedBy,
+		arg.LastErrorCode,
+		arg.LastErrorMessage,
+	)
+	var i EngineActivityTask
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunID,
+		&i.HistoryID,
+		&i.ActivityKey,
+		&i.ActivityType,
+		&i.Input,
+		&i.Output,
+		&i.Status,
+		&i.AvailableAt,
+		&i.AttemptCount,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.CompletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getActivityTask = `-- name: GetActivityTask :one
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at
+FROM engine.activity_tasks
+WHERE id = $1
+`
+
+func (q *Queries) GetActivityTask(ctx context.Context, id uuid.UUID) (EngineActivityTask, error) {
+	row := q.db.QueryRow(ctx, getActivityTask, id)
 	var i EngineActivityTask
 	err := row.Scan(
 		&i.ID,
@@ -260,4 +305,52 @@ func (q *Queries) GetActivityTaskByRunAndKey(ctx context.Context, arg GetActivit
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const listActivityTasksByRun = `-- name: ListActivityTasksByRun :many
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at
+FROM engine.activity_tasks
+WHERE run_id = $1
+ORDER BY created_at ASC, id ASC
+`
+
+func (q *Queries) ListActivityTasksByRun(ctx context.Context, runID uuid.UUID) ([]EngineActivityTask, error) {
+	rows, err := q.db.Query(ctx, listActivityTasksByRun, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineActivityTask{}
+	for rows.Next() {
+		var i EngineActivityTask
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.ActivityKey,
+			&i.ActivityType,
+			&i.Input,
+			&i.Output,
+			&i.Status,
+			&i.AvailableAt,
+			&i.AttemptCount,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.LastErrorCode,
+			&i.LastErrorMessage,
+			&i.CompletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/engine/db/gen/go/inbox.sql.go
+++ b/engine/db/gen/go/inbox.sql.go
@@ -120,6 +120,82 @@ func (q *Queries) CreateInboxItem(ctx context.Context, arg CreateInboxItemParams
 	return i, err
 }
 
+const listDueTimerRunIDs = `-- name: ListDueTimerRunIDs :many
+SELECT DISTINCT run_id
+FROM engine.inbox
+WHERE kind = 'timer'
+  AND run_id IS NOT NULL
+  AND status = 'pending'
+  AND available_at <= NOW()
+ORDER BY run_id ASC
+`
+
+func (q *Queries) ListDueTimerRunIDs(ctx context.Context) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, listDueTimerRunIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var run_id pgtype.UUID
+		if err := rows.Scan(&run_id); err != nil {
+			return nil, err
+		}
+		items = append(items, run_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPendingInboxByRun = `-- name: ListPendingInboxByRun :many
+SELECT id, project_id, instance_id, run_id, history_id, kind, payload, status, available_at, claimed_by, claimed_at, lease_expires_at, dedupe_key, resolved_at, created_at, updated_at
+FROM engine.inbox
+WHERE run_id = $1
+  AND status = 'pending'
+  AND available_at <= NOW()
+ORDER BY available_at ASC, id ASC
+`
+
+func (q *Queries) ListPendingInboxByRun(ctx context.Context, runID pgtype.UUID) ([]EngineInbox, error) {
+	rows, err := q.db.Query(ctx, listPendingInboxByRun, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineInbox{}
+	for rows.Next() {
+		var i EngineInbox
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.Kind,
+			&i.Payload,
+			&i.Status,
+			&i.AvailableAt,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.DedupeKey,
+			&i.ResolvedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markInboxDiscarded = `-- name: MarkInboxDiscarded :one
 UPDATE engine.inbox
 SET status = 'discarded',
@@ -165,6 +241,7 @@ SET status = 'processed',
     lease_expires_at = NULL,
     updated_at = NOW()
 WHERE id = $1
+  AND status = 'pending'
 RETURNING id, project_id, instance_id, run_id, history_id, kind, payload, status, available_at, claimed_by, claimed_at, lease_expires_at, dedupe_key, resolved_at, created_at, updated_at
 `
 

--- a/engine/db/gen/go/models.go
+++ b/engine/db/gen/go/models.go
@@ -198,6 +198,7 @@ const (
 	EngineRunLifecycleStatusCompleted EngineRunLifecycleStatus = "completed"
 	EngineRunLifecycleStatusFailed    EngineRunLifecycleStatus = "failed"
 	EngineRunLifecycleStatusCancelled EngineRunLifecycleStatus = "cancelled"
+	EngineRunLifecycleStatusWaiting   EngineRunLifecycleStatus = "waiting"
 )
 
 func (e *EngineRunLifecycleStatus) Scan(src interface{}) error {
@@ -339,4 +340,8 @@ type EngineRun struct {
 	LeaseExpiresAt    pgtype.Timestamptz       `json:"lease_expires_at"`
 	CreatedAt         time.Time                `json:"created_at"`
 	UpdatedAt         time.Time                `json:"updated_at"`
+	Result            []byte                   `json:"result"`
+	CustomStatus      []byte                   `json:"custom_status"`
+	WaitingFor        []byte                   `json:"waiting_for"`
+	CompletedAt       pgtype.Timestamptz       `json:"completed_at"`
 }

--- a/engine/db/gen/go/request_dedupe.sql.go
+++ b/engine/db/gen/go/request_dedupe.sql.go
@@ -64,6 +64,68 @@ func (q *Queries) CreateRequestDedupe(ctx context.Context, arg CreateRequestDedu
 	return i, err
 }
 
+const createStartRequestDedupeClaim = `-- name: CreateStartRequestDedupeClaim :one
+INSERT INTO engine.request_dedupe (
+    project_id,
+    request_scope,
+    request_key,
+    expires_at
+)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (project_id, request_scope, request_key) DO NOTHING
+RETURNING id, project_id, request_scope, request_key, instance_id, run_id, status, response_payload, error_code, error_message, expires_at, finalized_at, created_at, updated_at
+`
+
+type CreateStartRequestDedupeClaimParams struct {
+	ProjectID    uuid.UUID `json:"project_id"`
+	RequestScope string    `json:"request_scope"`
+	RequestKey   string    `json:"request_key"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+func (q *Queries) CreateStartRequestDedupeClaim(ctx context.Context, arg CreateStartRequestDedupeClaimParams) (EngineRequestDedupe, error) {
+	row := q.db.QueryRow(ctx, createStartRequestDedupeClaim,
+		arg.ProjectID,
+		arg.RequestScope,
+		arg.RequestKey,
+		arg.ExpiresAt,
+	)
+	var i EngineRequestDedupe
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.RequestScope,
+		&i.RequestKey,
+		&i.InstanceID,
+		&i.RunID,
+		&i.Status,
+		&i.ResponsePayload,
+		&i.ErrorCode,
+		&i.ErrorMessage,
+		&i.ExpiresAt,
+		&i.FinalizedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const expireRequestDedupe = `-- name: ExpireRequestDedupe :execrows
+UPDATE engine.request_dedupe
+SET status = 'expired',
+    updated_at = NOW()
+WHERE status = 'in_progress'
+  AND expires_at < NOW()
+`
+
+func (q *Queries) ExpireRequestDedupe(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, expireRequestDedupe)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const finalizeRequestDedupeWithError = `-- name: FinalizeRequestDedupeWithError :one
 UPDATE engine.request_dedupe
 SET status = 'failed',
@@ -159,6 +221,85 @@ type GetRequestDedupeByScopeAndKeyParams struct {
 
 func (q *Queries) GetRequestDedupeByScopeAndKey(ctx context.Context, arg GetRequestDedupeByScopeAndKeyParams) (EngineRequestDedupe, error) {
 	row := q.db.QueryRow(ctx, getRequestDedupeByScopeAndKey, arg.ProjectID, arg.RequestScope, arg.RequestKey)
+	var i EngineRequestDedupe
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.RequestScope,
+		&i.RequestKey,
+		&i.InstanceID,
+		&i.RunID,
+		&i.Status,
+		&i.ResponsePayload,
+		&i.ErrorCode,
+		&i.ErrorMessage,
+		&i.ExpiresAt,
+		&i.FinalizedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getRequestDedupeByScopeAndKeyForUpdate = `-- name: GetRequestDedupeByScopeAndKeyForUpdate :one
+SELECT id, project_id, request_scope, request_key, instance_id, run_id, status, response_payload, error_code, error_message, expires_at, finalized_at, created_at, updated_at
+FROM engine.request_dedupe
+WHERE project_id = $1
+  AND request_scope = $2
+  AND request_key = $3
+FOR UPDATE
+`
+
+type GetRequestDedupeByScopeAndKeyForUpdateParams struct {
+	ProjectID    uuid.UUID `json:"project_id"`
+	RequestScope string    `json:"request_scope"`
+	RequestKey   string    `json:"request_key"`
+}
+
+func (q *Queries) GetRequestDedupeByScopeAndKeyForUpdate(ctx context.Context, arg GetRequestDedupeByScopeAndKeyForUpdateParams) (EngineRequestDedupe, error) {
+	row := q.db.QueryRow(ctx, getRequestDedupeByScopeAndKeyForUpdate, arg.ProjectID, arg.RequestScope, arg.RequestKey)
+	var i EngineRequestDedupe
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.RequestScope,
+		&i.RequestKey,
+		&i.InstanceID,
+		&i.RunID,
+		&i.Status,
+		&i.ResponsePayload,
+		&i.ErrorCode,
+		&i.ErrorMessage,
+		&i.ExpiresAt,
+		&i.FinalizedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const renewRequestDedupeClaim = `-- name: RenewRequestDedupeClaim :one
+UPDATE engine.request_dedupe
+SET status = 'in_progress',
+    instance_id = NULL,
+    run_id = NULL,
+    response_payload = NULL,
+    error_code = NULL,
+    error_message = NULL,
+    expires_at = $2,
+    finalized_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+RETURNING id, project_id, request_scope, request_key, instance_id, run_id, status, response_payload, error_code, error_message, expires_at, finalized_at, created_at, updated_at
+`
+
+type RenewRequestDedupeClaimParams struct {
+	ID        uuid.UUID `json:"id"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func (q *Queries) RenewRequestDedupeClaim(ctx context.Context, arg RenewRequestDedupeClaimParams) (EngineRequestDedupe, error) {
+	row := q.db.QueryRow(ctx, renewRequestDedupeClaim, arg.ID, arg.ExpiresAt)
 	var i EngineRequestDedupe
 	err := row.Scan(
 		&i.ID,

--- a/engine/db/gen/go/runs.sql.go
+++ b/engine/db/gen/go/runs.sql.go
@@ -29,7 +29,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
 `
 
 type ClaimNextRunParams struct {
@@ -56,6 +56,10 @@ func (q *Queries) ClaimNextRun(ctx context.Context, arg ClaimNextRunParams) (Eng
 		&i.LeaseExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
 	)
 	return i, err
 }
@@ -69,7 +73,7 @@ INSERT INTO engine.runs (
     ready_at
 )
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
 `
 
 type CreateRunParams struct {
@@ -105,12 +109,16 @@ func (q *Queries) CreateRun(ctx context.Context, arg CreateRunParams) (EngineRun
 		&i.LeaseExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
 	)
 	return i, err
 }
 
 const getRun = `-- name: GetRun :one
-SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at
+SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
 FROM engine.runs
 WHERE id = $1
 `
@@ -134,12 +142,50 @@ func (q *Queries) GetRun(ctx context.Context, id uuid.UUID) (EngineRun, error) {
 		&i.LeaseExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
+	)
+	return i, err
+}
+
+const getRunForUpdate = `-- name: GetRunForUpdate :one
+SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+FROM engine.runs
+WHERE id = $1
+FOR UPDATE
+`
+
+func (q *Queries) GetRunForUpdate(ctx context.Context, id uuid.UUID) (EngineRun, error) {
+	row := q.db.QueryRow(ctx, getRunForUpdate, id)
+	var i EngineRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunNumber,
+		&i.DefinitionVersion,
+		&i.Status,
+		&i.ReadyAt,
+		&i.AttemptCount,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
 	)
 	return i, err
 }
 
 const listRunsByInstance = `-- name: ListRunsByInstance :many
-SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at
+SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
 FROM engine.runs
 WHERE instance_id = $1
 ORDER BY created_at DESC, id DESC
@@ -177,6 +223,10 @@ func (q *Queries) ListRunsByInstance(ctx context.Context, arg ListRunsByInstance
 			&i.LeaseExpiresAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.Result,
+			&i.CustomStatus,
+			&i.WaitingFor,
+			&i.CompletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -188,6 +238,182 @@ func (q *Queries) ListRunsByInstance(ctx context.Context, arg ListRunsByInstance
 	return items, nil
 }
 
+const transitionRunToCompleted = `-- name: TransitionRunToCompleted :one
+UPDATE engine.runs
+SET status = 'completed',
+    result = $3,
+    custom_status = $4,
+    waiting_for = NULL,
+    completed_at = NOW(),
+    last_error_code = NULL,
+    last_error_message = NULL,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'running'
+  AND claimed_by = $2
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+`
+
+type TransitionRunToCompletedParams struct {
+	ID           uuid.UUID `json:"id"`
+	ClaimedBy    *string   `json:"claimed_by"`
+	Result       []byte    `json:"result"`
+	CustomStatus []byte    `json:"custom_status"`
+}
+
+func (q *Queries) TransitionRunToCompleted(ctx context.Context, arg TransitionRunToCompletedParams) (EngineRun, error) {
+	row := q.db.QueryRow(ctx, transitionRunToCompleted,
+		arg.ID,
+		arg.ClaimedBy,
+		arg.Result,
+		arg.CustomStatus,
+	)
+	var i EngineRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunNumber,
+		&i.DefinitionVersion,
+		&i.Status,
+		&i.ReadyAt,
+		&i.AttemptCount,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
+	)
+	return i, err
+}
+
+const transitionRunToFailed = `-- name: TransitionRunToFailed :one
+UPDATE engine.runs
+SET status = 'failed',
+    result = NULL,
+    custom_status = $3,
+    waiting_for = NULL,
+    completed_at = NOW(),
+    last_error_code = $4,
+    last_error_message = $5,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'running'
+  AND claimed_by = $2
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+`
+
+type TransitionRunToFailedParams struct {
+	ID               uuid.UUID `json:"id"`
+	ClaimedBy        *string   `json:"claimed_by"`
+	CustomStatus     []byte    `json:"custom_status"`
+	LastErrorCode    *string   `json:"last_error_code"`
+	LastErrorMessage *string   `json:"last_error_message"`
+}
+
+func (q *Queries) TransitionRunToFailed(ctx context.Context, arg TransitionRunToFailedParams) (EngineRun, error) {
+	row := q.db.QueryRow(ctx, transitionRunToFailed,
+		arg.ID,
+		arg.ClaimedBy,
+		arg.CustomStatus,
+		arg.LastErrorCode,
+		arg.LastErrorMessage,
+	)
+	var i EngineRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunNumber,
+		&i.DefinitionVersion,
+		&i.Status,
+		&i.ReadyAt,
+		&i.AttemptCount,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
+	)
+	return i, err
+}
+
+const transitionRunToWaiting = `-- name: TransitionRunToWaiting :one
+UPDATE engine.runs
+SET status = 'waiting',
+    waiting_for = $3,
+    custom_status = $4,
+    result = NULL,
+    completed_at = NULL,
+    last_error_code = NULL,
+    last_error_message = NULL,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'running'
+  AND claimed_by = $2
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+`
+
+type TransitionRunToWaitingParams struct {
+	ID           uuid.UUID `json:"id"`
+	ClaimedBy    *string   `json:"claimed_by"`
+	WaitingFor   []byte    `json:"waiting_for"`
+	CustomStatus []byte    `json:"custom_status"`
+}
+
+func (q *Queries) TransitionRunToWaiting(ctx context.Context, arg TransitionRunToWaitingParams) (EngineRun, error) {
+	row := q.db.QueryRow(ctx, transitionRunToWaiting,
+		arg.ID,
+		arg.ClaimedBy,
+		arg.WaitingFor,
+		arg.CustomStatus,
+	)
+	var i EngineRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunNumber,
+		&i.DefinitionVersion,
+		&i.Status,
+		&i.ReadyAt,
+		&i.AttemptCount,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
+	)
+	return i, err
+}
+
 const updateRunStatus = `-- name: UpdateRunStatus :one
 UPDATE engine.runs
 SET status = $2,
@@ -195,7 +421,7 @@ SET status = $2,
     last_error_message = $4,
     updated_at = NOW()
 WHERE id = $1
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
 `
 
 type UpdateRunStatusParams struct {
@@ -229,6 +455,51 @@ func (q *Queries) UpdateRunStatus(ctx context.Context, arg UpdateRunStatusParams
 		&i.LeaseExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
+	)
+	return i, err
+}
+
+const wakeWaitingRun = `-- name: WakeWaitingRun :one
+UPDATE engine.runs
+SET status = 'queued',
+    waiting_for = NULL,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    ready_at = NOW(),
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'waiting'
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+`
+
+func (q *Queries) WakeWaitingRun(ctx context.Context, id uuid.UUID) (EngineRun, error) {
+	row := q.db.QueryRow(ctx, wakeWaitingRun, id)
+	var i EngineRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunNumber,
+		&i.DefinitionVersion,
+		&i.Status,
+		&i.ReadyAt,
+		&i.AttemptCount,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
 	)
 	return i, err
 }

--- a/engine/db/migrations/postgres/000002_runtime_columns.down.sql
+++ b/engine/db/migrations/postgres/000002_runtime_columns.down.sql
@@ -20,12 +20,14 @@ CREATE TYPE engine.run_lifecycle_status AS ENUM (
 );
 
 ALTER TABLE engine.runs
+    ALTER COLUMN status DROP DEFAULT,
     ALTER COLUMN status TYPE engine.run_lifecycle_status
     USING status::text::engine.run_lifecycle_status;
 
 DROP TYPE engine.run_lifecycle_status_old;
 
 ALTER TABLE engine.runs
+    ALTER COLUMN status SET DEFAULT 'queued',
     DROP COLUMN completed_at,
     DROP COLUMN waiting_for,
     DROP COLUMN custom_status,

--- a/engine/db/migrations/postgres/000002_runtime_columns.down.sql
+++ b/engine/db/migrations/postgres/000002_runtime_columns.down.sql
@@ -9,6 +9,8 @@ BEGIN
     END IF;
 END $$;
 
+DROP INDEX IF EXISTS engine.idx_engine_runs_claim;
+
 ALTER TYPE engine.run_lifecycle_status RENAME TO run_lifecycle_status_old;
 
 CREATE TYPE engine.run_lifecycle_status AS ENUM (
@@ -32,3 +34,7 @@ ALTER TABLE engine.runs
     DROP COLUMN waiting_for,
     DROP COLUMN custom_status,
     DROP COLUMN result;
+
+CREATE INDEX idx_engine_runs_claim
+    ON engine.runs(status, ready_at, lease_expires_at)
+    WHERE status IN ('queued', 'running');

--- a/engine/db/migrations/postgres/000002_runtime_columns.down.sql
+++ b/engine/db/migrations/postgres/000002_runtime_columns.down.sql
@@ -1,0 +1,32 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM engine.runs
+        WHERE status = 'waiting'
+    ) THEN
+        RAISE EXCEPTION 'cannot roll back engine runtime columns while engine.runs still contains waiting rows';
+    END IF;
+END $$;
+
+ALTER TYPE engine.run_lifecycle_status RENAME TO run_lifecycle_status_old;
+
+CREATE TYPE engine.run_lifecycle_status AS ENUM (
+    'queued',
+    'running',
+    'completed',
+    'failed',
+    'cancelled'
+);
+
+ALTER TABLE engine.runs
+    ALTER COLUMN status TYPE engine.run_lifecycle_status
+    USING status::text::engine.run_lifecycle_status;
+
+DROP TYPE engine.run_lifecycle_status_old;
+
+ALTER TABLE engine.runs
+    DROP COLUMN completed_at,
+    DROP COLUMN waiting_for,
+    DROP COLUMN custom_status,
+    DROP COLUMN result;

--- a/engine/db/migrations/postgres/000002_runtime_columns.up.sql
+++ b/engine/db/migrations/postgres/000002_runtime_columns.up.sql
@@ -1,0 +1,7 @@
+ALTER TYPE engine.run_lifecycle_status ADD VALUE 'waiting';
+
+ALTER TABLE engine.runs
+    ADD COLUMN result JSONB,
+    ADD COLUMN custom_status JSONB,
+    ADD COLUMN waiting_for JSONB,
+    ADD COLUMN completed_at TIMESTAMPTZ;

--- a/engine/db/queries/activity_tasks.sql
+++ b/engine/db/queries/activity_tasks.sql
@@ -12,11 +12,22 @@ INSERT INTO engine.activity_tasks (
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING *;
 
+-- name: GetActivityTask :one
+SELECT *
+FROM engine.activity_tasks
+WHERE id = $1;
+
 -- name: GetActivityTaskByRunAndKey :one
 SELECT *
 FROM engine.activity_tasks
 WHERE run_id = $1
   AND activity_key = $2;
+
+-- name: ListActivityTasksByRun :many
+SELECT *
+FROM engine.activity_tasks
+WHERE run_id = $1
+ORDER BY created_at ASC, id ASC;
 
 -- name: ClaimNextActivityTask :one
 UPDATE engine.activity_tasks
@@ -40,24 +51,28 @@ RETURNING *;
 -- name: CompleteActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'completed',
-    output = $2,
+    output = $3,
     completed_at = NOW(),
     claimed_by = NULL,
     claimed_at = NULL,
     lease_expires_at = NULL,
     updated_at = NOW()
 WHERE id = $1
+  AND status = 'claimed'
+  AND claimed_by = $2
 RETURNING *;
 
 -- name: FailActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'failed',
-    last_error_code = $2,
-    last_error_message = $3,
+    last_error_code = $3,
+    last_error_message = $4,
     completed_at = NOW(),
     claimed_by = NULL,
     claimed_at = NULL,
     lease_expires_at = NULL,
     updated_at = NOW()
 WHERE id = $1
+  AND status = 'claimed'
+  AND claimed_by = $2
 RETURNING *;

--- a/engine/db/queries/inbox.sql
+++ b/engine/db/queries/inbox.sql
@@ -30,6 +30,23 @@ WHERE id = (
 )
 RETURNING *;
 
+-- name: ListPendingInboxByRun :many
+SELECT *
+FROM engine.inbox
+WHERE run_id = $1
+  AND status = 'pending'
+  AND available_at <= NOW()
+ORDER BY available_at ASC, id ASC;
+
+-- name: ListDueTimerRunIDs :many
+SELECT DISTINCT run_id
+FROM engine.inbox
+WHERE kind = 'timer'
+  AND run_id IS NOT NULL
+  AND status = 'pending'
+  AND available_at <= NOW()
+ORDER BY run_id ASC;
+
 -- name: MarkInboxProcessed :one
 UPDATE engine.inbox
 SET status = 'processed',
@@ -39,6 +56,7 @@ SET status = 'processed',
     lease_expires_at = NULL,
     updated_at = NOW()
 WHERE id = $1
+  AND status = 'pending'
 RETURNING *;
 
 -- name: MarkInboxDiscarded :one

--- a/engine/db/queries/request_dedupe.sql
+++ b/engine/db/queries/request_dedupe.sql
@@ -10,12 +10,45 @@ INSERT INTO engine.request_dedupe (
 VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING *;
 
+-- name: CreateStartRequestDedupeClaim :one
+INSERT INTO engine.request_dedupe (
+    project_id,
+    request_scope,
+    request_key,
+    expires_at
+)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (project_id, request_scope, request_key) DO NOTHING
+RETURNING *;
+
 -- name: GetRequestDedupeByScopeAndKey :one
 SELECT *
 FROM engine.request_dedupe
 WHERE project_id = $1
   AND request_scope = $2
   AND request_key = $3;
+
+-- name: GetRequestDedupeByScopeAndKeyForUpdate :one
+SELECT *
+FROM engine.request_dedupe
+WHERE project_id = $1
+  AND request_scope = $2
+  AND request_key = $3
+FOR UPDATE;
+
+-- name: RenewRequestDedupeClaim :one
+UPDATE engine.request_dedupe
+SET status = 'in_progress',
+    instance_id = NULL,
+    run_id = NULL,
+    response_payload = NULL,
+    error_code = NULL,
+    error_message = NULL,
+    expires_at = $2,
+    finalized_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+RETURNING *;
 
 -- name: FinalizeRequestDedupeWithResponse :one
 UPDATE engine.request_dedupe
@@ -38,3 +71,10 @@ SET status = 'failed',
     updated_at = NOW()
 WHERE id = $1
 RETURNING *;
+
+-- name: ExpireRequestDedupe :execrows
+UPDATE engine.request_dedupe
+SET status = 'expired',
+    updated_at = NOW()
+WHERE status = 'in_progress'
+  AND expires_at < NOW();

--- a/engine/db/queries/runs.sql
+++ b/engine/db/queries/runs.sql
@@ -14,6 +14,12 @@ SELECT *
 FROM engine.runs
 WHERE id = $1;
 
+-- name: GetRunForUpdate :one
+SELECT *
+FROM engine.runs
+WHERE id = $1
+FOR UPDATE;
+
 -- name: ListRunsByInstance :many
 SELECT *
 FROM engine.runs
@@ -28,6 +34,73 @@ SET status = $2,
     last_error_message = $4,
     updated_at = NOW()
 WHERE id = $1
+RETURNING *;
+
+-- name: TransitionRunToWaiting :one
+UPDATE engine.runs
+SET status = 'waiting',
+    waiting_for = $3,
+    custom_status = $4,
+    result = NULL,
+    completed_at = NULL,
+    last_error_code = NULL,
+    last_error_message = NULL,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'running'
+  AND claimed_by = $2
+RETURNING *;
+
+-- name: TransitionRunToCompleted :one
+UPDATE engine.runs
+SET status = 'completed',
+    result = $3,
+    custom_status = $4,
+    waiting_for = NULL,
+    completed_at = NOW(),
+    last_error_code = NULL,
+    last_error_message = NULL,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'running'
+  AND claimed_by = $2
+RETURNING *;
+
+-- name: TransitionRunToFailed :one
+UPDATE engine.runs
+SET status = 'failed',
+    result = NULL,
+    custom_status = $3,
+    waiting_for = NULL,
+    completed_at = NOW(),
+    last_error_code = $4,
+    last_error_message = $5,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'running'
+  AND claimed_by = $2
+RETURNING *;
+
+-- name: WakeWaitingRun :one
+UPDATE engine.runs
+SET status = 'queued',
+    waiting_for = NULL,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    ready_at = NOW(),
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'waiting'
 RETURNING *;
 
 -- name: ClaimNextRun :one

--- a/engine/internal/activity/registry.go
+++ b/engine/internal/activity/registry.go
@@ -1,0 +1,39 @@
+package activity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type Handler func(context.Context, json.RawMessage) (json.RawMessage, error)
+
+type Registry struct {
+	handlers map[string]Handler
+}
+
+func NewRegistry(handlers map[string]Handler) (*Registry, error) {
+	registry := &Registry{
+		handlers: make(map[string]Handler, len(handlers)),
+	}
+
+	for activityType, handler := range handlers {
+		if activityType == "" || handler == nil {
+			return nil, fmt.Errorf("activity registry entries require type and handler")
+		}
+		if _, exists := registry.handlers[activityType]; exists {
+			return nil, fmt.Errorf("duplicate activity handler for %q", activityType)
+		}
+		registry.handlers[activityType] = handler
+	}
+
+	return registry, nil
+}
+
+func (r *Registry) Get(activityType string) (Handler, bool) {
+	if r == nil {
+		return nil, false
+	}
+	handler, ok := r.handlers[activityType]
+	return handler, ok
+}

--- a/engine/internal/activity/worker.go
+++ b/engine/internal/activity/worker.go
@@ -1,0 +1,89 @@
+package activity
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/continua-ai/continua/engine/internal/store"
+)
+
+type Worker struct {
+	store            *store.Store
+	registry         *Registry
+	activityLeaseTTL time.Duration
+}
+
+func NewWorker(store *store.Store, registry *Registry, activityLeaseTTL time.Duration) *Worker {
+	return &Worker{
+		store:            store,
+		registry:         registry,
+		activityLeaseTTL: activityLeaseTTL,
+	}
+}
+
+func (w *Worker) PollOnce(ctx context.Context, workerID string) error {
+	task, err := w.store.ClaimNextActivityTask(ctx, workerID, w.activityLeaseTTL)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	handler, ok := w.registry.Get(task.ActivityType)
+	if !ok {
+		code := "activity_not_registered"
+		message := "no handler registered for activity type " + task.ActivityType
+		return w.failTask(ctx, task.ID, task.RunID, workerID, &code, &message)
+	}
+
+	output, handlerErr := handler(ctx, task.Input)
+	if handlerErr != nil {
+		code := "activity_failed"
+		message := handlerErr.Error()
+		return w.failTask(ctx, task.ID, task.RunID, workerID, &code, &message)
+	}
+
+	_, err = w.store.CompleteActivityTask(ctx, task.ID, workerID, output)
+	if err != nil {
+		if errors.Is(err, store.ErrStaleClaim) {
+			log.Printf("activity worker stale completion for task %s", task.ID)
+			return nil
+		}
+		return err
+	}
+
+	_, err = w.store.WakeWaitingRun(ctx, task.RunID)
+	if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return err
+	}
+	return nil
+}
+
+func (w *Worker) failTask(
+	ctx context.Context,
+	taskID uuid.UUID,
+	runID uuid.UUID,
+	workerID string,
+	errorCode *string,
+	errorMessage *string,
+) error {
+	_, err := w.store.FailActivityTask(ctx, taskID, workerID, errorCode, errorMessage)
+	if err != nil {
+		if errors.Is(err, store.ErrStaleClaim) {
+			log.Printf("activity worker stale failure for task %s", taskID)
+			return nil
+		}
+		return err
+	}
+
+	_, err = w.store.WakeWaitingRun(ctx, runID)
+	if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return err
+	}
+	return nil
+}

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -12,11 +12,18 @@ const (
 	defaultMaxConnLifetime = time.Hour
 	defaultMaxConnIdleTime = 30 * time.Minute
 	defaultHealthCheck     = time.Minute
+	defaultWorkflowPoll    = time.Second
+	defaultActivityPoll    = time.Second
+	defaultMaintenancePoll = 10 * time.Second
+	defaultRunLeaseTTL     = 30 * time.Second
+	defaultActivityLease   = 5 * time.Minute
+	defaultRequestDedupe   = time.Hour
 )
 
 // Config holds engine runtime configuration.
 type Config struct {
 	Database DatabaseConfig
+	Runtime  RuntimeConfig
 }
 
 // DatabaseConfig holds the engine database settings.
@@ -29,6 +36,16 @@ type DatabaseConfig struct {
 	HealthCheckPeriod time.Duration
 }
 
+// RuntimeConfig holds polling, lease, and dedupe settings for the engine runtime.
+type RuntimeConfig struct {
+	WorkflowPollInterval    time.Duration
+	ActivityPollInterval    time.Duration
+	MaintenancePollInterval time.Duration
+	RunLeaseTTL             time.Duration
+	ActivityLeaseTTL        time.Duration
+	RequestDedupeTTL        time.Duration
+}
+
 // Load resolves the engine database configuration from environment variables.
 func Load() (*Config, error) {
 	databaseURL := os.Getenv("ENGINE_DATABASE_URL")
@@ -37,6 +54,31 @@ func Load() (*Config, error) {
 	}
 	if databaseURL == "" {
 		return nil, errors.New("ENGINE_DATABASE_URL or DATABASE_URL environment variable is required")
+	}
+
+	workflowPollInterval, err := durationFromEnv("ENGINE_WORKFLOW_POLL_INTERVAL", defaultWorkflowPoll)
+	if err != nil {
+		return nil, err
+	}
+	activityPollInterval, err := durationFromEnv("ENGINE_ACTIVITY_POLL_INTERVAL", defaultActivityPoll)
+	if err != nil {
+		return nil, err
+	}
+	maintenancePollInterval, err := durationFromEnv("ENGINE_MAINTENANCE_POLL_INTERVAL", defaultMaintenancePoll)
+	if err != nil {
+		return nil, err
+	}
+	runLeaseTTL, err := durationFromEnv("ENGINE_RUN_LEASE_TTL", defaultRunLeaseTTL)
+	if err != nil {
+		return nil, err
+	}
+	activityLeaseTTL, err := durationFromEnv("ENGINE_ACTIVITY_LEASE_TTL", defaultActivityLease)
+	if err != nil {
+		return nil, err
+	}
+	requestDedupeTTL, err := durationFromEnv("ENGINE_REQUEST_DEDUPE_TTL", defaultRequestDedupe)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Config{
@@ -48,5 +90,26 @@ func Load() (*Config, error) {
 			MaxConnIdleTime:   defaultMaxConnIdleTime,
 			HealthCheckPeriod: defaultHealthCheck,
 		},
+		Runtime: RuntimeConfig{
+			WorkflowPollInterval:    workflowPollInterval,
+			ActivityPollInterval:    activityPollInterval,
+			MaintenancePollInterval: maintenancePollInterval,
+			RunLeaseTTL:             runLeaseTTL,
+			ActivityLeaseTTL:        activityLeaseTTL,
+			RequestDedupeTTL:        requestDedupeTTL,
+		},
 	}, nil
+}
+
+func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback, nil
+	}
+
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, errors.New(key + " must be a valid duration: " + err.Error())
+	}
+	return parsed, nil
 }

--- a/engine/internal/config/config_test.go
+++ b/engine/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestLoadPrefersEngineDatabaseURL(t *testing.T) {
 	t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
@@ -16,6 +19,14 @@ func TestLoadPrefersEngineDatabaseURL(t *testing.T) {
 	}
 	if cfg.Database.MaxConns != 10 || cfg.Database.MinConns != 2 {
 		t.Fatalf("unexpected pool defaults: %+v", cfg.Database)
+	}
+	if cfg.Runtime.WorkflowPollInterval != time.Second ||
+		cfg.Runtime.ActivityPollInterval != time.Second ||
+		cfg.Runtime.MaintenancePollInterval != 10*time.Second ||
+		cfg.Runtime.RunLeaseTTL != 30*time.Second ||
+		cfg.Runtime.ActivityLeaseTTL != 5*time.Minute ||
+		cfg.Runtime.RequestDedupeTTL != time.Hour {
+		t.Fatalf("unexpected runtime defaults: %+v", cfg.Runtime)
 	}
 }
 
@@ -39,5 +50,38 @@ func TestLoadRequiresDatabaseURL(t *testing.T) {
 
 	if _, err := Load(); err == nil {
 		t.Fatal("expected missing database URL error")
+	}
+}
+
+func TestLoadRuntimeOverrides(t *testing.T) {
+	t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_WORKFLOW_POLL_INTERVAL", "250ms")
+	t.Setenv("ENGINE_ACTIVITY_POLL_INTERVAL", "500ms")
+	t.Setenv("ENGINE_MAINTENANCE_POLL_INTERVAL", "2s")
+	t.Setenv("ENGINE_RUN_LEASE_TTL", "45s")
+	t.Setenv("ENGINE_ACTIVITY_LEASE_TTL", "3m")
+	t.Setenv("ENGINE_REQUEST_DEDUPE_TTL", "10m")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.Runtime.WorkflowPollInterval != 250*time.Millisecond ||
+		cfg.Runtime.ActivityPollInterval != 500*time.Millisecond ||
+		cfg.Runtime.MaintenancePollInterval != 2*time.Second ||
+		cfg.Runtime.RunLeaseTTL != 45*time.Second ||
+		cfg.Runtime.ActivityLeaseTTL != 3*time.Minute ||
+		cfg.Runtime.RequestDedupeTTL != 10*time.Minute {
+		t.Fatalf("unexpected runtime overrides: %+v", cfg.Runtime)
+	}
+}
+
+func TestLoadRejectsInvalidDuration(t *testing.T) {
+	t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_WORKFLOW_POLL_INTERVAL", "definitely-not-a-duration")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("expected invalid duration error")
 	}
 }

--- a/engine/internal/history/events.go
+++ b/engine/internal/history/events.go
@@ -1,0 +1,207 @@
+package history
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+const (
+	EventWorkflowStarted        = "workflow.started"
+	EventWorkflowCompleted      = "workflow.completed"
+	EventWorkflowFailed         = "workflow.failed"
+	EventWorkflowReplayMismatch = "workflow.replay_mismatch"
+	EventActivityScheduled      = "activity.scheduled"
+	EventActivityCompleted      = "activity.completed"
+	EventActivityFailed         = "activity.failed"
+	EventTimerScheduled         = "timer.scheduled"
+	EventTimerFired             = "timer.fired"
+	EventSignalReceived         = "signal.received"
+	EventCancelRequested        = "cancel.requested"
+	EventCustomStatusUpdated    = "custom_status.updated"
+)
+
+const (
+	WaitKindActivity = "activity"
+	WaitKindTimer    = "timer"
+	WaitKindSignal   = "signal"
+)
+
+type WorkflowStartedPayload struct {
+	DefinitionName    string          `json:"definition_name"`
+	DefinitionVersion string          `json:"definition_version"`
+	InstanceKey       string          `json:"instance_key"`
+	Input             json.RawMessage `json:"input,omitempty"`
+}
+
+type WorkflowCompletedPayload struct {
+	Result json.RawMessage `json:"result"`
+}
+
+type WorkflowFailedPayload struct {
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"error_message"`
+}
+
+type WorkflowReplayMismatchPayload struct {
+	ExpectedType string `json:"expected_type"`
+	ExpectedKey  string `json:"expected_key"`
+	ActualType   string `json:"actual_type"`
+	ActualKey    string `json:"actual_key"`
+	Detail       string `json:"detail"`
+}
+
+type ActivityScheduledPayload struct {
+	ActivityKey  string          `json:"activity_key"`
+	ActivityType string          `json:"activity_type"`
+	Input        json.RawMessage `json:"input"`
+}
+
+type ActivityCompletedPayload struct {
+	ActivityKey  string          `json:"activity_key"`
+	ActivityType string          `json:"activity_type"`
+	Output       json.RawMessage `json:"output"`
+}
+
+type ActivityFailedPayload struct {
+	ActivityKey  string `json:"activity_key"`
+	ActivityType string `json:"activity_type"`
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"error_message"`
+}
+
+type TimerScheduledPayload struct {
+	TimerKey string    `json:"timer_key"`
+	DueAt    time.Time `json:"due_at"`
+}
+
+type TimerFiredPayload struct {
+	TimerKey string `json:"timer_key"`
+}
+
+type SignalReceivedPayload struct {
+	SignalName string          `json:"signal_name"`
+	Payload    json.RawMessage `json:"payload"`
+}
+
+type CancelRequestedPayload struct{}
+
+type CustomStatusUpdatedPayload struct {
+	Status json.RawMessage `json:"status"`
+}
+
+type ActivityWait struct {
+	Kind         string `json:"kind"`
+	ActivityKey  string `json:"activity_key"`
+	ActivityType string `json:"activity_type"`
+}
+
+type TimerWait struct {
+	Kind     string    `json:"kind"`
+	TimerKey string    `json:"timer_key"`
+	DueAt    time.Time `json:"due_at"`
+}
+
+type SignalWait struct {
+	Kind       string `json:"kind"`
+	SignalName string `json:"signal_name"`
+}
+
+func MarshalPayload(value any) (json.RawMessage, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func UnmarshalPayload(raw []byte, out any) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	return json.Unmarshal(raw, out)
+}
+
+func DecodePayload(eventType string, raw []byte) (any, error) {
+	if len(raw) == 0 {
+		if eventType == EventCancelRequested {
+			return CancelRequestedPayload{}, nil
+		}
+		return nil, nil
+	}
+
+	payload, err := payloadTarget(eventType)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(raw, payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func EventKey(eventType string, payload any) string {
+	switch value := payload.(type) {
+	case ActivityScheduledPayload:
+		return value.ActivityKey
+	case *ActivityScheduledPayload:
+		return value.ActivityKey
+	case ActivityCompletedPayload:
+		return value.ActivityKey
+	case *ActivityCompletedPayload:
+		return value.ActivityKey
+	case ActivityFailedPayload:
+		return value.ActivityKey
+	case *ActivityFailedPayload:
+		return value.ActivityKey
+	case TimerScheduledPayload:
+		return value.TimerKey
+	case *TimerScheduledPayload:
+		return value.TimerKey
+	case TimerFiredPayload:
+		return value.TimerKey
+	case *TimerFiredPayload:
+		return value.TimerKey
+	case SignalReceivedPayload:
+		return value.SignalName
+	case *SignalReceivedPayload:
+		return value.SignalName
+	default:
+		return ""
+	}
+}
+
+func payloadTarget(eventType string) (any, error) {
+	switch eventType {
+	case EventWorkflowStarted:
+		return &WorkflowStartedPayload{}, nil
+	case EventWorkflowCompleted:
+		return &WorkflowCompletedPayload{}, nil
+	case EventWorkflowFailed:
+		return &WorkflowFailedPayload{}, nil
+	case EventWorkflowReplayMismatch:
+		return &WorkflowReplayMismatchPayload{}, nil
+	case EventActivityScheduled:
+		return &ActivityScheduledPayload{}, nil
+	case EventActivityCompleted:
+		return &ActivityCompletedPayload{}, nil
+	case EventActivityFailed:
+		return &ActivityFailedPayload{}, nil
+	case EventTimerScheduled:
+		return &TimerScheduledPayload{}, nil
+	case EventTimerFired:
+		return &TimerFiredPayload{}, nil
+	case EventSignalReceived:
+		return &SignalReceivedPayload{}, nil
+	case EventCancelRequested:
+		return &CancelRequestedPayload{}, nil
+	case EventCustomStatusUpdated:
+		return &CustomStatusUpdatedPayload{}, nil
+	default:
+		return nil, fmt.Errorf("unknown event type %q", eventType)
+	}
+}

--- a/engine/internal/store/activity_tasks.go
+++ b/engine/internal/store/activity_tasks.go
@@ -2,7 +2,11 @@ package store
 
 import (
 	"context"
+	"errors"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 )
@@ -15,11 +19,22 @@ func (o *storeOps) CreateActivityTask(
 	return mapResult(o.q.CreateActivityTask(ctx, arg))
 }
 
+func (o *storeOps) GetActivityTask(ctx context.Context, id uuid.UUID) (enginedb.EngineActivityTask, error) {
+	return mapResult(o.q.GetActivityTask(ctx, id))
+}
+
 func (o *storeOps) GetActivityTaskByRunAndKey(
 	ctx context.Context,
 	arg enginedb.GetActivityTaskByRunAndKeyParams,
 ) (enginedb.EngineActivityTask, error) {
 	return mapResult(o.q.GetActivityTaskByRunAndKey(ctx, arg))
+}
+
+func (o *storeOps) ListActivityTasksByRun(
+	ctx context.Context,
+	runID uuid.UUID,
+) ([]enginedb.EngineActivityTask, error) {
+	return o.q.ListActivityTasksByRun(ctx, runID)
 }
 
 func (o *storeOps) ClaimNextActivityTask(
@@ -35,14 +50,47 @@ func (o *storeOps) ClaimNextActivityTask(
 
 func (o *storeOps) CompleteActivityTask(
 	ctx context.Context,
-	arg enginedb.CompleteActivityTaskParams,
+	id uuid.UUID,
+	claimedBy string,
+	output []byte,
 ) (enginedb.EngineActivityTask, error) {
-	return mapResult(o.q.CompleteActivityTask(ctx, arg))
+	task, err := o.q.CompleteActivityTask(ctx, enginedb.CompleteActivityTaskParams{
+		ID:        id,
+		ClaimedBy: nullableWorkerID(claimedBy),
+		Output:    output,
+	})
+	if err == nil {
+		return task, nil
+	}
+	return enginedb.EngineActivityTask{}, o.classifyActivityTaskCASMiss(ctx, id, err)
 }
 
 func (o *storeOps) FailActivityTask(
 	ctx context.Context,
-	arg enginedb.FailActivityTaskParams,
+	id uuid.UUID,
+	claimedBy string,
+	errorCode *string,
+	errorMessage *string,
 ) (enginedb.EngineActivityTask, error) {
-	return mapResult(o.q.FailActivityTask(ctx, arg))
+	task, err := o.q.FailActivityTask(ctx, enginedb.FailActivityTaskParams{
+		ID:               id,
+		ClaimedBy:        nullableWorkerID(claimedBy),
+		LastErrorCode:    errorCode,
+		LastErrorMessage: errorMessage,
+	})
+	if err == nil {
+		return task, nil
+	}
+	return enginedb.EngineActivityTask{}, o.classifyActivityTaskCASMiss(ctx, id, err)
+}
+
+func (o *storeOps) classifyActivityTaskCASMiss(ctx context.Context, id uuid.UUID, err error) error {
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return normalizeError(err)
+	}
+
+	if _, lookupErr := o.GetActivityTask(ctx, id); lookupErr != nil {
+		return lookupErr
+	}
+	return ErrStaleClaim
 }

--- a/engine/internal/store/inbox.go
+++ b/engine/internal/store/inbox.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 )
@@ -23,6 +24,30 @@ func (o *storeOps) ClaimNextInboxItem(
 		ClaimedBy:           nullableWorkerID(workerID),
 		LeaseDurationMicros: leaseDurationMicros(leaseDuration),
 	}))
+}
+
+func (o *storeOps) ListPendingInboxByRun(
+	ctx context.Context,
+	runID uuid.UUID,
+) ([]enginedb.EngineInbox, error) {
+	return o.q.ListPendingInboxByRun(ctx, pgtype.UUID{Bytes: runID, Valid: true})
+}
+
+func (o *storeOps) ListDueTimerRunIDs(ctx context.Context) ([]uuid.UUID, error) {
+	rawIDs, err := o.q.ListDueTimerRunIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	runIDs := make([]uuid.UUID, 0, len(rawIDs))
+	for _, rawID := range rawIDs {
+		if !rawID.Valid {
+			continue
+		}
+		runIDs = append(runIDs, rawID.Bytes)
+	}
+
+	return runIDs, nil
 }
 
 func (o *storeOps) MarkInboxProcessed(ctx context.Context, id uuid.UUID) (enginedb.EngineInbox, error) {

--- a/engine/internal/store/request_dedupe.go
+++ b/engine/internal/store/request_dedupe.go
@@ -26,7 +26,7 @@ type StartRequestDedupeClaim struct {
 	State StartRequestDedupeClaimState
 }
 
-func (c StartRequestDedupeClaim) NeedsExecution() bool {
+func (c *StartRequestDedupeClaim) NeedsExecution() bool {
 	return c.State == StartRequestDedupeClaimStateClaimedNew || c.State == StartRequestDedupeClaimStateClaimedReclaimed
 }
 

--- a/engine/internal/store/request_dedupe.go
+++ b/engine/internal/store/request_dedupe.go
@@ -2,9 +2,40 @@ package store
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 )
+
+type StartRequestDedupeClaimState string
+
+const (
+	StartRequestDedupeClaimStateClaimedNew         StartRequestDedupeClaimState = "claimed_new"
+	StartRequestDedupeClaimStateClaimedReclaimed   StartRequestDedupeClaimState = "claimed_reclaimed"
+	StartRequestDedupeClaimStateExistingFinalized  StartRequestDedupeClaimState = "existing_finalized"
+	StartRequestDedupeClaimStateExistingInProgress StartRequestDedupeClaimState = "existing_in_progress"
+)
+
+type StartRequestDedupeClaim struct {
+	Row   enginedb.EngineRequestDedupe
+	State StartRequestDedupeClaimState
+}
+
+func (c StartRequestDedupeClaim) NeedsExecution() bool {
+	return c.State == StartRequestDedupeClaimStateClaimedNew || c.State == StartRequestDedupeClaimStateClaimedReclaimed
+}
+
+type ClaimStartRequestDedupeParams struct {
+	ProjectID    uuid.UUID
+	RequestScope string
+	RequestKey   string
+	ExpiresAt    time.Time
+}
 
 //nolint:gocritic // Mirror sqlc's generated value-based params in thin store wrappers.
 func (o *storeOps) CreateRequestDedupe(
@@ -33,4 +64,83 @@ func (o *storeOps) FinalizeRequestDedupeWithError(
 	arg enginedb.FinalizeRequestDedupeWithErrorParams,
 ) (enginedb.EngineRequestDedupe, error) {
 	return mapResult(o.q.FinalizeRequestDedupeWithError(ctx, arg))
+}
+
+func (o *storeOps) ExpireRequestDedupe(ctx context.Context) (int64, error) {
+	return o.q.ExpireRequestDedupe(ctx)
+}
+
+func (tx *Tx) ClaimStartRequestDedupe(
+	ctx context.Context,
+	arg ClaimStartRequestDedupeParams,
+) (StartRequestDedupeClaim, error) {
+	createArg := enginedb.CreateStartRequestDedupeClaimParams{
+		ProjectID:    arg.ProjectID,
+		RequestScope: arg.RequestScope,
+		RequestKey:   arg.RequestKey,
+		ExpiresAt:    arg.ExpiresAt,
+	}
+	lockArg := enginedb.GetRequestDedupeByScopeAndKeyForUpdateParams{
+		ProjectID:    arg.ProjectID,
+		RequestScope: arg.RequestScope,
+		RequestKey:   arg.RequestKey,
+	}
+
+	for attempts := 0; attempts < 2; attempts++ {
+		row, err := tx.q.CreateStartRequestDedupeClaim(ctx, createArg)
+		if err == nil {
+			return StartRequestDedupeClaim{
+				Row:   row,
+				State: StartRequestDedupeClaimStateClaimedNew,
+			}, nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return StartRequestDedupeClaim{}, normalizeError(err)
+		}
+
+		row, err = tx.q.GetRequestDedupeByScopeAndKeyForUpdate(ctx, lockArg)
+		if errors.Is(err, pgx.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return StartRequestDedupeClaim{}, normalizeError(err)
+		}
+
+		switch row.Status {
+		case enginedb.EngineRequestDedupeStatusCompleted, enginedb.EngineRequestDedupeStatusFailed:
+			return StartRequestDedupeClaim{
+				Row:   row,
+				State: StartRequestDedupeClaimStateExistingFinalized,
+			}, nil
+		case enginedb.EngineRequestDedupeStatusInProgress:
+			if !row.ExpiresAt.Before(time.Now()) {
+				return StartRequestDedupeClaim{
+					Row:   row,
+					State: StartRequestDedupeClaimStateExistingInProgress,
+				}, nil
+			}
+		case enginedb.EngineRequestDedupeStatusExpired:
+		default:
+			return StartRequestDedupeClaim{}, fmt.Errorf("engine store: unsupported request dedupe status %q", row.Status)
+		}
+
+		renewed, renewErr := tx.q.RenewRequestDedupeClaim(ctx, enginedb.RenewRequestDedupeClaimParams{
+			ID:        row.ID,
+			ExpiresAt: arg.ExpiresAt,
+		})
+		if renewErr != nil {
+			return StartRequestDedupeClaim{}, normalizeError(renewErr)
+		}
+
+		return StartRequestDedupeClaim{
+			Row:   renewed,
+			State: StartRequestDedupeClaimStateClaimedReclaimed,
+		}, nil
+	}
+
+	return StartRequestDedupeClaim{}, fmt.Errorf(
+		"engine store: could not acquire request dedupe claim for scope %q key %q",
+		arg.RequestScope,
+		arg.RequestKey,
+	)
 }

--- a/engine/internal/store/runs.go
+++ b/engine/internal/store/runs.go
@@ -2,12 +2,19 @@ package store
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 )
+
+type WakeWaitingRunResult struct {
+	Run     enginedb.EngineRun
+	Applied bool
+}
 
 //nolint:gocritic // Mirror sqlc's generated value-based params in thin store wrappers.
 func (o *storeOps) CreateRun(ctx context.Context, arg enginedb.CreateRunParams) (enginedb.EngineRun, error) {
@@ -16,6 +23,10 @@ func (o *storeOps) CreateRun(ctx context.Context, arg enginedb.CreateRunParams) 
 
 func (o *storeOps) GetRun(ctx context.Context, id uuid.UUID) (enginedb.EngineRun, error) {
 	return mapResult(o.q.GetRun(ctx, id))
+}
+
+func (o *storeOps) GetRunForUpdate(ctx context.Context, id uuid.UUID) (enginedb.EngineRun, error) {
+	return mapResult(o.q.GetRunForUpdate(ctx, id))
 }
 
 func (o *storeOps) ListRunsByInstance(
@@ -32,6 +43,55 @@ func (o *storeOps) UpdateRunStatus(
 	return mapResult(o.q.UpdateRunStatus(ctx, arg))
 }
 
+func (o *storeOps) TransitionRunToWaiting(
+	ctx context.Context,
+	arg enginedb.TransitionRunToWaitingParams,
+) (enginedb.EngineRun, error) {
+	run, err := o.q.TransitionRunToWaiting(ctx, arg)
+	if err == nil {
+		return run, nil
+	}
+	return enginedb.EngineRun{}, o.classifyRunCASMiss(ctx, arg.ID, err)
+}
+
+func (o *storeOps) TransitionRunToCompleted(
+	ctx context.Context,
+	arg enginedb.TransitionRunToCompletedParams,
+) (enginedb.EngineRun, error) {
+	run, err := o.q.TransitionRunToCompleted(ctx, arg)
+	if err == nil {
+		return run, nil
+	}
+	return enginedb.EngineRun{}, o.classifyRunCASMiss(ctx, arg.ID, err)
+}
+
+func (o *storeOps) TransitionRunToFailed(
+	ctx context.Context,
+	arg enginedb.TransitionRunToFailedParams,
+) (enginedb.EngineRun, error) {
+	run, err := o.q.TransitionRunToFailed(ctx, arg)
+	if err == nil {
+		return run, nil
+	}
+	return enginedb.EngineRun{}, o.classifyRunCASMiss(ctx, arg.ID, err)
+}
+
+func (o *storeOps) WakeWaitingRun(ctx context.Context, id uuid.UUID) (WakeWaitingRunResult, error) {
+	run, err := o.q.WakeWaitingRun(ctx, id)
+	if err == nil {
+		return WakeWaitingRunResult{Run: run, Applied: true}, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return WakeWaitingRunResult{}, normalizeError(err)
+	}
+
+	current, lookupErr := o.GetRun(ctx, id)
+	if lookupErr != nil {
+		return WakeWaitingRunResult{}, lookupErr
+	}
+	return WakeWaitingRunResult{Run: current, Applied: false}, nil
+}
+
 func (o *storeOps) ClaimNextRun(
 	ctx context.Context,
 	workerID string,
@@ -41,4 +101,15 @@ func (o *storeOps) ClaimNextRun(
 		ClaimedBy:           nullableWorkerID(workerID),
 		LeaseDurationMicros: leaseDurationMicros(leaseDuration),
 	}))
+}
+
+func (o *storeOps) classifyRunCASMiss(ctx context.Context, id uuid.UUID, err error) error {
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return normalizeError(err)
+	}
+
+	if _, lookupErr := o.GetRun(ctx, id); lookupErr != nil {
+		return lookupErr
+	}
+	return ErrStaleClaim
 }

--- a/engine/internal/store/runtime_store_test.go
+++ b/engine/internal/store/runtime_store_test.go
@@ -1,0 +1,226 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+)
+
+func TestWakeWaitingRunReportsAppliedAndNoOp(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	instance := ts.createInstance(t, projectID, "instance-wake")
+	run := ts.createRun(t, instance, 1)
+
+	claimed, err := ts.store.ClaimNextRun(ts.ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+	waitingFor := []byte(`{"kind":"signal","signal_name":"approval"}`)
+	if _, err := ts.store.TransitionRunToWaiting(ts.ctx, enginedb.TransitionRunToWaitingParams{
+		ID:           claimed.ID,
+		ClaimedBy:    claimed.ClaimedBy,
+		WaitingFor:   waitingFor,
+		CustomStatus: []byte(`{"phase":"signal"}`),
+	}); err != nil {
+		t.Fatalf("TransitionRunToWaiting() error = %v", err)
+	}
+
+	wake, err := ts.store.WakeWaitingRun(ts.ctx, run.ID)
+	if err != nil {
+		t.Fatalf("WakeWaitingRun() error = %v", err)
+	}
+	if !wake.Applied || wake.Run.Status != enginedb.EngineRunLifecycleStatusQueued {
+		t.Fatalf("expected applied wake to queue the run, got %+v", wake)
+	}
+
+	wake, err = ts.store.WakeWaitingRun(ts.ctx, run.ID)
+	if err != nil {
+		t.Fatalf("WakeWaitingRun() second call error = %v", err)
+	}
+	if wake.Applied {
+		t.Fatalf("expected second wake to be a no-op, got %+v", wake)
+	}
+}
+
+func TestActivityTaskCASRejectsStaleClaim(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	instance := ts.createInstance(t, projectID, "instance-stale-activity")
+	run := ts.createRun(t, instance, 1)
+	history := ts.createHistory(t, projectID, instance.ID, run.ID, 1, "activity.scheduled")
+
+	task, err := ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:    projectID,
+		InstanceID:   instance.ID,
+		RunID:        run.ID,
+		HistoryID:    &history.ID,
+		ActivityKey:  "activity-1",
+		ActivityType: "demo.echo",
+		Input:        []byte(`{"name":"Ada"}`),
+		AvailableAt:  time.Now().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("CreateActivityTask() error = %v", err)
+	}
+
+	if _, err := ts.store.ClaimNextActivityTask(ts.ctx, "worker-a", time.Minute); err != nil {
+		t.Fatalf("ClaimNextActivityTask() error = %v", err)
+	}
+
+	_, err = ts.store.CompleteActivityTask(ts.ctx, task.ID, "worker-b", []byte(`{"ok":true}`))
+	if !errors.Is(err, ErrStaleClaim) {
+		t.Fatalf("expected ErrStaleClaim, got %v", err)
+	}
+}
+
+func TestClaimStartRequestDedupeScenarios(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	requestScope := "engine.start"
+
+	tx, err := ts.store.BeginTx(ts.ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	claim, err := tx.ClaimStartRequestDedupe(ts.ctx, ClaimStartRequestDedupeParams{
+		ProjectID:    projectID,
+		RequestScope: requestScope,
+		RequestKey:   "req-new",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ClaimStartRequestDedupe() new error = %v", err)
+	}
+	if claim.State != StartRequestDedupeClaimStateClaimedNew {
+		t.Fatalf("expected new claim state, got %s", claim.State)
+	}
+	if err := tx.Commit(ts.ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	tx, err = ts.store.BeginTx(ts.ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	liveClaim, err := tx.ClaimStartRequestDedupe(ts.ctx, ClaimStartRequestDedupeParams{
+		ProjectID:    projectID,
+		RequestScope: requestScope,
+		RequestKey:   "req-new",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ClaimStartRequestDedupe() live error = %v", err)
+	}
+	if liveClaim.State != StartRequestDedupeClaimStateExistingInProgress {
+		t.Fatalf("expected existing in-progress state, got %s", liveClaim.State)
+	}
+	if err := tx.Rollback(ts.ctx); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+
+	if _, err := ts.db.Pool.Exec(ts.ctx, `
+		UPDATE engine.request_dedupe
+		SET expires_at = NOW() - INTERVAL '1 minute'
+		WHERE id = $1
+	`, claim.Row.ID); err != nil {
+		t.Fatalf("expire request dedupe: %v", err)
+	}
+
+	tx, err = ts.store.BeginTx(ts.ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	reclaimed, err := tx.ClaimStartRequestDedupe(ts.ctx, ClaimStartRequestDedupeParams{
+		ProjectID:    projectID,
+		RequestScope: requestScope,
+		RequestKey:   "req-new",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ClaimStartRequestDedupe() reclaimed error = %v", err)
+	}
+	if reclaimed.State != StartRequestDedupeClaimStateClaimedReclaimed {
+		t.Fatalf("expected reclaimed state, got %s", reclaimed.State)
+	}
+	if err := tx.Commit(ts.ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	if _, err := ts.store.FinalizeRequestDedupeWithResponse(ts.ctx, enginedb.FinalizeRequestDedupeWithResponseParams{
+		ID:              reclaimed.Row.ID,
+		ResponsePayload: []byte(`{"instance_id":"cached"}`),
+	}); err != nil {
+		t.Fatalf("FinalizeRequestDedupeWithResponse() error = %v", err)
+	}
+
+	tx, err = ts.store.BeginTx(ts.ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	finalized, err := tx.ClaimStartRequestDedupe(ts.ctx, ClaimStartRequestDedupeParams{
+		ProjectID:    projectID,
+		RequestScope: requestScope,
+		RequestKey:   "req-new",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ClaimStartRequestDedupe() finalized error = %v", err)
+	}
+	if finalized.State != StartRequestDedupeClaimStateExistingFinalized {
+		t.Fatalf("expected finalized state, got %s", finalized.State)
+	}
+	if err := tx.Rollback(ts.ctx); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+}
+
+func TestExpireRequestDedupeAllowsReclaim(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+
+	row, err := ts.store.CreateRequestDedupe(ts.ctx, enginedb.CreateRequestDedupeParams{
+		ProjectID:    projectID,
+		RequestScope: "engine.start",
+		RequestKey:   "req-expire",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("CreateRequestDedupe() error = %v", err)
+	}
+
+	expiredCount, err := ts.store.ExpireRequestDedupe(ts.ctx)
+	if err != nil {
+		t.Fatalf("ExpireRequestDedupe() error = %v", err)
+	}
+	if expiredCount != 1 {
+		t.Fatalf("expected one expired request dedupe row, got %d", expiredCount)
+	}
+
+	tx, err := ts.store.BeginTx(ts.ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	claim, err := tx.ClaimStartRequestDedupe(ts.ctx, ClaimStartRequestDedupeParams{
+		ProjectID:    projectID,
+		RequestScope: "engine.start",
+		RequestKey:   "req-expire",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ClaimStartRequestDedupe() error = %v", err)
+	}
+	if claim.State != StartRequestDedupeClaimStateClaimedReclaimed {
+		t.Fatalf("expected reclaimed claim after expiry, got %+v", claim)
+	}
+	if claim.Row.ID != row.ID {
+		t.Fatalf("expected reclaim to reuse row %s, got %s", row.ID, claim.Row.ID)
+	}
+	if err := tx.Rollback(ts.ctx); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+}

--- a/engine/internal/store/store.go
+++ b/engine/internal/store/store.go
@@ -19,6 +19,7 @@ const uniqueViolationSQLState = "23505"
 var (
 	ErrNotFound        = errors.New("engine store: record not found")
 	ErrAlreadyExists   = errors.New("engine store: record already exists")
+	ErrStaleClaim      = errors.New("engine store: stale claim")
 	ErrStaleCheckpoint = errors.New("engine store: stale checkpoint")
 )
 

--- a/engine/internal/testhooks/file_gate.go
+++ b/engine/internal/testhooks/file_gate.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func ApplyFileGate(ctx context.Context, markerFile string, releaseFile string) error {
+func ApplyFileGate(ctx context.Context, markerFile, releaseFile string) error {
 	if markerFile == "" && releaseFile == "" {
 		return nil
 	}

--- a/engine/internal/testhooks/file_gate.go
+++ b/engine/internal/testhooks/file_gate.go
@@ -1,0 +1,42 @@
+package testhooks
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+func ApplyFileGate(ctx context.Context, markerFile string, releaseFile string) error {
+	if markerFile == "" && releaseFile == "" {
+		return nil
+	}
+
+	if markerFile != "" {
+		if err := os.WriteFile(markerFile, []byte("ready"), 0o644); err != nil {
+			return err
+		}
+	}
+	if releaseFile == "" {
+		return nil
+	}
+
+	return WaitForReleaseFile(ctx, releaseFile)
+}
+
+func WaitForReleaseFile(ctx context.Context, releaseFile string) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if _, err := os.Stat(releaseFile); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/engine/internal/worker/loop.go
+++ b/engine/internal/worker/loop.go
@@ -1,0 +1,34 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type IterationFunc func(context.Context, string) error
+
+func RunLoop(ctx context.Context, pollInterval time.Duration, prefix string, fn IterationFunc) error {
+	if err := fn(ctx, workerID(prefix)); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := fn(ctx, workerID(prefix)); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func workerID(prefix string) string {
+	return prefix + ":" + uuid.NewString()
+}

--- a/engine/internal/worker/maintenance.go
+++ b/engine/internal/worker/maintenance.go
@@ -1,0 +1,33 @@
+package worker
+
+import (
+	"context"
+	"errors"
+
+	"github.com/continua-ai/continua/engine/internal/store"
+)
+
+type MaintenanceWorker struct {
+	store *store.Store
+}
+
+func NewMaintenanceWorker(store *store.Store) *MaintenanceWorker {
+	return &MaintenanceWorker{store: store}
+}
+
+func (w *MaintenanceWorker) PollOnce(ctx context.Context, _ string) error {
+	runIDs, err := w.store.ListDueTimerRunIDs(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, runID := range runIDs {
+		_, wakeErr := w.store.WakeWaitingRun(ctx, runID)
+		if wakeErr != nil && !errors.Is(wakeErr, store.ErrNotFound) {
+			return wakeErr
+		}
+	}
+
+	_, err = w.store.ExpireRequestDedupe(ctx)
+	return err
+}

--- a/engine/internal/workflow/activation.go
+++ b/engine/internal/workflow/activation.go
@@ -1,0 +1,218 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	"github.com/continua-ai/continua/engine/internal/store"
+)
+
+type Activator struct {
+	store       *store.Store
+	definitions *Registry
+}
+
+func NewActivator(store *store.Store, definitions *Registry) *Activator {
+	return &Activator{
+		store:       store,
+		definitions: definitions,
+	}
+}
+
+func (a *Activator) Activate(ctx context.Context, claimedRun enginedb.EngineRun) error {
+	tx, err := a.store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	run, err := tx.GetRunForUpdate(ctx, claimedRun.ID)
+	if err != nil {
+		return err
+	}
+	if run.Status != enginedb.EngineRunLifecycleStatusRunning || !sameClaimedBy(run.ClaimedBy, claimedRun.ClaimedBy) {
+		return store.ErrStaleClaim
+	}
+
+	workerClaimedBy := claimedRun.ClaimedBy
+	instance, err := tx.GetInstance(ctx, run.InstanceID)
+	if err != nil {
+		return err
+	}
+	historyRows, err := tx.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		return err
+	}
+	activityTasks, err := tx.ListActivityTasksByRun(ctx, run.ID)
+	if err != nil {
+		return err
+	}
+	inboxRows, err := tx.ListPendingInboxByRun(ctx, run.ID)
+	if err != nil {
+		return err
+	}
+
+	definition, ok := a.definitions.Get(instance.DefinitionName, run.DefinitionVersion)
+	if !ok {
+		decision := activationDecision{
+			Kind:         decisionFailed,
+			NextSequence: historyRows[len(historyRows)-1].SequenceNo + 1,
+			Events: []queuedHistoryEvent{{
+				EventType: enginehistory.EventWorkflowFailed,
+				Payload: mustMarshalPayload(enginehistory.WorkflowFailedPayload{
+					ErrorCode:    "definition_version_mismatch",
+					ErrorMessage: fmt.Sprintf("definition %s@%s is not registered", instance.DefinitionName, run.DefinitionVersion),
+				}),
+			}},
+			CustomStatus:   cloneRaw(run.CustomStatus),
+			FailureCode:    "definition_version_mismatch",
+			FailureMessage: fmt.Sprintf("definition %s@%s is not registered", instance.DefinitionName, run.DefinitionVersion),
+		}
+		if err := a.commitDecision(ctx, tx, instance, run, workerClaimedBy, decision); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	}
+
+	decision, err := replayDefinition(definition, historyRows, activityTasks, inboxRows)
+	if err != nil {
+		return err
+	}
+
+	if err := a.commitDecision(ctx, tx, instance, run, workerClaimedBy, decision); err != nil {
+		return err
+	}
+	if decision.Kind == decisionCompleted {
+		if err := applyTestFinalHook(ctx); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (a *Activator) commitDecision(
+	ctx context.Context,
+	tx *store.Tx,
+	instance enginedb.EngineInstance,
+	run enginedb.EngineRun,
+	workerClaimedBy *string,
+	decision activationDecision,
+) error {
+	sequence := decision.NextSequence
+	var activityHistoryID *int64
+	var timerHistoryID *int64
+
+	for _, event := range decision.Events {
+		appended, err := tx.AppendHistory(ctx, enginedb.AppendHistoryParams{
+			ProjectID:  run.ProjectID,
+			InstanceID: run.InstanceID,
+			RunID:      run.ID,
+			SequenceNo: sequence,
+			EventType:  event.EventType,
+			Payload:    event.Payload,
+		})
+		if err != nil {
+			return err
+		}
+
+		switch event.EventType {
+		case enginehistory.EventActivityScheduled:
+			activityHistoryID = &appended.ID
+		case enginehistory.EventTimerScheduled:
+			timerHistoryID = &appended.ID
+		}
+		sequence++
+	}
+
+	if decision.NewActivity != nil {
+		if activityHistoryID == nil {
+			return fmt.Errorf("activity schedule event missing history id")
+		}
+		if _, err := tx.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
+			ProjectID:    run.ProjectID,
+			InstanceID:   run.InstanceID,
+			RunID:        run.ID,
+			HistoryID:    activityHistoryID,
+			ActivityKey:  decision.NewActivity.ActivityKey,
+			ActivityType: decision.NewActivity.ActivityType,
+			Input:        decision.NewActivity.Input,
+			AvailableAt:  run.ReadyAt,
+		}); err != nil {
+			return err
+		}
+	}
+
+	if decision.NewTimer != nil {
+		if timerHistoryID == nil {
+			return fmt.Errorf("timer schedule event missing history id")
+		}
+		payload, err := enginehistory.MarshalPayload(*decision.NewTimer)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+			ProjectID:   run.ProjectID,
+			InstanceID:  run.InstanceID,
+			RunID:       pgtype.UUID{Bytes: run.ID, Valid: true},
+			HistoryID:   timerHistoryID,
+			Kind:        "timer",
+			Payload:     payload,
+			AvailableAt: decision.NewTimer.DueAt,
+		}); err != nil {
+			return err
+		}
+	}
+
+	for _, inboxID := range decision.ConsumedInboxIDs {
+		if _, err := tx.MarkInboxProcessed(ctx, inboxID); err != nil && err != store.ErrNotFound {
+			return err
+		}
+	}
+
+	switch decision.Kind {
+	case decisionWaiting:
+		_, err := tx.TransitionRunToWaiting(ctx, enginedb.TransitionRunToWaitingParams{
+			ID:           run.ID,
+			ClaimedBy:    workerClaimedBy,
+			WaitingFor:   decision.WaitingFor,
+			CustomStatus: decision.CustomStatus,
+		})
+		return err
+	case decisionCompleted:
+		_, err := tx.TransitionRunToCompleted(ctx, enginedb.TransitionRunToCompletedParams{
+			ID:           run.ID,
+			ClaimedBy:    workerClaimedBy,
+			Result:       decision.Result,
+			CustomStatus: decision.CustomStatus,
+		})
+		return err
+	case decisionFailed:
+		errorCode := decision.FailureCode
+		errorMessage := decision.FailureMessage
+		_, err := tx.TransitionRunToFailed(ctx, enginedb.TransitionRunToFailedParams{
+			ID:               run.ID,
+			ClaimedBy:        workerClaimedBy,
+			CustomStatus:     decision.CustomStatus,
+			LastErrorCode:    &errorCode,
+			LastErrorMessage: &errorMessage,
+		})
+		return err
+	default:
+		return fmt.Errorf("unsupported activation decision kind %q", decision.Kind)
+	}
+}
+
+func sameClaimedBy(left *string, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}

--- a/engine/internal/workflow/activation.go
+++ b/engine/internal/workflow/activation.go
@@ -24,7 +24,7 @@ func NewActivator(store *store.Store, definitions *Registry) *Activator {
 	}
 }
 
-func (a *Activator) Activate(ctx context.Context, claimedRun enginedb.EngineRun) error {
+func (a *Activator) Activate(ctx context.Context, claimedRun *enginedb.EngineRun) error {
 	tx, err := a.store.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func (a *Activator) Activate(ctx context.Context, claimedRun enginedb.EngineRun)
 			FailureCode:    "definition_version_mismatch",
 			FailureMessage: fmt.Sprintf("definition %s@%s is not registered", instance.DefinitionName, run.DefinitionVersion),
 		}
-		if err := a.commitDecision(ctx, tx, instance, run, workerClaimedBy, decision); err != nil {
+		if err := a.commitDecision(ctx, tx, &run, workerClaimedBy, &decision); err != nil {
 			return err
 		}
 		return tx.Commit(ctx)
@@ -86,7 +86,7 @@ func (a *Activator) Activate(ctx context.Context, claimedRun enginedb.EngineRun)
 		return err
 	}
 
-	if err := a.commitDecision(ctx, tx, instance, run, workerClaimedBy, decision); err != nil {
+	if err := a.commitDecision(ctx, tx, &run, workerClaimedBy, &decision); err != nil {
 		return err
 	}
 	if decision.Kind == decisionCompleted {
@@ -101,16 +101,16 @@ func (a *Activator) Activate(ctx context.Context, claimedRun enginedb.EngineRun)
 func (a *Activator) commitDecision(
 	ctx context.Context,
 	tx *store.Tx,
-	instance enginedb.EngineInstance,
-	run enginedb.EngineRun,
+	run *enginedb.EngineRun,
 	workerClaimedBy *string,
-	decision activationDecision,
+	decision *activationDecision,
 ) error {
 	sequence := decision.NextSequence
 	var activityHistoryID *int64
 	var timerHistoryID *int64
 
-	for _, event := range decision.Events {
+	for i := range decision.Events {
+		event := decision.Events[i]
 		appended, err := tx.AppendHistory(ctx, enginedb.AppendHistoryParams{
 			ProjectID:  run.ProjectID,
 			InstanceID: run.InstanceID,
@@ -210,7 +210,7 @@ func (a *Activator) commitDecision(
 	}
 }
 
-func sameClaimedBy(left *string, right *string) bool {
+func sameClaimedBy(left, right *string) bool {
 	if left == nil || right == nil {
 		return left == nil && right == nil
 	}

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -1,0 +1,469 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestActivatorFailsRunWhenDefinitionVersionIsMissing(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	instance, run := createStartedRun(t, store, workflowTestCase{
+		projectID:         uuidOrFatal(t),
+		instanceKey:       "instance-version-mismatch",
+		definitionName:    "demo",
+		definitionVersion: "v-missing",
+	})
+
+	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	activator := NewActivator(store, registry)
+	if err := activator.Activate(ctx, claimed); err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+
+	updatedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if updatedRun.Status != enginedb.EngineRunLifecycleStatusFailed {
+		t.Fatalf("expected failed run status, got %+v", updatedRun)
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	lastEvent := historyRows[len(historyRows)-1]
+	if lastEvent.EventType != enginehistory.EventWorkflowFailed {
+		t.Fatalf("expected terminal workflow.failed event, got %+v", lastEvent)
+	}
+	if instance.InstanceKey != "instance-version-mismatch" {
+		t.Fatalf("unexpected instance returned from setup: %+v", instance)
+	}
+}
+
+func TestActivatorPersistsReplayMismatchFailure(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	testCase := workflowTestCase{
+		projectID:         uuidOrFatal(t),
+		instanceKey:       "instance-replay-mismatch",
+		definitionName:    "demo",
+		definitionVersion: "v1",
+		input:             mustJSON(t, map[string]string{"name": "Ada"}),
+	}
+	instance, run := createStartedRun(t, store, testCase)
+	appendHistoryEvent(t, store, testCase.projectID, instance.ID, run.ID, 2, enginehistory.EventActivityScheduled, enginehistory.ActivityScheduledPayload{
+		ActivityKey:  "different",
+		ActivityType: "demo.activity",
+		Input:        testCase.input,
+	})
+
+	registry, err := NewRegistry(publicworkflow.Definition{
+		Name:    "demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			var input map[string]string
+			if err := ctx.Input(&input); err != nil {
+				return err
+			}
+			var output map[string]string
+			return ctx.Activity("expected", "demo.activity", input, &output)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+
+	activator := NewActivator(store, registry)
+	if err := activator.Activate(ctx, claimed); err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+
+	updatedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if updatedRun.Status != enginedb.EngineRunLifecycleStatusFailed {
+		t.Fatalf("expected failed run status, got %+v", updatedRun)
+	}
+	if updatedRun.LastErrorCode == nil || *updatedRun.LastErrorCode != "replay_mismatch" {
+		t.Fatalf("expected replay_mismatch last_error_code, got %+v", updatedRun)
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	if len(historyRows) != 4 {
+		t.Fatalf("expected started + scheduled + replay mismatch + workflow failed, got %+v", historyRows)
+	}
+	if historyRows[2].EventType != enginehistory.EventWorkflowReplayMismatch {
+		t.Fatalf("expected workflow.replay_mismatch event, got %+v", historyRows[2])
+	}
+	if historyRows[3].EventType != enginehistory.EventWorkflowFailed {
+		t.Fatalf("expected terminal workflow.failed event, got %+v", historyRows[3])
+	}
+}
+
+func TestActivatorRejectsStaleClaimBeforeAppendingHistory(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	testCase := workflowTestCase{
+		projectID:         uuidOrFatal(t),
+		instanceKey:       "instance-stale-claim",
+		definitionName:    "stale-claim",
+		definitionVersion: "v1",
+	}
+	_, run := createStartedRun(t, store, testCase)
+
+	registry, err := NewRegistry(publicworkflow.Definition{
+		Name:    "stale-claim",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			return ctx.SetResult(map[string]bool{"ok": true})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	staleClaim, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() first claim error = %v", err)
+	}
+	if _, err := db.Pool.Exec(ctx, `
+		UPDATE engine.runs
+		SET lease_expires_at = NOW() - INTERVAL '1 minute'
+		WHERE id = $1
+	`, run.ID); err != nil {
+		t.Fatalf("expire run lease: %v", err)
+	}
+	freshClaim, err := store.ClaimNextRun(ctx, "worker-b", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() reclaimed error = %v", err)
+	}
+
+	activator := NewActivator(store, registry)
+	err = activator.Activate(ctx, staleClaim)
+	if !errors.Is(err, enginestore.ErrStaleClaim) {
+		t.Fatalf("expected ErrStaleClaim, got %v", err)
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	if len(historyRows) != 1 || historyRows[0].EventType != enginehistory.EventWorkflowStarted {
+		t.Fatalf("expected no history mutation from stale activation, got %+v", historyRows)
+	}
+
+	if err := activator.Activate(ctx, freshClaim); err != nil {
+		t.Fatalf("Activate() fresh claim error = %v", err)
+	}
+
+	completedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if completedRun.Status != enginedb.EngineRunLifecycleStatusCompleted {
+		t.Fatalf("expected fresh claim to complete run, got %+v", completedRun)
+	}
+}
+
+func TestActivatorLateSignalWakeIsNotStranded(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	testCase := workflowTestCase{
+		projectID:         uuidOrFatal(t),
+		instanceKey:       "instance-late-signal",
+		definitionName:    "late-signal",
+		definitionVersion: "v1",
+	}
+	_, run := createStartedRun(t, store, testCase)
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	var blockedOnce sync.Once
+	registry, err := NewRegistry(publicworkflow.Definition{
+		Name:    "late-signal",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			blockedOnce.Do(func() {
+				close(blocked)
+			})
+			<-release
+
+			var signal map[string]string
+			if err := ctx.ReceiveSignal("approval", &signal); err != nil {
+				return err
+			}
+			return ctx.SetResult(signal)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+
+	activator := NewActivator(store, registry)
+	activationDone := make(chan error, 1)
+	go func() {
+		activationDone <- activator.Activate(ctx, claimed)
+	}()
+
+	select {
+	case <-blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("workflow did not reach blocking point before signal")
+	}
+
+	signalBody := mustJSON(t, map[string]string{"approval": "yes"})
+	type signalResult struct {
+		wakeApplied bool
+		err         error
+	}
+	signalDone := make(chan signalResult, 1)
+	go func() {
+		tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+		if err != nil {
+			signalDone <- signalResult{err: err}
+			return
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		payload, err := enginehistory.MarshalPayload(enginehistory.SignalReceivedPayload{
+			SignalName: "approval",
+			Payload:    signalBody,
+		})
+		if err != nil {
+			signalDone <- signalResult{err: err}
+			return
+		}
+
+		if _, err := tx.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+			ProjectID:   run.ProjectID,
+			InstanceID:  run.InstanceID,
+			RunID:       pgtype.UUID{Bytes: run.ID, Valid: true},
+			Kind:        "signal",
+			Payload:     payload,
+			AvailableAt: time.Now(),
+		}); err != nil {
+			signalDone <- signalResult{err: err}
+			return
+		}
+
+		wake, err := tx.WakeWaitingRun(ctx, run.ID)
+		if err != nil {
+			signalDone <- signalResult{err: err}
+			return
+		}
+		if err := tx.Commit(ctx); err != nil {
+			signalDone <- signalResult{err: err}
+			return
+		}
+		signalDone <- signalResult{wakeApplied: wake.Applied}
+	}()
+
+	close(release)
+
+	select {
+	case err := <-activationDone:
+		if err != nil {
+			t.Fatalf("Activate() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("activation did not finish")
+	}
+
+	var control signalResult
+	select {
+	case control = <-signalDone:
+		if control.err != nil {
+			t.Fatalf("signal transaction error = %v", control.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("signal transaction did not finish")
+	}
+	if !control.wakeApplied {
+		t.Fatal("expected late signal wake to requeue the waiting run")
+	}
+
+	queuedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if queuedRun.Status != enginedb.EngineRunLifecycleStatusQueued {
+		t.Fatalf("expected queued run after late signal wake, got %+v", queuedRun)
+	}
+
+	reclaimed, err := store.ClaimNextRun(ctx, "worker-b", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() second activation error = %v", err)
+	}
+	if err := activator.Activate(ctx, reclaimed); err != nil {
+		t.Fatalf("Activate() second pass error = %v", err)
+	}
+
+	completedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() completed error = %v", err)
+	}
+	if completedRun.Status != enginedb.EngineRunLifecycleStatusCompleted {
+		t.Fatalf("expected completed run after second activation, got %+v", completedRun)
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	eventTypes := make([]string, 0, len(historyRows))
+	for _, row := range historyRows {
+		eventTypes = append(eventTypes, row.EventType)
+	}
+	want := []string{
+		enginehistory.EventWorkflowStarted,
+		enginehistory.EventSignalReceived,
+		enginehistory.EventWorkflowCompleted,
+	}
+	if len(eventTypes) != len(want) {
+		t.Fatalf("unexpected history length: got %v want %v", eventTypes, want)
+	}
+	for index := range want {
+		if eventTypes[index] != want[index] {
+			t.Fatalf("unexpected history order: got %v want %v", eventTypes, want)
+		}
+	}
+}
+
+type workflowTestCase struct {
+	projectID         uuid.UUID
+	instanceKey       string
+	definitionName    string
+	definitionVersion string
+	input             json.RawMessage
+}
+
+func createStartedRun(
+	t *testing.T,
+	store *enginestore.Store,
+	testCase workflowTestCase,
+) (enginedb.EngineInstance, enginedb.EngineRun) {
+	t.Helper()
+
+	ctx := context.Background()
+	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      testCase.projectID,
+		InstanceKey:    testCase.instanceKey,
+		DefinitionName: testCase.definitionName,
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         testCase.projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: testCase.definitionVersion,
+		ReadyAt:           time.Now().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+
+	appendHistoryEvent(t, store, testCase.projectID, instance.ID, run.ID, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+		DefinitionName:    testCase.definitionName,
+		DefinitionVersion: testCase.definitionVersion,
+		InstanceKey:       testCase.instanceKey,
+		Input:             testCase.input,
+	})
+
+	return instance, run
+}
+
+func appendHistoryEvent(
+	t *testing.T,
+	store *enginestore.Store,
+	projectID uuid.UUID,
+	instanceID uuid.UUID,
+	runID uuid.UUID,
+	sequenceNo int32,
+	eventType string,
+	payload any,
+) {
+	t.Helper()
+
+	raw, err := enginehistory.MarshalPayload(payload)
+	if err != nil {
+		t.Fatalf("MarshalPayload() error = %v", err)
+	}
+	if _, err := store.AppendHistory(context.Background(), enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instanceID,
+		RunID:      runID,
+		SequenceNo: sequenceNo,
+		EventType:  eventType,
+		Payload:    raw,
+	}); err != nil {
+		t.Fatalf("AppendHistory() error = %v", err)
+	}
+}
+
+func mustJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return raw
+}
+
+func uuidOrFatal(t *testing.T) uuid.UUID {
+	t.Helper()
+
+	id, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("uuid.NewV7() error = %v", err)
+	}
+	return id
+}

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -41,7 +41,7 @@ func TestActivatorFailsRunWhenDefinitionVersionIsMissing(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 	activator := NewActivator(store, registry)
-	if err := activator.Activate(ctx, claimed); err != nil {
+	if err := activator.Activate(ctx, &claimed); err != nil {
 		t.Fatalf("Activate() error = %v", err)
 	}
 
@@ -107,7 +107,7 @@ func TestActivatorPersistsReplayMismatchFailure(t *testing.T) {
 	}
 
 	activator := NewActivator(store, registry)
-	if err := activator.Activate(ctx, claimed); err != nil {
+	if err := activator.Activate(ctx, &claimed); err != nil {
 		t.Fatalf("Activate() error = %v", err)
 	}
 
@@ -178,7 +178,7 @@ func TestActivatorRejectsStaleClaimBeforeAppendingHistory(t *testing.T) {
 	}
 
 	activator := NewActivator(store, registry)
-	err = activator.Activate(ctx, staleClaim)
+	err = activator.Activate(ctx, &staleClaim)
 	if !errors.Is(err, enginestore.ErrStaleClaim) {
 		t.Fatalf("expected ErrStaleClaim, got %v", err)
 	}
@@ -191,7 +191,7 @@ func TestActivatorRejectsStaleClaimBeforeAppendingHistory(t *testing.T) {
 		t.Fatalf("expected no history mutation from stale activation, got %+v", historyRows)
 	}
 
-	if err := activator.Activate(ctx, freshClaim); err != nil {
+	if err := activator.Activate(ctx, &freshClaim); err != nil {
 		t.Fatalf("Activate() fresh claim error = %v", err)
 	}
 
@@ -248,7 +248,7 @@ func TestActivatorLateSignalWakeIsNotStranded(t *testing.T) {
 	activator := NewActivator(store, registry)
 	activationDone := make(chan error, 1)
 	go func() {
-		activationDone <- activator.Activate(ctx, claimed)
+		activationDone <- activator.Activate(ctx, &claimed)
 	}()
 
 	select {
@@ -340,7 +340,7 @@ func TestActivatorLateSignalWakeIsNotStranded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ClaimNextRun() second activation error = %v", err)
 	}
-	if err := activator.Activate(ctx, reclaimed); err != nil {
+	if err := activator.Activate(ctx, &reclaimed); err != nil {
 		t.Fatalf("Activate() second pass error = %v", err)
 	}
 

--- a/engine/internal/workflow/registry.go
+++ b/engine/internal/workflow/registry.go
@@ -1,0 +1,45 @@
+package workflow
+
+import (
+	"fmt"
+
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+type definitionKey struct {
+	name    string
+	version string
+}
+
+type Registry struct {
+	definitions map[definitionKey]publicworkflow.Definition
+}
+
+func NewRegistry(definitions ...publicworkflow.Definition) (*Registry, error) {
+	registry := &Registry{
+		definitions: make(map[definitionKey]publicworkflow.Definition, len(definitions)),
+	}
+
+	for _, definition := range definitions {
+		if definition.Name == "" || definition.Version == "" || definition.Run == nil {
+			return nil, fmt.Errorf("workflow definition must include name, version, and run function")
+		}
+
+		key := definitionKey{name: definition.Name, version: definition.Version}
+		if _, exists := registry.definitions[key]; exists {
+			return nil, fmt.Errorf("duplicate workflow definition %s@%s", definition.Name, definition.Version)
+		}
+		registry.definitions[key] = definition
+	}
+
+	return registry, nil
+}
+
+func (r *Registry) Get(name, version string) (publicworkflow.Definition, bool) {
+	if r == nil {
+		return publicworkflow.Definition{}, false
+	}
+
+	definition, ok := r.definitions[definitionKey{name: name, version: version}]
+	return definition, ok
+}

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -62,6 +62,11 @@ type pendingTimer struct {
 	payload enginehistory.TimerScheduledPayload
 }
 
+type pendingInboxItem struct {
+	inboxID uuid.UUID
+	kind    string
+}
+
 type blockedPanic struct{}
 
 type replayMismatchPanic struct {
@@ -88,8 +93,7 @@ type workflowRunner struct {
 	pendingActivities map[string]activityOutcome
 	pendingSignals    map[string][]pendingSignal
 	pendingTimers     map[string]pendingTimer
-	pendingCancels    []uuid.UUID
-	frontierPrepared  bool
+	pendingFrontier   []pendingInboxItem
 
 	queuedEvents     []queuedHistoryEvent
 	waitingFor       json.RawMessage
@@ -137,7 +141,8 @@ func newWorkflowRunner(
 		pendingTimers:     make(map[string]pendingTimer),
 	}
 
-	for _, row := range historyRows[1:] {
+	for i := 1; i < len(historyRows); i++ {
+		row := historyRows[i]
 		payload, err := enginehistory.DecodePayload(row.EventType, row.Payload)
 		if err != nil {
 			return nil, fmt.Errorf("decode history event %s: %w", row.EventType, err)
@@ -152,7 +157,8 @@ func newWorkflowRunner(
 		})
 	}
 
-	for _, task := range activityTasks {
+	for i := range activityTasks {
+		task := activityTasks[i]
 		switch task.Status {
 		case enginedb.EngineActivityTaskStatusCompleted:
 			runner.pendingActivities[task.ActivityKey] = activityOutcome{
@@ -174,7 +180,8 @@ func newWorkflowRunner(
 		}
 	}
 
-	for _, inboxRow := range inboxRows {
+	for i := range inboxRows {
+		inboxRow := inboxRows[i]
 		switch inboxRow.Kind {
 		case "timer":
 			timerPayload := enginehistory.TimerScheduledPayload{}
@@ -195,10 +202,14 @@ func newWorkflowRunner(
 				pendingSignal{inboxID: inboxRow.ID, payload: signalPayload},
 			)
 		case "cancel":
-			runner.pendingCancels = append(runner.pendingCancels, inboxRow.ID)
 		default:
 			return nil, fmt.Errorf("unsupported inbox kind %q", inboxRow.Kind)
 		}
+
+		runner.pendingFrontier = append(runner.pendingFrontier, pendingInboxItem{
+			inboxID: inboxRow.ID,
+			kind:    inboxRow.Kind,
+		})
 	}
 
 	return runner, nil
@@ -292,7 +303,7 @@ func (r *workflowRunner) Input(out any) error {
 	return json.Unmarshal(r.input, out)
 }
 
-func (r *workflowRunner) Activity(key, activityType string, input any, out any) error {
+func (r *workflowRunner) Activity(key, activityType string, input, out any) error {
 	if key == "" {
 		return publicworkflow.ErrEmptyKey
 	}
@@ -397,6 +408,7 @@ func (r *workflowRunner) SleepUntil(key string, at time.Time) error {
 		}
 
 		if pending, ok := r.pendingTimers[key]; ok && pending.payload.DueAt.Equal(at) {
+			r.removePendingFrontier(pending.inboxID)
 			r.queueEvent(enginehistory.EventTimerFired, enginehistory.TimerFiredPayload{TimerKey: key})
 			r.consumedInboxIDs = append(r.consumedInboxIDs, pending.inboxID)
 			delete(r.pendingTimers, key)
@@ -447,6 +459,7 @@ func (r *workflowRunner) ReceiveSignal(name string, out any) error {
 	if signals := r.pendingSignals[name]; len(signals) > 0 {
 		nextSignal := signals[0]
 		r.pendingSignals[name] = signals[1:]
+		r.removePendingFrontier(nextSignal.inboxID)
 		r.queueEvent(enginehistory.EventSignalReceived, nextSignal.payload)
 		r.consumedInboxIDs = append(r.consumedInboxIDs, nextSignal.inboxID)
 		return unmarshalOptional(nextSignal.payload.Payload, out)
@@ -501,7 +514,7 @@ func (r *workflowRunner) SetResult(value any) error {
 
 func (r *workflowRunner) advanceState() {
 	r.consumeRecordedCancels()
-	r.prepareFrontier()
+	r.consumeFrontierCancels()
 }
 
 func (r *workflowRunner) consumeRecordedCancels() {
@@ -515,21 +528,18 @@ func (r *workflowRunner) consumeRecordedCancels() {
 	}
 }
 
-func (r *workflowRunner) prepareFrontier() {
-	if r.frontierPrepared || r.cursor != len(r.replayEvents) {
+func (r *workflowRunner) consumeFrontierCancels() {
+	if r.cursor != len(r.replayEvents) {
 		return
 	}
 
-	if len(r.pendingCancels) > 0 {
+	for len(r.pendingFrontier) > 0 && r.pendingFrontier[0].kind == "cancel" {
+		nextCancel := r.pendingFrontier[0]
+		r.pendingFrontier = r.pendingFrontier[1:]
 		r.cancelRequested = true
-		for _, inboxID := range r.pendingCancels {
-			r.queueEvent(enginehistory.EventCancelRequested, enginehistory.CancelRequestedPayload{})
-			r.consumedInboxIDs = append(r.consumedInboxIDs, inboxID)
-		}
-		r.pendingCancels = nil
+		r.queueEvent(enginehistory.EventCancelRequested, enginehistory.CancelRequestedPayload{})
+		r.consumedInboxIDs = append(r.consumedInboxIDs, nextCancel.inboxID)
 	}
-
-	r.frontierPrepared = true
 }
 
 func (r *workflowRunner) peek() (decodedEvent, bool) {
@@ -546,6 +556,19 @@ func (r *workflowRunner) queueEvent(eventType string, payload any) {
 	})
 }
 
+func (r *workflowRunner) removePendingFrontier(inboxID uuid.UUID) {
+	for idx, item := range r.pendingFrontier {
+		if item.inboxID != inboxID {
+			continue
+		}
+
+		r.pendingFrontier = append(r.pendingFrontier[:idx], r.pendingFrontier[idx+1:]...)
+		return
+	}
+
+	panic(fmt.Sprintf("frontier inbox %s missing from pending frontier", inboxID))
+}
+
 func (r *workflowRunner) blockOnWait(wait any, scheduledEvent *queuedHistoryEvent, _ any) {
 	if scheduledEvent != nil {
 		r.queuedEvents = append(r.queuedEvents, *scheduledEvent)
@@ -558,7 +581,7 @@ func (r *workflowRunner) blockOnWait(wait any, scheduledEvent *queuedHistoryEven
 	panic(blockedPanic{})
 }
 
-func (r *workflowRunner) replayMismatch(expectedType string, expectedKey string, actual decodedEvent, detail string) {
+func (r *workflowRunner) replayMismatch(expectedType, expectedKey string, actual decodedEvent, detail string) {
 	panic(replayMismatchPanic{
 		payload: enginehistory.WorkflowReplayMismatchPayload{
 			ExpectedType: expectedType,
@@ -608,8 +631,7 @@ func (r *workflowRunner) failedDecision(failure enginehistory.WorkflowFailedPayl
 
 func matchActivityScheduled(
 	recorded *enginehistory.ActivityScheduledPayload,
-	key string,
-	activityType string,
+	key, activityType string,
 	input json.RawMessage,
 ) bool {
 	return recorded.ActivityKey == key &&
@@ -632,7 +654,7 @@ func unmarshalOptional(raw []byte, out any) error {
 	return json.Unmarshal(raw, out)
 }
 
-func equalJSON(left json.RawMessage, right json.RawMessage) bool {
+func equalJSON(left, right json.RawMessage) bool {
 	if bytes.Equal(bytes.TrimSpace(left), bytes.TrimSpace(right)) {
 		return true
 	}

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -1,0 +1,666 @@
+package workflow
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/google/uuid"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+type decisionKind string
+
+const (
+	decisionWaiting   decisionKind = "waiting"
+	decisionCompleted decisionKind = "completed"
+	decisionFailed    decisionKind = "failed"
+)
+
+type queuedHistoryEvent struct {
+	EventType string
+	Payload   json.RawMessage
+}
+
+type activationDecision struct {
+	Kind             decisionKind
+	Events           []queuedHistoryEvent
+	NextSequence     int32
+	WaitingFor       json.RawMessage
+	CustomStatus     json.RawMessage
+	Result           json.RawMessage
+	NewActivity      *enginehistory.ActivityScheduledPayload
+	NewTimer         *enginehistory.TimerScheduledPayload
+	ConsumedInboxIDs []uuid.UUID
+	FailureCode      string
+	FailureMessage   string
+}
+
+type decodedEvent struct {
+	EventType string
+	Payload   any
+}
+
+type activityOutcome struct {
+	completed *enginehistory.ActivityCompletedPayload
+	failed    *enginehistory.ActivityFailedPayload
+}
+
+type pendingSignal struct {
+	inboxID uuid.UUID
+	payload enginehistory.SignalReceivedPayload
+}
+
+type pendingTimer struct {
+	inboxID uuid.UUID
+	payload enginehistory.TimerScheduledPayload
+}
+
+type blockedPanic struct{}
+
+type replayMismatchPanic struct {
+	payload enginehistory.WorkflowReplayMismatchPayload
+}
+
+type codedWorkflowError struct {
+	code    string
+	message string
+}
+
+func (e codedWorkflowError) Error() string {
+	return e.message
+}
+
+type workflowRunner struct {
+	input             json.RawMessage
+	replayEvents      []decodedEvent
+	cursor            int
+	nextSequence      int32
+	customStatus      json.RawMessage
+	result            json.RawMessage
+	cancelRequested   bool
+	pendingActivities map[string]activityOutcome
+	pendingSignals    map[string][]pendingSignal
+	pendingTimers     map[string]pendingTimer
+	pendingCancels    []uuid.UUID
+	frontierPrepared  bool
+
+	queuedEvents     []queuedHistoryEvent
+	waitingFor       json.RawMessage
+	newActivity      *enginehistory.ActivityScheduledPayload
+	newTimer         *enginehistory.TimerScheduledPayload
+	consumedInboxIDs []uuid.UUID
+}
+
+func replayDefinition(
+	definition publicworkflow.Definition,
+	historyRows []enginedb.EngineHistory,
+	activityTasks []enginedb.EngineActivityTask,
+	inboxRows []enginedb.EngineInbox,
+) (activationDecision, error) {
+	runner, err := newWorkflowRunner(historyRows, activityTasks, inboxRows)
+	if err != nil {
+		return activationDecision{}, err
+	}
+
+	return runner.execute(definition)
+}
+
+func newWorkflowRunner(
+	historyRows []enginedb.EngineHistory,
+	activityTasks []enginedb.EngineActivityTask,
+	inboxRows []enginedb.EngineInbox,
+) (*workflowRunner, error) {
+	if len(historyRows) == 0 {
+		return nil, fmt.Errorf("workflow replay requires at least one history event")
+	}
+	if historyRows[0].EventType != enginehistory.EventWorkflowStarted {
+		return nil, fmt.Errorf("first history event must be %s", enginehistory.EventWorkflowStarted)
+	}
+
+	startedPayload := enginehistory.WorkflowStartedPayload{}
+	if err := enginehistory.UnmarshalPayload(historyRows[0].Payload, &startedPayload); err != nil {
+		return nil, fmt.Errorf("decode workflow.started payload: %w", err)
+	}
+
+	runner := &workflowRunner{
+		input:             cloneRaw(startedPayload.Input),
+		nextSequence:      historyRows[len(historyRows)-1].SequenceNo + 1,
+		pendingActivities: make(map[string]activityOutcome),
+		pendingSignals:    make(map[string][]pendingSignal),
+		pendingTimers:     make(map[string]pendingTimer),
+	}
+
+	for _, row := range historyRows[1:] {
+		payload, err := enginehistory.DecodePayload(row.EventType, row.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("decode history event %s: %w", row.EventType, err)
+		}
+		if statusPayload, ok := payload.(*enginehistory.CustomStatusUpdatedPayload); ok {
+			runner.customStatus = cloneRaw(statusPayload.Status)
+		}
+
+		runner.replayEvents = append(runner.replayEvents, decodedEvent{
+			EventType: row.EventType,
+			Payload:   payload,
+		})
+	}
+
+	for _, task := range activityTasks {
+		switch task.Status {
+		case enginedb.EngineActivityTaskStatusCompleted:
+			runner.pendingActivities[task.ActivityKey] = activityOutcome{
+				completed: &enginehistory.ActivityCompletedPayload{
+					ActivityKey:  task.ActivityKey,
+					ActivityType: task.ActivityType,
+					Output:       cloneRaw(task.Output),
+				},
+			}
+		case enginedb.EngineActivityTaskStatusFailed:
+			runner.pendingActivities[task.ActivityKey] = activityOutcome{
+				failed: &enginehistory.ActivityFailedPayload{
+					ActivityKey:  task.ActivityKey,
+					ActivityType: task.ActivityType,
+					ErrorCode:    stringValue(task.LastErrorCode),
+					ErrorMessage: stringValue(task.LastErrorMessage),
+				},
+			}
+		}
+	}
+
+	for _, inboxRow := range inboxRows {
+		switch inboxRow.Kind {
+		case "timer":
+			timerPayload := enginehistory.TimerScheduledPayload{}
+			if err := enginehistory.UnmarshalPayload(inboxRow.Payload, &timerPayload); err != nil {
+				return nil, fmt.Errorf("decode timer inbox payload: %w", err)
+			}
+			runner.pendingTimers[timerPayload.TimerKey] = pendingTimer{
+				inboxID: inboxRow.ID,
+				payload: timerPayload,
+			}
+		case "signal":
+			signalPayload := enginehistory.SignalReceivedPayload{}
+			if err := enginehistory.UnmarshalPayload(inboxRow.Payload, &signalPayload); err != nil {
+				return nil, fmt.Errorf("decode signal inbox payload: %w", err)
+			}
+			runner.pendingSignals[signalPayload.SignalName] = append(
+				runner.pendingSignals[signalPayload.SignalName],
+				pendingSignal{inboxID: inboxRow.ID, payload: signalPayload},
+			)
+		case "cancel":
+			runner.pendingCancels = append(runner.pendingCancels, inboxRow.ID)
+		default:
+			return nil, fmt.Errorf("unsupported inbox kind %q", inboxRow.Kind)
+		}
+	}
+
+	return runner, nil
+}
+
+func (r *workflowRunner) execute(definition publicworkflow.Definition) (decision activationDecision, err error) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			return
+		}
+
+		switch value := recovered.(type) {
+		case blockedPanic:
+			decision = r.waitingDecision()
+			err = nil
+		case replayMismatchPanic:
+			r.queueEvent(enginehistory.EventWorkflowReplayMismatch, value.payload)
+			failure := enginehistory.WorkflowFailedPayload{
+				ErrorCode:    "replay_mismatch",
+				ErrorMessage: value.payload.Detail,
+			}
+			r.queueEvent(enginehistory.EventWorkflowFailed, failure)
+			decision = r.failedDecision(failure)
+			err = nil
+		default:
+			panicMessage := fmt.Sprintf("workflow panic: %v", value)
+			failure := enginehistory.WorkflowFailedPayload{
+				ErrorCode:    "workflow_panic",
+				ErrorMessage: panicMessage,
+			}
+			r.advanceState()
+			r.queueEvent(enginehistory.EventWorkflowFailed, failure)
+			decision = r.failedDecision(failure)
+			err = nil
+		}
+	}()
+
+	runErr := definition.Run(r)
+	r.advanceState()
+
+	if runErr != nil {
+		code := "workflow_failed"
+		message := runErr.Error()
+		var coded codedWorkflowError
+		if errors.As(runErr, &coded) {
+			code = coded.code
+			message = coded.message
+		}
+		failure := enginehistory.WorkflowFailedPayload{
+			ErrorCode:    code,
+			ErrorMessage: message,
+		}
+		if next, ok := r.peek(); ok {
+			recorded, ok := next.Payload.(*enginehistory.WorkflowFailedPayload)
+			if !ok || recorded.ErrorCode != failure.ErrorCode || recorded.ErrorMessage != failure.ErrorMessage {
+				r.replayMismatch(enginehistory.EventWorkflowFailed, "", next, "workflow failure did not match recorded history")
+			}
+			r.cursor++
+		} else {
+			r.queueEvent(enginehistory.EventWorkflowFailed, failure)
+		}
+		if next, ok := r.peek(); ok {
+			r.replayMismatch("", "", next, "recorded history contains events after workflow failure")
+		}
+		return r.failedDecision(failure), nil
+	}
+
+	completed := enginehistory.WorkflowCompletedPayload{Result: cloneRaw(r.result)}
+	if next, ok := r.peek(); ok {
+		recorded, ok := next.Payload.(*enginehistory.WorkflowCompletedPayload)
+		if !ok || !equalJSON(recorded.Result, completed.Result) {
+			r.replayMismatch(enginehistory.EventWorkflowCompleted, "", next, "workflow completion did not match recorded history")
+		}
+		r.cursor++
+	} else {
+		r.queueEvent(enginehistory.EventWorkflowCompleted, completed)
+	}
+	if next, ok := r.peek(); ok {
+		r.replayMismatch("", "", next, "recorded history contains events after workflow completion")
+	}
+
+	return r.completedDecision(), nil
+}
+
+func (r *workflowRunner) Input(out any) error {
+	r.advanceState()
+	if out == nil || len(r.input) == 0 {
+		return nil
+	}
+	return json.Unmarshal(r.input, out)
+}
+
+func (r *workflowRunner) Activity(key, activityType string, input any, out any) error {
+	if key == "" {
+		return publicworkflow.ErrEmptyKey
+	}
+	r.advanceState()
+
+	inputRaw, err := enginehistory.MarshalPayload(input)
+	if err != nil {
+		return err
+	}
+
+	if next, ok := r.peek(); ok {
+		scheduled, ok := next.Payload.(*enginehistory.ActivityScheduledPayload)
+		if !ok || !matchActivityScheduled(scheduled, key, activityType, inputRaw) {
+			r.replayMismatch(enginehistory.EventActivityScheduled, key, next, "activity scheduling did not match recorded history")
+		}
+		r.cursor++
+		r.advanceState()
+
+		if outcomeEvent, ok := r.peek(); ok {
+			switch payload := outcomeEvent.Payload.(type) {
+			case *enginehistory.ActivityCompletedPayload:
+				if payload.ActivityKey == key && payload.ActivityType == activityType {
+					r.cursor++
+					return unmarshalOptional(payload.Output, out)
+				}
+			case *enginehistory.ActivityFailedPayload:
+				if payload.ActivityKey == key && payload.ActivityType == activityType {
+					r.cursor++
+					return codedWorkflowError{
+						code:    payload.ErrorCode,
+						message: payload.ErrorMessage,
+					}
+				}
+			}
+		}
+
+		if outcome, ok := r.pendingActivities[key]; ok {
+			if outcome.completed != nil && outcome.completed.ActivityType == activityType {
+				r.queueEvent(enginehistory.EventActivityCompleted, *outcome.completed)
+				return unmarshalOptional(outcome.completed.Output, out)
+			}
+			if outcome.failed != nil && outcome.failed.ActivityType == activityType {
+				r.queueEvent(enginehistory.EventActivityFailed, *outcome.failed)
+				return codedWorkflowError{
+					code:    outcome.failed.ErrorCode,
+					message: outcome.failed.ErrorMessage,
+				}
+			}
+		}
+
+		if nextAfter, ok := r.peek(); ok {
+			r.replayMismatch(enginehistory.EventActivityCompleted, key, nextAfter, "activity history is missing a terminal outcome")
+		}
+
+		r.blockOnWait(enginehistory.ActivityWait{
+			Kind:         enginehistory.WaitKindActivity,
+			ActivityKey:  key,
+			ActivityType: activityType,
+		}, nil, nil)
+		return nil
+	}
+
+	r.advanceState()
+	scheduled := enginehistory.ActivityScheduledPayload{
+		ActivityKey:  key,
+		ActivityType: activityType,
+		Input:        cloneRaw(inputRaw),
+	}
+	r.newActivity = &scheduled
+	r.blockOnWait(
+		enginehistory.ActivityWait{
+			Kind:         enginehistory.WaitKindActivity,
+			ActivityKey:  key,
+			ActivityType: activityType,
+		},
+		&queuedHistoryEvent{EventType: enginehistory.EventActivityScheduled, Payload: mustMarshalPayload(scheduled)},
+		nil,
+	)
+	return nil
+}
+
+func (r *workflowRunner) SleepUntil(key string, at time.Time) error {
+	if key == "" {
+		return publicworkflow.ErrEmptyKey
+	}
+	r.advanceState()
+
+	if next, ok := r.peek(); ok {
+		scheduled, ok := next.Payload.(*enginehistory.TimerScheduledPayload)
+		if !ok || scheduled.TimerKey != key || !scheduled.DueAt.Equal(at) {
+			r.replayMismatch(enginehistory.EventTimerScheduled, key, next, "timer scheduling did not match recorded history")
+		}
+		r.cursor++
+		r.advanceState()
+
+		if firedEvent, ok := r.peek(); ok {
+			fired, ok := firedEvent.Payload.(*enginehistory.TimerFiredPayload)
+			if ok && fired.TimerKey == key {
+				r.cursor++
+				return nil
+			}
+		}
+
+		if pending, ok := r.pendingTimers[key]; ok && pending.payload.DueAt.Equal(at) {
+			r.queueEvent(enginehistory.EventTimerFired, enginehistory.TimerFiredPayload{TimerKey: key})
+			r.consumedInboxIDs = append(r.consumedInboxIDs, pending.inboxID)
+			delete(r.pendingTimers, key)
+			return nil
+		}
+
+		if nextAfter, ok := r.peek(); ok {
+			r.replayMismatch(enginehistory.EventTimerFired, key, nextAfter, "timer history is missing a fired event")
+		}
+
+		r.blockOnWait(enginehistory.TimerWait{
+			Kind:     enginehistory.WaitKindTimer,
+			TimerKey: key,
+			DueAt:    at,
+		}, nil, nil)
+		return nil
+	}
+
+	r.advanceState()
+	scheduled := enginehistory.TimerScheduledPayload{
+		TimerKey: key,
+		DueAt:    at,
+	}
+	r.newTimer = &scheduled
+	r.blockOnWait(
+		enginehistory.TimerWait{
+			Kind:     enginehistory.WaitKindTimer,
+			TimerKey: key,
+			DueAt:    at,
+		},
+		&queuedHistoryEvent{EventType: enginehistory.EventTimerScheduled, Payload: mustMarshalPayload(scheduled)},
+		nil,
+	)
+	return nil
+}
+
+func (r *workflowRunner) ReceiveSignal(name string, out any) error {
+	r.advanceState()
+	if next, ok := r.peek(); ok {
+		recorded, ok := next.Payload.(*enginehistory.SignalReceivedPayload)
+		if !ok || recorded.SignalName != name {
+			r.replayMismatch(enginehistory.EventSignalReceived, name, next, "signal receive did not match recorded history")
+		}
+		r.cursor++
+		return unmarshalOptional(recorded.Payload, out)
+	}
+
+	if signals := r.pendingSignals[name]; len(signals) > 0 {
+		nextSignal := signals[0]
+		r.pendingSignals[name] = signals[1:]
+		r.queueEvent(enginehistory.EventSignalReceived, nextSignal.payload)
+		r.consumedInboxIDs = append(r.consumedInboxIDs, nextSignal.inboxID)
+		return unmarshalOptional(nextSignal.payload.Payload, out)
+	}
+
+	r.blockOnWait(enginehistory.SignalWait{
+		Kind:       enginehistory.WaitKindSignal,
+		SignalName: name,
+	}, nil, nil)
+	return nil
+}
+
+func (r *workflowRunner) CancellationRequested() bool {
+	r.advanceState()
+	return r.cancelRequested
+}
+
+func (r *workflowRunner) SetCustomStatus(value any) error {
+	r.advanceState()
+
+	statusRaw, err := enginehistory.MarshalPayload(value)
+	if err != nil {
+		return err
+	}
+
+	if next, ok := r.peek(); ok {
+		recorded, ok := next.Payload.(*enginehistory.CustomStatusUpdatedPayload)
+		if !ok || !equalJSON(recorded.Status, statusRaw) {
+			r.replayMismatch(enginehistory.EventCustomStatusUpdated, "", next, "custom status update did not match recorded history")
+		}
+		r.customStatus = cloneRaw(statusRaw)
+		r.cursor++
+		return nil
+	}
+
+	r.customStatus = cloneRaw(statusRaw)
+	r.queueEvent(enginehistory.EventCustomStatusUpdated, enginehistory.CustomStatusUpdatedPayload{
+		Status: cloneRaw(statusRaw),
+	})
+	return nil
+}
+
+func (r *workflowRunner) SetResult(value any) error {
+	r.advanceState()
+	resultRaw, err := enginehistory.MarshalPayload(value)
+	if err != nil {
+		return err
+	}
+	r.result = cloneRaw(resultRaw)
+	return nil
+}
+
+func (r *workflowRunner) advanceState() {
+	r.consumeRecordedCancels()
+	r.prepareFrontier()
+}
+
+func (r *workflowRunner) consumeRecordedCancels() {
+	for {
+		next, ok := r.peek()
+		if !ok || next.EventType != enginehistory.EventCancelRequested {
+			return
+		}
+		r.cancelRequested = true
+		r.cursor++
+	}
+}
+
+func (r *workflowRunner) prepareFrontier() {
+	if r.frontierPrepared || r.cursor != len(r.replayEvents) {
+		return
+	}
+
+	if len(r.pendingCancels) > 0 {
+		r.cancelRequested = true
+		for _, inboxID := range r.pendingCancels {
+			r.queueEvent(enginehistory.EventCancelRequested, enginehistory.CancelRequestedPayload{})
+			r.consumedInboxIDs = append(r.consumedInboxIDs, inboxID)
+		}
+		r.pendingCancels = nil
+	}
+
+	r.frontierPrepared = true
+}
+
+func (r *workflowRunner) peek() (decodedEvent, bool) {
+	if r.cursor >= len(r.replayEvents) {
+		return decodedEvent{}, false
+	}
+	return r.replayEvents[r.cursor], true
+}
+
+func (r *workflowRunner) queueEvent(eventType string, payload any) {
+	r.queuedEvents = append(r.queuedEvents, queuedHistoryEvent{
+		EventType: eventType,
+		Payload:   mustMarshalPayload(payload),
+	})
+}
+
+func (r *workflowRunner) blockOnWait(wait any, scheduledEvent *queuedHistoryEvent, _ any) {
+	if scheduledEvent != nil {
+		r.queuedEvents = append(r.queuedEvents, *scheduledEvent)
+	}
+	waitingFor, err := enginehistory.MarshalPayload(wait)
+	if err != nil {
+		panic(fmt.Sprintf("marshal waiting state: %v", err))
+	}
+	r.waitingFor = waitingFor
+	panic(blockedPanic{})
+}
+
+func (r *workflowRunner) replayMismatch(expectedType string, expectedKey string, actual decodedEvent, detail string) {
+	panic(replayMismatchPanic{
+		payload: enginehistory.WorkflowReplayMismatchPayload{
+			ExpectedType: expectedType,
+			ExpectedKey:  expectedKey,
+			ActualType:   actual.EventType,
+			ActualKey:    enginehistory.EventKey(actual.EventType, actual.Payload),
+			Detail:       detail,
+		},
+	})
+}
+
+func (r *workflowRunner) waitingDecision() activationDecision {
+	return activationDecision{
+		Kind:             decisionWaiting,
+		Events:           append([]queuedHistoryEvent(nil), r.queuedEvents...),
+		NextSequence:     r.nextSequence,
+		WaitingFor:       cloneRaw(r.waitingFor),
+		CustomStatus:     cloneRaw(r.customStatus),
+		NewActivity:      r.newActivity,
+		NewTimer:         r.newTimer,
+		ConsumedInboxIDs: append([]uuid.UUID(nil), r.consumedInboxIDs...),
+	}
+}
+
+func (r *workflowRunner) completedDecision() activationDecision {
+	return activationDecision{
+		Kind:             decisionCompleted,
+		Events:           append([]queuedHistoryEvent(nil), r.queuedEvents...),
+		NextSequence:     r.nextSequence,
+		CustomStatus:     cloneRaw(r.customStatus),
+		Result:           cloneRaw(r.result),
+		ConsumedInboxIDs: append([]uuid.UUID(nil), r.consumedInboxIDs...),
+	}
+}
+
+func (r *workflowRunner) failedDecision(failure enginehistory.WorkflowFailedPayload) activationDecision {
+	return activationDecision{
+		Kind:             decisionFailed,
+		Events:           append([]queuedHistoryEvent(nil), r.queuedEvents...),
+		NextSequence:     r.nextSequence,
+		CustomStatus:     cloneRaw(r.customStatus),
+		ConsumedInboxIDs: append([]uuid.UUID(nil), r.consumedInboxIDs...),
+		FailureCode:      failure.ErrorCode,
+		FailureMessage:   failure.ErrorMessage,
+	}
+}
+
+func matchActivityScheduled(
+	recorded *enginehistory.ActivityScheduledPayload,
+	key string,
+	activityType string,
+	input json.RawMessage,
+) bool {
+	return recorded.ActivityKey == key &&
+		recorded.ActivityType == activityType &&
+		equalJSON(recorded.Input, input)
+}
+
+func mustMarshalPayload(payload any) json.RawMessage {
+	raw, err := enginehistory.MarshalPayload(payload)
+	if err != nil {
+		panic(fmt.Sprintf("marshal history payload: %v", err))
+	}
+	return raw
+}
+
+func unmarshalOptional(raw []byte, out any) error {
+	if out == nil || len(raw) == 0 {
+		return nil
+	}
+	return json.Unmarshal(raw, out)
+}
+
+func equalJSON(left json.RawMessage, right json.RawMessage) bool {
+	if bytes.Equal(bytes.TrimSpace(left), bytes.TrimSpace(right)) {
+		return true
+	}
+	if len(left) == 0 && len(right) == 0 {
+		return true
+	}
+
+	var leftValue any
+	var rightValue any
+	if err := json.Unmarshal(left, &leftValue); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(right, &rightValue); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
+}
+
+func cloneRaw(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/engine/internal/workflow/replay_test.go
+++ b/engine/internal/workflow/replay_test.go
@@ -1,0 +1,261 @@
+package workflow
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestReplayDefinitionHappyPath(t *testing.T) {
+	input, _ := json.Marshal(map[string]string{"name": "Ada"})
+	output, _ := json.Marshal(map[string]string{"greeting": "hello, Ada"})
+	signal, _ := json.Marshal(map[string]string{"approval": "yes"})
+	result, _ := json.Marshal(map[string]string{"greeting": "hello, Ada", "approval": "yes"})
+	timerAt := time.Unix(0, 0).UTC()
+
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-1",
+			Input:             input,
+		}),
+		historyRow(t, 2, enginehistory.EventActivityScheduled, enginehistory.ActivityScheduledPayload{
+			ActivityKey:  "fetch",
+			ActivityType: "demo.activity",
+			Input:        input,
+		}),
+		historyRow(t, 3, enginehistory.EventActivityCompleted, enginehistory.ActivityCompletedPayload{
+			ActivityKey:  "fetch",
+			ActivityType: "demo.activity",
+			Output:       output,
+		}),
+		historyRow(t, 4, enginehistory.EventTimerScheduled, enginehistory.TimerScheduledPayload{
+			TimerKey: "deadline",
+			DueAt:    timerAt,
+		}),
+		historyRow(t, 5, enginehistory.EventTimerFired, enginehistory.TimerFiredPayload{
+			TimerKey: "deadline",
+		}),
+		historyRow(t, 6, enginehistory.EventSignalReceived, enginehistory.SignalReceivedPayload{
+			SignalName: "approval",
+			Payload:    signal,
+		}),
+		historyRow(t, 7, enginehistory.EventWorkflowCompleted, enginehistory.WorkflowCompletedPayload{
+			Result: result,
+		}),
+	}
+
+	decision, err := replayDefinition(testDefinition(timerAt), historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision, got %+v", decision)
+	}
+	if len(decision.Events) != 0 {
+		t.Fatalf("expected no new history events during replay, got %+v", decision.Events)
+	}
+	if !equalJSON(decision.Result, result) {
+		t.Fatalf("expected replayed result %s, got %s", result, decision.Result)
+	}
+}
+
+func TestReplayDefinitionMismatchProducesFailureDecision(t *testing.T) {
+	input, _ := json.Marshal(map[string]string{"name": "Ada"})
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-1",
+			Input:             input,
+		}),
+		historyRow(t, 2, enginehistory.EventActivityScheduled, enginehistory.ActivityScheduledPayload{
+			ActivityKey:  "different",
+			ActivityType: "demo.activity",
+			Input:        input,
+		}),
+	}
+
+	decision, err := replayDefinition(testDefinition(time.Unix(0, 0).UTC()), historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionFailed {
+		t.Fatalf("expected failed decision, got %+v", decision)
+	}
+	if len(decision.Events) != 2 {
+		t.Fatalf("expected replay mismatch + workflow failed events, got %+v", decision.Events)
+	}
+	if decision.Events[0].EventType != enginehistory.EventWorkflowReplayMismatch {
+		t.Fatalf("expected first replay event to be workflow.replay_mismatch, got %+v", decision.Events)
+	}
+	if decision.Events[1].EventType != enginehistory.EventWorkflowFailed {
+		t.Fatalf("expected second replay event to be workflow.failed, got %+v", decision.Events)
+	}
+}
+
+func TestReplayDefinitionCancellationRequestedRespectsHistoryOrder(t *testing.T) {
+	result, _ := json.Marshal(map[string]bool{"early": false, "late": true})
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "cancel-order",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-cancel-order",
+		}),
+		historyRow(t, 2, enginehistory.EventCustomStatusUpdated, enginehistory.CustomStatusUpdatedPayload{
+			Status: mustRawJSON(t, map[string]string{"step": "before-cancel"}),
+		}),
+		historyRow(t, 3, enginehistory.EventCancelRequested, enginehistory.CancelRequestedPayload{}),
+		historyRow(t, 4, enginehistory.EventWorkflowCompleted, enginehistory.WorkflowCompletedPayload{
+			Result: result,
+		}),
+	}
+
+	definition := publicworkflow.Definition{
+		Name:    "cancel-order",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			early := ctx.CancellationRequested()
+			if err := ctx.SetCustomStatus(map[string]string{"step": "before-cancel"}); err != nil {
+				return err
+			}
+			late := ctx.CancellationRequested()
+			return ctx.SetResult(map[string]bool{
+				"early": early,
+				"late":  late,
+			})
+		},
+	}
+
+	decision, err := replayDefinition(definition, historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision, got %+v", decision)
+	}
+	if len(decision.Events) != 0 {
+		t.Fatalf("expected no new history events during replay, got %+v", decision.Events)
+	}
+	if !equalJSON(decision.Result, result) {
+		t.Fatalf("expected replayed result %s, got %s", result, decision.Result)
+	}
+}
+
+func TestReplayDefinitionCancellationRequestedFoldsPendingCancelAtFrontier(t *testing.T) {
+	cancelInboxID := uuid.Must(uuid.NewV7())
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "cancel-pending",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-cancel-pending",
+		}),
+	}
+	inboxRows := []enginedb.EngineInbox{{
+		ID:          cancelInboxID,
+		RunID:       pgtype.UUID{Bytes: uuid.Nil, Valid: false},
+		Kind:        "cancel",
+		Payload:     mustRawJSON(t, enginehistory.CancelRequestedPayload{}),
+		Status:      enginedb.EngineInboxStatusPending,
+		AvailableAt: time.Unix(1, 0).UTC(),
+	}}
+	result := mustRawJSON(t, map[string]bool{"cancelled": true})
+
+	definition := publicworkflow.Definition{
+		Name:    "cancel-pending",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			return ctx.SetResult(map[string]bool{
+				"cancelled": ctx.CancellationRequested(),
+			})
+		},
+	}
+
+	decision, err := replayDefinition(definition, historyRows, nil, inboxRows)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision, got %+v", decision)
+	}
+	if len(decision.Events) != 2 {
+		t.Fatalf("expected cancel.requested + workflow.completed, got %+v", decision.Events)
+	}
+	if decision.Events[0].EventType != enginehistory.EventCancelRequested {
+		t.Fatalf("expected first event to be cancel.requested, got %+v", decision.Events)
+	}
+	if decision.Events[1].EventType != enginehistory.EventWorkflowCompleted {
+		t.Fatalf("expected second event to be workflow.completed, got %+v", decision.Events)
+	}
+	if len(decision.ConsumedInboxIDs) != 1 || decision.ConsumedInboxIDs[0] != cancelInboxID {
+		t.Fatalf("expected pending cancel inbox to be consumed, got %+v", decision.ConsumedInboxIDs)
+	}
+	if !equalJSON(decision.Result, result) {
+		t.Fatalf("expected completed result %s, got %s", result, decision.Result)
+	}
+}
+
+func historyRow(t *testing.T, sequenceNo int32, eventType string, payload any) enginedb.EngineHistory {
+	t.Helper()
+	raw, err := enginehistory.MarshalPayload(payload)
+	if err != nil {
+		t.Fatalf("MarshalPayload() error = %v", err)
+	}
+
+	return enginedb.EngineHistory{
+		ID:         int64(sequenceNo),
+		ProjectID:  uuid.Nil,
+		InstanceID: uuid.Nil,
+		RunID:      uuid.Nil,
+		SequenceNo: sequenceNo,
+		EventType:  eventType,
+		Payload:    raw,
+		CreatedAt:  time.Unix(int64(sequenceNo), 0).UTC(),
+	}
+}
+
+func mustRawJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return raw
+}
+
+func testDefinition(timerAt time.Time) publicworkflow.Definition {
+	return publicworkflow.Definition{
+		Name:    "demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			var input map[string]string
+			if err := ctx.Input(&input); err != nil {
+				return err
+			}
+			var output map[string]string
+			if err := ctx.Activity("fetch", "demo.activity", input, &output); err != nil {
+				return err
+			}
+			if err := ctx.SleepUntil("deadline", timerAt); err != nil {
+				return err
+			}
+			var signal map[string]string
+			if err := ctx.ReceiveSignal("approval", &signal); err != nil {
+				return err
+			}
+			return ctx.SetResult(map[string]string{
+				"greeting": output["greeting"],
+				"approval": signal["approval"],
+			})
+		},
+	}
+}

--- a/engine/internal/workflow/testhooks.go
+++ b/engine/internal/workflow/testhooks.go
@@ -22,6 +22,6 @@ func applyTestFinalHook(ctx context.Context) error {
 	return applyTestHook(ctx, TestWorkflowFinalMarkerEnv, TestWorkflowFinalReleaseEnv)
 }
 
-func applyTestHook(ctx context.Context, markerEnv string, releaseEnv string) error {
+func applyTestHook(ctx context.Context, markerEnv, releaseEnv string) error {
 	return enginetesthooks.ApplyFileGate(ctx, os.Getenv(markerEnv), os.Getenv(releaseEnv))
 }

--- a/engine/internal/workflow/testhooks.go
+++ b/engine/internal/workflow/testhooks.go
@@ -1,0 +1,27 @@
+package workflow
+
+import (
+	"context"
+	"os"
+
+	enginetesthooks "github.com/continua-ai/continua/engine/internal/testhooks"
+)
+
+const (
+	TestWorkflowClaimMarkerEnv  = "CONTINUA_ENGINE_TEST_WORKFLOW_CLAIM_MARKER_FILE"
+	TestWorkflowClaimReleaseEnv = "CONTINUA_ENGINE_TEST_WORKFLOW_CLAIM_RELEASE_FILE"
+	TestWorkflowFinalMarkerEnv  = "CONTINUA_ENGINE_TEST_WORKFLOW_FINAL_MARKER_FILE"
+	TestWorkflowFinalReleaseEnv = "CONTINUA_ENGINE_TEST_WORKFLOW_FINAL_RELEASE_FILE"
+)
+
+func applyTestClaimHook(ctx context.Context) error {
+	return applyTestHook(ctx, TestWorkflowClaimMarkerEnv, TestWorkflowClaimReleaseEnv)
+}
+
+func applyTestFinalHook(ctx context.Context) error {
+	return applyTestHook(ctx, TestWorkflowFinalMarkerEnv, TestWorkflowFinalReleaseEnv)
+}
+
+func applyTestHook(ctx context.Context, markerEnv string, releaseEnv string) error {
+	return enginetesthooks.ApplyFileGate(ctx, os.Getenv(markerEnv), os.Getenv(releaseEnv))
+}

--- a/engine/internal/workflow/worker.go
+++ b/engine/internal/workflow/worker.go
@@ -35,7 +35,7 @@ func (w *Worker) PollOnce(ctx context.Context, workerID string) error {
 		return err
 	}
 
-	if err := w.activator.Activate(ctx, run); err != nil {
+	if err := w.activator.Activate(ctx, &run); err != nil {
 		if errors.Is(err, store.ErrStaleClaim) {
 			log.Printf("workflow worker stale claim for run %s", run.ID)
 			return nil

--- a/engine/internal/workflow/worker.go
+++ b/engine/internal/workflow/worker.go
@@ -1,0 +1,47 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/continua-ai/continua/engine/internal/store"
+)
+
+type Worker struct {
+	store       *store.Store
+	activator   *Activator
+	runLeaseTTL time.Duration
+}
+
+func NewWorker(store *store.Store, definitions *Registry, runLeaseTTL time.Duration) *Worker {
+	return &Worker{
+		store:       store,
+		activator:   NewActivator(store, definitions),
+		runLeaseTTL: runLeaseTTL,
+	}
+}
+
+func (w *Worker) PollOnce(ctx context.Context, workerID string) error {
+	run, err := w.store.ClaimNextRun(ctx, workerID, w.runLeaseTTL)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if err := applyTestClaimHook(ctx); err != nil {
+		return err
+	}
+
+	if err := w.activator.Activate(ctx, run); err != nil {
+		if errors.Is(err, store.ErrStaleClaim) {
+			log.Printf("workflow worker stale claim for run %s", run.ID)
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/engine/pkg/workflow/context.go
+++ b/engine/pkg/workflow/context.go
@@ -1,0 +1,18 @@
+package workflow
+
+import (
+	"errors"
+	"time"
+)
+
+var ErrEmptyKey = errors.New("workflow: stable key is required")
+
+type Context interface {
+	Input(out any) error
+	Activity(key, activityType string, input any, out any) error
+	SleepUntil(key string, at time.Time) error
+	ReceiveSignal(name string, out any) error
+	CancellationRequested() bool
+	SetCustomStatus(value any) error
+	SetResult(value any) error
+}

--- a/engine/pkg/workflow/definition.go
+++ b/engine/pkg/workflow/definition.go
@@ -1,0 +1,7 @@
+package workflow
+
+type Definition struct {
+	Name    string
+	Version string
+	Run     func(Context) error
+}

--- a/openspec/changes/add-engine-dark-launch-core/design.md
+++ b/openspec/changes/add-engine-dark-launch-core/design.md
@@ -1,0 +1,236 @@
+## Context
+
+Phase 10.1 delivered the engine foundation: 7 tables, 5 enums, sqlc queries, store wrappers, and a CLI with `version` and `migrate` commands. Phase 11 adds the runtime execution core that proves durable workflow execution end-to-end, entirely inside the `continua-engine` binary, before any public surface is exposed.
+
+### Current State
+
+- `engine.instances`, `engine.runs`, `engine.history`, `engine.inbox`, `engine.activity_tasks`, `engine.request_dedupe`, `engine.projection_checkpoints` exist with full schema, queries, and store wrappers
+- `engine.run_lifecycle_status` has values: `queued`, `running`, `completed`, `failed`, `cancelled`
+- `ClaimNextRun`, `ClaimNextActivityTask`, `ClaimNextInboxItem` implement lease-based claiming
+- `CompleteActivityTask` and `FailActivityTask` do not CAS on `claimed_by`
+- Placeholder packages exist at `engine/internal/workflow`, `engine/internal/activity`, `engine/internal/worker`, `engine/internal/history`
+- No runtime execution, replay, or workflow authoring API exists
+
+### Constraints
+
+- Zero changes to the live product: `cmd/continua`, `internal/*`, `contracts/*`, `db/platform/*`, `web/*`, `sdks/*`
+- Engine module isolation: cannot import root `internal/*` or root `db/gen/go/*`
+- Postgres is the only runtime DB target
+- Existing migrations are immutable
+- No new tables in Phase 11; only column additions and enum extension
+- No `lease_token` columns; lease identity uses existing `claimed_by`
+
+## Goals / Non-Goals
+
+**Goals**
+- Prove one complete internal workflow: start -> activity -> timer -> signal -> replay-correct completion
+- Prove restart recovery: mid-activity, timer-persistence, signal-persistence
+- Establish the activation transaction model as the single write path for workflow state
+- Establish CAS-based guarded transitions for all runtime state changes
+- Establish history as the authoritative truth with materialized caches on `runs`
+- Ship `serve`, `start`, `signal`, `cancel`, and `inspect` commands
+- Ship a minimal public Go workflow authoring API
+
+**Non-Goals**
+- Public OpenAPI routes for engine operations
+- Debugger projection from engine history
+- `cmd/continua` integration or Fx wiring
+- SDK control surface (Python or TypeScript)
+- Multi-primitive waits (blocking on activity AND timer simultaneously)
+- ContinueAsNew, subworkflows, or child workflows
+- Sticky cache or worker affinity
+- Remote activity workers
+- Orphan `waiting` run recovery (see Decision 6)
+
+## Decisions
+
+### Decision 1: Activation Transaction Model
+
+**Choice:** Each workflow activation is a single DB transaction that loads state, replays history, folds in completions/inbox, appends new events, writes caches, and transitions the run.
+
+**Alternatives considered:**
+- Multi-step approach with separate load, process, and commit phases using optimistic locking
+- Event-sourcing with a separate projection step
+
+**Why this choice:**
+- Single transaction guarantees atomicity: either the entire activation succeeds (new events + state transition) or nothing changes
+- Eliminates race conditions between loading state and writing results
+- History and side-table consumption happen in the same isolation boundary, so no external observer can see partial state
+- Simpler to reason about for Phase 11's single-primitive blocking model
+- Performance is acceptable because Phase 11 workflows are small (one activity, one timer, one signal)
+
+**Event append discipline:**
+- `workflow.started` is appended by the `start` transaction for the new run.
+- The activation transaction appends `activity.scheduled` and `timer.scheduled` when those primitives first block.
+- The activation transaction appends `activity.completed` / `activity.failed` when it observes durable activity outcomes after replay reaches the history frontier.
+- The activation transaction appends `timer.fired`, `signal.received`, and `cancel.requested` when it consumes those inbox rows.
+- The activation transaction appends `custom_status.updated` for each new `SetCustomStatus()` call and appends `workflow.completed` / `workflow.failed` on the terminal transition.
+
+**Risk:** Large workflows with many history events could make transactions long-running. Mitigation: Phase 11 workflows are bounded; transaction optimization is a future concern when workflow complexity grows.
+
+### Decision 2: CAS-Based Guarded Transitions
+
+**Choice:** All runtime state transitions use compare-and-swap (CAS) queries. Workflow-owned transitions CAS on `(status, claimed_by)`. External wakeups CAS on `status` only.
+
+**Why two CAS patterns:**
+- Workflow-owned transitions (`running -> waiting`, `running -> completed`, `running -> failed`) must verify the current worker still owns the run. A stale worker that lost its lease must not overwrite a new owner's state.
+- External wakeups (`waiting -> queued`) are status-only because they don't need ownership — any caller (signal handler, activity completer, maintenance worker) can wake a waiting run, and the wake is idempotent.
+
+**Why not use `UpdateRunStatus` for runtime transitions:**
+- `UpdateRunStatus` is a generic status setter with no CAS guard. Using it in runtime paths would create TOCTOU races between checking ownership and applying the transition.
+- `UpdateRunStatus` remains available for legacy/admin/test-only use cases.
+
+**New error: `ErrStaleClaim`:**
+- Ownership-based CAS wrappers must distinguish three outcomes: (1) transition succeeded, (2) row not found (`ErrNotFound`), (3) row exists but CAS failed (`ErrStaleClaim`)
+- Status-only wakeups do not use `ErrStaleClaim`. They distinguish: (1) wake applied, (2) row exists but was already past `waiting` (idempotent no-op), (3) row missing (`ErrNotFound`)
+- This is implemented by checking `rows affected = 0` after the update, then doing a follow-up existence check when the wrapper needs to distinguish missing from stale/no-op
+
+### Decision 3: Single-Primitive Blocking
+
+**Choice:** Phase 11 blocks on exactly one primitive at a time. When a workflow calls `Activity()`, `SleepUntil()`, or `ReceiveSignal()`, the run transitions to `waiting` with a `waiting_for` JSON tag identifying the single blocked primitive.
+
+**Alternatives considered:**
+- Multi-primitive select/race (block on activity OR timer, whichever completes first)
+- Callback-based continuation model
+
+**Why single-primitive:**
+- Dramatically simpler activation logic: after replay, the activation either (a) encounters a blocking call and transitions to `waiting`, or (b) reaches the end and completes/fails
+- Wakeup logic can check `status = 'waiting'` without validating `waiting_for` contents, because exactly one wake source exists
+- Multi-primitive waits require validating `waiting_for` on every wakeup to determine if the specific primitive that completed is the one the workflow is waiting for. This validation logic is non-trivial and deferred.
+
+**Migration path:** When multi-primitive waits are introduced, wakeup queries must add a `waiting_for` content check. The `waiting_for` JSON structure already supports this via the `kind` discriminator.
+
+### Decision 4: History as Authoritative Truth
+
+**Choice:** The `engine.history` table is the sole source of truth for workflow execution state. `runs.result`, `runs.custom_status`, and `runs.waiting_for` are materialized caches rewritten by each activation.
+
+**Why caches on `runs`:**
+- `inspect` needs to return current status without replaying history
+- `waiting_for` enables maintenance worker timer checks without history replay
+- `result` enables completion queries without scanning history for `workflow.completed`
+
+**Why rewrite on every activation:**
+- Cache invalidation is hard. Rewriting is simple and correct.
+- Activation already has the full state in memory after replay. Writing it back is cheap.
+- No stale cache risk: if a cache value is wrong, the next activation fixes it.
+
+**Initial workflow input:**
+- Phase 11 stores `start --input` only in the initial `workflow.started` history event; no new input column or side table is added.
+- The `start` transaction appends `workflow.started` as the first history row for the new run, and replay seeds `Context.Input(out)` from that payload on both first execution and later replays.
+
+### Decision 5: Worker Identity Model
+
+**Choice:** Each loop iteration generates a unique `claimed_by` identity: `workflow:<uuid>`, `activity:<uuid>`, or `maintenance:<uuid>`.
+
+**Alternatives considered:**
+- Per-process identity (one UUID for the entire `serve` process)
+- Per-loop identity (one UUID per worker loop, reused across iterations)
+
+**Why per-iteration:**
+- Per-process identity would mean a crashed-and-restarted process with the same identity could satisfy its own stale CAS checks, bypassing lease expiry
+- Per-loop identity has the same problem for a loop that panics and restarts
+- Per-iteration identity is the simplest model: every claim is unique, and stale claims are always detectable
+- The UUID is cheap to generate and appears in logs for tracing
+
+### Decision 6: Waiting Run Orphan Recovery
+
+**Choice:** Phase 11 does not implement orphan recovery for `waiting` runs. A `waiting` run with no satisfiable wake path is considered an orphan but is not automatically recovered.
+
+**Why this is safe in Phase 11:**
+- For activity and timer waits, the activation transaction creates the durable wake source (activity task row or timer inbox row) before committing `running -> waiting`. These happen in the same transaction.
+- For signal waits, Phase 11 does not create a separate side-table registration row. The durable registration is `runs.waiting_for = {"kind":"signal",...}` on the run itself, and future `signal` commands enqueue the wakeup inbox row against that waiting run.
+- Therefore, activity and timer waits always have a corresponding durable wake source at the moment they become `waiting`, while signal waits are durably registered on the run and rely on later signal delivery rather than pre-created inbox rows.
+- The main orphan risk is therefore a bug that writes `waiting_for` incorrectly, or an external deletion of an activity/timer wake source (which nothing in Phase 11 does). A maintenance-worker crash after a timer becomes due is not an orphan: the same timer inbox row remains and will be retried on the next iteration.
+
+**Risk:** A bug that creates a malformed `waiting_for` registration or omits an activity/timer wake source would leave the run stuck. Mitigation: gate tests verify the complete lifecycle, and `inspect` makes stuck runs visible.
+
+### Decision 7: At-Least-Once Activity Execution
+
+**Choice:** Activity execution is explicitly at-least-once. The activity worker claims a task, executes the handler outside a transaction, then completes/fails with a CAS on `claimed_by`.
+
+**Why outside a transaction:**
+- Activity handlers may be long-running (network calls, external APIs). Holding a DB transaction open for the duration would exhaust connection pool resources.
+- Executing outside the transaction means the claim could expire while the handler runs. Another worker could reclaim and re-execute the same activity.
+
+**Why CAS on complete/fail:**
+- If the original worker finishes after its lease expired and another worker reclaimed the task, the CAS on `claimed_by` rejects the stale completion.
+- The stale worker receives `ErrStaleClaim` and drops its result — no double-completion, but the activity handler may have executed twice.
+
+**Implication for workflow authors:** Activity handlers should be idempotent or tolerate duplicate execution.
+
+### Decision 8: Replay Semantics
+
+**Choice:** Replay compares primitive kind, stable key, and canonical payload against recorded history. For activities, replay must honor both `activity.completed` and `activity.failed` outcomes. On mismatch, append `workflow.replay_mismatch` and fail the run terminally.
+
+**Why terminal failure on mismatch:**
+- A replay mismatch means the workflow definition has changed in a way that is incompatible with the recorded history. Continuing execution would produce incorrect state.
+- Recording `workflow.replay_mismatch` in history provides a diagnostic trail.
+- Phase 11 requires exact `definition_name` + `definition_version` match, so mismatches indicate a code bug rather than a version migration.
+
+**Stable key requirement:**
+- Activities and timers must have caller-supplied stable keys (e.g., `"fetch-user"`, `"wait-for-approval"`), not auto-generated sequence numbers.
+- Stable keys survive code refactoring that changes execution order, as long as the logical operation is the same.
+- This is enforced at the authoring API level: `Context.Activity(key, ...)` and `Context.SleepUntil(key, ...)` require a non-empty key.
+
+### Decision 9: Observational Cancellation
+
+**Choice:** Cancellation is observational in Phase 11. `cancel` inserts an inbox row for the active non-terminal run; the workflow checks `Context.CancellationRequested()` during execution.
+
+**Why not forced preemption:**
+- Forced preemption (killing a running workflow mid-execution) creates partial state that is difficult to reason about and clean up.
+- Observational cancellation lets the workflow decide how to handle cancellation: clean up resources, return a partial result, or ignore it.
+- The inbox dedupe key ensures repeated `cancel` calls coalesce into a single inbox row.
+
+**Terminal-run boundary:**
+- Phase 11 rejects `signal` and `cancel` for terminal runs instead of persisting unconsumable inbox rows.
+- This keeps the dark-launch storage surface clean and avoids implying that terminal runs can still observe new control-plane input.
+
+### Decision 10: `waiting_for` JSON Union Structure
+
+**Choice:** `waiting_for` is a tagged JSON union with a `kind` discriminator:
+- Activity wait: `{"kind":"activity","activity_key":"...","activity_type":"..."}`
+- Timer wait: `{"kind":"timer","timer_key":"...","due_at":"RFC3339"}`
+- Signal wait: `{"kind":"signal","signal_name":"..."}`
+
+**Why tagged union:**
+- Enables future multi-primitive waits by extending to an array of tagged objects
+- Self-documenting: `inspect` output shows exactly what the workflow is waiting for
+- Maintenance worker can check `kind = "timer"` and `due_at` without history replay
+
+### Decision 11: Start Command Transaction Ordering
+
+**Choice:** The `start` command executes its entire flow — atomic dedupe claim/takeover, instance creation, run creation, initial `workflow.started` append, dedupe finalization — in a single database transaction.
+
+**Why single transaction:**
+- If the process crashes after creating the instance/run but before finalizing the dedupe row, the dedupe row would be stranded as `in_progress` forever, blocking retries until it expires.
+- A single transaction makes this impossible: either everything commits (instance, run, finalized dedupe) or nothing does.
+- The `request_dedupe.expires_at` column still serves as a safety net for any truly orphaned `in_progress` rows (e.g., if a transaction hangs beyond the TTL and the connection is killed by Postgres). The maintenance worker's `ExpireRequestDedupe` query cleans these up.
+
+**Atomic claim primitive requirement:**
+- Phase 11 cannot safely implement `start` with an unlocked get-then-insert or delete-then-insert pattern because `request_dedupe` is unique on `(project_id, request_scope, request_key)`.
+- The store layer therefore needs a dedicated atomic start-claim primitive that, under row lock inside the transaction, does exactly one of: create a new `in_progress` row, return a finalized row, return a live `in_progress` row, or reclaim an expired claim.
+- A claim is reclaimable either when it is still `in_progress` with `expires_at < NOW()` or when maintenance has already transitioned it to `status = 'expired'`.
+- Reclaiming an expired claim renews the existing dedupe record in place rather than deleting and reinserting under the unique key.
+
+**Initial history write:**
+- The same `start` transaction appends `workflow.started` as `sequence_no = 1` for the new run, with `definition_name`, `definition_version`, `instance_key`, and optional input payload.
+- This makes the CLI request input executable by the workflow runtime without introducing a separate storage path.
+
+**Retry behavior for stranded rows:**
+- A `start` retry that finds an `in_progress` row with `expires_at < NOW()` treats it as expired and atomically takes over that same claim with a refreshed `expires_at`.
+- A `start` retry that finds an already `expired` row atomically reclaims that same row with `status = 'in_progress'` and a refreshed `expires_at`.
+- A `start` retry that finds an `in_progress` row with `expires_at >= NOW()` returns `request_in_progress` (another `start` is actively executing).
+
+## Risks / Trade-offs
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Long-running activation transactions | DB contention under load | Phase 11 workflows are bounded; optimize in future phases |
+| At-least-once activity duplicates | Activity side effects may execute twice | Document idempotency requirement; CAS prevents double-completion |
+| No orphan recovery | Stuck `waiting` runs if bug creates malformed signal registration or omits an activity/timer wake source | Activity/timer waits create durable wake sources in-transaction, signal waits are registered via `waiting_for`, and `inspect` makes stuck runs visible |
+| Exact version match is restrictive | Cannot evolve definitions without creating new instances | Phase 11 simplification; versioned compatibility is a future concern |
+| Single-primitive blocking limits expressiveness | Cannot model select/race patterns | Explicit deferral; `waiting_for` structure supports future extension |
+
+## Open Questions
+
+None. The user specification is comprehensive and all design decisions are resolved.

--- a/openspec/changes/add-engine-dark-launch-core/proposal.md
+++ b/openspec/changes/add-engine-dark-launch-core/proposal.md
@@ -1,0 +1,81 @@
+# Change: Add Engine Dark-Launch Core (Phase 11)
+
+## Why
+
+The engine foundation (Phase 10.1) established schema, store, CLI, and generation but contains no runtime execution. Before exposing any public surface — OpenAPI routes, debugger projection, SDK control, or `cmd/continua` integration — the engine must prove one complete internal workflow end-to-end: start, activity, timer, signal, restart recovery, and replay-correct completion. This dark-launch phase builds that proof entirely inside `continua-engine`.
+
+## What Changes
+
+### Capabilities
+
+| Capability | Type | Description |
+|------------|------|-------------|
+| **engine-schema-runtime-delta** | NEW | Migration 000002 adding `waiting` to `run_lifecycle_status`, plus `result`, `custom_status`, `waiting_for`, `completed_at` columns on `engine.runs` |
+| **engine-runtime-config** | NEW | Env-only config vars for runtime poll intervals, lease TTLs, and request-dedupe TTL |
+| **engine-workflow-authoring** | NEW | Minimal public Go API in `engine/pkg/workflow` for defining workflow `Definition` and using `Context` primitives |
+| **engine-history-events** | NEW | Canonical event types, payload structs, and JSON encoding in `engine/internal/history` |
+| **engine-runtime-execution** | NEW | Three worker loops (workflow, activity, maintenance), activation transaction, replay-from-history, guarded CAS transitions, activity at-least-once execution |
+| **engine-cli-runtime** | NEW | `serve`, `start`, `signal`, `cancel`, and `inspect` commands with JSON output for `continua-engine` |
+
+### Key Design Decisions
+
+1. **Internal-only surface**: No OpenAPI routes, no debugger projection, no `cmd/continua` wiring, no SDK control surface. All interaction is via `continua-engine` CLI commands.
+2. **Single-primitive blocking**: Phase 11 blocks on one primitive at a time (activity, timer, or signal). Multi-primitive waits are deferred.
+3. **History is authoritative**: `runs.result`, `runs.custom_status`, and `runs.waiting_for` are materialized caches rewritten by each activation. History events are the only source of truth, including the initial `workflow.started` event that durably carries optional workflow input.
+4. **CAS-based guarded transitions**: Workflow-owned transitions CAS on `(status, claimed_by)`. External wakeups CAS on `status` only. `ErrStaleClaim` is reserved for ownership-based CAS paths; status-only wakeups report applied vs no-op.
+5. **Activation transaction**: One DB transaction per workflow activation loads state, replays history, processes side-table completions and inbox, appends the full event stream at explicit schedule/consume/terminal points, writes caches, and transitions the run.
+6. **At-least-once activities**: Activity execution is explicitly at-least-once. Stale claim rejection prevents double-completion but does not prevent duplicate execution.
+7. **Exact version match**: `start` validates the requested `definition_name` + `definition_version` against the compiled registry before writing, and replay requires the same exact match. This is a Phase 11 simplification.
+8. **Observational cancellation**: Cancel inserts an inbox row; workflow code checks `CancellationRequested()`. No forced preemption.
+
+### Breaking Changes
+
+None. The live product path (`POST /v1/ingest`, `/api/traces*`, `/api/sessions*`, debugger UI, `cmd/continua` runtime) is completely untouched. All changes are isolated to the `engine/` module.
+
+## Impact
+
+### Affected Specs
+
+- `engine-schema-runtime-delta` (new — extends `engine-schema-foundation`)
+- `engine-runtime-config` (new — extends `engine-cli-foundation`)
+- `engine-workflow-authoring` (new)
+- `engine-history-events` (new)
+- `engine-runtime-execution` (new)
+- `engine-cli-runtime` (new — extends `engine-cli-foundation`)
+
+### Affected Code
+
+| Path | Change |
+|------|--------|
+| `engine/db/migrations/postgres/000002_runtime_columns.{up,down}.sql` | ADD: enum extension, four new columns on `engine.runs` |
+| `engine/db/queries/runs.sql` | MODIFY: add guarded transition queries |
+| `engine/db/queries/activity_tasks.sql` | MODIFY: CAS `claimed_by` on complete/fail, add `ListActivityTasksByRun` |
+| `engine/db/queries/inbox.sql` | MODIFY: add run-scoped listing/consumption queries |
+| `engine/db/queries/request_dedupe.sql` | MODIFY: add atomic start-claim/takeover helpers plus expiry query |
+| `engine/internal/config/config.go` | MODIFY: add runtime config vars |
+| `engine/internal/store/*.go` | MODIFY: add new store wrappers including atomic start-dedupe claim, `ErrStaleClaim` sentinel |
+| `engine/pkg/workflow/` | ADD: `Definition`, `Context`, primitive methods including workflow input access |
+| `engine/internal/history/` | ADD: event type registry, payload structs, canonical encoding |
+| `engine/internal/workflow/` | ADD: replay engine, activation transaction |
+| `engine/internal/activity/` | ADD: activity worker loop |
+| `engine/internal/worker/` | ADD: worker loop infrastructure, identity generation |
+| `engine/cmd/continua-engine/main.go` | MODIFY: add `serve`, `start`, `signal`, `cancel`, `inspect` commands |
+| `engine/cmd/continua-engine/internal/darklaunch/` | ADD: demo workflow definition and activity handlers |
+
+### Not Affected
+
+- `cmd/continua` — no changes to the main server binary
+- `internal/api`, `internal/ingest`, `internal/jobs`, `internal/store` — untouched
+- `contracts/openapi/openapi.yaml` — no API surface changes
+- `web/src` — no frontend changes
+- `sdks/python`, `sdks/typescript` — no SDK changes
+- `db/platform` — no platform schema or query changes
+
+## Assumptions
+
+- Activity execution is explicitly at-least-once in Phase 11.
+- Engine tables are the only execution truth.
+- Restart recovery reclaims the same run; it does not create a new `run_number`.
+- `projection_checkpoints`, debugger projection, ContinueAsNew, subworkflows, sticky cache, remote activity workers, and public lifecycle APIs remain deferred.
+- `ClaimNextInboxItem` is explicitly unused in Phase 11; inbox is consumed inside the activation transaction.
+- `instance_key` is the consistent external identifier in Phase 11. Public naming can change later.

--- a/openspec/changes/add-engine-dark-launch-core/specs/engine-cli-runtime/spec.md
+++ b/openspec/changes/add-engine-dark-launch-core/specs/engine-cli-runtime/spec.md
@@ -1,0 +1,176 @@
+# Capability: engine-cli-runtime
+
+CLI commands for engine runtime: `serve`, `start`, `signal`, `cancel`, and `inspect`. Extends [engine-cli-foundation](../../../../changes/add-engine-foundation/specs/engine-cli-foundation/spec.md).
+
+Related capabilities: [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-runtime-config](../engine-runtime-config/spec.md)
+
+## ADDED Requirements
+
+### Requirement: serve command
+
+The `continua-engine serve` command MUST start the engine runtime with three worker loops.
+
+#### Scenario: Serve startup
+- **WHEN** `continua-engine serve` is invoked
+- **THEN** it starts workflow, activity, and maintenance worker loops
+- **THEN** it uses normal process logging (not JSON command output)
+
+#### Scenario: Serve shutdown
+- **WHEN** the process receives a termination signal
+- **THEN** worker loops drain gracefully and the process exits
+
+#### Scenario: Serve fatal error
+- **WHEN** a fatal startup or runtime error occurs
+- **THEN** the process exits with nonzero exit code
+
+#### Scenario: Serve is not a JSON command
+- **WHEN** `serve` runs
+- **THEN** it does NOT emit structured JSON to stdout for success/failure; it uses standard logging
+
+---
+
+### Requirement: start command
+
+The `continua-engine start` command MUST create a new workflow instance with durable request deduplication.
+
+#### Scenario: Start success
+- **WHEN** `start` is invoked with a unique `instance_key` and `request_key`
+- **THEN** it creates one instance and one run with `run_number = 1`
+- **THEN** it outputs JSON to stdout: `{"instance_id":"...","instance_key":"...","run_id":"...","run_number":1,"status":"queued"}`
+- **THEN** exit code is `0`
+
+#### Scenario: Start transaction ordering
+- **WHEN** `start` executes
+- **THEN** within a single DB transaction: (1) run the atomic start-dedupe claim primitive, (2) if it returns a newly claimed or expired-takeover `in_progress` row, create the instance and run, (3) append `workflow.started` as the first history row for the run, carrying `definition_name`, `definition_version`, `instance_key`, and optional `input`, (4) finalize that dedupe row with the success response, (5) commit
+- **THEN** if the transaction fails at any step, it rolls back atomically — no stranded `in_progress` dedupe rows
+
+#### Scenario: Stranded in-progress dedupe row
+- **WHEN** `start` encounters an existing dedupe row with `status = 'in_progress'` and `expires_at < NOW()`
+- **THEN** it treats the row as expired (the original `start` crashed before finalizing) and atomically takes over that same claim with a refreshed `expires_at`
+- **WHEN** `start` encounters an existing dedupe row with `status = 'in_progress'` and `expires_at >= NOW()`
+- **THEN** it returns `request_in_progress` (another `start` is actively executing)
+
+#### Scenario: Retry after maintenance expiry
+- **WHEN** `start` encounters an existing dedupe row with `status = 'expired'`
+- **THEN** it atomically reclaims that same row as a new `in_progress` claim with a refreshed `expires_at`
+
+#### Scenario: Start input persistence
+- **WHEN** `start` is invoked with `--input`
+- **THEN** that value is durably persisted in the `workflow.started` history payload for the new run
+- **THEN** workflow code can read it through `Context.Input(...)` on first activation and replay
+
+#### Scenario: Unknown definition or version
+- **WHEN** `start` is invoked with a `(definition, version)` pair that is not registered in the compiled runtime
+- **THEN** it returns `{"error":{"code":"definition_not_registered","message":"..."}}`
+- **THEN** it does not write any `instances`, `runs`, or `request_dedupe` rows
+- **THEN** exit code is `1`
+
+#### Scenario: Duplicate request_key (finalized)
+- **WHEN** `start` is invoked with a `request_key` that was already finalized with `status = 'completed'`
+- **THEN** it returns the recorded response from the original request
+- **THEN** exit code is `0`
+
+#### Scenario: Duplicate request_key (failed)
+- **WHEN** `start` is invoked with a `request_key` that was already finalized with `status = 'failed'`
+- **THEN** it returns the recorded error from the original request
+- **THEN** exit code is `1`
+
+#### Scenario: Instance key conflict
+- **WHEN** `start` is invoked with an `instance_key` that already exists but a different request
+- **THEN** it returns `{"error":{"code":"instance_conflict","message":"..."}}`
+- **THEN** exit code is `1`
+
+#### Scenario: Request dedupe scope
+- **WHEN** `start` creates a request dedupe entry
+- **THEN** the `request_scope` is `engine.start`
+
+---
+
+### Requirement: signal command
+
+The `continua-engine signal` command MUST deliver a durable signal to the active non-terminal run of a workflow instance.
+
+#### Scenario: Signal success
+- **WHEN** `signal` is invoked with an `instance_key`, `signal_name`, and optional payload
+- **THEN** it inserts an inbox row with `kind = 'signal'` and `available_at = NOW()`
+- **THEN** it attempts guarded `waiting -> queued` on the active run
+- **THEN** it outputs JSON: `{"instance_id":"...","run_id":"...","accepted":true,"wake_applied":true|false}`
+- **THEN** exit code is `0`
+
+#### Scenario: Signal with dedupe key
+- **WHEN** `signal` is invoked with a caller-supplied dedupe key
+- **THEN** the inbox row uses that dedupe key for idempotent delivery
+
+#### Scenario: Signal to non-waiting run
+- **WHEN** `signal` is invoked and the run is not in `waiting` status
+- **THEN** the inbox row is still inserted (signal is queued for next activation)
+- **THEN** `wake_applied` is `false`
+
+#### Scenario: Signal to terminal run
+- **WHEN** `signal` is invoked and the active run is in `completed`, `failed`, or `cancelled` status
+- **THEN** it returns `{"error":{"code":"run_terminal","message":"..."}}`
+- **THEN** it does not insert an inbox row
+- **THEN** exit code is `1`
+
+---
+
+### Requirement: cancel command
+
+The `continua-engine cancel` command MUST deliver a durable cancellation request to the active non-terminal run of a workflow instance.
+
+#### Scenario: Cancel success
+- **WHEN** `cancel` is invoked with an `instance_key`
+- **THEN** it inserts an inbox row with `kind = 'cancel'` using a fixed per-run dedupe key
+- **THEN** it attempts guarded `waiting -> queued` on the active run
+- **THEN** it outputs JSON: `{"instance_id":"...","run_id":"...","accepted":true,"wake_applied":true|false}`
+- **THEN** exit code is `0`
+
+#### Scenario: Repeated cancel coalescing
+- **WHEN** `cancel` is invoked multiple times for the same run
+- **THEN** the fixed dedupe key ensures only one cancel inbox row exists
+
+#### Scenario: Cancellation is observational
+- **WHEN** `cancel` succeeds
+- **THEN** the workflow is NOT forcibly terminated; it must check `CancellationRequested()` to observe the cancellation
+
+#### Scenario: Cancel on terminal run
+- **WHEN** `cancel` is invoked and the active run is in `completed`, `failed`, or `cancelled` status
+- **THEN** it returns `{"error":{"code":"run_terminal","message":"..."}}`
+- **THEN** it does not insert an inbox row
+- **THEN** exit code is `1`
+
+---
+
+### Requirement: inspect command
+
+The `continua-engine inspect` command MUST return the current state of a workflow instance.
+
+#### Scenario: Inspect success
+- **WHEN** `inspect` is invoked with an `instance_key`
+- **THEN** it outputs JSON to stdout containing: `instance_id`, `instance_key`, `definition_name`, `definition_version`, `run_id`, `run_number`, `status`, `result`, `custom_status`, `waiting_for`, `history`
+- **THEN** exit code is `0`
+
+#### Scenario: Inspect not found
+- **WHEN** `inspect` is invoked with a non-existent `instance_key`
+- **THEN** it returns `{"error":{"code":"not_found","message":"..."}}`
+- **THEN** exit code is `1`
+
+---
+
+### Requirement: JSON output conventions
+
+All command output (except `serve`) MUST follow consistent JSON conventions.
+
+#### Scenario: Success output
+- **WHEN** a command succeeds
+- **THEN** it outputs a JSON object to stdout with command-specific fields
+- **THEN** exit code is `0`
+
+#### Scenario: Error output
+- **WHEN** a command fails
+- **THEN** it outputs `{"error":{"code":"...","message":"..."}}` to stdout
+- **THEN** exit code is `1`
+
+#### Scenario: Error codes
+- **WHEN** an error occurs
+- **THEN** the `code` field uses one of: `definition_not_registered`, `instance_conflict`, `request_in_progress`, `run_terminal`, `not_found`, `internal_error`

--- a/openspec/changes/add-engine-dark-launch-core/specs/engine-history-events/spec.md
+++ b/openspec/changes/add-engine-dark-launch-core/specs/engine-history-events/spec.md
@@ -1,0 +1,108 @@
+# Capability: engine-history-events
+
+Canonical event types, payload structs, and JSON encoding for the engine history table. Lives in `engine/internal/history`.
+
+Related capabilities: [engine-workflow-authoring](../engine-workflow-authoring/spec.md), [engine-runtime-execution](../engine-runtime-execution/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Canonical event type registry
+
+The history package MUST define canonical event type constants for all runtime events.
+
+#### Scenario: Workflow lifecycle events
+- **WHEN** the event type registry is defined
+- **THEN** it includes: `workflow.started`, `workflow.completed`, `workflow.failed`, `workflow.replay_mismatch`
+
+#### Scenario: Activity events
+- **WHEN** the event type registry is defined
+- **THEN** it includes: `activity.scheduled`, `activity.completed`, `activity.failed`
+
+#### Scenario: Timer events
+- **WHEN** the event type registry is defined
+- **THEN** it includes: `timer.scheduled`, `timer.fired`
+
+#### Scenario: Signal and cancel events
+- **WHEN** the event type registry is defined
+- **THEN** it includes: `signal.received`, `cancel.requested`
+
+#### Scenario: Status events
+- **WHEN** the event type registry is defined
+- **THEN** it includes: `custom_status.updated`
+
+---
+
+### Requirement: Typed payload structs
+
+Each event type MUST have a corresponding Go struct for its payload, with canonical JSON field names.
+
+#### Scenario: Workflow started payload
+- **WHEN** a `workflow.started` event is created
+- **THEN** its payload includes: `definition_name`, `definition_version`, `instance_key`, `input` (optional)
+
+#### Scenario: Workflow started is the initial run event
+- **WHEN** `start` creates a new run
+- **THEN** it appends `workflow.started` as the first history row for that run
+- **THEN** the payload carries the durable workflow input contract for later replay via `Context.Input(...)`
+
+#### Scenario: Activity scheduled payload
+- **WHEN** an `activity.scheduled` event is created
+- **THEN** its payload includes: `activity_key`, `activity_type`, `input`
+
+#### Scenario: Activity completed payload
+- **WHEN** an `activity.completed` event is created
+- **THEN** its payload includes: `activity_key`, `activity_type`, `output`
+
+#### Scenario: Activity failed payload
+- **WHEN** an `activity.failed` event is created
+- **THEN** its payload includes: `activity_key`, `activity_type`, `error_code`, `error_message`
+
+#### Scenario: Timer scheduled payload
+- **WHEN** a `timer.scheduled` event is created
+- **THEN** its payload includes: `timer_key`, `due_at` (RFC 3339)
+
+#### Scenario: Timer fired payload
+- **WHEN** a `timer.fired` event is created
+- **THEN** its payload includes: `timer_key`
+
+#### Scenario: Signal received payload
+- **WHEN** a `signal.received` event is created
+- **THEN** its payload includes: `signal_name`, `payload` (the signal data)
+
+#### Scenario: Cancel requested payload
+- **WHEN** a `cancel.requested` event is created
+- **THEN** its payload is empty or minimal (no additional data required)
+
+#### Scenario: Workflow completed payload
+- **WHEN** a `workflow.completed` event is created
+- **THEN** its payload includes: `result`
+
+#### Scenario: Workflow failed payload
+- **WHEN** a `workflow.failed` event is created
+- **THEN** its payload includes: `error_code`, `error_message`
+
+#### Scenario: Replay mismatch payload
+- **WHEN** a `workflow.replay_mismatch` event is created
+- **THEN** its payload includes: `expected_type`, `expected_key`, `actual_type`, `actual_key`, `detail`
+
+#### Scenario: Custom status updated payload
+- **WHEN** a `custom_status.updated` event is created
+- **THEN** its payload includes: `status` (the custom status value)
+
+---
+
+### Requirement: Structured replay comparison
+
+Event payloads MUST support structured comparison for replay validation. Phase 11 uses typed Go structs for all events, so comparison operates on deserialized struct fields rather than raw JSON bytes.
+
+#### Scenario: Typed struct comparison
+- **WHEN** the replay engine compares a new event against a recorded history event
+- **THEN** comparison deserializes both payloads into the corresponding typed Go struct and compares primitive kind, stable key, and struct field values
+
+#### Scenario: Failed activity outcomes participate in replay
+- **WHEN** replay encounters an `activity.failed` history event for a workflow `Activity(...)` call
+- **THEN** it uses the recorded `activity_key`, `activity_type`, `error_code`, and `error_message` fields to deterministically return the same failure without re-executing the handler
+
+#### Scenario: Standard JSON encoding
+- **WHEN** an event payload is serialized to JSON
+- **THEN** standard `encoding/json` marshaling is used (no custom canonicalizer required in Phase 11 because all payloads are typed structs with deterministic field ordering)

--- a/openspec/changes/add-engine-dark-launch-core/specs/engine-runtime-config/spec.md
+++ b/openspec/changes/add-engine-dark-launch-core/specs/engine-runtime-config/spec.md
@@ -1,0 +1,59 @@
+# Capability: engine-runtime-config
+
+Env-only configuration for engine runtime workers, leases, and request deduplication. Extends [engine-cli-foundation](../../../../changes/add-engine-foundation/specs/engine-cli-foundation/spec.md).
+
+Related capabilities: [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-cli-runtime](../engine-cli-runtime/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Worker poll intervals
+
+The engine config MUST provide configurable poll intervals for each worker loop.
+
+#### Scenario: Workflow poll interval
+- **WHEN** `ENGINE_WORKFLOW_POLL_INTERVAL` is set
+- **THEN** the workflow worker polls at the specified interval
+
+#### Scenario: Activity poll interval
+- **WHEN** `ENGINE_ACTIVITY_POLL_INTERVAL` is set
+- **THEN** the activity worker polls at the specified interval
+
+#### Scenario: Maintenance poll interval
+- **WHEN** `ENGINE_MAINTENANCE_POLL_INTERVAL` is set
+- **THEN** the maintenance worker polls at the specified interval
+
+#### Scenario: Default poll intervals
+- **WHEN** poll interval env vars are not set
+- **THEN** reasonable defaults are used (e.g., 1s for workflow/activity, 10s for maintenance)
+
+---
+
+### Requirement: Lease TTL configuration
+
+The engine config MUST provide configurable lease TTLs for run claims and activity task claims.
+
+#### Scenario: Run lease TTL
+- **WHEN** `ENGINE_RUN_LEASE_TTL` is set
+- **THEN** `ClaimNextRun` uses the specified duration as the lease expiry
+
+#### Scenario: Activity lease TTL
+- **WHEN** `ENGINE_ACTIVITY_LEASE_TTL` is set
+- **THEN** `ClaimNextActivityTask` uses the specified duration as the lease expiry
+
+#### Scenario: Default lease TTLs
+- **WHEN** lease TTL env vars are not set
+- **THEN** reasonable defaults are used (e.g., 30s for runs, 5m for activities)
+
+---
+
+### Requirement: Request dedupe TTL
+
+The engine config MUST provide `ENGINE_REQUEST_DEDUPE_TTL` to control the expiry window for request deduplication entries.
+
+#### Scenario: Custom dedupe TTL
+- **WHEN** `ENGINE_REQUEST_DEDUPE_TTL` is set to `10m`
+- **THEN** new request dedupe entries are created with `expires_at = NOW() + 10m`
+
+#### Scenario: Default dedupe TTL
+- **WHEN** `ENGINE_REQUEST_DEDUPE_TTL` is not set
+- **THEN** a reasonable default is used (e.g., 1h)

--- a/openspec/changes/add-engine-dark-launch-core/specs/engine-runtime-execution/spec.md
+++ b/openspec/changes/add-engine-dark-launch-core/specs/engine-runtime-execution/spec.md
@@ -1,0 +1,228 @@
+# Capability: engine-runtime-execution
+
+Worker loops, activation transaction, replay-from-history, guarded state transitions, and activity execution for the engine runtime.
+
+Related capabilities: [engine-schema-runtime-delta](../engine-schema-runtime-delta/spec.md), [engine-history-events](../engine-history-events/spec.md), [engine-workflow-authoring](../engine-workflow-authoring/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Three worker loops
+
+The `serve` command MUST run exactly three polling loops: workflow, activity, and maintenance.
+
+#### Scenario: Workflow worker loop
+- **WHEN** `serve` starts
+- **THEN** a workflow worker loop polls for claimable runs at the configured `ENGINE_WORKFLOW_POLL_INTERVAL`
+- **THEN** each iteration generates a unique `claimed_by` identity like `workflow:<uuid>`
+
+#### Scenario: Activity worker loop
+- **WHEN** `serve` starts
+- **THEN** an activity worker loop polls for claimable activity tasks at the configured `ENGINE_ACTIVITY_POLL_INTERVAL`
+- **THEN** each iteration generates a unique `claimed_by` identity like `activity:<uuid>`
+
+#### Scenario: Maintenance worker loop
+- **WHEN** `serve` starts
+- **THEN** a maintenance worker loop polls at the configured `ENGINE_MAINTENANCE_POLL_INTERVAL`
+- **THEN** each iteration generates a unique `claimed_by` identity like `maintenance:<uuid>`
+
+---
+
+### Requirement: Workflow activation transaction
+
+Each workflow activation MUST execute as a single database transaction.
+
+#### Scenario: Activation load phase
+- **WHEN** a workflow worker claims a run
+- **THEN** within a single transaction, it loads: the claimed run, its instance, ordered history, run-scoped activity tasks, and due pending inbox rows
+
+#### Scenario: Activation replay phase
+- **WHEN** history is loaded
+- **THEN** the replay engine re-executes the workflow definition against recorded history events, comparing primitive kind, stable key, and typed payload fields
+
+#### Scenario: Replay bootstraps workflow input
+- **WHEN** replay starts for a run
+- **THEN** the initial `workflow.started` event seeds definition metadata and `Context.Input(...)` before user workflow code advances past the history frontier
+
+#### Scenario: Activation fold phase
+- **WHEN** replay reaches the end of recorded history
+- **THEN** durable activity outcomes (completed and failed activity tasks) and pending inbox items (signals, cancels, timer fires) are folded into the workflow context
+
+#### Scenario: Activity outcomes become history events
+- **WHEN** activation observes a completed or failed activity task after replay reaches the history frontier
+- **THEN** it appends `activity.completed` or `activity.failed` to history before user code continues past that `Activity(...)` call
+- **THEN** the appended event becomes the deterministic replay source for later activations
+
+#### Scenario: Primitive scheduling becomes history
+- **WHEN** workflow execution first blocks on `Activity(...)` or `SleepUntil(...)`
+- **THEN** activation appends `activity.scheduled` or `timer.scheduled` before creating the corresponding wake source and transitioning the run to `waiting`
+
+#### Scenario: Inbox consumption becomes history
+- **WHEN** activation consumes due timer, signal, or cancel inbox rows after replay reaches the history frontier
+- **THEN** it appends `timer.fired`, `signal.received`, or `cancel.requested` before marking those inbox rows processed
+- **THEN** user workflow code observes the effect only through those appended history events
+
+#### Scenario: Custom status becomes history
+- **WHEN** workflow code calls `SetCustomStatus(...)` during an activation
+- **THEN** activation appends `custom_status.updated` in the same transaction that rewrites `runs.custom_status`
+
+#### Scenario: Terminal outcome becomes history
+- **WHEN** workflow execution reaches a terminal success or failure path
+- **THEN** activation appends `workflow.completed` or `workflow.failed` in the same transaction that transitions the run to its terminal lifecycle status
+
+#### Scenario: Activation commit phase
+- **WHEN** the workflow yields a new primitive or completes
+- **THEN** within the same transaction: scheduled, consumed, status, and terminal history rows are appended at their defined write points, materialized caches (`result`, `custom_status`, `waiting_for`) are rewritten, consumed inbox rows are marked processed, and the run transitions to `waiting`, `completed`, or `failed`
+
+#### Scenario: Activation atomicity
+- **WHEN** any step within the activation transaction fails
+- **THEN** the entire transaction rolls back and no state changes are persisted
+
+---
+
+### Requirement: Replay-from-history
+
+The runtime MUST replay workflow execution from history on every activation.
+
+#### Scenario: Replay happy path
+- **WHEN** a workflow is activated and history contains events matching the workflow's execution path
+- **THEN** replay succeeds and execution continues from the point after the last recorded event
+
+#### Scenario: Workflow input is history-backed
+- **WHEN** workflow code reads input through `Context.Input(...)`
+- **THEN** the value comes from the recorded `workflow.started` payload, not from ephemeral CLI process state
+
+#### Scenario: Replay mismatch detection
+- **WHEN** replay encounters a primitive call that does not match the next recorded history event (different kind, key, or typed payload fields)
+- **THEN** a `workflow.replay_mismatch` event is appended to history and the run is failed terminally
+
+#### Scenario: Version mismatch
+- **WHEN** a workflow is activated and the definition version does not exactly match `runs.definition_version`
+- **THEN** the activation fails the run with a compatibility error
+
+#### Scenario: Activity replay pending
+- **WHEN** a workflow calls `Activity()` during replay and the next matching history event is `activity.scheduled` with no later matching `activity.completed` or `activity.failed`
+- **THEN** replay treats the call as still pending and activation continues to rely on the durable activity task state instead of re-scheduling
+
+#### Scenario: Activity replay success
+- **WHEN** a workflow calls `Activity()` during replay and matching `activity.scheduled` then `activity.completed` events exist in history
+- **THEN** the recorded output is provided from history without re-executing the activity handler
+
+#### Scenario: Activity replay failure
+- **WHEN** a workflow calls `Activity()` during replay and matching `activity.scheduled` then `activity.failed` events exist in history
+- **THEN** the recorded failure is returned from the primitive without re-executing the activity handler
+
+#### Scenario: Timer replay pending
+- **WHEN** a workflow calls `SleepUntil()` during replay and the next matching history event is `timer.scheduled` with no later matching `timer.fired`
+- **THEN** replay treats the call as still pending and activation continues to rely on the durable timer inbox row instead of re-scheduling
+
+#### Scenario: Timer replay fired
+- **WHEN** a workflow calls `SleepUntil()` during replay and matching `timer.scheduled` then `timer.fired` events exist in history
+- **THEN** the call returns immediately without re-scheduling
+
+#### Scenario: Signal replay delivery
+- **WHEN** a workflow calls `ReceiveSignal()` during replay and a matching `signal.received` event exists in history
+- **THEN** the payload is provided from history without consuming another inbox row
+
+#### Scenario: Cancellation replay delivery
+- **WHEN** replay reconstructs workflow state and a `cancel.requested` event exists in history
+- **THEN** `CancellationRequested()` returns `true` without requiring a second inbox consume
+
+#### Scenario: Custom status replay state
+- **WHEN** replay reconstructs workflow state and one or more `custom_status.updated` events exist in history
+- **THEN** the latest recorded value becomes the in-memory custom status before user code continues
+
+---
+
+### Requirement: Run-scoped inbox consumption
+
+All Phase 11 inbox rows MUST be run-scoped and consumed only inside the workflow activation transaction.
+
+#### Scenario: Run-scoped inbox
+- **WHEN** an inbox item is created (signal, cancel, or timer)
+- **THEN** `run_id` is always set on the inbox row
+
+#### Scenario: Inbox consumption boundary
+- **WHEN** inbox items are consumed
+- **THEN** consumption happens only inside the workflow activation transaction via `MarkInboxProcessed`
+
+---
+
+### Requirement: Activity worker execution model
+
+The activity worker MUST execute handlers outside a database transaction with at-least-once semantics.
+
+#### Scenario: Activity claim and execute
+- **WHEN** the activity worker claims a task
+- **THEN** it executes the registered handler outside a transaction
+
+#### Scenario: Activity completion with CAS
+- **WHEN** the activity handler succeeds
+- **THEN** the worker completes the task with `WHERE id = $1 AND status = 'claimed' AND claimed_by = $2`
+- **THEN** on success, the worker wakes the owning run with guarded `waiting -> queued`
+
+#### Scenario: Activity failure with CAS
+- **WHEN** the activity handler fails
+- **THEN** the worker fails the task with the same CAS pattern
+- **THEN** on CAS success, the worker wakes the owning run with guarded `waiting -> queued` so activation can observe the failure and decide how to proceed
+
+#### Scenario: Stale claim handling
+- **WHEN** activity completion or failure returns `ErrStaleClaim`
+- **THEN** the worker drops the stale result silently (logs the event)
+
+---
+
+### Requirement: Maintenance worker scope
+
+The maintenance worker MUST handle timer wakeups and request dedupe expiry only.
+
+#### Scenario: Timer wakeup
+- **WHEN** the maintenance worker runs
+- **THEN** it finds `waiting` runs that have due pending timer inbox items (`available_at <= NOW()`)
+- **THEN** it wakes those runs with guarded `waiting -> queued`
+
+#### Scenario: Request dedupe expiry
+- **WHEN** the maintenance worker runs
+- **THEN** it expires stale `request_dedupe` rows where `status = 'in_progress'` and `expires_at < NOW()`
+
+#### Scenario: Maintenance worker boundaries
+- **WHEN** the maintenance worker runs
+- **THEN** it does NOT append history events, write projections, or perform control-plane behavior
+
+---
+
+### Requirement: Single-primitive blocking
+
+Phase 11 workflows MUST block on exactly one primitive at a time.
+
+#### Scenario: Single wait
+- **WHEN** a workflow calls `Activity()`, `SleepUntil()`, or `ReceiveSignal()` and the primitive is not yet resolved
+- **THEN** the activation transaction creates the corresponding durable wait registration before transitioning the run to `waiting` with `waiting_for` set to a single tagged JSON object
+- **THEN** activity waits create an activity task row, timer waits create a timer inbox row with `kind = 'timer'` and `available_at = due_at`, and signal waits are durably registered by the `waiting_for` value itself until a future `signal` command inserts the wakeup inbox row
+
+#### Scenario: Waiting_for structure
+- **WHEN** a run transitions to `waiting`
+- **THEN** `waiting_for` is one of:
+  - `{"kind":"activity","activity_key":"...","activity_type":"..."}`
+  - `{"kind":"timer","timer_key":"...","due_at":"RFC3339"}`
+  - `{"kind":"signal","signal_name":"..."}`
+
+---
+
+### Requirement: ClaimNextRun behavior with waiting status
+
+`ClaimNextRun` MUST NOT reclaim `waiting` runs. Only `queued` (ready) and `running` (expired lease) runs are claimable.
+
+#### Scenario: Waiting runs excluded from claim
+- **WHEN** `ClaimNextRun` polls for eligible runs
+- **THEN** it targets `(status = 'queued' AND ready_at <= NOW()) OR (status = 'running' AND lease_expires_at < NOW())`
+- **THEN** runs with `status = 'waiting'` are never claimed by this query
+
+---
+
+### Requirement: UpdateRunStatus exclusion from runtime
+
+`UpdateRunStatus` MUST NOT be used in runtime execution paths. It remains legacy/admin/test-only.
+
+#### Scenario: Runtime uses guarded transitions
+- **WHEN** the runtime needs to transition a run's status
+- **THEN** it uses the guarded CAS transition queries, never `UpdateRunStatus`

--- a/openspec/changes/add-engine-dark-launch-core/specs/engine-schema-runtime-delta/spec.md
+++ b/openspec/changes/add-engine-dark-launch-core/specs/engine-schema-runtime-delta/spec.md
@@ -1,0 +1,178 @@
+# Capability: engine-schema-runtime-delta
+
+Schema migration, new/modified queries, and store methods required for engine runtime execution. Extends [engine-schema-foundation](../../../../changes/add-engine-foundation/specs/engine-schema-foundation/spec.md).
+
+Related capabilities: [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-runtime-config](../engine-runtime-config/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Runtime migration 000002
+
+The engine MUST provide migration `000002_runtime_columns` that extends the existing schema for runtime execution without creating new tables.
+
+#### Scenario: Enum extension
+- **WHEN** the up migration runs
+- **THEN** `engine.run_lifecycle_status` gains the value `waiting`
+
+#### Scenario: New columns on engine.runs
+- **WHEN** the up migration runs
+- **THEN** `engine.runs` gains columns: `result JSONB`, `custom_status JSONB`, `waiting_for JSONB`, `completed_at TIMESTAMPTZ`
+
+#### Scenario: No new tables
+- **WHEN** the up migration runs
+- **THEN** no new tables are created; only ALTER statements are executed
+
+#### Scenario: No lease_token columns
+- **WHEN** the up migration runs
+- **THEN** no `lease_token` columns are added to any table
+
+#### Scenario: Down migration safety guard
+- **WHEN** the down migration runs and any run has `status = 'waiting'`
+- **THEN** the down migration fails with an explicit error rather than silently dropping data
+
+#### Scenario: Down migration enum replacement
+- **WHEN** the down migration runs and no run has `status = 'waiting'`
+- **THEN** the old enum is renamed, a replacement enum without `waiting` is created, `engine.runs.status` is altered with an explicit cast to the new type, and the old enum is dropped
+
+#### Scenario: Down migration column removal
+- **WHEN** the down migration completes
+- **THEN** the `result`, `custom_status`, `waiting_for`, and `completed_at` columns no longer exist on `engine.runs`
+
+---
+
+### Requirement: Guarded workflow-owned run transitions
+
+The engine MUST provide CAS queries for workflow-owned transitions that verify both expected status and claimant identity.
+
+#### Scenario: Running to waiting transition
+- **WHEN** a guarded transition query sets `status = 'waiting'` with `waiting_for` and `WHERE id = $1 AND status = 'running' AND claimed_by = $2`
+- **THEN** the run transitions to `waiting` and returns the updated row if the CAS matches
+- **THEN** returns zero rows affected if either the status or claimed_by does not match
+
+#### Scenario: Running to completed transition
+- **WHEN** a guarded transition query sets `status = 'completed'` with `result` and `completed_at = NOW()` and `WHERE id = $1 AND status = 'running' AND claimed_by = $2`
+- **THEN** the run transitions to `completed` and returns the updated row if the CAS matches
+
+#### Scenario: Running to failed transition
+- **WHEN** a guarded transition query sets `status = 'failed'` with error details and `completed_at = NOW()` and `WHERE id = $1 AND status = 'running' AND claimed_by = $2`
+- **THEN** the run transitions to `failed` and returns the updated row if the CAS matches
+
+---
+
+### Requirement: Guarded external wakeup transition
+
+The engine MUST provide a CAS query for external wakeups that verifies expected status without requiring claimant identity.
+
+#### Scenario: Waiting to queued transition
+- **WHEN** a guarded wakeup query sets `status = 'queued'` with `WHERE id = $1 AND status = 'waiting'`
+- **THEN** the run transitions to `queued` and returns the updated row if the status matches
+- **THEN** returns zero rows affected if the run is not in `waiting` status (idempotent no-op for already-queued, running, completed, failed, or cancelled runs)
+
+#### Scenario: WakeWaitingRun wrapper no-op
+- **WHEN** the guarded wakeup query returns zero rows affected but the run row still exists
+- **THEN** the store wrapper reports `applied = false` with no `ErrStaleClaim`
+
+#### Scenario: WakeWaitingRun wrapper missing row
+- **WHEN** the guarded wakeup query returns zero rows affected and the run row does not exist
+- **THEN** the store wrapper returns `ErrNotFound`
+
+---
+
+### Requirement: CAS activity completion and failure
+
+The activity completion and failure queries MUST CAS on `claimed_by` to prevent stale workers from overwriting results.
+
+#### Scenario: Activity completion with CAS
+- **WHEN** `CompleteActivityTask` is called with `WHERE id = $1 AND status = 'claimed' AND claimed_by = $2`
+- **THEN** the task completes only if the CAS matches
+
+#### Scenario: Activity failure with CAS
+- **WHEN** `FailActivityTask` is called with `WHERE id = $1 AND status = 'claimed' AND claimed_by = $2`
+- **THEN** the task fails only if the CAS matches
+
+#### Scenario: Stale claim rejection
+- **WHEN** a CAS query returns zero rows affected and the row exists
+- **THEN** the store wrapper returns `ErrStaleClaim` (not `ErrNotFound`)
+
+---
+
+### Requirement: Run-scoped inbox queries
+
+The engine MUST provide queries for listing and consuming inbox items scoped to a specific run.
+
+#### Scenario: List pending inbox by run
+- **WHEN** `ListPendingInboxByRun` is called with a `run_id` and `available_at <= NOW()`
+- **THEN** returns all `pending` inbox rows for that run ordered by `available_at ASC, id ASC`
+
+#### Scenario: Mark inbox processed with status guard
+- **WHEN** `MarkInboxProcessed` is called within the activation transaction
+- **THEN** the query uses `WHERE id = $1 AND status = 'pending'` to guard against double-processing
+- **THEN** the inbox row transitions from `pending` to `processed` with `resolved_at = NOW()`
+- **THEN** if the row is not in `pending` status, zero rows are affected (idempotent no-op)
+
+---
+
+### Requirement: ListActivityTasksByRun query
+
+The engine MUST provide a query to list activity tasks for a specific run.
+
+#### Scenario: List activity tasks by run
+- **WHEN** `ListActivityTasksByRun` is called with a `run_id`
+- **THEN** returns all activity tasks for that run ordered by `created_at ASC, id ASC`
+
+---
+
+### Requirement: Atomic start request dedupe claim
+
+The engine MUST provide a transaction-safe primitive for `start` request deduplication that can claim a new request, surface a finalized duplicate, detect a live in-progress duplicate, or reclaim an expired claim without racing the unique constraint on `(project_id, request_scope, request_key)`.
+
+#### Scenario: Claim new start request
+- **WHEN** the start dedupe primitive runs and no row exists for `(project_id, request_scope = 'engine.start', request_key)`
+- **THEN** it creates and returns a row with `status = 'in_progress'` and a fresh `expires_at`
+
+#### Scenario: Return finalized duplicate
+- **WHEN** the start dedupe primitive finds an existing row with `status = 'completed'` or `status = 'failed'`
+- **THEN** it returns that existing finalized row without creating or replacing a second row
+
+#### Scenario: Live in-progress duplicate
+- **WHEN** the start dedupe primitive finds an existing row with `status = 'in_progress'` and `expires_at >= NOW()`
+- **THEN** it returns that existing live claim so the caller can surface `request_in_progress`
+
+#### Scenario: Expired in-progress takeover
+- **WHEN** the start dedupe primitive finds an existing row with `status = 'in_progress'` and `expires_at < NOW()`
+- **THEN** it atomically renews that same logical claim with a refreshed `expires_at` and cleared finalized-response fields
+- **THEN** it does not rely on an unlocked get-then-insert or delete-then-insert pattern
+
+#### Scenario: Reclaim previously expired row
+- **WHEN** the start dedupe primitive finds an existing row with `status = 'expired'`
+- **THEN** it atomically renews that same logical claim with `status = 'in_progress'`, a refreshed `expires_at`, and cleared finalized-response fields
+- **THEN** the same `request_key` becomes usable again after maintenance expiry
+
+---
+
+### Requirement: Request dedupe expiry query
+
+The engine MUST provide a query to expire stale request dedupe rows.
+
+#### Scenario: Expire stale dedupe rows
+- **WHEN** `ExpireRequestDedupe` is called
+- **THEN** rows with `status = 'in_progress'` and `expires_at < NOW()` are transitioned to `expired`
+- **THEN** returns the count of expired rows
+
+---
+
+### Requirement: ErrStaleClaim sentinel error
+
+The store MUST provide `ErrStaleClaim` to distinguish stale ownership from a genuinely missing row.
+
+#### Scenario: CAS miss on existing row
+- **WHEN** a CAS update returns zero rows affected and the row exists in the table
+- **THEN** the store wrapper returns `ErrStaleClaim`
+
+#### Scenario: CAS miss on missing row
+- **WHEN** a CAS update returns zero rows affected and the row does not exist
+- **THEN** the store wrapper returns `ErrNotFound`
+
+#### Scenario: Status-only wakeup is not a stale-claim path
+- **WHEN** `WakeWaitingRun` finds an existing row that is no longer in `waiting`
+- **THEN** the wrapper reports an idempotent no-op rather than `ErrStaleClaim`

--- a/openspec/changes/add-engine-dark-launch-core/specs/engine-workflow-authoring/spec.md
+++ b/openspec/changes/add-engine-dark-launch-core/specs/engine-workflow-authoring/spec.md
@@ -1,0 +1,150 @@
+# Capability: engine-workflow-authoring
+
+Minimal public Go API for defining durable workflows. Lives in `engine/pkg/workflow` and is the only engine package importable by external consumers.
+
+Related capabilities: [engine-history-events](../engine-history-events/spec.md), [engine-runtime-execution](../engine-runtime-execution/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Workflow definition type
+
+The authoring API MUST provide a `Definition` struct for registering workflow implementations.
+
+#### Scenario: Definition structure
+- **WHEN** a workflow author creates a `Definition`
+- **THEN** the struct requires `Name string`, `Version string`, and `Run func(Context) error`
+
+#### Scenario: Definition registration
+- **WHEN** a `Definition` is passed to the `serve` command's workflow registry
+- **THEN** the runtime can look up the definition by `(Name, Version)` for execution and replay
+
+#### Scenario: Start requires a registered definition
+- **WHEN** `continua-engine start` is invoked with a `(definition, version)` pair that is not present in the compiled registry
+- **THEN** the command rejects the request before writing any `instances`, `runs`, or `request_dedupe` rows
+
+---
+
+### Requirement: Workflow input primitive
+
+The authoring API MUST provide `Context.Input(out)` for reading the workflow input captured by the initial `workflow.started` event.
+
+#### Scenario: Input on first activation
+- **WHEN** `start` creates a run with `--input` and workflow code calls `ctx.Input(&value)`
+- **THEN** the value is deserialized from the `workflow.started.input` payload for that run
+
+#### Scenario: Input on replay
+- **WHEN** workflow code calls `ctx.Input(&value)` during replay
+- **THEN** the same value is deserialized from the recorded `workflow.started` event without relying on process-local CLI state
+
+#### Scenario: No input supplied
+- **WHEN** workflow code calls `ctx.Input(&value)` and `start` omitted `--input`
+- **THEN** the call succeeds and leaves the target at its zero value
+
+---
+
+### Requirement: Activity primitive
+
+The authoring API MUST provide `Context.Activity(key, activityType, input, out)` for scheduling durable activities.
+
+#### Scenario: Activity scheduling
+- **WHEN** a workflow calls `ctx.Activity("fetch-user", "http.get", input, &result)`
+- **THEN** during first execution, the runtime appends `activity.scheduled` and schedules an activity task with the given key and type
+- **THEN** the workflow blocks until the activity completes
+
+#### Scenario: Activity replay
+- **WHEN** a workflow calls `ctx.Activity(...)` during replay and matching `activity.scheduled` then `activity.completed` events exist in history
+- **THEN** the result is deserialized from the recorded output without re-executing the activity
+
+#### Scenario: Activity replay failure
+- **WHEN** a workflow calls `ctx.Activity(...)` during replay and matching `activity.scheduled` then `activity.failed` events exist in history
+- **THEN** the call returns the recorded failure without re-executing the activity
+
+#### Scenario: Stable key required
+- **WHEN** a workflow calls `ctx.Activity("")` with an empty key
+- **THEN** the call returns an error
+
+---
+
+### Requirement: Timer primitive
+
+The authoring API MUST provide `Context.SleepUntil(key, at)` for durable timer scheduling.
+
+#### Scenario: Timer scheduling
+- **WHEN** a workflow calls `ctx.SleepUntil("approval-deadline", futureTime)`
+- **THEN** during first execution, the runtime records a `timer.scheduled` event, creates a run-scoped inbox row with `kind = 'timer'` and `available_at = due_at`, and the run transitions to `waiting`
+- **THEN** the workflow resumes after the maintenance worker detects the timer inbox row is due and wakes the run
+
+#### Scenario: Timer replay
+- **WHEN** a workflow calls `ctx.SleepUntil(...)` during replay and a matching `timer.fired` event exists in history
+- **THEN** the call returns immediately without re-scheduling
+
+#### Scenario: Stable key required
+- **WHEN** a workflow calls `ctx.SleepUntil("")` with an empty key
+- **THEN** the call returns an error
+
+---
+
+### Requirement: Signal primitive
+
+The authoring API MUST provide `Context.ReceiveSignal(name, out)` for receiving durable signals.
+
+#### Scenario: Signal reception
+- **WHEN** a workflow calls `ctx.ReceiveSignal("approval", &decision)`
+- **THEN** during first execution, the run transitions to `waiting` for the named signal with `waiting_for = {"kind":"signal","signal_name":"approval"}`
+- **THEN** the workflow resumes when a signal with the matching name arrives via the `signal` command and activation appends `signal.received`
+
+#### Scenario: Signal replay
+- **WHEN** a workflow calls `ctx.ReceiveSignal(...)` during replay and a matching `signal.received` event exists in history
+- **THEN** the payload is deserialized from the recorded event without re-waiting
+
+---
+
+### Requirement: Cancellation observation
+
+The authoring API MUST provide `Context.CancellationRequested()` for checking if cancellation has been requested.
+
+#### Scenario: Cancellation check
+- **WHEN** a workflow calls `ctx.CancellationRequested()`
+- **THEN** returns `true` if a `cancel.requested` event exists in the current activation's inbox/history
+- **THEN** returns `false` otherwise
+
+#### Scenario: Cancellation delivery
+- **WHEN** activation consumes a cancel inbox row for the active run
+- **THEN** it appends `cancel.requested` before `ctx.CancellationRequested()` can observe the cancellation
+
+#### Scenario: Cancellation is observational
+- **WHEN** cancellation is requested but the workflow does not check `CancellationRequested()`
+- **THEN** the workflow continues executing normally; cancellation is not forced
+
+---
+
+### Requirement: Custom status primitive
+
+The authoring API MUST provide `Context.SetCustomStatus(value)` for setting workflow-visible status.
+
+#### Scenario: Custom status update
+- **WHEN** a workflow calls `ctx.SetCustomStatus(map[string]string{"step": "processing"})`
+- **THEN** a `custom_status.updated` event is appended to history
+- **THEN** `runs.custom_status` cache is updated during activation commit
+
+---
+
+### Requirement: Non-determinism prohibition
+
+Workflow definitions MUST NOT perform non-deterministic operations.
+
+#### Scenario: Prohibited operations
+- **WHEN** a workflow definition is authored
+- **THEN** it MUST NOT read wall clocks, generate random values, perform network I/O, or spawn goroutines
+- **THEN** all external interaction MUST go through `Context` primitives
+
+---
+
+### Requirement: Dark-launch demo definitions
+
+Test and demo workflow definitions MUST live under `engine/cmd/continua-engine/internal/darklaunch`, not in `engine/pkg/workflow` or `engine/internal/workflow`.
+
+#### Scenario: Demo location
+- **WHEN** demo workflow definitions and activity handlers are created for testing the dark-launch
+- **THEN** they are placed in `engine/cmd/continua-engine/internal/darklaunch`
+- **THEN** they are not placed in the public API package or runtime machinery packages

--- a/openspec/changes/add-engine-dark-launch-core/tasks.md
+++ b/openspec/changes/add-engine-dark-launch-core/tasks.md
@@ -1,0 +1,153 @@
+## 1. Schema Delta & Generation
+
+- [x] 1.1 Create `engine/db/migrations/postgres/000002_runtime_columns.up.sql` with: `ALTER TYPE engine.run_lifecycle_status ADD VALUE 'waiting'`, `ALTER TABLE engine.runs ADD COLUMN result JSONB`, `ADD COLUMN custom_status JSONB`, `ADD COLUMN waiting_for JSONB`, `ADD COLUMN completed_at TIMESTAMPTZ`
+- [x] 1.2 Create `engine/db/migrations/postgres/000002_runtime_columns.down.sql` with: guard that fails if any run has `status = 'waiting'`, rename old enum, create replacement without `waiting`, alter `engine.runs.status` with explicit cast, drop old enum, drop the four added columns
+- [x] 1.3 Run `make generate` and verify new columns appear in generated `EngineRun` model and `EngineRunLifecycleStatus` includes `waiting`
+
+**Validation:** Migration up/down round-trips cleanly; `make generate` produces no drift
+
+## 2. New & Modified Queries
+
+- [x] 2.1 Add guarded workflow-owned transition queries to `engine/db/queries/runs.sql`: `TransitionRunToWaiting` (`running -> waiting` with `waiting_for`, CAS on `status + claimed_by`), `TransitionRunToCompleted` (`running -> completed` with `result + completed_at`, CAS on `status + claimed_by`), `TransitionRunToFailed` (`running -> failed` with error + `completed_at`, CAS on `status + claimed_by`)
+- [x] 2.2 Add guarded external wakeup query to `engine/db/queries/runs.sql`: `WakeWaitingRun` (`waiting -> queued`, CAS on `status` only, clears `waiting_for + claimed_by + claimed_at + lease_expires_at`)
+- [x] 2.3 Modify `CompleteActivityTask` and `FailActivityTask` in `engine/db/queries/activity_tasks.sql` to add `AND status = 'claimed' AND claimed_by = sqlc.arg(claimed_by)` to the WHERE clause (both status and claimant CAS required)
+- [x] 2.4 Add `ListActivityTasksByRun` to `engine/db/queries/activity_tasks.sql` (all tasks for a run, ordered by `created_at ASC, id ASC`)
+- [x] 2.5 Add `ListPendingInboxByRun` to `engine/db/queries/inbox.sql` (pending rows for a run where `available_at <= NOW()`, ordered by `available_at ASC, id ASC`)
+- [x] 2.5a Tighten `MarkInboxProcessed` in `engine/db/queries/inbox.sql` to add `AND status = 'pending'` to the WHERE clause (guard against double-processing)
+- [x] 2.6 Add request-dedupe helpers to `engine/db/queries/request_dedupe.sql` for atomic `start` claims (helper query/query pair needed to lock an existing row and renew either an expired `in_progress` claim or an already `expired` row under the unique key without delete-then-insert races)
+- [x] 2.7 Add `ExpireRequestDedupe` to `engine/db/queries/request_dedupe.sql` (transition `in_progress` rows with `expires_at < NOW()` to `expired`, return count)
+- [x] 2.8 Run `make generate` and verify all new queries produce correct Go signatures
+
+**Validation:** `make generate` succeeds; generated code matches query intent; existing query signatures preserved where not modified
+
+## 3. Store Layer Updates
+
+- [x] 3.1 Add `ErrStaleClaim` sentinel error to `engine/internal/store/store.go`
+- [x] 3.2 Add store wrappers for guarded workflow-owned run transitions: `TransitionRunToWaiting`, `TransitionRunToCompleted`, `TransitionRunToFailed` — each must distinguish `ErrNotFound` vs `ErrStaleClaim` on zero rows affected
+- [x] 3.2a Add `WakeWaitingRun` store wrapper that returns applied-vs-no-op semantics for status-only wakeups; it returns `ErrNotFound` only when the run row is missing and never uses `ErrStaleClaim`
+- [x] 3.3 Update `CompleteActivityTask` and `FailActivityTask` store wrappers to accept `claimedBy` parameter and return `ErrStaleClaim` on CAS miss
+- [x] 3.4 Add `ClaimStartRequestDedupe` store primitive that, inside the caller transaction, returns one of: newly claimed row, expired-claim reclaim (`status = 'expired'` or stale `in_progress`), finalized existing row, or live `in_progress` duplicate
+- [x] 3.5 Add store wrappers: `ListActivityTasksByRun`, `ListPendingInboxByRun`, `ExpireRequestDedupe`
+
+**Validation:** Store compiles; wrappers match new query signatures; `ErrStaleClaim` is testable
+
+## 4. Runtime Config
+
+- [x] 4.1 Extend `engine/internal/config/config.go` with `RuntimeConfig` struct: `WorkflowPollInterval time.Duration`, `ActivityPollInterval time.Duration`, `MaintenancePollInterval time.Duration`, `RunLeaseTTL time.Duration`, `ActivityLeaseTTL time.Duration`, `RequestDedupeTTL time.Duration`
+- [x] 4.2 Load from env vars: `ENGINE_WORKFLOW_POLL_INTERVAL`, `ENGINE_ACTIVITY_POLL_INTERVAL`, `ENGINE_MAINTENANCE_POLL_INTERVAL`, `ENGINE_RUN_LEASE_TTL`, `ENGINE_ACTIVITY_LEASE_TTL`, `ENGINE_REQUEST_DEDUPE_TTL` with sensible defaults (no `ENGINE_RUNTIME_ENABLED` — invoking `serve` is the gate)
+
+**Validation:** Config loads; defaults are applied; missing optional vars don't error
+
+## 5. History Event Package
+
+- [x] 5.1 Create `engine/internal/history/events.go` with canonical event type constants: `workflow.started`, `workflow.completed`, `workflow.failed`, `workflow.replay_mismatch`, `activity.scheduled`, `activity.completed`, `activity.failed`, `timer.scheduled`, `timer.fired`, `signal.received`, `cancel.requested`, `custom_status.updated`
+- [x] 5.2 Create typed payload structs for each event type with canonical JSON tags
+- [x] 5.3 Use standard `encoding/json` for payload serialization; replay comparison deserializes into typed structs rather than comparing raw bytes (no custom canonicalizer in Phase 11)
+- [x] 5.4 Add `WaitingFor` tagged union types: `ActivityWait`, `TimerWait`, `SignalWait` with `kind` discriminator
+
+**Validation:** Package compiles; payload round-trips through JSON deterministically
+
+## 6. Workflow Authoring API
+
+- [x] 6.1 Create `engine/pkg/workflow/definition.go` with `Definition{Name, Version, Run}` struct
+- [x] 6.2 Create `engine/pkg/workflow/context.go` with `Context` type and primitives: `Input(out)`, `Activity(key, activityType, input, out)`, `SleepUntil(key, at)`, `ReceiveSignal(name, out)`, `CancellationRequested()`, `SetCustomStatus(value)`
+- [x] 6.3 Enforce stable key requirement: `Activity()` and `SleepUntil()` return error on empty key
+
+**Validation:** Package compiles; public API surface matches spec; no runtime dependencies leak into the public package
+
+## 7. Replay Engine
+
+- [x] 7.1 Create `engine/internal/workflow/replay.go` with replay state machine that walks recorded history, initializes workflow input from `workflow.started`, and compares against workflow execution
+- [x] 7.2 Implement replay comparison: match primitive kind, stable key, and canonical payload against recorded events, including `workflow.started` input bootstrap, `activity.scheduled` before `activity.completed` / `activity.failed`, `timer.scheduled` before `timer.fired`, `signal.received`, `cancel.requested`, `custom_status.updated`, and terminal `workflow.completed` / `workflow.failed`
+- [x] 7.3 Implement mismatch handling: append `workflow.replay_mismatch` event and fail the run terminally
+- [x] 7.4 Implement version check: exact `definition_name + definition_version` match required; fail with compatibility error on mismatch
+
+**Validation:** Unit tests for replay match, mismatch, and version check scenarios
+
+## 8. Workflow Activation
+
+- [x] 8.1 Create `engine/internal/workflow/activation.go` with activation transaction: load claimed run + instance + ordered history (including the initial `workflow.started` event) + run-scoped activity tasks + due pending inbox rows
+- [x] 8.2 Implement replay phase: re-execute workflow definition against history, seed `Context.Input(...)` from `workflow.started`, and fold in durable activity outcomes (completed and failed) and inbox items
+- [x] 8.3 Implement commit phase: append new history rows at explicit write points (`activity.scheduled`, `activity.completed`, `activity.failed`, `timer.scheduled`, `timer.fired`, `signal.received`, `cancel.requested`, `custom_status.updated`, `workflow.completed`, `workflow.failed`), write materialized caches (`result`, `custom_status`, `waiting_for`), create wake sources before transitioning (activity task row for `Activity()`, timer inbox row with `kind = 'timer'` and `available_at = due_at` for `SleepUntil()`, signal waits durably registered via `waiting_for` only), mark consumed inbox rows processed, transition run via guarded CAS
+- [x] 8.4 Implement error handling: rollback entire transaction on any failure
+
+**Validation:** Activation compiles; unit tests for load/replay/commit phases
+
+## 9. Worker Loops
+
+- [x] 9.1 Create `engine/internal/worker/loop.go` with generic poll-based worker loop infrastructure (poll interval, identity generation, graceful shutdown)
+- [x] 9.2 Create `engine/internal/workflow/worker.go` with workflow worker: claim run via `ClaimNextRun`, execute activation, handle `ErrStaleClaim`
+- [x] 9.3 Create `engine/internal/activity/worker.go` with activity worker: claim task, execute handler outside transaction, complete/fail with CAS, wake owning run on both success and failure (so activation can observe the outcome)
+- [x] 9.4 Create maintenance worker (in `engine/internal/worker/` or `engine/cmd/continua-engine/`): wake waiting runs with due timers, expire stale request dedupe rows
+
+**Validation:** Worker loops compile; can start and stop gracefully
+
+## 10. CLI Commands
+
+- [x] 10.1 Add `serve` command to `engine/cmd/continua-engine/main.go`: start all three worker loops, register demo definitions, handle graceful shutdown
+- [x] 10.2 Add `start` command: accept `--instance-key`, `--definition`, `--version`, `--request-key`, `--input`; validate `(definition, version)` against the compiled registry before writing; implement in a single transaction using `ClaimStartRequestDedupe`; append initial `workflow.started` with optional input; handle stranded `in_progress` rows via atomic expiry reclaim; output JSON
+- [x] 10.3 Add `signal` command: accept `--instance-key`, `--signal-name`, `--payload`, optional `--dedupe-key`; reject terminal active runs before writing; otherwise insert inbox row, attempt guarded wakeup, output JSON
+- [x] 10.4 Add `cancel` command: accept `--instance-key`; reject terminal active runs before writing; otherwise insert inbox row with fixed dedupe key, attempt guarded wakeup, output JSON
+- [x] 10.5 Add `inspect` command: accept `--instance-key`; load instance + latest run + history; output JSON
+- [x] 10.6 Implement JSON output conventions: success at exit 0, error at exit 1 with `{"error":{"code":"...","message":"..."}}`
+
+**Validation:** All commands compile and produce correct JSON output format
+
+## 11. Dark-Launch Demo
+
+- [x] 11.1 Create `engine/cmd/continua-engine/internal/darklaunch/workflow.go` with a demo workflow: schedules one activity, sleeps on a timer, receives a signal, completes with a result
+- [x] 11.2 Create `engine/cmd/continua-engine/internal/darklaunch/activities.go` with demo activity handlers
+- [x] 11.3 Register demo definitions in the `serve` command
+
+**Validation:** Demo workflow can be started, executed, and inspected via CLI commands
+
+## 12. Gate Tests
+
+- [x] 12.1 Happy path: start -> activity completes -> timer fires -> signal received -> workflow completes; verify via `inspect`, including history order `workflow.started`, `activity.scheduled`, `activity.completed`, `timer.scheduled`, `timer.fired`, `signal.received`, `workflow.completed`
+- [x] 12.2 Duplicate start: same `instance_key` with different request returns `instance_conflict`; same `request_key` returns recorded response
+- [x] 12.2a Unknown definition/version: `start` returns `definition_not_registered` and writes no engine rows
+- [x] 12.2b Request-key retry after maintenance expiry: expire a stale `request_dedupe` row to `status = 'expired'`, retry the same `request_key`, and verify the claim is reusable
+- [x] 12.2c Workflow input round-trip: `start --input` writes `workflow.started.input`, `Context.Input(...)` reads it on first activation, and replay reads the same value deterministically
+- [x] 12.3 Mid-activity restart recovery: start workflow, let activity schedule, stop `serve`, restart `serve`, verify activity completes and workflow progresses (document at-least-once duplicate execution)
+- [x] 12.4 Timer-persistence restart recovery: start workflow, let timer schedule, stop `serve`, restart `serve`, verify timer fires and workflow resumes
+- [x] 12.5 Signal-persistence restart recovery: send signal while `serve` is stopped, restart `serve`, verify signal is consumed
+- [x] 12.5a Terminal signal/cancel rejection: after a run reaches terminal state, both commands return `run_terminal` and do not insert new inbox rows
+- [x] 12.6 Stale-claim rejection: activity completion with wrong `claimed_by` returns `ErrStaleClaim`
+- [x] 12.7 Replay mismatch: modify workflow definition between activations, verify `workflow.replay_mismatch` event and failed run
+- [x] 12.8 Version mismatch: register definition with different version, verify compatibility failure
+
+**Validation:** All gate tests pass with `cd engine && go test ./...`
+
+## 13. Secondary Hardening Tests
+
+- [x] 13.1 Restart after run claim: stop `serve` after `ClaimNextRun` but before activation completes; verify run is reclaimable after lease expiry
+- [x] 13.2 Restart after activity schedule but before worker pickup: verify activity task is claimed by new worker
+- [x] 13.3 Restart just before final run completion commit: verify run is reclaimable and completes on retry
+
+**Validation:** All hardening tests pass
+
+## 14. Regression Guard
+
+- [ ] 14.1 Run `make generate` and verify no drift
+- [x] 14.2 Run `cd engine && go test ./...` — all engine tests pass
+- [x] 14.3 Run root Go regression: `go test ./internal/api/... ./internal/ingest/... ./internal/store/... ./internal/jobs/...`
+- [ ] 14.4 Run existing web tests: `pnpm --filter web test`
+
+**Validation:** Engine and root Go regressions pass; `make generate` still requires a plain `pnpm` binary in PATH and `pnpm --filter web test` still hangs after suite completion in this environment
+
+---
+
+### Parallelization Notes
+
+- Tasks 1, 4, 5, 6 can run in parallel (schema delta, config, history events, and authoring API are independent)
+- Task 2 depends on task 1 (queries reference new columns/enum)
+- Task 3 depends on task 2 (store wraps new queries)
+- Task 6 is independent (authoring API defines primitives; runtime maps them to history events, not the reverse)
+- Task 7 depends on tasks 5+6 (replay uses history events and authoring primitives)
+- Task 8 depends on tasks 3+7 (activation uses store wrappers and replay)
+- Task 9 depends on task 8 (workers use activation)
+- Task 10 depends on task 9 (CLI commands wire workers)
+- Task 11 depends on tasks 6+10 (demo uses authoring API and CLI)
+- Task 12 depends on tasks 10+11 (gate tests exercise full stack)
+- Task 13 depends on task 12 (hardening after gate tests pass)
+- Task 14 runs after task 12 (regression guard)

--- a/web/src/pages/testUtils.tsx
+++ b/web/src/pages/testUtils.tsx
@@ -223,7 +223,11 @@ function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
+        gcTime: Infinity,
         retry: false,
+      },
+      mutations: {
+        gcTime: Infinity,
       },
     },
   });


### PR DESCRIPTION
## What changed
- adds the dark-launch engine runtime schema, store primitives, and public workflow authoring API
- adds the workflow/activity runtime, CLI commands, and demo dark-launch workflow
- adds hardening coverage and the approved OpenSpec change package for add-engine-dark-launch-core

## Why
- implements the approved OpenSpec change for the internal-only engine runtime
- proves the end-to-end start -> activity -> timer -> signal -> restart recovery path
- hardens activation, replay, and restart behavior around stale claims and terminal races

## Validation
- cd engine && /usr/local/go/bin/go test ./cmd/continua-engine -count=1
- cd engine && /usr/local/go/bin/go test ./... -count=1
- go test ./internal/api/... ./internal/ingest/... ./internal/store/... ./internal/jobs/... -count=1
- PATH=/opt/homebrew/bin:/usr/local/bin:/Users/aryanvijaywargia/.codex/tmp/arg0/codex-arg0tLwWWi:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/corepack pnpm dlx @fission-ai/openspec validate add-engine-dark-launch-core --strict

## Notes
- openspec/changes/add-engine-public-surface is intentionally excluded from this PR
- make generate and pnpm --filter web test remain environment-level follow-ups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime execution core with workflow, activity, and maintenance workers plus new CLI commands: serve, start, signal, cancel, inspect (JSON outputs).
  * Durable workflow API, typed history events, request-deduplication, activity/task processing, and a dark-launch demo workflow.
  * Persistent timer/signal waiting and inspectable run state.

* **Bug Fixes**
  * Migration down now blocks when runs are in waiting to prevent unsafe rollbacks.

* **Documentation**
  * Added design, specs, and task docs covering runtime, CLI, schema, config, and workflow authoring.

* **Tests**
  * Extensive unit, integration, and end-to-end runtime/replay/activation test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->