### PR TITLE
Implement engine operational hardening core

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -82,12 +82,13 @@ const (
 
 // Defines values for EngineRunStatus.
 const (
-	EngineRunStatusCANCELLED EngineRunStatus = "CANCELLED"
-	EngineRunStatusCOMPLETED EngineRunStatus = "COMPLETED"
-	EngineRunStatusFAILED    EngineRunStatus = "FAILED"
-	EngineRunStatusQUEUED    EngineRunStatus = "QUEUED"
-	EngineRunStatusRUNNING   EngineRunStatus = "RUNNING"
-	EngineRunStatusWAITING   EngineRunStatus = "WAITING"
+	EngineRunStatusCANCELLED  EngineRunStatus = "CANCELLED"
+	EngineRunStatusCOMPLETED  EngineRunStatus = "COMPLETED"
+	EngineRunStatusFAILED     EngineRunStatus = "FAILED"
+	EngineRunStatusQUEUED     EngineRunStatus = "QUEUED"
+	EngineRunStatusRUNNING    EngineRunStatus = "RUNNING"
+	EngineRunStatusTERMINATED EngineRunStatus = "TERMINATED"
+	EngineRunStatusWAITING    EngineRunStatus = "WAITING"
 )
 
 // Defines values for IngestEventLevel.
@@ -427,10 +428,49 @@ type EngineInstanceResponse struct {
 	Status         string             `json:"status"`
 }
 
+// EnginePendingActivityItem defines model for EnginePendingActivityItem.
+type EnginePendingActivityItem struct {
+	ActivityKey  string             `json:"activity_key"`
+	ActivityType string             `json:"activity_type"`
+	AttemptCount int32              `json:"attempt_count"`
+	AvailableAt  time.Time          `json:"available_at"`
+	Status       string             `json:"status"`
+	TaskId       openapi_types.UUID `json:"task_id"`
+}
+
+// EnginePendingSignalItem defines model for EnginePendingSignalItem.
+type EnginePendingSignalItem struct {
+	AvailableAt time.Time          `json:"available_at"`
+	InboxId     openapi_types.UUID `json:"inbox_id"`
+	SignalName  string             `json:"signal_name"`
+	Status      string             `json:"status"`
+}
+
+// EnginePendingTimerItem defines model for EnginePendingTimerItem.
+type EnginePendingTimerItem struct {
+	AvailableAt time.Time          `json:"available_at"`
+	InboxId     openapi_types.UUID `json:"inbox_id"`
+	Status      string             `json:"status"`
+	TimerKey    string             `json:"timer_key"`
+}
+
 // EnginePendingWork defines model for EnginePendingWork.
 type EnginePendingWork struct {
 	PendingActivityTasks int64 `json:"pending_activity_tasks"`
 	PendingInboxItems    int64 `json:"pending_inbox_items"`
+}
+
+// EnginePendingWorkResponse defines model for EnginePendingWorkResponse.
+type EnginePendingWorkResponse struct {
+	Activities []EnginePendingActivityItem `json:"activities"`
+
+	// CurrentWait Current synthesized wait state from the run row when present.
+	CurrentWait          *EngineWaitState           `json:"current_wait"`
+	PendingActivityTasks int64                     `json:"pending_activity_tasks"`
+	PendingInboxItems    int64                     `json:"pending_inbox_items"`
+	RunId                openapi_types.UUID        `json:"run_id"`
+	Signals              []EnginePendingSignalItem `json:"signals"`
+	Timers               []EnginePendingTimerItem  `json:"timers"`
 }
 
 // EngineProjectionState defines model for EngineProjectionState.
@@ -469,7 +509,7 @@ type EngineRunResultResponse struct {
 	Failure *EngineFailureSummary `json:"failure,omitempty"`
 
 	// Result Terminal workflow result payload when available.
-	Result interface{}        `json:"result,omitempty"`
+	Result interface{}        `json:"result"`
 	RunId  openapi_types.UUID `json:"run_id"`
 	Status EngineRunStatus    `json:"status"`
 }
@@ -1088,13 +1128,13 @@ type GetTraceEventsParams struct {
 // StartEngineRunParams defines parameters for StartEngineRun.
 type StartEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
 }
 
 // CancelEngineRunParams defines parameters for CancelEngineRun.
 type CancelEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
 }
 
 // GetEngineRunHistoryParams defines parameters for GetEngineRunHistory.
@@ -1106,7 +1146,13 @@ type GetEngineRunHistoryParams struct {
 // SignalEngineRunParams defines parameters for SignalEngineRun.
 type SignalEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// TerminateEngineRunParams defines parameters for TerminateEngineRun.
+type TerminateEngineRunParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
 }
 
 // IngestParams defines parameters for Ingest.
@@ -1313,12 +1359,18 @@ type ServerInterface interface {
 	// Get engine run history
 	// (GET /v1/engine/runs/{run_id}/history)
 	GetEngineRunHistory(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params GetEngineRunHistoryParams)
+	// Get the durable pending work held by an engine run
+	// (GET /v1/engine/runs/{run_id}/pending-work)
+	GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
 	// Get the terminal result for an engine run
 	// (GET /v1/engine/runs/{run_id}/result)
 	GetEngineRunResult(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
 	// Deliver a signal to an engine run
 	// (POST /v1/engine/runs/{run_id}/signal)
 	SignalEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params SignalEngineRunParams)
+	// Forcefully terminate an engine run
+	// (POST /v1/engine/runs/{run_id}/terminate)
+	TerminateEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params TerminateEngineRunParams)
 	// Ingest traces, spans, and events
 	// (POST /v1/ingest)
 	Ingest(w http.ResponseWriter, r *http.Request, params IngestParams)
@@ -1409,6 +1461,12 @@ func (_ Unimplemented) GetEngineRunHistory(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Get the durable pending work held by an engine run
+// (GET /v1/engine/runs/{run_id}/pending-work)
+func (_ Unimplemented) GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Get the terminal result for an engine run
 // (GET /v1/engine/runs/{run_id}/result)
 func (_ Unimplemented) GetEngineRunResult(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID) {
@@ -1418,6 +1476,12 @@ func (_ Unimplemented) GetEngineRunResult(w http.ResponseWriter, r *http.Request
 // Deliver a signal to an engine run
 // (POST /v1/engine/runs/{run_id}/signal)
 func (_ Unimplemented) SignalEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params SignalEngineRunParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Forcefully terminate an engine run
+// (POST /v1/engine/runs/{run_id}/terminate)
+func (_ Unimplemented) TerminateEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params TerminateEngineRunParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1921,7 +1985,7 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -1930,14 +1994,18 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = &XContinuaEnginePreview
+		params.XContinuaEnginePreview = XContinuaEnginePreview
 
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2007,7 +2075,7 @@ func (siw *ServerInterfaceWrapper) CancelEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2016,14 +2084,18 @@ func (siw *ServerInterfaceWrapper) CancelEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = &XContinuaEnginePreview
+		params.XContinuaEnginePreview = XContinuaEnginePreview
 
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2078,6 +2150,37 @@ func (siw *ServerInterfaceWrapper) GetEngineRunHistory(w http.ResponseWriter, r 
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetEngineRunHistory(w, r, runId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetEngineRunPendingWork operation middleware
+func (siw *ServerInterfaceWrapper) GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "run_id" -------------
+	var runId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "run_id", chi.URLParam(r, "run_id"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "run_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetEngineRunPendingWork(w, r, runId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2143,7 +2246,7 @@ func (siw *ServerInterfaceWrapper) SignalEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2152,18 +2255,81 @@ func (siw *ServerInterfaceWrapper) SignalEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = &XContinuaEnginePreview
+		params.XContinuaEnginePreview = XContinuaEnginePreview
 
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.SignalEngineRun(w, r, runId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// TerminateEngineRun operation middleware
+func (siw *ServerInterfaceWrapper) TerminateEngineRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "run_id" -------------
+	var runId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "run_id", chi.URLParam(r, "run_id"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "run_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params TerminateEngineRunParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.TerminateEngineRun(w, r, runId, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2411,10 +2577,16 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/history", wrapper.GetEngineRunHistory)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/pending-work", wrapper.GetEngineRunPendingWork)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/result", wrapper.GetEngineRunResult)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/engine/runs/{run_id}/signal", wrapper.SignalEngineRun)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/runs/{run_id}/terminate", wrapper.TerminateEngineRun)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/ingest", wrapper.Ingest)

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -105,8 +105,31 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get the terminal result for an engine run */
+        /**
+         * Get the terminal result for an engine run
+         * @description Returns the terminal result shape for the run.
+         *     `COMPLETED` returns the workflow result payload.
+         *     `CANCELLED` and `TERMINATED` return `result=null` with a populated `failure` object.
+         *
+         */
         get: operations["getEngineRunResult"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/engine/runs/{run_id}/pending-work": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the durable pending work held by an engine run */
+        get: operations["getEngineRunPendingWork"];
         put?: never;
         post?: never;
         delete?: never;
@@ -158,8 +181,31 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Request cancellation of an engine run */
+        /**
+         * Request cancellation of an engine run
+         * @description Cooperative cancellation request. Success only enqueues durable cancel intent and may wake the run;
+         *     it does not guarantee the final outcome becomes `CANCELLED`.
+         *     Workflow code decides between `COMPLETED` and `CANCELLED` by returning `workflow.ErrCancelled`.
+         *
+         */
         post: operations["cancelEngineRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/engine/runs/{run_id}/terminate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Forcefully terminate an engine run */
+        post: operations["terminateEngineRun"];
         delete?: never;
         options?: never;
         head?: never;
@@ -318,7 +364,7 @@ export interface components {
         /** @enum {string} */
         EngineProjectionState: "up_to_date" | "catching_up" | "summary_only" | "journal_expired";
         /** @enum {string} */
-        EngineRunStatus: "QUEUED" | "RUNNING" | "WAITING" | "COMPLETED" | "FAILED" | "CANCELLED";
+        EngineRunStatus: "QUEUED" | "RUNNING" | "WAITING" | "COMPLETED" | "FAILED" | "CANCELLED" | "TERMINATED";
         EngineTraceInfo: {
             /** Format: uuid */
             run_id: string;
@@ -338,6 +384,46 @@ export interface components {
             [key: string]: unknown;
         };
         EnginePendingWork: {
+            /** Format: int64 */
+            pending_activity_tasks: number;
+            /** Format: int64 */
+            pending_inbox_items: number;
+        };
+        EnginePendingActivityItem: {
+            /** Format: uuid */
+            task_id: string;
+            activity_key: string;
+            activity_type: string;
+            status: string;
+            /** Format: date-time */
+            available_at: string;
+            /** Format: int32 */
+            attempt_count: number;
+        };
+        EnginePendingTimerItem: {
+            /** Format: uuid */
+            inbox_id: string;
+            timer_key: string;
+            status: string;
+            /** Format: date-time */
+            available_at: string;
+        };
+        EnginePendingSignalItem: {
+            /** Format: uuid */
+            inbox_id: string;
+            signal_name: string;
+            status: string;
+            /** Format: date-time */
+            available_at: string;
+        };
+        EnginePendingWorkResponse: {
+            /** Format: uuid */
+            run_id: string;
+            /** @description Current synthesized wait state from the run row when present. */
+            current_wait: components["schemas"]["EngineWaitState"] | null;
+            activities: components["schemas"]["EnginePendingActivityItem"][];
+            timers: components["schemas"]["EnginePendingTimerItem"][];
+            signals: components["schemas"]["EnginePendingSignalItem"][];
             /** Format: int64 */
             pending_activity_tasks: number;
             /** Format: int64 */
@@ -443,7 +529,7 @@ export interface components {
             run_id: string;
             status: components["schemas"]["EngineRunStatus"];
             /** @description Terminal workflow result payload when available. */
-            result?: unknown;
+            result: unknown | null;
             failure?: components["schemas"]["EngineFailureSummary"];
         };
         EngineHistoryEvent: {
@@ -1059,9 +1145,9 @@ export interface operations {
     startEngineRun: {
         parameters: {
             query?: never;
-            header?: {
+            header: {
                 /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview"?: string;
+                "X-Continua-Engine-Preview": string;
             };
             path?: never;
             cookie?: never;
@@ -1248,6 +1334,46 @@ export interface operations {
             };
         };
     };
+    getEngineRunPendingWork: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pending work snapshot for the run */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnginePendingWorkResponse"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Run not found or engine API disabled */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     getEngineRunHistory: {
         parameters: {
             query?: {
@@ -1294,9 +1420,9 @@ export interface operations {
     signalEngineRun: {
         parameters: {
             query?: never;
-            header?: {
+            header: {
                 /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview"?: string;
+                "X-Continua-Engine-Preview": string;
             };
             path: {
                 run_id: string;
@@ -1359,9 +1485,9 @@ export interface operations {
     cancelEngineRun: {
         parameters: {
             query?: never;
-            header?: {
+            header: {
                 /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview"?: string;
+                "X-Continua-Engine-Preview": string;
             };
             path: {
                 run_id: string;
@@ -1408,6 +1534,58 @@ export interface operations {
             };
             /** @description Run terminal */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    terminateEngineRun: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required preview header for mutating engine routes. */
+                "X-Continua-Engine-Preview": string;
+            };
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Run terminated or already terminal */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EngineRunResultResponse"];
+                };
+            };
+            /** @description Missing preview header */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Run not found or engine API disabled */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -116,6 +116,7 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
+          required: true
           description: Required preview header for mutating engine routes.
           schema:
             type: string
@@ -223,6 +224,10 @@ paths:
     get:
       operationId: getEngineRunResult
       summary: Get the terminal result for an engine run
+      description: |
+        Returns the terminal result shape for the run.
+        `COMPLETED` returns the workflow result payload.
+        `CANCELLED` and `TERMINATED` return `result=null` with a populated `failure` object.
       tags:
         - Engine
       parameters:
@@ -253,6 +258,38 @@ paths:
                 $ref: '#/components/schemas/Error'
         '409':
           description: Run not terminal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/engine/runs/{run_id}/pending-work:
+    get:
+      operationId: getEngineRunPendingWork
+      summary: Get the durable pending work held by an engine run
+      tags:
+        - Engine
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Pending work snapshot for the run
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnginePendingWorkResponse'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Run not found or engine API disabled
           content:
             application/json:
               schema:
@@ -315,6 +352,7 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
+          required: true
           description: Required preview header for mutating engine routes.
           schema:
             type: string
@@ -359,6 +397,10 @@ paths:
     post:
       operationId: cancelEngineRun
       summary: Request cancellation of an engine run
+      description: |
+        Cooperative cancellation request. Success only enqueues durable cancel intent and may wake the run;
+        it does not guarantee the final outcome becomes `CANCELLED`.
+        Workflow code decides between `COMPLETED` and `CANCELLED` by returning `workflow.ErrCancelled`.
       tags:
         - Engine
       parameters:
@@ -370,6 +412,7 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
+          required: true
           description: Required preview header for mutating engine routes.
           schema:
             type: string
@@ -400,6 +443,50 @@ paths:
                 $ref: '#/components/schemas/Error'
         '409':
           description: Run terminal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/engine/runs/{run_id}/terminate:
+    post:
+      operationId: terminateEngineRun
+      summary: Forcefully terminate an engine run
+      tags:
+        - Engine
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Run terminated or already terminal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineRunResultResponse'
+        '400':
+          description: Missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Run not found or engine API disabled
           content:
             application/json:
               schema:
@@ -830,6 +917,7 @@ components:
         - COMPLETED
         - FAILED
         - CANCELLED
+        - TERMINATED
     EngineTraceInfo:
       type: object
       required:
@@ -870,6 +958,104 @@ components:
         - pending_activity_tasks
         - pending_inbox_items
       properties:
+        pending_activity_tasks:
+          type: integer
+          format: int64
+        pending_inbox_items:
+          type: integer
+          format: int64
+    EnginePendingActivityItem:
+      type: object
+      required:
+        - task_id
+        - activity_key
+        - activity_type
+        - status
+        - available_at
+        - attempt_count
+      properties:
+        task_id:
+          type: string
+          format: uuid
+        activity_key:
+          type: string
+        activity_type:
+          type: string
+        status:
+          type: string
+        available_at:
+          type: string
+          format: date-time
+        attempt_count:
+          type: integer
+          format: int32
+    EnginePendingTimerItem:
+      type: object
+      required:
+        - inbox_id
+        - timer_key
+        - status
+        - available_at
+      properties:
+        inbox_id:
+          type: string
+          format: uuid
+        timer_key:
+          type: string
+        status:
+          type: string
+        available_at:
+          type: string
+          format: date-time
+    EnginePendingSignalItem:
+      type: object
+      required:
+        - inbox_id
+        - signal_name
+        - status
+        - available_at
+      properties:
+        inbox_id:
+          type: string
+          format: uuid
+        signal_name:
+          type: string
+        status:
+          type: string
+        available_at:
+          type: string
+          format: date-time
+    EnginePendingWorkResponse:
+      type: object
+      required:
+        - run_id
+        - current_wait
+        - activities
+        - timers
+        - signals
+        - pending_activity_tasks
+        - pending_inbox_items
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        current_wait:
+          description: Current synthesized wait state from the run row when present.
+          allOf:
+            - $ref: '#/components/schemas/EngineWaitState'
+          x-nullable: true
+        activities:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnginePendingActivityItem'
+        timers:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnginePendingTimerItem'
+        signals:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnginePendingSignalItem'
         pending_activity_tasks:
           type: integer
           format: int64
@@ -1086,6 +1272,7 @@ components:
       required:
         - run_id
         - status
+        - result
       properties:
         run_id:
           type: string
@@ -1094,6 +1281,7 @@ components:
           $ref: '#/components/schemas/EngineRunStatus'
         result:
           description: Terminal workflow result payload when available.
+          x-nullable: true
         failure:
           $ref: '#/components/schemas/EngineFailureSummary'
     EngineHistoryEvent:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -121,6 +121,7 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
+          required: true
           description: Required preview header for mutating engine routes.
           schema:
             type: string
@@ -229,6 +230,10 @@ paths:
     get:
       operationId: getEngineRunResult
       summary: Get the terminal result for an engine run
+      description: |
+        Returns the terminal result shape for the run.
+        `COMPLETED` returns the workflow result payload.
+        `CANCELLED` and `TERMINATED` return `result=null` with a populated `failure` object.
       tags: [Engine]
       parameters:
         - name: run_id
@@ -258,6 +263,38 @@ paths:
                 $ref: '#/components/schemas/Error'
         '409':
           description: Run not terminal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/engine/runs/{run_id}/pending-work:
+    get:
+      operationId: getEngineRunPendingWork
+      summary: Get the durable pending work held by an engine run
+      tags: [Engine]
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Pending work snapshot for the run
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnginePendingWorkResponse'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Run not found or engine API disabled
           content:
             application/json:
               schema:
@@ -320,6 +357,7 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
+          required: true
           description: Required preview header for mutating engine routes.
           schema:
             type: string
@@ -365,6 +403,10 @@ paths:
     post:
       operationId: cancelEngineRun
       summary: Request cancellation of an engine run
+      description: |
+        Cooperative cancellation request. Success only enqueues durable cancel intent and may wake the run;
+        it does not guarantee the final outcome becomes `CANCELLED`.
+        Workflow code decides between `COMPLETED` and `CANCELLED` by returning `workflow.ErrCancelled`.
       tags: [Engine]
       parameters:
         - name: run_id
@@ -375,6 +417,7 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
+          required: true
           description: Required preview header for mutating engine routes.
           schema:
             type: string
@@ -405,6 +448,50 @@ paths:
                 $ref: '#/components/schemas/Error'
         '409':
           description: Run terminal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/engine/runs/{run_id}/terminate:
+    post:
+      operationId: terminateEngineRun
+      summary: Forcefully terminate an engine run
+      tags: [Engine]
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Run terminated or already terminal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineRunResultResponse'
+        '400':
+          description: Missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Run not found or engine API disabled
           content:
             application/json:
               schema:
@@ -816,7 +903,7 @@ components:
 
     EngineRunStatus:
       type: string
-      enum: [QUEUED, RUNNING, WAITING, COMPLETED, FAILED, CANCELLED]
+      enum: [QUEUED, RUNNING, WAITING, COMPLETED, FAILED, CANCELLED, TERMINATED]
 
     EngineTraceInfo:
       type: object
@@ -854,6 +941,87 @@ components:
       type: object
       required: [pending_activity_tasks, pending_inbox_items]
       properties:
+        pending_activity_tasks:
+          type: integer
+          format: int64
+        pending_inbox_items:
+          type: integer
+          format: int64
+
+    EnginePendingActivityItem:
+      type: object
+      required: [task_id, activity_key, activity_type, status, available_at, attempt_count]
+      properties:
+        task_id:
+          type: string
+          format: uuid
+        activity_key:
+          type: string
+        activity_type:
+          type: string
+        status:
+          type: string
+        available_at:
+          type: string
+          format: date-time
+        attempt_count:
+          type: integer
+          format: int32
+
+    EnginePendingTimerItem:
+      type: object
+      required: [inbox_id, timer_key, status, available_at]
+      properties:
+        inbox_id:
+          type: string
+          format: uuid
+        timer_key:
+          type: string
+        status:
+          type: string
+        available_at:
+          type: string
+          format: date-time
+
+    EnginePendingSignalItem:
+      type: object
+      required: [inbox_id, signal_name, status, available_at]
+      properties:
+        inbox_id:
+          type: string
+          format: uuid
+        signal_name:
+          type: string
+        status:
+          type: string
+        available_at:
+          type: string
+          format: date-time
+
+    EnginePendingWorkResponse:
+      type: object
+      required: [run_id, current_wait, activities, timers, signals, pending_activity_tasks, pending_inbox_items]
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        current_wait:
+          description: Current synthesized wait state from the run row when present.
+          allOf:
+            - $ref: '#/components/schemas/EngineWaitState'
+          x-nullable: true
+        activities:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnginePendingActivityItem'
+        timers:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnginePendingTimerItem'
+        signals:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnginePendingSignalItem'
         pending_activity_tasks:
           type: integer
           format: int64
@@ -1050,7 +1218,7 @@ components:
 
     EngineRunResultResponse:
       type: object
-      required: [run_id, status]
+      required: [run_id, status, result]
       properties:
         run_id:
           type: string
@@ -1059,6 +1227,7 @@ components:
           $ref: '#/components/schemas/EngineRunStatus'
         result:
           description: Terminal workflow result payload when available.
+          x-nullable: true
         failure:
           $ref: '#/components/schemas/EngineFailureSummary'
 

--- a/contracts/scripts/postprocess-generated-nullable-refs.mjs
+++ b/contracts/scripts/postprocess-generated-nullable-refs.mjs
@@ -45,6 +45,18 @@ function patchTypescript() {
     'candidate_event: components["schemas"]["CompareSemanticSummary"] | null;',
     "typescript candidate_event",
   );
+  source = replaceOrThrow(
+    source,
+    'current_wait: components["schemas"]["EngineWaitState"];',
+    'current_wait: components["schemas"]["EngineWaitState"] | null;',
+    "typescript current_wait",
+  );
+  source = replaceOrThrow(
+    source,
+    'result: unknown;',
+    'result: unknown | null;',
+    "typescript engine run result",
+  );
 
   writeFileSync(targetPath, source);
 }
@@ -76,6 +88,12 @@ function patchGo() {
     /(CandidateSpan\s+)(CompareSpanSummary)(\s+`json:"candidate_span"`)/,
     "$1*$2$3",
     "go candidate_span",
+  );
+  source = replaceOrThrow(
+    source,
+    /(CurrentWait\s+)(EngineWaitState)(\s+`json:"current_wait"`)/,
+    "$1*$2$3",
+    "go current_wait",
   );
 
   writeFileSync(targetPath, source);

--- a/db/platform/migrations/postgres/000017_engine_run_status_terminated.down.sql
+++ b/db/platform/migrations/postgres/000017_engine_run_status_terminated.down.sql
@@ -1,0 +1,43 @@
+DO $$
+DECLARE
+    terminated_count INTEGER;
+    offending_rows TEXT;
+    overflow_suffix TEXT := '';
+BEGIN
+    SELECT COUNT(*)
+    INTO terminated_count
+    FROM traces
+    WHERE engine_run_status = 'terminated';
+
+    IF terminated_count > 0 THEN
+        SELECT string_agg(format('id=%s trace_id=%s', id, trace_id), ', ' ORDER BY id)
+        INTO offending_rows
+        FROM (
+            SELECT id, trace_id
+            FROM traces
+            WHERE engine_run_status = 'terminated'
+            ORDER BY id
+            LIMIT 10
+        ) blocked;
+
+        IF terminated_count > 10 THEN
+            overflow_suffix := format(' (and %s more)', terminated_count - 10);
+        END IF;
+
+        RAISE EXCEPTION '%', format(
+            'cannot roll back traces_engine_run_status_check while traces.engine_run_status still contains terminated rows: %s%s',
+            offending_rows,
+            overflow_suffix
+        );
+    END IF;
+END $$;
+
+ALTER TABLE traces
+    DROP CONSTRAINT IF EXISTS traces_engine_run_status_check;
+
+ALTER TABLE traces
+    ADD CONSTRAINT traces_engine_run_status_check
+    CHECK (
+        engine_run_status IS NULL
+        OR engine_run_status IN ('queued', 'running', 'waiting', 'completed', 'failed', 'cancelled')
+    );

--- a/db/platform/migrations/postgres/000017_engine_run_status_terminated.up.sql
+++ b/db/platform/migrations/postgres/000017_engine_run_status_terminated.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE traces
+    DROP CONSTRAINT IF EXISTS traces_engine_run_status_check;
+
+ALTER TABLE traces
+    ADD CONSTRAINT traces_engine_run_status_check
+    CHECK (
+        engine_run_status IS NULL
+        OR engine_run_status IN ('queued', 'running', 'waiting', 'completed', 'failed', 'cancelled', 'terminated')
+    );

--- a/engine/cmd/continua-engine/internal/darklaunch/workflow.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/workflow.go
@@ -7,8 +7,10 @@ import (
 )
 
 const (
-	DemoDefinitionName    = "darklaunch.demo"
-	DemoDefinitionVersion = "v1"
+	DemoDefinitionName               = "darklaunch.demo"
+	DemoDefinitionVersion            = "v1"
+	CancelCompletesDefinitionName    = "darklaunch.cancel-completes"
+	CancelCompletesDefinitionVersion = "v1"
 )
 
 type WorkflowInput struct {
@@ -32,10 +34,23 @@ func Definitions() []workflow.Definition {
 			Version: DemoDefinitionVersion,
 			Run:     runDemoWorkflow,
 		},
+		{
+			Name:    CancelCompletesDefinitionName,
+			Version: CancelCompletesDefinitionVersion,
+			Run:     runCancelCompletesWorkflow,
+		},
 	}
 }
 
 func runDemoWorkflow(ctx workflow.Context) error {
+	return runDemoLikeWorkflow(ctx, true)
+}
+
+func runCancelCompletesWorkflow(ctx workflow.Context) error {
+	return runDemoLikeWorkflow(ctx, false)
+}
+
+func runDemoLikeWorkflow(ctx workflow.Context, cancelReturnsCancelled bool) error {
 	var input WorkflowInput
 	if err := ctx.Input(&input); err != nil {
 		return err
@@ -48,7 +63,7 @@ func runDemoWorkflow(ctx workflow.Context) error {
 		return err
 	}
 	if ctx.CancellationRequested() {
-		return workflow.ErrCancelled
+		return cancelOutcome(cancelReturnsCancelled)
 	}
 
 	var activityOutput ActivityOutput
@@ -60,7 +75,7 @@ func runDemoWorkflow(ctx workflow.Context) error {
 		return err
 	}
 	if ctx.CancellationRequested() {
-		return workflow.ErrCancelled
+		return cancelOutcome(cancelReturnsCancelled)
 	}
 	if err := ctx.SleepUntil("demo-timer", timerDeadline(input)); err != nil {
 		return err
@@ -70,7 +85,7 @@ func runDemoWorkflow(ctx workflow.Context) error {
 		return err
 	}
 	if ctx.CancellationRequested() {
-		return workflow.ErrCancelled
+		return cancelOutcome(cancelReturnsCancelled)
 	}
 
 	var signal SignalPayload
@@ -87,6 +102,13 @@ func runDemoWorkflow(ctx workflow.Context) error {
 	}
 	if err := ctx.SetResult(result); err != nil {
 		return err
+	}
+	return nil
+}
+
+func cancelOutcome(cancelReturnsCancelled bool) error {
+	if cancelReturnsCancelled {
+		return workflow.ErrCancelled
 	}
 	return nil
 }

--- a/engine/cmd/continua-engine/main_test.go
+++ b/engine/cmd/continua-engine/main_test.go
@@ -44,14 +44,14 @@ func TestMigrateCommandsRoundTrip(t *testing.T) {
 	t.Setenv("ENGINE_DATABASE_URL", db.DatabaseURL)
 	t.Setenv("DATABASE_URL", "")
 
-	stdout, stderr, err := executeCommand(t, "migrate", "down", "2")
+	stdout, stderr, err := executeCommand(t, "migrate", "down", "4")
 	if err != nil {
-		t.Fatalf("execute migrate down 1: %v", err)
+		t.Fatalf("execute migrate down 4: %v", err)
 	}
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, "Rolled back 2 engine migration step(s)") {
+	if !strings.Contains(stdout, "Rolled back 4 engine migration step(s)") {
 		t.Fatalf("unexpected migrate down output: %q", stdout)
 	}
 
@@ -60,11 +60,11 @@ func TestMigrateCommandsRoundTrip(t *testing.T) {
 	}
 	for _, column := range []string{"result", "custom_status", "waiting_for", "completed_at"} {
 		if columnExists(t, db.DatabaseURL, "engine", "runs", column) {
-			t.Fatalf("expected engine.runs.%s to be removed after migrate down 1", column)
+			t.Fatalf("expected engine.runs.%s to be removed after migrate down 4", column)
 		}
 	}
 	if enumLabelExists(t, db.DatabaseURL, "engine", "run_lifecycle_status", "waiting") {
-		t.Fatal("expected waiting enum label to be removed after migrate down 1")
+		t.Fatal("expected waiting enum label to be removed after migrate down 4")
 	}
 
 	stdout, stderr, err = executeCommand(t, "migrate", "up")
@@ -143,9 +143,9 @@ func TestMigrateDownRejectsWaitingRuns(t *testing.T) {
 		t.Fatalf("TransitionRunToWaiting() error = %v", err)
 	}
 
-	stdout, stderr, err := executeCommand(t, "migrate", "down", "2")
+	stdout, stderr, err := executeCommand(t, "migrate", "down", "4")
 	if err == nil {
-		t.Fatal("expected migrate down 2 to fail when waiting rows exist")
+		t.Fatal("expected migrate down 4 to fail when waiting rows exist")
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout on failed rollback, got %q", stdout)
@@ -168,6 +168,120 @@ func TestMigrateDownRejectsWaitingRuns(t *testing.T) {
 	}
 	if updatedRun.Status != enginedb.EngineRunLifecycleStatusWaiting {
 		t.Fatalf("expected waiting run to remain unchanged after failed rollback, got %+v", updatedRun)
+	}
+}
+
+func TestBackfillMigrationRecomputesInstanceStatusesFromLatestRun(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+
+	t.Setenv("ENGINE_DATABASE_URL", db.DatabaseURL)
+	t.Setenv("DATABASE_URL", "")
+
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+	latestQueuedInstance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "migration-backfill-active",
+		DefinitionName: "demo",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance(active) error = %v", err)
+	}
+	oldCompletedRun, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        latestQueuedInstance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now().Add(-2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun(old completed) error = %v", err)
+	}
+	if _, err := db.Pool.Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'completed',
+		    completed_at = NOW(),
+		    updated_at = NOW()
+		WHERE id = $1
+	`, oldCompletedRun.ID); err != nil {
+		t.Fatalf("mark old run completed: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        latestQueuedInstance.ID,
+		RunNumber:         2,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateRun(latest queued) error = %v", err)
+	}
+
+	latestFailedInstance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "migration-backfill-failed",
+		DefinitionName: "demo",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance(failed) error = %v", err)
+	}
+	latestFailedRun, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        latestFailedInstance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun(failed) error = %v", err)
+	}
+	if _, err := db.Pool.Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'failed',
+		    completed_at = NOW(),
+		    last_error_code = 'boom',
+		    last_error_message = 'workflow failed',
+		    updated_at = NOW()
+		WHERE id = $1
+	`, latestFailedRun.ID); err != nil {
+		t.Fatalf("mark latest run failed: %v", err)
+	}
+
+	if _, err := db.Pool.Exec(ctx, `
+		UPDATE engine.instances
+		SET status = CASE
+		        WHEN id = $1 THEN 'failed'::engine.instance_lifecycle_status
+		        WHEN id = $2 THEN 'active'::engine.instance_lifecycle_status
+		        ELSE status
+		    END,
+		    updated_at = NOW()
+		WHERE id IN ($1, $2)
+	`, latestQueuedInstance.ID, latestFailedInstance.ID); err != nil {
+		t.Fatalf("corrupt instance statuses: %v", err)
+	}
+
+	if stdout, stderr, err := executeCommand(t, "migrate", "down", "1"); err != nil {
+		t.Fatalf("execute migrate down 1: %v (stdout=%q stderr=%q)", err, stdout, stderr)
+	}
+	if stdout, stderr, err := executeCommand(t, "migrate", "up"); err != nil {
+		t.Fatalf("execute migrate up after backfill rollback: %v (stdout=%q stderr=%q)", err, stdout, stderr)
+	}
+
+	reloadedQueuedInstance, err := store.GetInstance(ctx, latestQueuedInstance.ID)
+	if err != nil {
+		t.Fatalf("GetInstance(active) error = %v", err)
+	}
+	if reloadedQueuedInstance.Status != enginedb.EngineInstanceLifecycleStatusActive {
+		t.Fatalf("expected latest queued instance to backfill as active, got %+v", reloadedQueuedInstance)
+	}
+
+	reloadedFailedInstance, err := store.GetInstance(ctx, latestFailedInstance.ID)
+	if err != nil {
+		t.Fatalf("GetInstance(failed) error = %v", err)
+	}
+	if reloadedFailedInstance.Status != enginedb.EngineInstanceLifecycleStatusFailed {
+		t.Fatalf("expected latest failed instance to backfill as failed, got %+v", reloadedFailedInstance)
 	}
 }
 

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -241,14 +241,18 @@ func startCmd() *cobra.Command {
 				if err != nil {
 					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
 				}
-				if _, err := tx.AppendHistory(ctx, enginedb.AppendHistoryParams{
+				startedEvent, err := tx.AppendHistory(ctx, enginedb.AppendHistoryParams{
 					ProjectID:  darkLaunchProjectID,
 					InstanceID: instance.ID,
 					RunID:      run.ID,
 					SequenceNo: 1,
 					EventType:  enginehistory.EventWorkflowStarted,
 					Payload:    startedRaw,
-				}); err != nil {
+				})
+				if err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
+				if err := ensureDarkLaunchProjectedShell(ctx, tx.Tx(), &instance, &run, definitionName, definitionVersion, inputPayload, startedEvent.ID); err != nil {
 					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
 				}
 
@@ -765,4 +769,100 @@ func cloneRaw(raw json.RawMessage) json.RawMessage {
 		return nil
 	}
 	return append(json.RawMessage(nil), raw...)
+}
+
+func ensureDarkLaunchProjectedShell(
+	ctx context.Context,
+	tx pgx.Tx,
+	instance *enginedb.EngineInstance,
+	run *enginedb.EngineRun,
+	definitionName string,
+	definitionVersion string,
+	input json.RawMessage,
+	startedHistoryID int64,
+) error {
+	if instance == nil || run == nil || startedHistoryID == 0 {
+		return errors.New("workflow.started history row is required before creating projected shell")
+	}
+
+	now := time.Now()
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO public.projects (id, name, api_key_hash)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (id) DO NOTHING
+	`, darkLaunchProjectID, "Engine Dark Launch", "engine-dark-launch"); err != nil {
+		return err
+	}
+
+	traceID := darkLaunchTraceID(run.ID)
+	traceUUID := uuid.New()
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO public.traces (
+		    id,
+		    project_id,
+		    trace_id,
+		    name,
+		    input,
+		    status,
+		    start_time,
+		    engine_run_id,
+		    engine_instance_key,
+		    engine_run_status,
+		    engine_pending_activity_tasks,
+		    engine_pending_inbox_items,
+		    engine_definition_name,
+		    engine_definition_version,
+		    engine_projection_state,
+		    engine_latest_history_id,
+		    engine_last_projected_history_id,
+		    engine_projection_updated_at
+		)
+		VALUES (
+		    $1,
+		    $2,
+		    $3,
+		    $4,
+		    $5::jsonb,
+		    'running',
+		    $6::timestamptz,
+		    $7,
+		    $8,
+		    'queued',
+		    0,
+		    0,
+		    $9,
+		    $10,
+		    'up_to_date',
+		    $11,
+		    $11,
+		    $6::timestamptz
+		)
+	`, traceUUID, darkLaunchProjectID, traceID, definitionName, cloneRaw(input), now, run.ID, instance.InstanceKey, definitionName, definitionVersion, startedHistoryID); err != nil {
+		return err
+	}
+
+	_, spanErr := tx.Exec(ctx, `
+		INSERT INTO public.spans (
+		    project_id,
+		    trace_id,
+		    span_id,
+		    name,
+		    type,
+		    status,
+		    level,
+		    start_time,
+		    input,
+		    depth
+		)
+		VALUES ($1, $2, $3, $4, 'chain', 'running', 'default', $5::timestamptz, $6::jsonb, 0)
+	`, darkLaunchProjectID, traceUUID, darkLaunchRootSpanID(run.ID), definitionName, now, cloneRaw(input))
+	return spanErr
+}
+
+func darkLaunchTraceID(runID uuid.UUID) string {
+	return "engine:" + runID.String()
+}
+
+func darkLaunchRootSpanID(runID uuid.UUID) string {
+	return "engine:root:" + runID.String()
 }

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -742,7 +742,8 @@ func parseOptionalJSON(value string) (json.RawMessage, error) {
 func isTerminalRun(status enginedb.EngineRunLifecycleStatus) bool {
 	return status == enginedb.EngineRunLifecycleStatusCompleted ||
 		status == enginedb.EngineRunLifecycleStatusFailed ||
-		status == enginedb.EngineRunLifecycleStatusCancelled
+		status == enginedb.EngineRunLifecycleStatusCancelled ||
+		status == enginedb.EngineRunLifecycleStatusTerminated
 }
 
 func stringPtrOrNil(value string) *string {

--- a/engine/cmd/continua-engine/runtime_e2e_test.go
+++ b/engine/cmd/continua-engine/runtime_e2e_test.go
@@ -266,15 +266,114 @@ func TestEngineRuntimeCancelTransitionsRunToCancelled(t *testing.T) {
 		t.Fatalf("expected cancel.requested + terminal history, got %+v", state.History)
 	}
 	lastEvent := state.History[len(state.History)-1]
-	if lastEvent.EventType != enginehistory.EventWorkflowFailed {
-		t.Fatalf("expected terminal cancellation history row to use workflow.failed, got %+v", lastEvent)
+	if lastEvent.EventType != enginehistory.EventWorkflowCancelled {
+		t.Fatalf("expected terminal cancellation history row to use workflow.cancelled, got %+v", lastEvent)
 	}
-	var failurePayload map[string]any
-	if err := json.Unmarshal(lastEvent.Payload, &failurePayload); err != nil {
-		t.Fatalf("Unmarshal(cancel terminal payload) error = %v", err)
+	decodedPayload, err := enginehistory.DecodePayload(lastEvent.EventType, lastEvent.Payload)
+	if err != nil {
+		t.Fatalf("DecodePayload(cancel terminal payload) error = %v", err)
 	}
-	if failurePayload["error_code"] != "cancelled" {
-		t.Fatalf("expected cancelled failure payload, got %+v", failurePayload)
+	if _, ok := decodedPayload.(*enginehistory.WorkflowCancelledPayload); !ok {
+		t.Fatalf("expected workflow.cancelled payload, got %+v", decodedPayload)
+	}
+
+	instance, err := enginedb.New(db.Pool).GetInstanceByProjectAndKey(context.Background(), enginedb.GetInstanceByProjectAndKeyParams{
+		ProjectID:   darkLaunchProjectID,
+		InstanceKey: instanceKey,
+	})
+	if err != nil {
+		t.Fatalf("GetInstanceByProjectAndKey() error = %v", err)
+	}
+	if instance.Status != enginedb.EngineInstanceLifecycleStatusCancelled {
+		t.Fatalf("expected cancelled instance status, got %+v", instance)
+	}
+
+	projectedStatus, projectedWaitState := waitForProjectedEngineSummary(t, db, state.RunID, func(status string, waitState []byte) bool {
+		return status == string(enginedb.EngineRunLifecycleStatusCancelled) && len(waitState) == 0
+	})
+	if projectedStatus != string(enginedb.EngineRunLifecycleStatusCancelled) {
+		t.Fatalf("expected projected engine status cancelled, got %q", projectedStatus)
+	}
+	if len(projectedWaitState) != 0 {
+		t.Fatalf("expected projected engine_wait_state to be cleared, got %s", projectedWaitState)
+	}
+}
+
+func TestEngineRuntimeCancelCanStillCompleteWhenWorkflowReturnsNil(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+
+	serve := startServe(t)
+	defer serve.stop(t)
+
+	instanceKey := "runtime-cancel-completed"
+	input := map[string]any{
+		"name":     "CancelCompletes",
+		"timer_at": time.Now().Add(10 * time.Second).UTC().Format(time.RFC3339Nano),
+	}
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("Marshal(input) error = %v", err)
+	}
+
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.CancelCompletesDefinitionName,
+		"--version", darklaunch.CancelCompletesDefinitionVersion,
+		"--request-key", "req-cancel-completed",
+		"--input", string(inputJSON),
+	); err != nil {
+		t.Fatalf("start command error = %v", err)
+	}
+
+	waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "timer")
+	})
+
+	stdout, stderr, err := executeCommand(t, "cancel", "--instance-key", instanceKey)
+	if err != nil {
+		t.Fatalf("cancel command error = %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var cancelled controlResponse
+	if err := json.Unmarshal([]byte(stdout), &cancelled); err != nil {
+		t.Fatalf("Unmarshal(cancel stdout) error = %v", err)
+	}
+	if !cancelled.Accepted || !cancelled.WakeApplied {
+		t.Fatalf("expected cancel accepted with wake, got %+v", cancelled)
+	}
+
+	state := waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusCompleted)
+	})
+	if len(state.Result) != 0 {
+		t.Fatalf("expected nil-after-cancel workflow to complete without result, got %s", state.Result)
+	}
+
+	eventTypes := filterEventTypes(state.History)
+	if eventTypes[len(eventTypes)-1] != enginehistory.EventWorkflowCompleted {
+		t.Fatalf("expected workflow.completed terminal event, got %v", eventTypes)
+	}
+	for _, eventType := range eventTypes {
+		if eventType == enginehistory.EventWorkflowCancelled {
+			t.Fatalf("expected nil-after-cancel workflow to avoid workflow.cancelled, got %v", eventTypes)
+		}
+	}
+
+	instance, err := enginedb.New(db.Pool).GetInstanceByProjectAndKey(context.Background(), enginedb.GetInstanceByProjectAndKeyParams{
+		ProjectID:   darkLaunchProjectID,
+		InstanceKey: instanceKey,
+	})
+	if err != nil {
+		t.Fatalf("GetInstanceByProjectAndKey() error = %v", err)
+	}
+	if instance.Status != enginedb.EngineInstanceLifecycleStatusCompleted {
+		t.Fatalf("expected completed instance status, got %+v", instance)
 	}
 }
 
@@ -728,6 +827,35 @@ func waitForInspect(t *testing.T, instanceKey string, predicate func(inspectResp
 	}
 	t.Fatalf("timed out waiting for inspect predicate, last state = %+v", last)
 	return inspectResponse{}
+}
+
+func waitForProjectedEngineSummary(
+	t *testing.T,
+	db *enginetest.TestDatabase,
+	runID string,
+	predicate func(status string, waitState []byte) bool,
+) (string, []byte) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	var lastStatus string
+	var lastWaitState []byte
+	for time.Now().Before(deadline) {
+		err := db.Pool.QueryRow(context.Background(), `
+			SELECT engine_run_status, engine_wait_state
+			FROM public.traces
+			WHERE engine_run_id = $1::uuid
+		`, runID).Scan(&lastStatus, &lastWaitState)
+		if err != nil {
+			t.Fatalf("query projected engine summary: %v", err)
+		}
+		if predicate(lastStatus, lastWaitState) {
+			return lastStatus, lastWaitState
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for projected engine summary, last status=%q wait_state=%s", lastStatus, string(lastWaitState))
+	return "", nil
 }
 
 func assertConcurrentTerminalizationRejectsControlCommand(

--- a/engine/db/gen/go/activity_tasks.sql.go
+++ b/engine/db/gen/go/activity_tasks.sql.go
@@ -12,6 +12,60 @@ import (
 	"github.com/google/uuid"
 )
 
+const cancelOpenActivityTasksByRun = `-- name: CancelOpenActivityTasksByRun :many
+UPDATE engine.activity_tasks
+SET status = 'cancelled',
+    completed_at = NOW(),
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE run_id = $1
+  AND status IN ('queued', 'claimed')
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at
+`
+
+func (q *Queries) CancelOpenActivityTasksByRun(ctx context.Context, runID uuid.UUID) ([]EngineActivityTask, error) {
+	rows, err := q.db.Query(ctx, cancelOpenActivityTasksByRun, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineActivityTask{}
+	for rows.Next() {
+		var i EngineActivityTask
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.ActivityKey,
+			&i.ActivityType,
+			&i.Input,
+			&i.Output,
+			&i.Status,
+			&i.AvailableAt,
+			&i.AttemptCount,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.LastErrorCode,
+			&i.LastErrorMessage,
+			&i.CompletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const claimNextActivityTask = `-- name: ClaimNextActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'claimed',
@@ -330,6 +384,104 @@ ORDER BY created_at ASC, id ASC
 
 func (q *Queries) ListActivityTasksByRun(ctx context.Context, runID uuid.UUID) ([]EngineActivityTask, error) {
 	rows, err := q.db.Query(ctx, listActivityTasksByRun, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineActivityTask{}
+	for rows.Next() {
+		var i EngineActivityTask
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.ActivityKey,
+			&i.ActivityType,
+			&i.Input,
+			&i.Output,
+			&i.Status,
+			&i.AvailableAt,
+			&i.AttemptCount,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.LastErrorCode,
+			&i.LastErrorMessage,
+			&i.CompletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCancelledActivityTasksByRun = `-- name: ListCancelledActivityTasksByRun :many
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at
+FROM engine.activity_tasks
+WHERE run_id = $1
+  AND status = 'cancelled'
+ORDER BY available_at ASC, id ASC
+`
+
+func (q *Queries) ListCancelledActivityTasksByRun(ctx context.Context, runID uuid.UUID) ([]EngineActivityTask, error) {
+	rows, err := q.db.Query(ctx, listCancelledActivityTasksByRun, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineActivityTask{}
+	for rows.Next() {
+		var i EngineActivityTask
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.ActivityKey,
+			&i.ActivityType,
+			&i.Input,
+			&i.Output,
+			&i.Status,
+			&i.AvailableAt,
+			&i.AttemptCount,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.LastErrorCode,
+			&i.LastErrorMessage,
+			&i.CompletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listOpenActivityTasksByRun = `-- name: ListOpenActivityTasksByRun :many
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at
+FROM engine.activity_tasks
+WHERE run_id = $1
+  AND status IN ('queued', 'claimed')
+ORDER BY available_at ASC, id ASC
+`
+
+func (q *Queries) ListOpenActivityTasksByRun(ctx context.Context, runID uuid.UUID) ([]EngineActivityTask, error) {
+	rows, err := q.db.Query(ctx, listOpenActivityTasksByRun, runID)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/db/gen/go/history.sql.go
+++ b/engine/db/gen/go/history.sql.go
@@ -128,6 +128,19 @@ func (q *Queries) GetHistoryByRun(ctx context.Context, runID uuid.UUID) ([]Engin
 	return items, nil
 }
 
+const getLatestHistoryIDByRun = `-- name: GetLatestHistoryIDByRun :one
+SELECT COALESCE(MAX(id), 0)::bigint
+FROM engine.history
+WHERE run_id = $1
+`
+
+func (q *Queries) GetLatestHistoryIDByRun(ctx context.Context, runID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, getLatestHistoryIDByRun, runID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const listHistoryByRunAfterID = `-- name: ListHistoryByRunAfterID :many
 SELECT id, project_id, instance_id, run_id, sequence_no, event_type, payload, created_at
 FROM engine.history

--- a/engine/db/gen/go/inbox.sql.go
+++ b/engine/db/gen/go/inbox.sql.go
@@ -66,6 +66,7 @@ SELECT COUNT(*)
 FROM engine.inbox
 WHERE run_id = $1
   AND status IN ('pending', 'claimed')
+  AND kind <> 'cancel'
 `
 
 func (q *Queries) CountOpenInboxByRun(ctx context.Context, runID pgtype.UUID) (int64, error) {
@@ -134,6 +135,102 @@ func (q *Queries) CreateInboxItem(ctx context.Context, arg CreateInboxItemParams
 	return i, err
 }
 
+const discardOpenInboxItemsByRun = `-- name: DiscardOpenInboxItemsByRun :many
+UPDATE engine.inbox
+SET status = 'discarded',
+    resolved_at = NOW(),
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE run_id = $1
+  AND status IN ('pending', 'claimed')
+RETURNING id, project_id, instance_id, run_id, history_id, kind, payload, status, available_at, claimed_by, claimed_at, lease_expires_at, dedupe_key, resolved_at, created_at, updated_at
+`
+
+func (q *Queries) DiscardOpenInboxItemsByRun(ctx context.Context, runID pgtype.UUID) ([]EngineInbox, error) {
+	rows, err := q.db.Query(ctx, discardOpenInboxItemsByRun, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineInbox{}
+	for rows.Next() {
+		var i EngineInbox
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.Kind,
+			&i.Payload,
+			&i.Status,
+			&i.AvailableAt,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.DedupeKey,
+			&i.ResolvedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listDiscardedTimerInboxItemsByRun = `-- name: ListDiscardedTimerInboxItemsByRun :many
+SELECT id, project_id, instance_id, run_id, history_id, kind, payload, status, available_at, claimed_by, claimed_at, lease_expires_at, dedupe_key, resolved_at, created_at, updated_at
+FROM engine.inbox
+WHERE run_id = $1
+  AND kind = 'timer'
+  AND status = 'discarded'
+ORDER BY available_at ASC, id ASC
+`
+
+func (q *Queries) ListDiscardedTimerInboxItemsByRun(ctx context.Context, runID pgtype.UUID) ([]EngineInbox, error) {
+	rows, err := q.db.Query(ctx, listDiscardedTimerInboxItemsByRun, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineInbox{}
+	for rows.Next() {
+		var i EngineInbox
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.Kind,
+			&i.Payload,
+			&i.Status,
+			&i.AvailableAt,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.DedupeKey,
+			&i.ResolvedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDueTimerRunIDs = `-- name: ListDueTimerRunIDs :many
 SELECT DISTINCT run_id
 FROM engine.inbox
@@ -157,6 +254,57 @@ func (q *Queries) ListDueTimerRunIDs(ctx context.Context) ([]pgtype.UUID, error)
 			return nil, err
 		}
 		items = append(items, run_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listOpenInboxItemsByRunAndKind = `-- name: ListOpenInboxItemsByRunAndKind :many
+SELECT id, project_id, instance_id, run_id, history_id, kind, payload, status, available_at, claimed_by, claimed_at, lease_expires_at, dedupe_key, resolved_at, created_at, updated_at
+FROM engine.inbox
+WHERE run_id = $1
+  AND kind = $2
+  AND status IN ('pending', 'claimed')
+ORDER BY available_at ASC, id ASC
+`
+
+type ListOpenInboxItemsByRunAndKindParams struct {
+	RunID pgtype.UUID `json:"run_id"`
+	Kind  string      `json:"kind"`
+}
+
+func (q *Queries) ListOpenInboxItemsByRunAndKind(ctx context.Context, arg ListOpenInboxItemsByRunAndKindParams) ([]EngineInbox, error) {
+	rows, err := q.db.Query(ctx, listOpenInboxItemsByRunAndKind, arg.RunID, arg.Kind)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineInbox{}
+	for rows.Next() {
+		var i EngineInbox
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.Kind,
+			&i.Payload,
+			&i.Status,
+			&i.AvailableAt,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.DedupeKey,
+			&i.ResolvedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/engine/db/gen/go/models.go
+++ b/engine/db/gen/go/models.go
@@ -105,10 +105,11 @@ func (ns NullEngineInboxStatus) Value() (driver.Value, error) {
 type EngineInstanceLifecycleStatus string
 
 const (
-	EngineInstanceLifecycleStatusActive    EngineInstanceLifecycleStatus = "active"
-	EngineInstanceLifecycleStatusCompleted EngineInstanceLifecycleStatus = "completed"
-	EngineInstanceLifecycleStatusFailed    EngineInstanceLifecycleStatus = "failed"
-	EngineInstanceLifecycleStatusCancelled EngineInstanceLifecycleStatus = "cancelled"
+	EngineInstanceLifecycleStatusActive     EngineInstanceLifecycleStatus = "active"
+	EngineInstanceLifecycleStatusCompleted  EngineInstanceLifecycleStatus = "completed"
+	EngineInstanceLifecycleStatusFailed     EngineInstanceLifecycleStatus = "failed"
+	EngineInstanceLifecycleStatusCancelled  EngineInstanceLifecycleStatus = "cancelled"
+	EngineInstanceLifecycleStatusTerminated EngineInstanceLifecycleStatus = "terminated"
 )
 
 func (e *EngineInstanceLifecycleStatus) Scan(src interface{}) error {
@@ -193,12 +194,13 @@ func (ns NullEngineRequestDedupeStatus) Value() (driver.Value, error) {
 type EngineRunLifecycleStatus string
 
 const (
-	EngineRunLifecycleStatusQueued    EngineRunLifecycleStatus = "queued"
-	EngineRunLifecycleStatusRunning   EngineRunLifecycleStatus = "running"
-	EngineRunLifecycleStatusCompleted EngineRunLifecycleStatus = "completed"
-	EngineRunLifecycleStatusFailed    EngineRunLifecycleStatus = "failed"
-	EngineRunLifecycleStatusCancelled EngineRunLifecycleStatus = "cancelled"
-	EngineRunLifecycleStatusWaiting   EngineRunLifecycleStatus = "waiting"
+	EngineRunLifecycleStatusQueued     EngineRunLifecycleStatus = "queued"
+	EngineRunLifecycleStatusRunning    EngineRunLifecycleStatus = "running"
+	EngineRunLifecycleStatusCompleted  EngineRunLifecycleStatus = "completed"
+	EngineRunLifecycleStatusFailed     EngineRunLifecycleStatus = "failed"
+	EngineRunLifecycleStatusCancelled  EngineRunLifecycleStatus = "cancelled"
+	EngineRunLifecycleStatusWaiting    EngineRunLifecycleStatus = "waiting"
+	EngineRunLifecycleStatusTerminated EngineRunLifecycleStatus = "terminated"
 )
 
 func (e *EngineRunLifecycleStatus) Scan(src interface{}) error {

--- a/engine/db/gen/go/runs.sql.go
+++ b/engine/db/gen/go/runs.sql.go
@@ -356,37 +356,27 @@ const transitionRunToCancelled = `-- name: TransitionRunToCancelled :one
 UPDATE engine.runs
 SET status = 'cancelled',
     result = NULL,
-    custom_status = $3,
+    custom_status = $2,
     waiting_for = NULL,
     completed_at = NOW(),
-    last_error_code = $4,
-    last_error_message = $5,
+    last_error_code = 'cancelled',
+    last_error_message = 'workflow cancelled',
     claimed_by = NULL,
     claimed_at = NULL,
     lease_expires_at = NULL,
     updated_at = NOW()
 WHERE id = $1
   AND status = 'running'
-  AND claimed_by = $2
 RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
 `
 
 type TransitionRunToCancelledParams struct {
-	ID               uuid.UUID `json:"id"`
-	ClaimedBy        *string   `json:"claimed_by"`
-	CustomStatus     []byte    `json:"custom_status"`
-	LastErrorCode    *string   `json:"last_error_code"`
-	LastErrorMessage *string   `json:"last_error_message"`
+	ID           uuid.UUID `json:"id"`
+	CustomStatus []byte    `json:"custom_status"`
 }
 
 func (q *Queries) TransitionRunToCancelled(ctx context.Context, arg TransitionRunToCancelledParams) (EngineRun, error) {
-	row := q.db.QueryRow(ctx, transitionRunToCancelled,
-		arg.ID,
-		arg.ClaimedBy,
-		arg.CustomStatus,
-		arg.LastErrorCode,
-		arg.LastErrorMessage,
-	)
+	row := q.db.QueryRow(ctx, transitionRunToCancelled, arg.ID, arg.CustomStatus)
 	var i EngineRun
 	err := row.Scan(
 		&i.ID,
@@ -505,6 +495,50 @@ func (q *Queries) TransitionRunToFailed(ctx context.Context, arg TransitionRunTo
 		arg.LastErrorCode,
 		arg.LastErrorMessage,
 	)
+	var i EngineRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunNumber,
+		&i.DefinitionVersion,
+		&i.Status,
+		&i.ReadyAt,
+		&i.AttemptCount,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
+	)
+	return i, err
+}
+
+const transitionRunToTerminated = `-- name: TransitionRunToTerminated :one
+UPDATE engine.runs
+SET status = 'terminated',
+    result = NULL,
+    waiting_for = NULL,
+    completed_at = NOW(),
+    last_error_code = 'terminated',
+    last_error_message = 'run terminated by operator',
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status IN ('queued', 'running', 'waiting')
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+`
+
+func (q *Queries) TransitionRunToTerminated(ctx context.Context, id uuid.UUID) (EngineRun, error) {
+	row := q.db.QueryRow(ctx, transitionRunToTerminated, id)
 	var i EngineRun
 	err := row.Scan(
 		&i.ID,

--- a/engine/db/migrations/postgres/000004_terminated_lifecycle.down.sql
+++ b/engine/db/migrations/postgres/000004_terminated_lifecycle.down.sql
@@ -1,0 +1,65 @@
+DO $$
+DECLARE
+    offending_tables TEXT[] := ARRAY[]::TEXT[];
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM engine.runs
+        WHERE status = 'terminated'
+    ) THEN
+        offending_tables := array_append(offending_tables, 'engine.runs');
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM engine.instances
+        WHERE status = 'terminated'
+    ) THEN
+        offending_tables := array_append(offending_tables, 'engine.instances');
+    END IF;
+
+    IF array_length(offending_tables, 1) IS NOT NULL THEN
+        RAISE EXCEPTION 'cannot roll back terminated lifecycle enums while terminated rows still exist in: %',
+            array_to_string(offending_tables, ', ');
+    END IF;
+END $$;
+
+ALTER TYPE engine.run_lifecycle_status RENAME TO run_lifecycle_status_old;
+
+CREATE TYPE engine.run_lifecycle_status AS ENUM (
+    'queued',
+    'running',
+    'waiting',
+    'completed',
+    'failed',
+    'cancelled'
+);
+
+ALTER TABLE engine.runs
+    ALTER COLUMN status DROP DEFAULT,
+    ALTER COLUMN status TYPE engine.run_lifecycle_status
+    USING status::text::engine.run_lifecycle_status;
+
+DROP TYPE engine.run_lifecycle_status_old;
+
+ALTER TABLE engine.runs
+    ALTER COLUMN status SET DEFAULT 'queued';
+
+ALTER TYPE engine.instance_lifecycle_status RENAME TO instance_lifecycle_status_old;
+
+CREATE TYPE engine.instance_lifecycle_status AS ENUM (
+    'active',
+    'completed',
+    'failed',
+    'cancelled'
+);
+
+ALTER TABLE engine.instances
+    ALTER COLUMN status DROP DEFAULT,
+    ALTER COLUMN status TYPE engine.instance_lifecycle_status
+    USING status::text::engine.instance_lifecycle_status;
+
+DROP TYPE engine.instance_lifecycle_status_old;
+
+ALTER TABLE engine.instances
+    ALTER COLUMN status SET DEFAULT 'active';

--- a/engine/db/migrations/postgres/000004_terminated_lifecycle.down.sql
+++ b/engine/db/migrations/postgres/000004_terminated_lifecycle.down.sql
@@ -5,7 +5,7 @@ BEGIN
     IF EXISTS (
         SELECT 1
         FROM engine.runs
-        WHERE status = 'terminated'
+        WHERE status::text = 'terminated'
     ) THEN
         offending_tables := array_append(offending_tables, 'engine.runs');
     END IF;
@@ -13,7 +13,7 @@ BEGIN
     IF EXISTS (
         SELECT 1
         FROM engine.instances
-        WHERE status = 'terminated'
+        WHERE status::text = 'terminated'
     ) THEN
         offending_tables := array_append(offending_tables, 'engine.instances');
     END IF;
@@ -23,6 +23,9 @@ BEGIN
             array_to_string(offending_tables, ', ');
     END IF;
 END $$;
+
+DROP INDEX IF EXISTS engine.idx_engine_runs_claim;
+DROP INDEX IF EXISTS engine.idx_engine_instances_status_updated;
 
 ALTER TYPE engine.run_lifecycle_status RENAME TO run_lifecycle_status_old;
 
@@ -63,3 +66,10 @@ DROP TYPE engine.instance_lifecycle_status_old;
 
 ALTER TABLE engine.instances
     ALTER COLUMN status SET DEFAULT 'active';
+
+CREATE INDEX idx_engine_runs_claim
+    ON engine.runs(status, ready_at, lease_expires_at)
+    WHERE status IN ('queued', 'running');
+
+CREATE INDEX idx_engine_instances_status_updated
+    ON engine.instances(project_id, status, updated_at DESC);

--- a/engine/db/migrations/postgres/000004_terminated_lifecycle.up.sql
+++ b/engine/db/migrations/postgres/000004_terminated_lifecycle.up.sql
@@ -1,0 +1,3 @@
+ALTER TYPE engine.run_lifecycle_status ADD VALUE 'terminated';
+
+ALTER TYPE engine.instance_lifecycle_status ADD VALUE 'terminated';

--- a/engine/db/migrations/postgres/000005_backfill_instance_status.down.sql
+++ b/engine/db/migrations/postgres/000005_backfill_instance_status.down.sql
@@ -1,0 +1,1 @@
+-- No-op: the instance status backfill is advisory and idempotent.

--- a/engine/db/migrations/postgres/000005_backfill_instance_status.up.sql
+++ b/engine/db/migrations/postgres/000005_backfill_instance_status.up.sql
@@ -1,0 +1,13 @@
+UPDATE engine.instances AS instances
+SET status = latest.status
+FROM (
+    SELECT DISTINCT ON (runs.instance_id)
+        runs.instance_id,
+        CASE
+            WHEN runs.status IN ('completed', 'failed', 'cancelled', 'terminated') THEN runs.status::text::engine.instance_lifecycle_status
+            ELSE 'active'::engine.instance_lifecycle_status
+        END AS status
+    FROM engine.runs AS runs
+    ORDER BY runs.instance_id, runs.created_at DESC, runs.id DESC
+) AS latest
+WHERE instances.id = latest.instance_id;

--- a/engine/db/queries/activity_tasks.sql
+++ b/engine/db/queries/activity_tasks.sql
@@ -35,6 +35,20 @@ FROM engine.activity_tasks
 WHERE run_id = $1
   AND status IN ('queued', 'claimed');
 
+-- name: ListOpenActivityTasksByRun :many
+SELECT *
+FROM engine.activity_tasks
+WHERE run_id = $1
+  AND status IN ('queued', 'claimed')
+ORDER BY available_at ASC, id ASC;
+
+-- name: ListCancelledActivityTasksByRun :many
+SELECT *
+FROM engine.activity_tasks
+WHERE run_id = $1
+  AND status = 'cancelled'
+ORDER BY available_at ASC, id ASC;
+
 -- name: ClaimNextActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'claimed',
@@ -81,4 +95,16 @@ SET status = 'failed',
 WHERE id = $1
   AND status = 'claimed'
   AND claimed_by = $2
+RETURNING *;
+
+-- name: CancelOpenActivityTasksByRun :many
+UPDATE engine.activity_tasks
+SET status = 'cancelled',
+    completed_at = NOW(),
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE run_id = $1
+  AND status IN ('queued', 'claimed')
 RETURNING *;

--- a/engine/db/queries/history.sql
+++ b/engine/db/queries/history.sql
@@ -16,6 +16,11 @@ FROM engine.history
 WHERE run_id = $1
 ORDER BY sequence_no ASC, id ASC;
 
+-- name: GetLatestHistoryIDByRun :one
+SELECT COALESCE(MAX(id), 0)::bigint
+FROM engine.history
+WHERE run_id = $1;
+
 -- name: ListHistoryByRunAfterID :many
 SELECT *
 FROM engine.history

--- a/engine/db/queries/inbox.sql
+++ b/engine/db/queries/inbox.sql
@@ -42,7 +42,24 @@ ORDER BY available_at ASC, id ASC;
 SELECT COUNT(*)
 FROM engine.inbox
 WHERE run_id = $1
-  AND status IN ('pending', 'claimed');
+  AND status IN ('pending', 'claimed')
+  AND kind <> 'cancel';
+
+-- name: ListOpenInboxItemsByRunAndKind :many
+SELECT *
+FROM engine.inbox
+WHERE run_id = $1
+  AND kind = $2
+  AND status IN ('pending', 'claimed')
+ORDER BY available_at ASC, id ASC;
+
+-- name: ListDiscardedTimerInboxItemsByRun :many
+SELECT *
+FROM engine.inbox
+WHERE run_id = $1
+  AND kind = 'timer'
+  AND status = 'discarded'
+ORDER BY available_at ASC, id ASC;
 
 -- name: ListDueTimerRunIDs :many
 SELECT DISTINCT run_id
@@ -74,4 +91,16 @@ SET status = 'discarded',
     lease_expires_at = NULL,
     updated_at = NOW()
 WHERE id = $1
+RETURNING *;
+
+-- name: DiscardOpenInboxItemsByRun :many
+UPDATE engine.inbox
+SET status = 'discarded',
+    resolved_at = NOW(),
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE run_id = $1
+  AND status IN ('pending', 'claimed')
 RETURNING *;

--- a/engine/db/queries/runs.sql
+++ b/engine/db/queries/runs.sql
@@ -114,18 +114,33 @@ RETURNING *;
 UPDATE engine.runs
 SET status = 'cancelled',
     result = NULL,
-    custom_status = $3,
+    custom_status = $2,
     waiting_for = NULL,
     completed_at = NOW(),
-    last_error_code = $4,
-    last_error_message = $5,
+    last_error_code = 'cancelled',
+    last_error_message = 'workflow cancelled',
     claimed_by = NULL,
     claimed_at = NULL,
     lease_expires_at = NULL,
     updated_at = NOW()
 WHERE id = $1
   AND status = 'running'
-  AND claimed_by = $2
+RETURNING *;
+
+-- name: TransitionRunToTerminated :one
+UPDATE engine.runs
+SET status = 'terminated',
+    result = NULL,
+    waiting_for = NULL,
+    completed_at = NOW(),
+    last_error_code = 'terminated',
+    last_error_message = 'run terminated by operator',
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status IN ('queued', 'running', 'waiting')
 RETURNING *;
 
 -- name: WakeWaitingRun :one

--- a/engine/internal/activity/worker_test.go
+++ b/engine/internal/activity/worker_test.go
@@ -1,0 +1,229 @@
+package activity
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+)
+
+func TestWorkerLateCompletionAfterTerminateReturnsNoOp(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	projectID := uuid.New()
+	instance, run, task := createRunWithPendingActivity(t, store, projectID, "instance-activity-terminate", "ship-order")
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+
+	registry, err := NewRegistry(map[string]Handler{
+		"demo.activity": func(context.Context, json.RawMessage) (json.RawMessage, error) {
+			close(blocked)
+			<-release
+			return []byte(`{"ok":true}`), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	worker := NewWorker(store, registry, time.Minute)
+	workerDone := make(chan error, 1)
+	go func() {
+		workerDone <- worker.PollOnce(ctx, "activity-worker")
+	}()
+
+	select {
+	case <-blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("activity handler did not reach blocking point before terminate")
+	}
+
+	tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	payload, err := enginehistory.MarshalPayload(enginehistory.WorkflowTerminatedPayload{
+		ErrorCode:    "terminated",
+		ErrorMessage: "run terminated by operator",
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(terminated) error = %v", err)
+	}
+	if _, err := tx.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 3,
+		EventType:  enginehistory.EventWorkflowTerminated,
+		Payload:    payload,
+	}); err != nil {
+		t.Fatalf("AppendHistory(terminated) error = %v", err)
+	}
+	if _, err := tx.TransitionRunToTerminated(ctx, run.ID); err != nil {
+		t.Fatalf("TransitionRunToTerminated() error = %v", err)
+	}
+	if _, err := tx.CancelOpenActivityTasksByRun(ctx, run.ID); err != nil {
+		t.Fatalf("CancelOpenActivityTasksByRun() error = %v", err)
+	}
+	if _, err := tx.UpdateInstanceStatus(ctx, enginedb.UpdateInstanceStatusParams{
+		ID:     instance.ID,
+		Status: enginedb.EngineInstanceLifecycleStatusTerminated,
+	}); err != nil {
+		t.Fatalf("UpdateInstanceStatus() error = %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	close(release)
+
+	select {
+	case err := <-workerDone:
+		if err != nil {
+			t.Fatalf("PollOnce() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("activity worker did not finish after terminate")
+	}
+
+	terminatedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if terminatedRun.Status != enginedb.EngineRunLifecycleStatusTerminated {
+		t.Fatalf("expected terminated run status, got %+v", terminatedRun)
+	}
+
+	terminatedInstance, err := store.GetInstance(ctx, instance.ID)
+	if err != nil {
+		t.Fatalf("GetInstance() error = %v", err)
+	}
+	if terminatedInstance.Status != enginedb.EngineInstanceLifecycleStatusTerminated {
+		t.Fatalf("expected terminated instance status, got %+v", terminatedInstance)
+	}
+
+	cancelledTask, err := store.GetActivityTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask() error = %v", err)
+	}
+	if cancelledTask.Status != enginedb.EngineActivityTaskStatusCancelled {
+		t.Fatalf("expected cancelled activity task after terminate wins, got %+v", cancelledTask)
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	if len(historyRows) != 3 || historyRows[2].EventType != enginehistory.EventWorkflowTerminated {
+		t.Fatalf("expected started + activity.scheduled + workflow.terminated history, got %+v", historyRows)
+	}
+}
+
+func createRunWithPendingActivity(
+	t *testing.T,
+	store *enginestore.Store,
+	projectID uuid.UUID,
+	instanceKey string,
+	activityKey string,
+) (enginedb.EngineInstance, enginedb.EngineRun, enginedb.EngineActivityTask) {
+	t.Helper()
+
+	ctx := context.Background()
+	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    instanceKey,
+		DefinitionName: "activity-terminate",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+
+	run, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+
+	startedPayload, err := enginehistory.MarshalPayload(enginehistory.WorkflowStartedPayload{
+		DefinitionName:    "activity-terminate",
+		DefinitionVersion: "v1",
+		InstanceKey:       instanceKey,
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(started) error = %v", err)
+	}
+	if _, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 1,
+		EventType:  enginehistory.EventWorkflowStarted,
+		Payload:    startedPayload,
+	}); err != nil {
+		t.Fatalf("AppendHistory(started) error = %v", err)
+	}
+
+	activityPayload, err := enginehistory.MarshalPayload(enginehistory.ActivityScheduledPayload{
+		ActivityKey:  activityKey,
+		ActivityType: "demo.activity",
+		Input:        mustJSON(t, map[string]string{"step": "work"}),
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(activity scheduled) error = %v", err)
+	}
+	activityHistory, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 2,
+		EventType:  enginehistory.EventActivityScheduled,
+		Payload:    activityPayload,
+	})
+	if err != nil {
+		t.Fatalf("AppendHistory(activity scheduled) error = %v", err)
+	}
+
+	task, err := store.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:    projectID,
+		InstanceID:   instance.ID,
+		RunID:        run.ID,
+		HistoryID:    &activityHistory.ID,
+		ActivityKey:  activityKey,
+		ActivityType: "demo.activity",
+		Input:        mustJSON(t, map[string]string{"step": "work"}),
+		AvailableAt:  time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("CreateActivityTask() error = %v", err)
+	}
+
+	return instance, run, task
+}
+
+func mustJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return raw
+}

--- a/engine/internal/history/events.go
+++ b/engine/internal/history/events.go
@@ -10,6 +10,8 @@ const (
 	EventWorkflowStarted        = publichistory.EventWorkflowStarted
 	EventWorkflowCompleted      = publichistory.EventWorkflowCompleted
 	EventWorkflowFailed         = publichistory.EventWorkflowFailed
+	EventWorkflowCancelled      = publichistory.EventWorkflowCancelled
+	EventWorkflowTerminated     = publichistory.EventWorkflowTerminated
 	EventWorkflowReplayMismatch = publichistory.EventWorkflowReplayMismatch
 	EventActivityScheduled      = publichistory.EventActivityScheduled
 	EventActivityCompleted      = publichistory.EventActivityCompleted
@@ -30,6 +32,8 @@ const (
 type WorkflowStartedPayload = publichistory.WorkflowStartedPayload
 type WorkflowCompletedPayload = publichistory.WorkflowCompletedPayload
 type WorkflowFailedPayload = publichistory.WorkflowFailedPayload
+type WorkflowCancelledPayload = publichistory.WorkflowCancelledPayload
+type WorkflowTerminatedPayload = publichistory.WorkflowTerminatedPayload
 type WorkflowReplayMismatchPayload = publichistory.WorkflowReplayMismatchPayload
 type ActivityScheduledPayload = publichistory.ActivityScheduledPayload
 type ActivityCompletedPayload = publichistory.ActivityCompletedPayload

--- a/engine/internal/projector/projector.go
+++ b/engine/internal/projector/projector.go
@@ -201,7 +201,7 @@ func WriteTerminalSummary(
 		SET status = $3,
 		    end_time = $4::timestamptz,
 		    output = $5::jsonb,
-		    status_message = $6,
+		    status_message = $6::text,
 		    duration_ms = CASE
 		        WHEN $4::timestamptz IS NOT NULL THEN EXTRACT(EPOCH FROM ($4::timestamptz - start_time)) * 1000
 		        ELSE duration_ms
@@ -214,7 +214,7 @@ func WriteTerminalSummary(
 		        WHERE engine_run_id = $1
 		    )
 		  AND span_id = $2
-	`, runID, rootSpanID, spanStatus, completedAt, outputPayload, errorMessage)
+	`, runID, rootSpanID, spanStatus, completedAt, outputPayload, nullableText(errorMessage))
 	if err != nil {
 		return err
 	}
@@ -302,25 +302,25 @@ func projectHistoryRow(
 
 	switch typed := payload.(type) {
 	case *publichistory.WorkflowCompletedPayload:
-		return projectTerminalHistoryRow(ctx, tx, target, row, terminalProjection{
+		return projectTerminalHistoryRow(ctx, tx, target, row, &terminalProjection{
 			RunStatus: enginedb.EngineRunLifecycleStatusCompleted,
 			Result:    cloneRaw(typed.Result),
 		})
 	case *publichistory.WorkflowFailedPayload:
-		return projectTerminalHistoryRow(ctx, tx, target, row, terminalProjection{
+		return projectTerminalHistoryRow(ctx, tx, target, row, &terminalProjection{
 			RunStatus:    enginedb.EngineRunLifecycleStatusFailed,
 			ErrorCode:    typed.ErrorCode,
 			ErrorMessage: typed.ErrorMessage,
 		})
 	case *publichistory.WorkflowCancelledPayload:
-		return projectTerminalHistoryRow(ctx, tx, target, row, terminalProjection{
+		return projectTerminalHistoryRow(ctx, tx, target, row, &terminalProjection{
 			RunStatus:     enginedb.EngineRunLifecycleStatusCancelled,
 			ErrorCode:     "cancelled",
 			ErrorMessage:  "workflow cancelled",
 			CleanupReason: "cancelled",
 		})
 	case *publichistory.WorkflowTerminatedPayload:
-		return projectTerminalHistoryRow(ctx, tx, target, row, terminalProjection{
+		return projectTerminalHistoryRow(ctx, tx, target, row, &terminalProjection{
 			RunStatus:     enginedb.EngineRunLifecycleStatusTerminated,
 			ErrorCode:     typed.ErrorCode,
 			ErrorMessage:  typed.ErrorMessage,
@@ -374,7 +374,7 @@ func projectTerminalHistoryRow(
 	tx *enginestore.Tx,
 	target *projectionTarget,
 	row *enginedb.EngineHistory,
-	projection terminalProjection,
+	projection *terminalProjection,
 ) error {
 	if err := projectCustomHistoryEvent(ctx, tx.Tx(), target, row); err != nil {
 		return err
@@ -398,9 +398,9 @@ func writeTerminalProjection(
 	tx pgx.Tx,
 	target *projectionTarget,
 	completedAt time.Time,
-	projection terminalProjection,
+	projection *terminalProjection,
 ) error {
-	if target == nil {
+	if target == nil || projection == nil {
 		return errors.New("projection target is required")
 	}
 
@@ -436,7 +436,7 @@ func writeTerminalProjection(
 		SET status = $3,
 		    end_time = $4::timestamptz,
 		    output = $5::jsonb,
-		    status_message = $6,
+		    status_message = $6::text,
 		    duration_ms = CASE
 		        WHEN $4::timestamptz IS NOT NULL THEN EXTRACT(EPOCH FROM ($4::timestamptz - start_time)) * 1000
 		        ELSE duration_ms
@@ -445,7 +445,7 @@ func writeTerminalProjection(
 		    version = COALESCE(version, 1) + 1
 		WHERE trace_id = $1
 		  AND span_id = $2
-	`, target.TraceID, rootSpanExternalID(target.RunID), spanStatus, completedAt, outputPayload, stringPtr(projection.ErrorMessage))
+	`, target.TraceID, rootSpanExternalID(target.RunID), spanStatus, completedAt, outputPayload, nullableText(stringPtr(projection.ErrorMessage)))
 	if err != nil {
 		return err
 	}
@@ -461,8 +461,11 @@ func projectTerminalCleanup(
 	tx *enginestore.Tx,
 	target *projectionTarget,
 	row *enginedb.EngineHistory,
-	projection terminalProjection,
+	projection *terminalProjection,
 ) error {
+	if projection == nil {
+		return errors.New("terminal projection is required")
+	}
 	cancelledActivities, err := tx.ListCancelledActivityTasksByRun(ctx, target.RunID)
 	if err != nil {
 		return err
@@ -539,9 +542,9 @@ func closeTerminalActivitySpan(
 	target *projectionTarget,
 	row *enginedb.EngineHistory,
 	task *enginedb.EngineActivityTask,
-	projection terminalProjection,
+	projection *terminalProjection,
 ) error {
-	if target == nil || row == nil || task == nil {
+	if target == nil || row == nil || task == nil || projection == nil {
 		return errors.New("projection target, history row, and activity task are required")
 	}
 
@@ -551,7 +554,7 @@ func closeTerminalActivitySpan(
 		    status_message = $3,
 		    end_time = $4::timestamptz,
 		    output = $5::jsonb,
-		    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object($6, to_jsonb($7::bigint)),
+		    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object($6::text, to_jsonb($7::bigint)),
 		    duration_ms = CASE
 		        WHEN start_time IS NOT NULL THEN EXTRACT(EPOCH FROM ($4::timestamptz - start_time)) * 1000
 		        ELSE duration_ms
@@ -1083,6 +1086,13 @@ func cloneRaw(raw json.RawMessage) json.RawMessage {
 		return nil
 	}
 	return append(json.RawMessage(nil), raw...)
+}
+
+func nullableText(value *string) pgtype.Text {
+	if value == nil {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: *value, Valid: true}
 }
 
 func derefString(value *string) string {

--- a/engine/internal/projector/projector.go
+++ b/engine/internal/projector/projector.go
@@ -1,5 +1,7 @@
 // Package projector owns all cross-schema writes from engine history into the
-// platform debugger tables.
+// platform debugger tables, including terminal debugger cleanup when
+// workflow.cancelled or workflow.terminated history rows are projected. No
+// other code path writes projection tables for terminal cleanup.
 //
 // Authoritative platform dependencies:
 // - db/platform/migrations/postgres/000001_initial_schema.up.sql
@@ -36,6 +38,7 @@ const (
 	defaultProjectedSpanLevel    = "default"
 	defaultProjectedSpanTypeRoot = "chain"
 	defaultProjectedSpanTypeTool = "tool"
+	terminalHistoryMetadataKey   = "__continua_terminal_history_id"
 )
 
 var darkLaunchProjectID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
@@ -53,6 +56,14 @@ type projectionTarget struct {
 	LastProjectedHistoryID int64
 	ProjectionState        string
 	ProjectionUpdatedAt    *time.Time
+}
+
+type terminalProjection struct {
+	RunStatus     enginedb.EngineRunLifecycleStatus
+	Result        json.RawMessage
+	ErrorCode     string
+	ErrorMessage  string
+	CleanupReason string
 }
 
 func New(store *enginestore.Store) *Projector {
@@ -91,7 +102,7 @@ func (p *Projector) PollOnce(ctx context.Context, _ string) error {
 		return tx.Commit(ctx)
 	}
 
-	lastProjectedID, err := p.projectHistoryRows(ctx, tx.Tx(), &target, historyRows)
+	lastProjectedID, err := p.projectHistoryRows(ctx, tx, &target, historyRows)
 	if err != nil {
 		return err
 	}
@@ -228,6 +239,8 @@ func SyncProjectedRunSummary(
 		return err
 	}
 
+	// CountOpenInboxByRun excludes cancel rows so projected counts mirror the
+	// public pending-work surface instead of internal control intents.
 	pendingInboxItems, err := queries.CountOpenInboxByRun(ctx, pgtype.UUID{Bytes: run.ID, Valid: true})
 	if err != nil {
 		return err
@@ -255,7 +268,7 @@ func SyncProjectedRunSummary(
 
 func (p *Projector) projectHistoryRows(
 	ctx context.Context,
-	tx pgx.Tx,
+	tx *enginestore.Tx,
 	target *projectionTarget,
 	rows []enginedb.EngineHistory,
 ) (int64, error) {
@@ -275,7 +288,7 @@ func (p *Projector) projectHistoryRows(
 
 func projectHistoryRow(
 	ctx context.Context,
-	tx pgx.Tx,
+	tx *enginestore.Tx,
 	target *projectionTarget,
 	row *enginedb.EngineHistory,
 ) error {
@@ -288,14 +301,39 @@ func projectHistoryRow(
 	}
 
 	switch typed := payload.(type) {
+	case *publichistory.WorkflowCompletedPayload:
+		return projectTerminalHistoryRow(ctx, tx, target, row, terminalProjection{
+			RunStatus: enginedb.EngineRunLifecycleStatusCompleted,
+			Result:    cloneRaw(typed.Result),
+		})
+	case *publichistory.WorkflowFailedPayload:
+		return projectTerminalHistoryRow(ctx, tx, target, row, terminalProjection{
+			RunStatus:    enginedb.EngineRunLifecycleStatusFailed,
+			ErrorCode:    typed.ErrorCode,
+			ErrorMessage: typed.ErrorMessage,
+		})
+	case *publichistory.WorkflowCancelledPayload:
+		return projectTerminalHistoryRow(ctx, tx, target, row, terminalProjection{
+			RunStatus:     enginedb.EngineRunLifecycleStatusCancelled,
+			ErrorCode:     "cancelled",
+			ErrorMessage:  "workflow cancelled",
+			CleanupReason: "cancelled",
+		})
+	case *publichistory.WorkflowTerminatedPayload:
+		return projectTerminalHistoryRow(ctx, tx, target, row, terminalProjection{
+			RunStatus:     enginedb.EngineRunLifecycleStatusTerminated,
+			ErrorCode:     typed.ErrorCode,
+			ErrorMessage:  typed.ErrorMessage,
+			CleanupReason: "terminated",
+		})
 	case *publichistory.ActivityScheduledPayload:
-		return projectActivityScheduled(ctx, tx, target, row, typed)
+		return projectActivityScheduled(ctx, tx.Tx(), target, row, typed)
 	case *publichistory.ActivityCompletedPayload:
-		return projectActivityCompleted(ctx, tx, target, row, typed)
+		return projectActivityCompleted(ctx, tx.Tx(), target, row, typed)
 	case *publichistory.ActivityFailedPayload:
-		return projectActivityFailed(ctx, tx, target, row, typed)
+		return projectActivityFailed(ctx, tx.Tx(), target, row, typed)
 	case *publichistory.TimerScheduledPayload:
-		return emitProjectedEvent(ctx, tx, &projectedEvent{
+		return emitProjectedEvent(ctx, tx.Tx(), &projectedEvent{
 			ProjectID:  target.ProjectID,
 			TraceID:    target.TraceID,
 			SpanID:     rootSpanExternalID(target.RunID),
@@ -309,7 +347,7 @@ func projectHistoryRow(
 			VariantKey: "timer_wait_entered",
 		})
 	case *publichistory.TimerFiredPayload:
-		return emitProjectedEvent(ctx, tx, &projectedEvent{
+		return emitProjectedEvent(ctx, tx.Tx(), &projectedEvent{
 			ProjectID: target.ProjectID,
 			TraceID:   target.TraceID,
 			SpanID:    rootSpanExternalID(target.RunID),
@@ -327,8 +365,213 @@ func projectHistoryRow(
 			VariantKey: "timer_wait_resolved",
 		})
 	default:
-		return projectCustomHistoryEvent(ctx, tx, target, row)
+		return projectCustomHistoryEvent(ctx, tx.Tx(), target, row)
 	}
+}
+
+func projectTerminalHistoryRow(
+	ctx context.Context,
+	tx *enginestore.Tx,
+	target *projectionTarget,
+	row *enginedb.EngineHistory,
+	projection terminalProjection,
+) error {
+	if err := projectCustomHistoryEvent(ctx, tx.Tx(), target, row); err != nil {
+		return err
+	}
+
+	if err := writeTerminalProjection(ctx, tx.Tx(), target, row.CreatedAt, projection); err != nil {
+		return err
+	}
+
+	if projection.CleanupReason != "" {
+		if err := projectTerminalCleanup(ctx, tx, target, row, projection); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeTerminalProjection(
+	ctx context.Context,
+	tx pgx.Tx,
+	target *projectionTarget,
+	completedAt time.Time,
+	projection terminalProjection,
+) error {
+	if target == nil {
+		return errors.New("projection target is required")
+	}
+
+	traceStatus, spanStatus := terminalStatuses(projection.RunStatus)
+	outputPayload, err := terminalOutputPayload(
+		projection.RunStatus,
+		projection.Result,
+		stringPtr(projection.ErrorCode),
+		stringPtr(projection.ErrorMessage),
+	)
+	if err != nil {
+		return err
+	}
+
+	commandTag, err := tx.Exec(ctx, `
+		UPDATE public.traces
+		SET status = $2,
+		    end_time = $3::timestamptz,
+		    output = $4::jsonb,
+		    updated_at = NOW(),
+		    version = COALESCE(version, 1) + 1
+		WHERE id = $1
+	`, target.TraceID, traceStatus, completedAt, outputPayload)
+	if err != nil {
+		return err
+	}
+	if commandTag.RowsAffected() == 0 && target.ProjectID != darkLaunchProjectID {
+		return fmt.Errorf("projected trace not found for run %s", target.RunID)
+	}
+
+	commandTag, err = tx.Exec(ctx, `
+		UPDATE public.spans
+		SET status = $3,
+		    end_time = $4::timestamptz,
+		    output = $5::jsonb,
+		    status_message = $6,
+		    duration_ms = CASE
+		        WHEN $4::timestamptz IS NOT NULL THEN EXTRACT(EPOCH FROM ($4::timestamptz - start_time)) * 1000
+		        ELSE duration_ms
+		    END,
+		    updated_at = NOW(),
+		    version = COALESCE(version, 1) + 1
+		WHERE trace_id = $1
+		  AND span_id = $2
+	`, target.TraceID, rootSpanExternalID(target.RunID), spanStatus, completedAt, outputPayload, stringPtr(projection.ErrorMessage))
+	if err != nil {
+		return err
+	}
+	if commandTag.RowsAffected() == 0 && target.ProjectID != darkLaunchProjectID {
+		return fmt.Errorf("projected root span not found for run %s", target.RunID)
+	}
+
+	return nil
+}
+
+func projectTerminalCleanup(
+	ctx context.Context,
+	tx *enginestore.Tx,
+	target *projectionTarget,
+	row *enginedb.EngineHistory,
+	projection terminalProjection,
+) error {
+	cancelledActivities, err := tx.ListCancelledActivityTasksByRun(ctx, target.RunID)
+	if err != nil {
+		return err
+	}
+
+	discardedTimers, err := tx.ListDiscardedTimerInboxItemsByRun(ctx, target.RunID)
+	if err != nil {
+		return err
+	}
+
+	sequence := row.SequenceNo*10 + 1
+	for i := range cancelledActivities {
+		task := cancelledActivities[i]
+		if err := closeTerminalActivitySpan(ctx, tx.Tx(), target, row, &task, projection); err != nil {
+			return err
+		}
+		if err := emitProjectedEvent(ctx, tx.Tx(), &projectedEvent{
+			ProjectID: target.ProjectID,
+			TraceID:   target.TraceID,
+			SpanID:    rootSpanExternalID(target.RunID),
+			EventType: "wait",
+			EventTS:   row.CreatedAt,
+			Sequence:  sequence,
+			Payload: mustMarshalMap(map[string]any{
+				"wait_kind":  "activity",
+				"phase":      "resolved",
+				"wait_id":    "activity:" + task.ActivityKey,
+				"resolution": projection.CleanupReason,
+			}),
+			HistoryID:  row.ID,
+			RunID:      target.RunID,
+			VariantKey: projection.CleanupReason + ":activity:" + task.ActivityKey,
+		}); err != nil {
+			return err
+		}
+		sequence++
+	}
+
+	for i := range discardedTimers {
+		inboxRow := discardedTimers[i]
+		timerPayload := publichistory.TimerScheduledPayload{}
+		if err := publichistory.UnmarshalPayload(inboxRow.Payload, &timerPayload); err != nil {
+			return fmt.Errorf("decode discarded timer inbox payload: %w", err)
+		}
+
+		if err := emitProjectedEvent(ctx, tx.Tx(), &projectedEvent{
+			ProjectID: target.ProjectID,
+			TraceID:   target.TraceID,
+			SpanID:    rootSpanExternalID(target.RunID),
+			EventType: "wait",
+			EventTS:   row.CreatedAt,
+			Sequence:  sequence,
+			Payload: mustMarshalMap(map[string]any{
+				"wait_kind":  "timer",
+				"phase":      "resolved",
+				"wait_id":    "timer:" + timerPayload.TimerKey,
+				"resolution": projection.CleanupReason,
+			}),
+			HistoryID:  row.ID,
+			RunID:      target.RunID,
+			VariantKey: projection.CleanupReason + ":timer:" + timerPayload.TimerKey,
+		}); err != nil {
+			return err
+		}
+		sequence++
+	}
+
+	return nil
+}
+
+func closeTerminalActivitySpan(
+	ctx context.Context,
+	tx pgx.Tx,
+	target *projectionTarget,
+	row *enginedb.EngineHistory,
+	task *enginedb.EngineActivityTask,
+	projection terminalProjection,
+) error {
+	if target == nil || row == nil || task == nil {
+		return errors.New("projection target, history row, and activity task are required")
+	}
+
+	commandTag, err := tx.Exec(ctx, `
+		UPDATE public.spans
+		SET status = 'failed',
+		    status_message = $3,
+		    end_time = $4::timestamptz,
+		    output = $5::jsonb,
+		    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object($6, to_jsonb($7::bigint)),
+		    duration_ms = CASE
+		        WHEN start_time IS NOT NULL THEN EXTRACT(EPOCH FROM ($4::timestamptz - start_time)) * 1000
+		        ELSE duration_ms
+		    END,
+		    updated_at = NOW(),
+		    version = COALESCE(version, 1) + 1
+		WHERE trace_id = $1
+		  AND span_id = $2
+		  AND end_time IS NULL
+	`, target.TraceID, activitySpanExternalID(target.RunID, task.ActivityKey), projection.ErrorMessage, row.CreatedAt, mustMarshalMap(map[string]any{
+		"error_code":    projection.ErrorCode,
+		"error_message": projection.ErrorMessage,
+	}), terminalHistoryMetadataKey, row.ID)
+	if err != nil {
+		return err
+	}
+	if commandTag.RowsAffected() == 0 {
+		return nil
+	}
+	return nil
 }
 
 func projectActivityScheduled(
@@ -657,17 +900,33 @@ func selectProjectionTarget(ctx context.Context, tx pgx.Tx) (projectionTarget, e
 	var target projectionTarget
 	var projectionUpdatedAt pgtypeTimestamptz
 	err := tx.QueryRow(ctx, `
+		WITH targets AS (
+		    SELECT t.id,
+		           t.project_id,
+		           COALESCE(t.name, t.trace_id) AS trace_name,
+		           t.engine_run_id,
+		           COALESCE((
+		               SELECT MAX(h.id)
+		               FROM engine.history AS h
+		               WHERE h.run_id = t.engine_run_id
+		           ), COALESCE(t.engine_latest_history_id, 0), 0) AS latest_history_id,
+		           COALESCE(t.engine_last_projected_history_id, 0) AS last_projected_history_id,
+		           COALESCE(t.engine_projection_state, '') AS projection_state,
+		           t.engine_projection_updated_at,
+		           t.updated_at
+		    FROM public.traces AS t
+		    WHERE t.engine_run_id IS NOT NULL
+		)
 		SELECT id,
 		       project_id,
-		       COALESCE(name, trace_id),
+		       trace_name,
 		       engine_run_id,
-		       COALESCE(engine_latest_history_id, 0),
-		       COALESCE(engine_last_projected_history_id, 0),
-		       COALESCE(engine_projection_state, ''),
+		       latest_history_id,
+		       last_projected_history_id,
+		       projection_state,
 		       engine_projection_updated_at
-		FROM public.traces
-		WHERE engine_run_id IS NOT NULL
-		  AND COALESCE(engine_last_projected_history_id, 0) < COALESCE(engine_latest_history_id, 0)
+		FROM targets
+		WHERE last_projected_history_id < latest_history_id
 		ORDER BY engine_projection_updated_at ASC NULLS FIRST, updated_at ASC, id ASC
 		LIMIT 1
 	`).Scan(
@@ -697,19 +956,26 @@ func advanceProjectionCheckpoint(
 	lastProjectedHistoryID int64,
 ) error {
 	commandTag, err := tx.Exec(ctx, `
+		WITH latest AS (
+		    SELECT COALESCE(MAX(id), 0) AS latest_history_id
+		    FROM engine.history
+		    WHERE run_id = $2
+		)
 		UPDATE public.traces
-		SET engine_last_projected_history_id = CASE
-		        WHEN COALESCE(engine_last_projected_history_id, 0) < $3 THEN $3
-		        ELSE engine_last_projected_history_id
+		SET engine_latest_history_id = GREATEST(COALESCE(public.traces.engine_latest_history_id, 0), latest.latest_history_id),
+		    engine_last_projected_history_id = CASE
+		        WHEN COALESCE(public.traces.engine_last_projected_history_id, 0) < $3 THEN $3
+		        ELSE public.traces.engine_last_projected_history_id
 		    END,
 		    engine_projection_state = CASE
-		        WHEN COALESCE(engine_latest_history_id, 0) <= GREATEST(COALESCE(engine_last_projected_history_id, 0), $3) THEN $4
+		        WHEN latest.latest_history_id <= GREATEST(COALESCE(public.traces.engine_last_projected_history_id, 0), $3) THEN $4
 		        ELSE $5
 		    END,
 		    engine_projection_updated_at = NOW(),
 		    updated_at = NOW()
-		WHERE id = $1
-		  AND engine_run_id = $2
+		FROM latest
+		WHERE public.traces.id = $1
+		  AND public.traces.engine_run_id = $2
 	`, traceID, runID, lastProjectedHistoryID, publicprojection.StateUpToDate.String(), publicprojection.StateCatchingUp.String())
 	if err != nil {
 		return err
@@ -744,6 +1010,8 @@ func terminalStatuses(status enginedb.EngineRunLifecycleStatus) (traceStatus, sp
 		return "completed", "completed"
 	case enginedb.EngineRunLifecycleStatusCancelled:
 		return "cancelled", "failed"
+	case enginedb.EngineRunLifecycleStatusTerminated:
+		return "failed", "failed"
 	default:
 		return "failed", "failed"
 	}

--- a/engine/internal/projector/projector_test.go
+++ b/engine/internal/projector/projector_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 	enginestore "github.com/continua-ai/continua/engine/internal/store"
@@ -49,7 +50,7 @@ func TestProjectorPollOnce_RestartSafeForProjectedActivityRows(t *testing.T) {
 		_ = tx.Rollback(fixture.ctx)
 		t.Fatalf("expected 1 history row, got %d", len(rows))
 	}
-	if err := projectHistoryRow(fixture.ctx, tx.Tx(), &target, &rows[0]); err != nil {
+	if err := projectHistoryRow(fixture.ctx, tx, &target, &rows[0]); err != nil {
 		_ = tx.Rollback(fixture.ctx)
 		t.Fatalf("projectHistoryRow() error = %v", err)
 	}
@@ -376,6 +377,492 @@ func TestProjectionStateAdvancesAcrossStartActivationAndProjector(t *testing.T) 
 	}
 }
 
+func TestProjectorPollOnce_TerminatedHistoryProjectsFailureAndCleanup(t *testing.T) {
+	fixture := newProjectorFixture(t)
+	baseTime := time.Now().UTC().Round(time.Microsecond)
+
+	activityHistory := fixture.appendHistoryEvent(2, publichistory.EventActivityScheduled, publichistory.ActivityScheduledPayload{
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+	})
+	timerHistory := fixture.appendHistoryEvent(3, publichistory.EventTimerScheduled, publichistory.TimerScheduledPayload{
+		TimerKey: "deadline",
+		DueAt:    baseTime.Add(5 * time.Minute),
+	})
+
+	if _, err := fixture.store.CreateActivityTask(fixture.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:    fixture.projectID,
+		InstanceID:   fixture.instance.ID,
+		RunID:        fixture.run.ID,
+		HistoryID:    &activityHistory.ID,
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+		AvailableAt:  baseTime.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateActivityTask() error = %v", err)
+	}
+
+	timerPayload, err := publichistory.MarshalPayload(publichistory.TimerScheduledPayload{
+		TimerKey: "deadline",
+		DueAt:    baseTime.Add(5 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(timer) error = %v", err)
+	}
+	if _, err := fixture.store.CreateInboxItem(fixture.ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   fixture.projectID,
+		InstanceID:  fixture.instance.ID,
+		RunID:       pgtype.UUID{Bytes: fixture.run.ID, Valid: true},
+		HistoryID:   &timerHistory.ID,
+		Kind:        "timer",
+		Payload:     timerPayload,
+		AvailableAt: baseTime.Add(5 * time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateInboxItem(timer) error = %v", err)
+	}
+
+	fixture.setTraceProjection(timerHistory.ID, fixture.startedHistory.ID, publicprojection.StateCatchingUp.String())
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-terminal-prep"); err != nil {
+		t.Fatalf("PollOnce() initial projection error = %v", err)
+	}
+
+	if _, err := fixture.store.CancelOpenActivityTasksByRun(fixture.ctx, fixture.run.ID); err != nil {
+		t.Fatalf("CancelOpenActivityTasksByRun() error = %v", err)
+	}
+	if _, err := fixture.store.DiscardOpenInboxItemsByRun(fixture.ctx, fixture.run.ID); err != nil {
+		t.Fatalf("DiscardOpenInboxItemsByRun() error = %v", err)
+	}
+
+	terminatedAt := baseTime.Add(6 * time.Minute)
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE engine.runs
+		SET status = 'terminated',
+		    waiting_for = NULL,
+		    result = NULL,
+		    completed_at = $2,
+		    last_error_code = 'terminated',
+		    last_error_message = 'run terminated by operator',
+		    updated_at = $2
+		WHERE id = $1
+	`, fixture.run.ID, terminatedAt); err != nil {
+		t.Fatalf("mark run terminated: %v", err)
+	}
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE engine.instances
+		SET status = 'terminated',
+		    updated_at = $2
+		WHERE id = $1
+	`, fixture.instance.ID, terminatedAt); err != nil {
+		t.Fatalf("mark instance terminated: %v", err)
+	}
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE public.traces
+		SET engine_wait_state = $2::jsonb,
+		    updated_at = NOW()
+		WHERE id = $1
+	`, fixture.traceID, mustJSON(t, map[string]any{"kind": "signal", "signal_name": "approval"})); err != nil {
+		t.Fatalf("seed projected wait state: %v", err)
+	}
+
+	terminalHistory := fixture.appendHistoryEvent(4, publichistory.EventWorkflowTerminated, publichistory.WorkflowTerminatedPayload{
+		ErrorCode:    "terminated",
+		ErrorMessage: "run terminated by operator",
+	})
+
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-terminated"); err != nil {
+		t.Fatalf("PollOnce() terminal projection error = %v", err)
+	}
+
+	var traceStatus string
+	var runStatus string
+	var waitState []byte
+	var pendingActivityTasks int64
+	var pendingInboxItems int64
+	var traceOutput []byte
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT status,
+		       engine_run_status,
+		       engine_wait_state,
+		       engine_pending_activity_tasks,
+		       engine_pending_inbox_items,
+		       output
+		FROM public.traces
+		WHERE id = $1
+	`, fixture.traceID).Scan(&traceStatus, &runStatus, &waitState, &pendingActivityTasks, &pendingInboxItems, &traceOutput); err != nil {
+		t.Fatalf("query terminated trace summary: %v", err)
+	}
+	if traceStatus != "failed" {
+		t.Fatalf("expected failed trace status for terminated run, got %q", traceStatus)
+	}
+	if runStatus != string(enginedb.EngineRunLifecycleStatusTerminated) {
+		t.Fatalf("expected projected terminated engine status, got %q", runStatus)
+	}
+	if len(waitState) != 0 {
+		t.Fatalf("expected terminal projection to clear wait state, got %s", waitState)
+	}
+	if pendingActivityTasks != 0 || pendingInboxItems != 0 {
+		t.Fatalf("expected terminal projection to clear pending counts, got activity=%d inbox=%d", pendingActivityTasks, pendingInboxItems)
+	}
+
+	var outputPayload map[string]any
+	if err := json.Unmarshal(traceOutput, &outputPayload); err != nil {
+		t.Fatalf("json.Unmarshal(trace output) error = %v", err)
+	}
+	if outputPayload["error_code"] != "terminated" || outputPayload["error_message"] != "run terminated by operator" {
+		t.Fatalf("unexpected terminated trace output: %+v", outputPayload)
+	}
+
+	var rootSpanStatus string
+	var rootSpanMessage *string
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT status, status_message
+		FROM public.spans
+		WHERE trace_id = $1
+		  AND span_id = $2
+	`, fixture.traceID, rootSpanExternalID(fixture.run.ID)).Scan(&rootSpanStatus, &rootSpanMessage); err != nil {
+		t.Fatalf("query terminated root span: %v", err)
+	}
+	if rootSpanStatus != "failed" {
+		t.Fatalf("expected failed root span for terminated run, got %q", rootSpanStatus)
+	}
+	if rootSpanMessage == nil || *rootSpanMessage != "run terminated by operator" {
+		t.Fatalf("expected terminated root span message, got %+v", rootSpanMessage)
+	}
+
+	var activitySpanStatus string
+	var activitySpanMessage *string
+	var activitySpanMetadata []byte
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT status, status_message, metadata
+		FROM public.spans
+		WHERE trace_id = $1
+		  AND span_id = $2
+	`, fixture.traceID, activitySpanExternalID(fixture.run.ID, "ship-order")).Scan(&activitySpanStatus, &activitySpanMessage, &activitySpanMetadata); err != nil {
+		t.Fatalf("query terminated activity span: %v", err)
+	}
+	if activitySpanStatus != "failed" {
+		t.Fatalf("expected failed activity span after termination, got %q", activitySpanStatus)
+	}
+	if activitySpanMessage == nil || *activitySpanMessage != "run terminated by operator" {
+		t.Fatalf("expected terminated activity span message, got %+v", activitySpanMessage)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(activitySpanMetadata, &metadata); err != nil {
+		t.Fatalf("json.Unmarshal(activity span metadata) error = %v", err)
+	}
+	if metadata[terminalHistoryMetadataKey] != float64(terminalHistory.ID) {
+		t.Fatalf("expected terminal history metadata %d, got %+v", terminalHistory.ID, metadata)
+	}
+
+	resolvedWaits := queryResolvedWaitEvents(t, fixture, "terminated")
+	if len(resolvedWaits) != 2 {
+		t.Fatalf("expected 2 terminated wait resolution events, got %+v", resolvedWaits)
+	}
+	if resolvedWaits[0].Sequence != terminalHistory.SequenceNo*10+1 || resolvedWaits[0].WaitID != "activity:ship-order" {
+		t.Fatalf("unexpected first terminated wait event: %+v", resolvedWaits[0])
+	}
+	if resolvedWaits[1].Sequence != terminalHistory.SequenceNo*10+2 || resolvedWaits[1].WaitID != "timer:deadline" {
+		t.Fatalf("unexpected second terminated wait event: %+v", resolvedWaits[1])
+	}
+
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-terminated-idempotent"); err != nil {
+		t.Fatalf("PollOnce() idempotent projection error = %v", err)
+	}
+	resolvedWaitsAfterReplay := queryResolvedWaitEvents(t, fixture, "terminated")
+	if len(resolvedWaitsAfterReplay) != len(resolvedWaits) {
+		t.Fatalf("expected terminated cleanup replay to stay idempotent, got before=%d after=%d", len(resolvedWaits), len(resolvedWaitsAfterReplay))
+	}
+}
+
+func TestProjectorPollOnce_CancelledHistoryClearsPureSignalWaitWithoutSyntheticSignalEvent(t *testing.T) {
+	fixture := newProjectorFixture(t)
+	cancelledAt := time.Now().UTC().Round(time.Microsecond)
+
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE engine.runs
+		SET status = 'cancelled',
+		    waiting_for = NULL,
+		    result = NULL,
+		    completed_at = $2,
+		    last_error_code = 'cancelled',
+		    last_error_message = 'workflow cancelled',
+		    updated_at = $2
+		WHERE id = $1
+	`, fixture.run.ID, cancelledAt); err != nil {
+		t.Fatalf("mark run cancelled: %v", err)
+	}
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE engine.instances
+		SET status = 'cancelled',
+		    updated_at = $2
+		WHERE id = $1
+	`, fixture.instance.ID, cancelledAt); err != nil {
+		t.Fatalf("mark instance cancelled: %v", err)
+	}
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE public.traces
+		SET engine_wait_state = $2::jsonb,
+		    updated_at = NOW()
+		WHERE id = $1
+	`, fixture.traceID, mustJSON(t, map[string]any{"kind": "signal", "signal_name": "approval"})); err != nil {
+		t.Fatalf("seed signal wait state: %v", err)
+	}
+
+	fixture.appendHistoryEvent(2, publichistory.EventWorkflowCancelled, publichistory.WorkflowCancelledPayload{})
+
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-cancelled-signal"); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+
+	var traceStatus string
+	var waitState []byte
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT status, engine_wait_state
+		FROM public.traces
+		WHERE id = $1
+	`, fixture.traceID).Scan(&traceStatus, &waitState); err != nil {
+		t.Fatalf("query cancelled trace summary: %v", err)
+	}
+	if traceStatus != "cancelled" {
+		t.Fatalf("expected cancelled trace status, got %q", traceStatus)
+	}
+	if len(waitState) != 0 {
+		t.Fatalf("expected cancelled projection to clear pure signal wait state, got %s", waitState)
+	}
+	if resolvedWaits := queryResolvedWaitEvents(t, fixture, "cancelled"); len(resolvedWaits) != 0 {
+		t.Fatalf("expected no synthetic signal wait resolution events, got %+v", resolvedWaits)
+	}
+}
+
+func TestProjectorPollOnce_ClearsWaitStateOnEveryTerminalTransition(t *testing.T) {
+	testCases := []struct {
+		name           string
+		runStatus      enginedb.EngineRunLifecycleStatus
+		instanceStatus enginedb.EngineInstanceLifecycleStatus
+		eventType      string
+		payload        any
+		result         []byte
+		errorCode      *string
+		errorMessage   *string
+	}{
+		{
+			name:           "completed",
+			runStatus:      enginedb.EngineRunLifecycleStatusCompleted,
+			instanceStatus: enginedb.EngineInstanceLifecycleStatusCompleted,
+			eventType:      publichistory.EventWorkflowCompleted,
+			payload: publichistory.WorkflowCompletedPayload{
+				Result: mustJSON(t, map[string]bool{"ok": true}),
+			},
+			result: mustJSON(t, map[string]bool{"ok": true}),
+		},
+		{
+			name:           "failed",
+			runStatus:      enginedb.EngineRunLifecycleStatusFailed,
+			instanceStatus: enginedb.EngineInstanceLifecycleStatusFailed,
+			eventType:      publichistory.EventWorkflowFailed,
+			payload: publichistory.WorkflowFailedPayload{
+				ErrorCode:    "failed",
+				ErrorMessage: "workflow failed",
+			},
+			errorCode:    enginetest.Ptr("failed"),
+			errorMessage: enginetest.Ptr("workflow failed"),
+		},
+		{
+			name:           "cancelled",
+			runStatus:      enginedb.EngineRunLifecycleStatusCancelled,
+			instanceStatus: enginedb.EngineInstanceLifecycleStatusCancelled,
+			eventType:      publichistory.EventWorkflowCancelled,
+			payload:        publichistory.WorkflowCancelledPayload{},
+			errorCode:      enginetest.Ptr("cancelled"),
+			errorMessage:   enginetest.Ptr("workflow cancelled"),
+		},
+		{
+			name:           "terminated",
+			runStatus:      enginedb.EngineRunLifecycleStatusTerminated,
+			instanceStatus: enginedb.EngineInstanceLifecycleStatusTerminated,
+			eventType:      publichistory.EventWorkflowTerminated,
+			payload: publichistory.WorkflowTerminatedPayload{
+				ErrorCode:    "terminated",
+				ErrorMessage: "run terminated by operator",
+			},
+			errorCode:    enginetest.Ptr("terminated"),
+			errorMessage: enginetest.Ptr("run terminated by operator"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newProjectorFixture(t)
+			completedAt := time.Now().UTC().Round(time.Microsecond)
+
+			if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+				UPDATE engine.runs
+				SET status = $2,
+				    waiting_for = NULL,
+				    result = $3,
+				    completed_at = $4,
+				    last_error_code = $5,
+				    last_error_message = $6,
+				    updated_at = $4
+				WHERE id = $1
+			`, fixture.run.ID, tc.runStatus, tc.result, completedAt, tc.errorCode, tc.errorMessage); err != nil {
+				t.Fatalf("mark run terminal: %v", err)
+			}
+			if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+				UPDATE engine.instances
+				SET status = $2,
+				    updated_at = $3
+				WHERE id = $1
+			`, fixture.instance.ID, tc.instanceStatus, completedAt); err != nil {
+				t.Fatalf("mark instance terminal: %v", err)
+			}
+			if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+				UPDATE public.traces
+				SET engine_wait_state = $2::jsonb,
+				    updated_at = NOW()
+				WHERE id = $1
+			`, fixture.traceID, mustJSON(t, map[string]any{"kind": "signal", "signal_name": "approval"})); err != nil {
+				t.Fatalf("seed wait state: %v", err)
+			}
+
+			terminalHistory := fixture.appendHistoryEvent(2, tc.eventType, tc.payload)
+			fixture.setTraceProjection(terminalHistory.ID, fixture.startedHistory.ID, publicprojection.StateCatchingUp.String())
+
+			if err := fixture.projector.PollOnce(fixture.ctx, "projector-terminal-clear-"+tc.name); err != nil {
+				t.Fatalf("PollOnce() error = %v", err)
+			}
+
+			var waitState []byte
+			if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+				SELECT engine_wait_state
+				FROM public.traces
+				WHERE id = $1
+			`, fixture.traceID).Scan(&waitState); err != nil {
+				t.Fatalf("query wait state: %v", err)
+			}
+			if len(waitState) != 0 {
+				t.Fatalf("expected terminal projection to clear wait state, got %s", waitState)
+			}
+		})
+	}
+}
+
+func TestProjectorPollOnce_TerminatedCleanupSkipsAlreadyCompletedActivities(t *testing.T) {
+	fixture := newProjectorFixture(t)
+	baseTime := time.Now().UTC().Round(time.Microsecond)
+
+	activityHistory := fixture.appendHistoryEvent(2, publichistory.EventActivityScheduled, publichistory.ActivityScheduledPayload{
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+	})
+	activityTask, err := fixture.store.CreateActivityTask(fixture.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:    fixture.projectID,
+		InstanceID:   fixture.instance.ID,
+		RunID:        fixture.run.ID,
+		HistoryID:    &activityHistory.ID,
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+		AvailableAt:  baseTime,
+	})
+	if err != nil {
+		t.Fatalf("CreateActivityTask() error = %v", err)
+	}
+	fixture.setTraceProjection(activityHistory.ID, fixture.startedHistory.ID, publicprojection.StateCatchingUp.String())
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-activity-started"); err != nil {
+		t.Fatalf("PollOnce(activity scheduled) error = %v", err)
+	}
+
+	completedHistory := fixture.appendHistoryEvent(3, publichistory.EventActivityCompleted, publichistory.ActivityCompletedPayload{
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Output:       mustJSON(t, map[string]bool{"ok": true}),
+	})
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE engine.activity_tasks
+		SET status = 'completed',
+		    output = $2,
+		    completed_at = $3,
+		    updated_at = $3
+		WHERE id = $1
+	`, activityTask.ID, mustJSON(t, map[string]bool{"ok": true}), baseTime.Add(time.Second)); err != nil {
+		t.Fatalf("mark activity task completed: %v", err)
+	}
+	fixture.setTraceProjection(completedHistory.ID, activityHistory.ID, publicprojection.StateCatchingUp.String())
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-activity-completed"); err != nil {
+		t.Fatalf("PollOnce(activity completed) error = %v", err)
+	}
+
+	timerHistory := fixture.appendHistoryEvent(4, publichistory.EventTimerScheduled, publichistory.TimerScheduledPayload{
+		TimerKey: "deadline",
+		DueAt:    baseTime.Add(5 * time.Minute),
+	})
+	timerPayload, err := publichistory.MarshalPayload(publichistory.TimerScheduledPayload{
+		TimerKey: "deadline",
+		DueAt:    baseTime.Add(5 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(timer) error = %v", err)
+	}
+	if _, err := fixture.store.CreateInboxItem(fixture.ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   fixture.projectID,
+		InstanceID:  fixture.instance.ID,
+		RunID:       pgtype.UUID{Bytes: fixture.run.ID, Valid: true},
+		HistoryID:   &timerHistory.ID,
+		Kind:        "timer",
+		Payload:     timerPayload,
+		AvailableAt: baseTime.Add(5 * time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateInboxItem(timer) error = %v", err)
+	}
+
+	terminatedAt := baseTime.Add(2 * time.Second)
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE engine.runs
+		SET status = 'terminated',
+		    waiting_for = NULL,
+		    completed_at = $2,
+		    last_error_code = 'terminated',
+		    last_error_message = 'run terminated by operator',
+		    updated_at = $2
+		WHERE id = $1
+	`, fixture.run.ID, terminatedAt); err != nil {
+		t.Fatalf("mark run terminated: %v", err)
+	}
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE engine.instances
+		SET status = 'terminated',
+		    updated_at = $2
+		WHERE id = $1
+	`, fixture.instance.ID, terminatedAt); err != nil {
+		t.Fatalf("mark instance terminated: %v", err)
+	}
+	if _, err := fixture.store.DiscardOpenInboxItemsByRun(fixture.ctx, fixture.run.ID); err != nil {
+		t.Fatalf("DiscardOpenInboxItemsByRun() error = %v", err)
+	}
+
+	terminalHistory := fixture.appendHistoryEvent(5, publichistory.EventWorkflowTerminated, publichistory.WorkflowTerminatedPayload{
+		ErrorCode:    "terminated",
+		ErrorMessage: "run terminated by operator",
+	})
+	fixture.setTraceProjection(terminalHistory.ID, completedHistory.ID, publicprojection.StateCatchingUp.String())
+
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-terminate-after-completion"); err != nil {
+		t.Fatalf("PollOnce(terminated) error = %v", err)
+	}
+
+	resolvedWaits := queryResolvedWaitEvents(t, fixture, "terminated")
+	if len(resolvedWaits) != 1 {
+		t.Fatalf("expected only timer cleanup event after completed activity, got %+v", resolvedWaits)
+	}
+	if resolvedWaits[0].WaitID != "timer:deadline" {
+		t.Fatalf("expected terminated cleanup to resolve only the timer wait, got %+v", resolvedWaits)
+	}
+}
+
 func TestSyncProjectedRunSummary_MissingProjectedTraceFailsForPublicRuns(t *testing.T) {
 	db := enginetest.NewTestDatabase(t)
 	store := enginestore.New(db.Pool)
@@ -645,4 +1132,52 @@ func mustJSON(t *testing.T, value any) json.RawMessage {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 	return raw
+}
+
+type resolvedWaitEvent struct {
+	Sequence int32
+	WaitID   string
+}
+
+func queryResolvedWaitEvents(t *testing.T, fixture *projectorFixture, resolution string) []resolvedWaitEvent {
+	t.Helper()
+
+	rows, err := fixture.db.Pool.Query(fixture.ctx, `
+		SELECT sequence, payload
+		FROM public.span_events
+		WHERE trace_id = $1
+		  AND event_type = 'wait'
+		ORDER BY sequence ASC, created_at ASC
+	`, fixture.traceID)
+	if err != nil {
+		t.Fatalf("query wait events: %v", err)
+	}
+	defer rows.Close()
+
+	var resolved []resolvedWaitEvent
+	for rows.Next() {
+		var sequence int32
+		var payload []byte
+		if err := rows.Scan(&sequence, &payload); err != nil {
+			t.Fatalf("scan wait event: %v", err)
+		}
+
+		var decoded map[string]any
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal(wait event payload) error = %v", err)
+		}
+		if decoded["resolution"] != resolution {
+			continue
+		}
+		waitID, _ := decoded["wait_id"].(string)
+		resolved = append(resolved, resolvedWaitEvent{
+			Sequence: sequence,
+			WaitID:   waitID,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate wait events: %v", err)
+	}
+
+	return resolved
 }

--- a/engine/internal/store/activity_tasks.go
+++ b/engine/internal/store/activity_tasks.go
@@ -37,6 +37,20 @@ func (o *storeOps) ListActivityTasksByRun(
 	return o.q.ListActivityTasksByRun(ctx, runID)
 }
 
+func (o *storeOps) ListOpenActivityTasksByRun(
+	ctx context.Context,
+	runID uuid.UUID,
+) ([]enginedb.EngineActivityTask, error) {
+	return o.q.ListOpenActivityTasksByRun(ctx, runID)
+}
+
+func (o *storeOps) ListCancelledActivityTasksByRun(
+	ctx context.Context,
+	runID uuid.UUID,
+) ([]enginedb.EngineActivityTask, error) {
+	return o.q.ListCancelledActivityTasksByRun(ctx, runID)
+}
+
 func (o *storeOps) ClaimNextActivityTask(
 	ctx context.Context,
 	workerID string,
@@ -82,6 +96,13 @@ func (o *storeOps) FailActivityTask(
 		return task, nil
 	}
 	return enginedb.EngineActivityTask{}, o.classifyActivityTaskCASMiss(ctx, id, err)
+}
+
+func (o *storeOps) CancelOpenActivityTasksByRun(
+	ctx context.Context,
+	runID uuid.UUID,
+) ([]enginedb.EngineActivityTask, error) {
+	return o.q.CancelOpenActivityTasksByRun(ctx, runID)
 }
 
 func (o *storeOps) classifyActivityTaskCASMiss(ctx context.Context, id uuid.UUID, err error) error {

--- a/engine/internal/store/history.go
+++ b/engine/internal/store/history.go
@@ -17,6 +17,10 @@ func (o *storeOps) GetHistoryByRun(ctx context.Context, runID uuid.UUID) ([]engi
 	return o.q.GetHistoryByRun(ctx, runID)
 }
 
+func (o *storeOps) GetLatestHistoryIDByRun(ctx context.Context, runID uuid.UUID) (int64, error) {
+	return o.q.GetLatestHistoryIDByRun(ctx, runID)
+}
+
 func (o *storeOps) ListHistoryByRunAfterID(
 	ctx context.Context,
 	arg enginedb.ListHistoryByRunAfterIDParams,

--- a/engine/internal/store/inbox.go
+++ b/engine/internal/store/inbox.go
@@ -33,6 +33,24 @@ func (o *storeOps) ListPendingInboxByRun(
 	return o.q.ListPendingInboxByRun(ctx, pgtype.UUID{Bytes: runID, Valid: true})
 }
 
+func (o *storeOps) ListOpenInboxItemsByRunAndKind(
+	ctx context.Context,
+	runID uuid.UUID,
+	kind string,
+) ([]enginedb.EngineInbox, error) {
+	return o.q.ListOpenInboxItemsByRunAndKind(ctx, enginedb.ListOpenInboxItemsByRunAndKindParams{
+		RunID: pgtype.UUID{Bytes: runID, Valid: true},
+		Kind:  kind,
+	})
+}
+
+func (o *storeOps) ListDiscardedTimerInboxItemsByRun(
+	ctx context.Context,
+	runID uuid.UUID,
+) ([]enginedb.EngineInbox, error) {
+	return o.q.ListDiscardedTimerInboxItemsByRun(ctx, pgtype.UUID{Bytes: runID, Valid: true})
+}
+
 func (o *storeOps) ListDueTimerRunIDs(ctx context.Context) ([]uuid.UUID, error) {
 	rawIDs, err := o.q.ListDueTimerRunIDs(ctx)
 	if err != nil {
@@ -56,4 +74,11 @@ func (o *storeOps) MarkInboxProcessed(ctx context.Context, id uuid.UUID) (engine
 
 func (o *storeOps) MarkInboxDiscarded(ctx context.Context, id uuid.UUID) (enginedb.EngineInbox, error) {
 	return mapResult(o.q.MarkInboxDiscarded(ctx, id))
+}
+
+func (o *storeOps) DiscardOpenInboxItemsByRun(
+	ctx context.Context,
+	runID uuid.UUID,
+) ([]enginedb.EngineInbox, error) {
+	return o.q.DiscardOpenInboxItemsByRun(ctx, pgtype.UUID{Bytes: runID, Valid: true})
 }

--- a/engine/internal/store/runs.go
+++ b/engine/internal/store/runs.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -84,7 +85,18 @@ func (o *storeOps) TransitionRunToCancelled(
 	if err == nil {
 		return run, nil
 	}
-	return enginedb.EngineRun{}, o.classifyRunCASMiss(ctx, arg.ID, err)
+	return enginedb.EngineRun{}, o.classifyRunInvariantMiss(ctx, arg.ID, "cancel", err)
+}
+
+func (o *storeOps) TransitionRunToTerminated(
+	ctx context.Context,
+	id uuid.UUID,
+) (enginedb.EngineRun, error) {
+	run, err := o.q.TransitionRunToTerminated(ctx, id)
+	if err == nil {
+		return run, nil
+	}
+	return enginedb.EngineRun{}, o.classifyRunInvariantMiss(ctx, id, "terminate", err)
 }
 
 func (o *storeOps) WakeWaitingRun(ctx context.Context, id uuid.UUID) (WakeWaitingRunResult, error) {
@@ -123,4 +135,16 @@ func (o *storeOps) classifyRunCASMiss(ctx context.Context, id uuid.UUID, err err
 		return lookupErr
 	}
 	return ErrStaleClaim
+}
+
+func (o *storeOps) classifyRunInvariantMiss(ctx context.Context, id uuid.UUID, operation string, err error) error {
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return normalizeError(err)
+	}
+
+	current, err := o.GetRun(ctx, id)
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("%w: run %s transition %s returned zero rows with current status %s", ErrInvariant, id, operation, current.Status)
 }

--- a/engine/internal/store/store.go
+++ b/engine/internal/store/store.go
@@ -21,6 +21,7 @@ var (
 	ErrAlreadyExists   = errors.New("engine store: record already exists")
 	ErrStaleClaim      = errors.New("engine store: stale claim")
 	ErrStaleCheckpoint = errors.New("engine store: stale checkpoint")
+	ErrInvariant       = errors.New("engine store: invariant violation")
 )
 
 type storeOps struct {

--- a/engine/internal/workflow/activation.go
+++ b/engine/internal/workflow/activation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -109,7 +110,13 @@ func (a *Activator) commitDecision(
 	sequence := decision.NextSequence
 	var activityHistoryID *int64
 	var timerHistoryID *int64
-	var lastHistoryID int64
+	var latestHistoryID *int64
+
+	for _, inboxID := range decision.ConsumedInboxIDs {
+		if _, err := tx.MarkInboxProcessed(ctx, inboxID); err != nil && err != store.ErrNotFound {
+			return err
+		}
+	}
 
 	for i := range decision.Events {
 		event := decision.Events[i]
@@ -131,8 +138,18 @@ func (a *Activator) commitDecision(
 		case enginehistory.EventTimerScheduled:
 			timerHistoryID = &appended.ID
 		}
-		lastHistoryID = appended.ID
+		latestHistoryID = &appended.ID
 		sequence++
+	}
+
+	// Non-cancel activation paths still maintain the stored per-trace freshness
+	// checkpoint so projected shells can move into catching_up before the
+	// projector catches up. decisionCancelled remains engine-only per the
+	// operational hardening change.
+	if latestHistoryID != nil && decision.Kind != decisionCancelled {
+		if err := engineprojector.UpdateLatestHistory(ctx, tx.Tx(), run.ProjectID, run.ID, *latestHistoryID); err != nil {
+			return err
+		}
 	}
 
 	if decision.NewActivity != nil {
@@ -174,15 +191,9 @@ func (a *Activator) commitDecision(
 		}
 	}
 
-	for _, inboxID := range decision.ConsumedInboxIDs {
-		if _, err := tx.MarkInboxProcessed(ctx, inboxID); err != nil && err != store.ErrNotFound {
-			return err
-		}
-	}
-
 	switch decision.Kind {
 	case decisionWaiting:
-		updatedRun, err := tx.TransitionRunToWaiting(ctx, enginedb.TransitionRunToWaitingParams{
+		_, err := tx.TransitionRunToWaiting(ctx, enginedb.TransitionRunToWaitingParams{
 			ID:           run.ID,
 			ClaimedBy:    workerClaimedBy,
 			WaitingFor:   decision.WaitingFor,
@@ -191,96 +202,58 @@ func (a *Activator) commitDecision(
 		if err != nil {
 			return err
 		}
-		if lastHistoryID > 0 {
-			if err := engineprojector.UpdateLatestHistory(ctx, tx.Tx(), run.ProjectID, run.ID, lastHistoryID); err != nil {
-				return err
-			}
-		}
-		return engineprojector.SyncProjectedRunSummary(ctx, tx.Tx(), &updatedRun)
+		return nil
 	case decisionCompleted:
-		updatedRun, err := tx.TransitionRunToCompleted(ctx, enginedb.TransitionRunToCompletedParams{
+		if _, err := tx.TransitionRunToCompleted(ctx, enginedb.TransitionRunToCompletedParams{
 			ID:           run.ID,
 			ClaimedBy:    workerClaimedBy,
 			Result:       decision.Result,
 			CustomStatus: decision.CustomStatus,
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
-		if err := engineprojector.WriteTerminalSummary(
-			ctx,
-			tx.Tx(),
-			run.ProjectID,
-			run.ID,
-			updatedRun.Status,
-			updatedRun.CompletedAt.Time,
-			decision.Result,
-			nil,
-			nil,
-			lastHistoryID,
-		); err != nil {
-			return err
-		}
-		return engineprojector.SyncProjectedRunSummary(ctx, tx.Tx(), &updatedRun)
+		return updateRunInstanceStatus(ctx, tx, run.InstanceID, enginedb.EngineInstanceLifecycleStatusCompleted)
 	case decisionFailed:
-		errorCode := decision.FailureCode
-		errorMessage := decision.FailureMessage
-		updatedRun, err := tx.TransitionRunToFailed(ctx, enginedb.TransitionRunToFailedParams{
+		if _, err := tx.TransitionRunToFailed(ctx, enginedb.TransitionRunToFailedParams{
 			ID:               run.ID,
 			ClaimedBy:        workerClaimedBy,
 			CustomStatus:     decision.CustomStatus,
-			LastErrorCode:    &errorCode,
-			LastErrorMessage: &errorMessage,
-		})
-		if err != nil {
+			LastErrorCode:    &decision.FailureCode,
+			LastErrorMessage: &decision.FailureMessage,
+		}); err != nil {
 			return err
 		}
-		if err := engineprojector.WriteTerminalSummary(
-			ctx,
-			tx.Tx(),
-			run.ProjectID,
-			run.ID,
-			updatedRun.Status,
-			updatedRun.CompletedAt.Time,
-			nil,
-			&errorCode,
-			&errorMessage,
-			lastHistoryID,
-		); err != nil {
-			return err
-		}
-		return engineprojector.SyncProjectedRunSummary(ctx, tx.Tx(), &updatedRun)
+		return updateRunInstanceStatus(ctx, tx, run.InstanceID, enginedb.EngineInstanceLifecycleStatusFailed)
 	case decisionCancelled:
-		errorCode := decision.FailureCode
-		errorMessage := decision.FailureMessage
-		updatedRun, err := tx.TransitionRunToCancelled(ctx, enginedb.TransitionRunToCancelledParams{
-			ID:               run.ID,
-			ClaimedBy:        workerClaimedBy,
-			CustomStatus:     decision.CustomStatus,
-			LastErrorCode:    &errorCode,
-			LastErrorMessage: &errorMessage,
-		})
-		if err != nil {
+		if _, err := tx.TransitionRunToCancelled(ctx, enginedb.TransitionRunToCancelledParams{
+			ID:           run.ID,
+			CustomStatus: decision.CustomStatus,
+		}); err != nil {
 			return err
 		}
-		if err := engineprojector.WriteTerminalSummary(
-			ctx,
-			tx.Tx(),
-			run.ProjectID,
-			run.ID,
-			updatedRun.Status,
-			updatedRun.CompletedAt.Time,
-			nil,
-			&errorCode,
-			&errorMessage,
-			lastHistoryID,
-		); err != nil {
+		if _, err := tx.CancelOpenActivityTasksByRun(ctx, run.ID); err != nil {
 			return err
 		}
-		return engineprojector.SyncProjectedRunSummary(ctx, tx.Tx(), &updatedRun)
+		if _, err := tx.DiscardOpenInboxItemsByRun(ctx, run.ID); err != nil {
+			return err
+		}
+		return updateRunInstanceStatus(ctx, tx, run.InstanceID, enginedb.EngineInstanceLifecycleStatusCancelled)
 	default:
 		return fmt.Errorf("unsupported activation decision kind %q", decision.Kind)
 	}
+}
+
+func updateRunInstanceStatus(
+	ctx context.Context,
+	tx *store.Tx,
+	instanceID uuid.UUID,
+	status enginedb.EngineInstanceLifecycleStatus,
+) error {
+	_, err := tx.UpdateInstanceStatus(ctx, enginedb.UpdateInstanceStatusParams{
+		ID:     instanceID,
+		Status: status,
+	})
+	return err
 }
 
 func sameClaimedBy(left, right *string) bool {

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -900,6 +900,7 @@ func createStartedRun(
 	return instance, run
 }
 
+//nolint:revive // Keep testing.T first in test helper signatures.
 func insertProjectedTraceShell(
 	t *testing.T,
 	ctx context.Context,

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 	enginehistory "github.com/continua-ai/continua/engine/internal/history"
 	enginestore "github.com/continua-ai/continua/engine/internal/store"
 	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
 	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
 )
 
@@ -51,6 +53,13 @@ func TestActivatorFailsRunWhenDefinitionVersionIsMissing(t *testing.T) {
 	}
 	if updatedRun.Status != enginedb.EngineRunLifecycleStatusFailed {
 		t.Fatalf("expected failed run status, got %+v", updatedRun)
+	}
+	updatedInstance, err := store.GetInstance(ctx, instance.ID)
+	if err != nil {
+		t.Fatalf("GetInstance() error = %v", err)
+	}
+	if updatedInstance.Status != enginedb.EngineInstanceLifecycleStatusFailed {
+		t.Fatalf("expected failed instance status, got %+v", updatedInstance)
 	}
 
 	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
@@ -120,6 +129,13 @@ func TestActivatorPersistsReplayMismatchFailure(t *testing.T) {
 	}
 	if updatedRun.LastErrorCode == nil || *updatedRun.LastErrorCode != "replay_mismatch" {
 		t.Fatalf("expected replay_mismatch last_error_code, got %+v", updatedRun)
+	}
+	updatedInstance, err := store.GetInstance(ctx, instance.ID)
+	if err != nil {
+		t.Fatalf("GetInstance() error = %v", err)
+	}
+	if updatedInstance.Status != enginedb.EngineInstanceLifecycleStatusFailed {
+		t.Fatalf("expected failed instance status, got %+v", updatedInstance)
 	}
 
 	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
@@ -202,9 +218,112 @@ func TestActivatorRejectsStaleClaimBeforeAppendingHistory(t *testing.T) {
 	if completedRun.Status != enginedb.EngineRunLifecycleStatusCompleted {
 		t.Fatalf("expected fresh claim to complete run, got %+v", completedRun)
 	}
+	completedInstance, err := store.GetInstance(ctx, run.InstanceID)
+	if err != nil {
+		t.Fatalf("GetInstance() error = %v", err)
+	}
+	if completedInstance.Status != enginedb.EngineInstanceLifecycleStatusCompleted {
+		t.Fatalf("expected completed instance status, got %+v", completedInstance)
+	}
 }
 
-func TestActivatorWaitingDecisionRefreshesProjectedTraceSummary(t *testing.T) {
+func TestActivatorRejectsStaleClaimAfterTerminate(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	testCase := workflowTestCase{
+		projectID:         enginetest.DefaultPlatformProjectID,
+		instanceKey:       "instance-stale-after-terminate",
+		definitionName:    "stale-after-terminate",
+		definitionVersion: "v1",
+	}
+	instance, run := createStartedRun(t, store, testCase)
+
+	registry, err := NewRegistry(publicworkflow.Definition{
+		Name:    "stale-after-terminate",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			return ctx.SetResult(map[string]bool{"ok": true})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	staleClaim, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+
+	tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	payload, err := enginehistory.MarshalPayload(enginehistory.WorkflowTerminatedPayload{
+		ErrorCode:    "terminated",
+		ErrorMessage: "run terminated by operator",
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(terminated) error = %v", err)
+	}
+	if _, err := tx.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  run.ProjectID,
+		InstanceID: run.InstanceID,
+		RunID:      run.ID,
+		SequenceNo: 2,
+		EventType:  enginehistory.EventWorkflowTerminated,
+		Payload:    payload,
+	}); err != nil {
+		t.Fatalf("AppendHistory(terminated) error = %v", err)
+	}
+	if _, err := tx.TransitionRunToTerminated(ctx, run.ID); err != nil {
+		t.Fatalf("TransitionRunToTerminated() error = %v", err)
+	}
+	if _, err := tx.UpdateInstanceStatus(ctx, enginedb.UpdateInstanceStatusParams{
+		ID:     run.InstanceID,
+		Status: enginedb.EngineInstanceLifecycleStatusTerminated,
+	}); err != nil {
+		t.Fatalf("UpdateInstanceStatus() error = %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	activator := NewActivator(store, registry)
+	err = activator.Activate(ctx, &staleClaim)
+	if !errors.Is(err, enginestore.ErrStaleClaim) {
+		t.Fatalf("expected ErrStaleClaim after terminate, got %v", err)
+	}
+
+	terminatedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if terminatedRun.Status != enginedb.EngineRunLifecycleStatusTerminated {
+		t.Fatalf("expected terminated run status, got %+v", terminatedRun)
+	}
+
+	terminatedInstance, err := store.GetInstance(ctx, instance.ID)
+	if err != nil {
+		t.Fatalf("GetInstance() error = %v", err)
+	}
+	if terminatedInstance.Status != enginedb.EngineInstanceLifecycleStatusTerminated {
+		t.Fatalf("expected terminated instance status, got %+v", terminatedInstance)
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	if len(historyRows) != 2 || historyRows[1].EventType != enginehistory.EventWorkflowTerminated {
+		t.Fatalf("expected started + workflow.terminated history, got %+v", historyRows)
+	}
+}
+
+func TestActivatorWaitingDecisionDoesNotMutateProjectedTraceSummary(t *testing.T) {
 	db := enginetest.NewTestDatabase(t)
 	store := enginestore.New(db.Pool)
 	ctx := context.Background()
@@ -225,48 +344,7 @@ func TestActivatorWaitingDecisionRefreshesProjectedTraceSummary(t *testing.T) {
 		t.Fatalf("expected started history row, got %+v", historyRows)
 	}
 
-	if _, err := db.Pool.Exec(ctx, `
-		INSERT INTO public.traces (
-		    id,
-		    project_id,
-		    trace_id,
-		    name,
-		    status,
-		    start_time,
-		    engine_run_id,
-		    engine_instance_key,
-		    engine_run_status,
-		    engine_pending_activity_tasks,
-		    engine_pending_inbox_items,
-		    engine_definition_name,
-		    engine_definition_version,
-		    engine_projection_state,
-		    engine_latest_history_id,
-		    engine_last_projected_history_id,
-		    engine_projection_updated_at
-		)
-		VALUES (
-		    $1,
-		    $2,
-		    $3,
-		    $4,
-		    'running',
-		    NOW(),
-		    $5,
-		    $6,
-		    'queued',
-		    0,
-		    0,
-		    $7,
-		    $8,
-		    'up_to_date',
-		    $9,
-		    $9,
-		    NOW()
-		)
-	`, uuidOrFatal(t), testCase.projectID, "engine:"+run.ID.String(), "Projected Wait", run.ID, instance.InstanceKey, instance.DefinitionName, run.DefinitionVersion, historyRows[0].ID); err != nil {
-		t.Fatalf("insert projected trace shell: %v", err)
-	}
+	insertProjectedTraceShell(t, ctx, db.Pool, instance, run, "Projected Wait", historyRows[0].ID)
 
 	registry, err := NewRegistry(publicworkflow.Definition{
 		Name:    "projected-wait",
@@ -305,23 +383,103 @@ func TestActivatorWaitingDecisionRefreshesProjectedTraceSummary(t *testing.T) {
 		t.Fatalf("query projected trace summary: %v", err)
 	}
 
-	if engineRunStatus != string(enginedb.EngineRunLifecycleStatusWaiting) {
-		t.Fatalf("expected projected waiting run status, got %q", engineRunStatus)
+	if engineRunStatus != string(enginedb.EngineRunLifecycleStatusQueued) {
+		t.Fatalf("expected projected summary to remain unchanged before projector catch-up, got %q", engineRunStatus)
 	}
 	if pendingActivityTasks != 0 || pendingInboxItems != 0 {
 		t.Fatalf("expected no pending work for signal wait, got activity=%d inbox=%d", pendingActivityTasks, pendingInboxItems)
 	}
-
-	var waitPayload map[string]any
-	if err := json.Unmarshal(waitState, &waitPayload); err != nil {
-		t.Fatalf("json.Unmarshal(waitState) error = %v", err)
-	}
-	if waitPayload["kind"] != "signal" || waitPayload["signal_name"] != "approval" {
-		t.Fatalf("unexpected projected wait state: %+v", waitPayload)
+	if len(waitState) != 0 {
+		t.Fatalf("expected projected wait state to remain nil before projector catch-up, got %s", waitState)
 	}
 }
 
-func TestActivatorCancellationTransitionsRunToCancelledAndProjectsTerminalSummary(t *testing.T) {
+func TestActivatorFailureMovesProjectedTraceIntoCatchingUpWithoutProjectingTerminalSummary(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	testCase := workflowTestCase{
+		projectID:         enginetest.DefaultPlatformProjectID,
+		instanceKey:       "instance-projected-failure",
+		definitionName:    "missing-definition",
+		definitionVersion: "v-missing",
+	}
+	instance, run := createStartedRun(t, store, testCase)
+
+	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	insertProjectedTraceShell(t, ctx, db.Pool, instance, run, "Projected Failure", historyRows[0].ID)
+
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+
+	activator := NewActivator(store, registry)
+	if err := activator.Activate(ctx, &claimed); err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+
+	historyAfterFailure, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	lastEvent := historyAfterFailure[len(historyAfterFailure)-1]
+	if lastEvent.EventType != enginehistory.EventWorkflowFailed {
+		t.Fatalf("expected terminal workflow.failed event, got %+v", lastEvent)
+	}
+
+	var traceStatus string
+	var traceRunStatus string
+	var traceOutput []byte
+	var traceProjectionState string
+	var latestHistoryID int64
+	var lastProjectedHistoryID int64
+	if err := db.Pool.QueryRow(ctx, `
+			SELECT status,
+			       engine_run_status,
+			       output,
+			       engine_projection_state,
+			       engine_latest_history_id,
+			       engine_last_projected_history_id
+			FROM public.traces
+			WHERE engine_run_id = $1
+		`, run.ID).Scan(
+		&traceStatus,
+		&traceRunStatus,
+		&traceOutput,
+		&traceProjectionState,
+		&latestHistoryID,
+		&lastProjectedHistoryID,
+	); err != nil {
+		t.Fatalf("query projected trace summary: %v", err)
+	}
+	if traceStatus != "running" || traceRunStatus != "queued" {
+		t.Fatalf("expected projected summary to remain unchanged before projector catch-up, got trace=%q run=%q", traceStatus, traceRunStatus)
+	}
+	if len(traceOutput) != 0 {
+		t.Fatalf("expected projected terminal output to remain empty before projector catch-up, got %s", traceOutput)
+	}
+	if traceProjectionState != publicprojection.StateCatchingUp.String() {
+		t.Fatalf("expected projected trace state to move to catching_up, got %q", traceProjectionState)
+	}
+	if latestHistoryID != lastEvent.ID {
+		t.Fatalf("expected latest history checkpoint to advance to %d before catch-up, got %d", lastEvent.ID, latestHistoryID)
+	}
+	if lastProjectedHistoryID != historyRows[0].ID {
+		t.Fatalf("expected projector checkpoint to remain at %d before catch-up, got %d", historyRows[0].ID, lastProjectedHistoryID)
+	}
+}
+
+func TestActivatorCancellationTransitionsRunToCancelledWithoutProjectingTerminalSummary(t *testing.T) {
 	db := enginetest.NewTestDatabase(t)
 	store := enginestore.New(db.Pool)
 	ctx := context.Background()
@@ -338,48 +496,7 @@ func TestActivatorCancellationTransitionsRunToCancelledAndProjectsTerminalSummar
 	if err != nil {
 		t.Fatalf("GetHistoryByRun() error = %v", err)
 	}
-	if _, err := db.Pool.Exec(ctx, `
-		INSERT INTO public.traces (
-		    id,
-		    project_id,
-		    trace_id,
-		    name,
-		    status,
-		    start_time,
-		    engine_run_id,
-		    engine_instance_key,
-		    engine_run_status,
-		    engine_pending_activity_tasks,
-		    engine_pending_inbox_items,
-		    engine_definition_name,
-		    engine_definition_version,
-		    engine_projection_state,
-		    engine_latest_history_id,
-		    engine_last_projected_history_id,
-		    engine_projection_updated_at
-		)
-		VALUES (
-		    $1,
-		    $2,
-		    $3,
-		    $4,
-		    'running',
-		    NOW(),
-		    $5,
-		    $6,
-		    'queued',
-		    0,
-		    0,
-		    $7,
-		    $8,
-		    'up_to_date',
-		    $9,
-		    $9,
-		    NOW()
-		)
-	`, uuidOrFatal(t), testCase.projectID, "engine:"+run.ID.String(), "Cancelled Run", run.ID, instance.InstanceKey, instance.DefinitionName, run.DefinitionVersion, historyRows[0].ID); err != nil {
-		t.Fatalf("insert projected trace shell: %v", err)
-	}
+	insertProjectedTraceShell(t, ctx, db.Pool, instance, run, "Cancelled Run", historyRows[0].ID)
 	if _, err := db.Pool.Exec(ctx, `
 		INSERT INTO public.spans (
 		    project_id,
@@ -403,15 +520,34 @@ func TestActivatorCancellationTransitionsRunToCancelledAndProjectsTerminalSummar
 	if err != nil {
 		t.Fatalf("MarshalPayload(cancel) error = %v", err)
 	}
-	if _, err := store.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+	cancelInbox, err := store.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
 		ProjectID:   run.ProjectID,
 		InstanceID:  run.InstanceID,
 		RunID:       pgtype.UUID{Bytes: run.ID, Valid: true},
 		Kind:        "cancel",
 		Payload:     cancelPayload,
 		AvailableAt: time.Now().UTC(),
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("CreateInboxItem(cancel) error = %v", err)
+	}
+	signalPayload, err := enginehistory.MarshalPayload(enginehistory.SignalReceivedPayload{
+		SignalName: "approval",
+		Payload:    mustJSON(t, map[string]bool{"approved": true}),
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(signal) error = %v", err)
+	}
+	signalInbox, err := store.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   run.ProjectID,
+		InstanceID:  run.InstanceID,
+		RunID:       pgtype.UUID{Bytes: run.ID, Valid: true},
+		Kind:        "signal",
+		Payload:     signalPayload,
+		AvailableAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("CreateInboxItem(signal) error = %v", err)
 	}
 
 	registry, err := NewRegistry(publicworkflow.Definition{
@@ -448,27 +584,103 @@ func TestActivatorCancellationTransitionsRunToCancelledAndProjectsTerminalSummar
 	if updatedRun.LastErrorCode == nil || *updatedRun.LastErrorCode != "cancelled" {
 		t.Fatalf("expected cancelled error code, got %+v", updatedRun)
 	}
+	updatedInstance, err := store.GetInstance(ctx, instance.ID)
+	if err != nil {
+		t.Fatalf("GetInstance() error = %v", err)
+	}
+	if updatedInstance.Status != enginedb.EngineInstanceLifecycleStatusCancelled {
+		t.Fatalf("expected cancelled instance status, got %+v", updatedInstance)
+	}
+
+	historyAfterCancel, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	lastEvent := historyAfterCancel[len(historyAfterCancel)-1]
+	if lastEvent.EventType != enginehistory.EventWorkflowCancelled {
+		t.Fatalf("expected terminal workflow.cancelled event, got %+v", lastEvent)
+	}
 
 	var traceStatus string
 	var traceRunStatus string
 	var traceOutput []byte
+	var traceProjectionState string
+	var latestHistoryID int64
+	var lastProjectedHistoryID int64
 	if err := db.Pool.QueryRow(ctx, `
-		SELECT status, engine_run_status, output
-		FROM public.traces
-		WHERE engine_run_id = $1
-	`, run.ID).Scan(&traceStatus, &traceRunStatus, &traceOutput); err != nil {
+			SELECT status,
+			       engine_run_status,
+			       output,
+			       engine_projection_state,
+			       engine_latest_history_id,
+			       engine_last_projected_history_id
+			FROM public.traces
+			WHERE engine_run_id = $1
+		`, run.ID).Scan(
+		&traceStatus,
+		&traceRunStatus,
+		&traceOutput,
+		&traceProjectionState,
+		&latestHistoryID,
+		&lastProjectedHistoryID,
+	); err != nil {
 		t.Fatalf("query projected trace summary: %v", err)
 	}
-	if traceStatus != "cancelled" || traceRunStatus != "cancelled" {
-		t.Fatalf("expected cancelled projected summary, got trace=%q run=%q", traceStatus, traceRunStatus)
+	if traceStatus != "running" || traceRunStatus != "queued" {
+		t.Fatalf("expected projected summary to remain unchanged before projector catch-up, got trace=%q run=%q", traceStatus, traceRunStatus)
+	}
+	if len(traceOutput) != 0 {
+		t.Fatalf("expected projected terminal output to remain empty before projector catch-up, got %s", traceOutput)
+	}
+	if traceProjectionState != "up_to_date" {
+		t.Fatalf("expected projected trace state to remain unchanged before projector catch-up, got %q", traceProjectionState)
+	}
+	if latestHistoryID != historyRows[0].ID {
+		t.Fatalf("expected latest history checkpoint to remain at %d before catch-up, got %d", historyRows[0].ID, latestHistoryID)
+	}
+	if lastProjectedHistoryID != historyRows[0].ID {
+		t.Fatalf("expected projector checkpoint to stay at %d before catch-up, got %d", historyRows[0].ID, lastProjectedHistoryID)
 	}
 
-	var outputPayload map[string]any
-	if err := json.Unmarshal(traceOutput, &outputPayload); err != nil {
-		t.Fatalf("json.Unmarshal(trace output) error = %v", err)
+	var rootSpanStatus string
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT status
+		FROM public.spans
+		WHERE trace_id = (
+		        SELECT id
+		        FROM public.traces
+		        WHERE engine_run_id = $1
+		    )
+		  AND span_id = $2
+	`, run.ID, "engine:root:"+run.ID.String()).Scan(&rootSpanStatus); err != nil {
+		t.Fatalf("query projected root span: %v", err)
 	}
-	if outputPayload["status"] != "cancelled" || outputPayload["error_code"] != "cancelled" {
-		t.Fatalf("unexpected cancelled terminal payload %+v", outputPayload)
+	if rootSpanStatus != "running" {
+		t.Fatalf("expected projected root span to remain running before projector catch-up, got %q", rootSpanStatus)
+	}
+
+	var cancelInboxStatus enginedb.EngineInboxStatus
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT status
+		FROM engine.inbox
+		WHERE id = $1
+	`, cancelInbox.ID).Scan(&cancelInboxStatus); err != nil {
+		t.Fatalf("query cancel inbox status: %v", err)
+	}
+	if cancelInboxStatus != enginedb.EngineInboxStatusProcessed {
+		t.Fatalf("expected consumed cancel inbox to be processed, got %q", cancelInboxStatus)
+	}
+
+	var signalInboxStatus enginedb.EngineInboxStatus
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT status
+		FROM engine.inbox
+		WHERE id = $1
+	`, signalInbox.ID).Scan(&signalInboxStatus); err != nil {
+		t.Fatalf("query signal inbox status: %v", err)
+	}
+	if signalInboxStatus != enginedb.EngineInboxStatusDiscarded {
+		t.Fatalf("expected unrelated signal inbox to be discarded, got %q", signalInboxStatus)
 	}
 }
 
@@ -686,6 +898,63 @@ func createStartedRun(
 	})
 
 	return instance, run
+}
+
+func insertProjectedTraceShell(
+	t *testing.T,
+	ctx context.Context,
+	pool interface {
+		Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	},
+	instance enginedb.EngineInstance,
+	run enginedb.EngineRun,
+	traceName string,
+	latestHistoryID int64,
+) {
+	t.Helper()
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.traces (
+		    id,
+		    project_id,
+		    trace_id,
+		    name,
+		    status,
+		    start_time,
+		    engine_run_id,
+		    engine_instance_key,
+		    engine_run_status,
+		    engine_pending_activity_tasks,
+		    engine_pending_inbox_items,
+		    engine_definition_name,
+		    engine_definition_version,
+		    engine_projection_state,
+		    engine_latest_history_id,
+		    engine_last_projected_history_id,
+		    engine_projection_updated_at
+		)
+		VALUES (
+		    $1,
+		    $2,
+		    $3,
+		    $4,
+		    'running',
+		    NOW(),
+		    $5,
+		    $6,
+		    'queued',
+		    0,
+		    0,
+		    $7,
+		    $8,
+		    'up_to_date',
+		    $9,
+		    $9,
+		    NOW()
+		)
+	`, uuidOrFatal(t), run.ProjectID, "engine:"+run.ID.String(), traceName, run.ID, instance.InstanceKey, instance.DefinitionName, run.DefinitionVersion, latestHistoryID); err != nil {
+		t.Fatalf("insert projected trace shell: %v", err)
+	}
 }
 
 func appendHistoryEvent(

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -254,23 +254,19 @@ func (r *workflowRunner) execute(definition publicworkflow.Definition) (decision
 
 	if runErr != nil {
 		if errors.Is(runErr, publicworkflow.ErrCancelled) {
-			failure := enginehistory.WorkflowFailedPayload{
-				ErrorCode:    "cancelled",
-				ErrorMessage: "workflow cancelled",
-			}
+			cancelled := enginehistory.WorkflowCancelledPayload{}
 			if next, ok := r.peek(); ok {
-				recorded, ok := next.Payload.(*enginehistory.WorkflowFailedPayload)
-				if !ok || recorded.ErrorCode != failure.ErrorCode || recorded.ErrorMessage != failure.ErrorMessage {
-					r.replayMismatch(enginehistory.EventWorkflowFailed, "", next, "workflow cancellation did not match recorded history")
+				if _, ok := next.Payload.(*enginehistory.WorkflowCancelledPayload); !ok {
+					r.replayMismatch(enginehistory.EventWorkflowCancelled, "", next, "workflow cancellation did not match recorded history")
 				}
 				r.cursor++
 			} else {
-				r.queueEvent(enginehistory.EventWorkflowFailed, failure)
+				r.queueEvent(enginehistory.EventWorkflowCancelled, cancelled)
 			}
 			if next, ok := r.peek(); ok {
 				r.replayMismatch("", "", next, "recorded history contains events after workflow cancellation")
 			}
-			return r.cancelledDecision(failure), nil
+			return r.cancelledDecision(), nil
 		}
 
 		code := "workflow_failed"
@@ -650,15 +646,15 @@ func (r *workflowRunner) failedDecision(failure enginehistory.WorkflowFailedPayl
 	}
 }
 
-func (r *workflowRunner) cancelledDecision(failure enginehistory.WorkflowFailedPayload) activationDecision {
+func (r *workflowRunner) cancelledDecision() activationDecision {
 	return activationDecision{
 		Kind:             decisionCancelled,
 		Events:           append([]queuedHistoryEvent(nil), r.queuedEvents...),
 		NextSequence:     r.nextSequence,
 		CustomStatus:     cloneRaw(r.customStatus),
 		ConsumedInboxIDs: append([]uuid.UUID(nil), r.consumedInboxIDs...),
-		FailureCode:      failure.ErrorCode,
-		FailureMessage:   failure.ErrorMessage,
+		FailureCode:      "cancelled",
+		FailureMessage:   "workflow cancelled",
 	}
 }
 

--- a/engine/internal/workflow/replay_test.go
+++ b/engine/internal/workflow/replay_test.go
@@ -240,13 +240,13 @@ func TestReplayDefinitionCancelledWorkflowReturnsCancelledDecision(t *testing.T)
 		t.Fatalf("expected cancelled decision, got %+v", decision)
 	}
 	if len(decision.Events) != 2 {
-		t.Fatalf("expected cancel.requested + workflow.failed events, got %+v", decision.Events)
+		t.Fatalf("expected cancel.requested + workflow.cancelled events, got %+v", decision.Events)
 	}
 	if decision.Events[0].EventType != enginehistory.EventCancelRequested {
 		t.Fatalf("expected first event to be cancel.requested, got %+v", decision.Events)
 	}
-	if decision.Events[1].EventType != enginehistory.EventWorkflowFailed {
-		t.Fatalf("expected second event to be workflow.failed, got %+v", decision.Events)
+	if decision.Events[1].EventType != enginehistory.EventWorkflowCancelled {
+		t.Fatalf("expected second event to be workflow.cancelled, got %+v", decision.Events)
 	}
 	if decision.FailureCode != "cancelled" || decision.FailureMessage != "workflow cancelled" {
 		t.Fatalf("expected cancelled failure summary, got %+v", decision)

--- a/engine/pkg/history/history.go
+++ b/engine/pkg/history/history.go
@@ -10,6 +10,8 @@ const (
 	EventWorkflowStarted        = "workflow.started"
 	EventWorkflowCompleted      = "workflow.completed"
 	EventWorkflowFailed         = "workflow.failed"
+	EventWorkflowCancelled      = "workflow.cancelled"
+	EventWorkflowTerminated     = "workflow.terminated"
 	EventWorkflowReplayMismatch = "workflow.replay_mismatch"
 	EventActivityScheduled      = "activity.scheduled"
 	EventActivityCompleted      = "activity.completed"
@@ -39,6 +41,13 @@ type WorkflowCompletedPayload struct {
 }
 
 type WorkflowFailedPayload struct {
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"error_message"`
+}
+
+type WorkflowCancelledPayload struct{}
+
+type WorkflowTerminatedPayload struct {
 	ErrorCode    string `json:"error_code"`
 	ErrorMessage string `json:"error_message"`
 }
@@ -131,6 +140,9 @@ func DecodePayload(eventType string, raw []byte) (any, error) {
 		if eventType == EventCancelRequested {
 			return CancelRequestedPayload{}, nil
 		}
+		if eventType == EventWorkflowCancelled {
+			return WorkflowCancelledPayload{}, nil
+		}
 		return nil, nil
 	}
 
@@ -183,6 +195,10 @@ func payloadTarget(eventType string) (any, error) {
 		return &WorkflowCompletedPayload{}, nil
 	case EventWorkflowFailed:
 		return &WorkflowFailedPayload{}, nil
+	case EventWorkflowCancelled:
+		return &WorkflowCancelledPayload{}, nil
+	case EventWorkflowTerminated:
+		return &WorkflowTerminatedPayload{}, nil
 	case EventWorkflowReplayMismatch:
 		return &WorkflowReplayMismatchPayload{}, nil
 	case EventActivityScheduled:

--- a/engine/pkg/history/history_test.go
+++ b/engine/pkg/history/history_test.go
@@ -1,0 +1,47 @@
+package history
+
+import (
+	"testing"
+)
+
+func TestDecodePayloadRoundTripsCancelledAndTerminated(t *testing.T) {
+	t.Run("workflow.cancelled", func(t *testing.T) {
+		raw, err := MarshalPayload(WorkflowCancelledPayload{})
+		if err != nil {
+			t.Fatalf("MarshalPayload() error = %v", err)
+		}
+
+		payload, err := DecodePayload(EventWorkflowCancelled, raw)
+		if err != nil {
+			t.Fatalf("DecodePayload() error = %v", err)
+		}
+
+		if _, ok := payload.(*WorkflowCancelledPayload); !ok {
+			t.Fatalf("expected *WorkflowCancelledPayload, got %T", payload)
+		}
+	})
+
+	t.Run("workflow.terminated", func(t *testing.T) {
+		expected := WorkflowTerminatedPayload{
+			ErrorCode:    "terminated",
+			ErrorMessage: "run terminated by operator",
+		}
+		raw, err := MarshalPayload(expected)
+		if err != nil {
+			t.Fatalf("MarshalPayload() error = %v", err)
+		}
+
+		payload, err := DecodePayload(EventWorkflowTerminated, raw)
+		if err != nil {
+			t.Fatalf("DecodePayload() error = %v", err)
+		}
+
+		typed, ok := payload.(*WorkflowTerminatedPayload)
+		if !ok {
+			t.Fatalf("expected *WorkflowTerminatedPayload, got %T", payload)
+		}
+		if typed.ErrorCode != expected.ErrorCode || typed.ErrorMessage != expected.ErrorMessage {
+			t.Fatalf("unexpected terminated payload: %+v", typed)
+		}
+	})
+}

--- a/engine/pkg/workflow/context.go
+++ b/engine/pkg/workflow/context.go
@@ -6,6 +6,11 @@ import (
 )
 
 var ErrEmptyKey = errors.New("workflow: stable key is required")
+
+// ErrCancelled is the explicit replay-aware cancellation sentinel.
+// Returning it records a terminal workflow.cancelled event and transitions the
+// run to CANCELLED; returning nil after observing cancellation still produces
+// COMPLETED. Replay consults this sentinel through errors.Is.
 var ErrCancelled = errors.New("workflow: cancelled")
 
 type Context interface {

--- a/internal/api/engine_control.go
+++ b/internal/api/engine_control.go
@@ -23,6 +23,8 @@ const (
 	engineTracePrefix       = "engine:"
 	engineRootSpanPrefix    = "engine:root:"
 	engineCancelDedupeKey   = "cancel:"
+	engineTerminateCode     = "terminated"
+	engineTerminateMessage  = "run terminated by operator"
 )
 
 type engineControlService struct {
@@ -102,6 +104,37 @@ type engineControlResult struct {
 	InstanceKey string
 	Accepted    bool
 	WakeApplied bool
+}
+
+type enginePendingWorkResult struct {
+	RunID       uuid.UUID
+	CurrentWait json.RawMessage
+	Activities  []enginePendingActivityItem
+	Timers      []enginePendingTimerItem
+	Signals     []enginePendingSignalItem
+}
+
+type enginePendingActivityItem struct {
+	TaskID       uuid.UUID
+	ActivityKey  string
+	ActivityType string
+	Status       string
+	AvailableAt  time.Time
+	AttemptCount int32
+}
+
+type enginePendingTimerItem struct {
+	InboxID     uuid.UUID
+	TimerKey    string
+	Status      string
+	AvailableAt time.Time
+}
+
+type enginePendingSignalItem struct {
+	InboxID     uuid.UUID
+	SignalName  string
+	Status      string
+	AvailableAt time.Time
 }
 
 type engineAPIError struct {
@@ -438,7 +471,102 @@ func (s *engineControlService) GetRunResult(
 		}
 	}
 
+	if summary.Status == enginedb.EngineRunLifecycleStatusCancelled ||
+		summary.Status == enginedb.EngineRunLifecycleStatusTerminated {
+		summary.Result = nil
+	}
+
 	return summary, nil
+}
+
+func (s *engineControlService) GetRunPendingWork(
+	ctx context.Context,
+	projectID uuid.UUID,
+	runID uuid.UUID,
+) (enginePendingWorkResult, error) {
+	run, err := s.engine.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        runID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return enginePendingWorkResult{}, &engineAPIError{
+				Code:       "not_found",
+				Message:    "engine run not found",
+				HTTPStatus: 404,
+			}
+		}
+		return enginePendingWorkResult{}, err
+	}
+
+	activities, err := s.engine.ListOpenActivityTasksByRun(ctx, run.ID)
+	if err != nil {
+		return enginePendingWorkResult{}, err
+	}
+	timers, err := s.engine.ListOpenInboxItemsByRunAndKind(ctx, enginedb.ListOpenInboxItemsByRunAndKindParams{
+		RunID: pgtype.UUID{Bytes: run.ID, Valid: true},
+		Kind:  "timer",
+	})
+	if err != nil {
+		return enginePendingWorkResult{}, err
+	}
+	signals, err := s.engine.ListOpenInboxItemsByRunAndKind(ctx, enginedb.ListOpenInboxItemsByRunAndKindParams{
+		RunID: pgtype.UUID{Bytes: run.ID, Valid: true},
+		Kind:  "signal",
+	})
+	if err != nil {
+		return enginePendingWorkResult{}, err
+	}
+
+	result := enginePendingWorkResult{
+		RunID:       run.ID,
+		CurrentWait: cloneRaw(run.WaitingFor),
+		Activities:  make([]enginePendingActivityItem, 0, len(activities)),
+		Timers:      make([]enginePendingTimerItem, 0, len(timers)),
+		Signals:     make([]enginePendingSignalItem, 0, len(signals)),
+	}
+
+	for i := range activities {
+		task := activities[i]
+		result.Activities = append(result.Activities, enginePendingActivityItem{
+			TaskID:       task.ID,
+			ActivityKey:  task.ActivityKey,
+			ActivityType: task.ActivityType,
+			Status:       string(task.Status),
+			AvailableAt:  task.AvailableAt,
+			AttemptCount: task.AttemptCount,
+		})
+	}
+
+	for i := range timers {
+		inboxRow := timers[i]
+		timerKey, err := decodePendingTimerKey(inboxRow.Payload)
+		if err != nil {
+			return enginePendingWorkResult{}, err
+		}
+		result.Timers = append(result.Timers, enginePendingTimerItem{
+			InboxID:     inboxRow.ID,
+			TimerKey:    timerKey,
+			Status:      string(inboxRow.Status),
+			AvailableAt: inboxRow.AvailableAt,
+		})
+	}
+
+	for i := range signals {
+		inboxRow := signals[i]
+		signalName, err := decodePendingSignalName(inboxRow.Payload)
+		if err != nil {
+			return enginePendingWorkResult{}, err
+		}
+		result.Signals = append(result.Signals, enginePendingSignalItem{
+			InboxID:     inboxRow.ID,
+			SignalName:  signalName,
+			Status:      string(inboxRow.Status),
+			AvailableAt: inboxRow.AvailableAt,
+		})
+	}
+
+	return result, nil
 }
 
 func (s *engineControlService) GetRunHistory(
@@ -584,6 +712,99 @@ func (s *engineControlService) SignalRun(
 	}, nil
 }
 
+func (s *engineControlService) TerminateRun(
+	ctx context.Context,
+	projectID uuid.UUID,
+	runID uuid.UUID,
+) (engineRunSummary, error) {
+	tx, err := s.platform.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return engineRunSummary{}, err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	engineTx := enginedb.New(tx.Tx())
+	run, err := engineTx.GetRunByProjectAndIDForUpdate(ctx, enginedb.GetRunByProjectAndIDForUpdateParams{
+		ProjectID: projectID,
+		ID:        runID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return engineRunSummary{}, &engineAPIError{
+				Code:       "not_found",
+				Message:    "engine run not found",
+				HTTPStatus: 404,
+			}
+		}
+		return engineRunSummary{}, err
+	}
+
+	if isTerminalEngineRun(run.Status) {
+		if err := tx.Commit(ctx); err != nil {
+			return engineRunSummary{}, err
+		}
+		return terminalRunSummaryFromRun(&run), nil
+	}
+
+	historyRows, err := engineTx.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		return engineRunSummary{}, err
+	}
+
+	nextSequence := int32(1)
+	if len(historyRows) > 0 {
+		nextSequence = historyRows[len(historyRows)-1].SequenceNo + 1
+	}
+
+	payload, err := publichistory.MarshalPayload(publichistory.WorkflowTerminatedPayload{
+		ErrorCode:    engineTerminateCode,
+		ErrorMessage: engineTerminateMessage,
+	})
+	if err != nil {
+		return engineRunSummary{}, err
+	}
+	if _, err := engineTx.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  run.ProjectID,
+		InstanceID: run.InstanceID,
+		RunID:      run.ID,
+		SequenceNo: nextSequence,
+		EventType:  publichistory.EventWorkflowTerminated,
+		Payload:    payload,
+	}); err != nil {
+		return engineRunSummary{}, err
+	}
+
+	updatedRun, err := engineTx.TransitionRunToTerminated(ctx, run.ID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return engineRunSummary{}, fmt.Errorf("terminate transition invariant failed for run %s", run.ID)
+		}
+		return engineRunSummary{}, err
+	}
+	if _, err := engineTx.CancelOpenActivityTasksByRun(ctx, run.ID); err != nil {
+		return engineRunSummary{}, err
+	}
+	if _, err := engineTx.DiscardOpenInboxItemsByRun(ctx, pgtype.UUID{Bytes: run.ID, Valid: true}); err != nil {
+		return engineRunSummary{}, err
+	}
+	if _, err := engineTx.UpdateInstanceStatus(ctx, enginedb.UpdateInstanceStatusParams{
+		ID:     run.InstanceID,
+		Status: enginedb.EngineInstanceLifecycleStatusTerminated,
+	}); err != nil {
+		return engineRunSummary{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return engineRunSummary{}, err
+	}
+	return terminalRunSummaryFromRun(&updatedRun), nil
+}
+
+// CancelRun is cooperative only: success enqueues cancel intent and may wake the
+// run, but the workflow decides between COMPLETED and CANCELLED by returning
+// workflow.ErrCancelled on a later activation.
 func (s *engineControlService) CancelRun(
 	ctx context.Context,
 	projectID uuid.UUID,
@@ -696,6 +917,8 @@ func (s *engineControlService) buildRunSummary(
 		return engineRunSummary{}, err
 	}
 
+	// CountOpenInboxByRun intentionally excludes cancel inbox rows so read APIs
+	// reflect only operator-visible pending work: timers plus signals.
 	pendingInboxItems, err := s.engine.CountOpenInboxByRun(ctx, pgtype.UUID{Bytes: run.ID, Valid: true})
 	if err != nil {
 		return engineRunSummary{}, err
@@ -745,10 +968,63 @@ func (s *engineControlService) projectionStateForRun(ctx context.Context, projec
 		}
 		return "", err
 	}
-	if stringsTrimSpaceEmpty(derefString(trace.EngineProjectionState)) {
+	return s.effectiveProjectionState(ctx, runID, normalizedProjectionState(trace.EngineProjectionState), trace.EngineLastProjectedHistoryID)
+}
+
+func (s *engineControlService) shouldReadLiveTraceSummary(
+	ctx context.Context,
+	trace *store.TraceRead,
+) (bool, error) {
+	if shouldReadLiveEngineSummary(trace) {
+		return true, nil
+	}
+	if trace == nil || !trace.EngineRunID.Valid {
+		return false, nil
+	}
+	if normalizedProjectionState(trace.EngineProjectionState) == publicprojection.StateJournalExpired.String() {
+		return false, nil
+	}
+	return s.traceProjectionCheckpointStale(ctx, uuid.UUID(trace.EngineRunID.Bytes), trace.EngineLastProjectedHistoryID)
+}
+
+func (s *engineControlService) projectionStateForTrace(ctx context.Context, trace *store.TraceRead) (string, error) {
+	if trace == nil || !trace.EngineRunID.Valid {
 		return publicprojection.StateUpToDate.String(), nil
 	}
-	return *trace.EngineProjectionState, nil
+	return s.effectiveProjectionState(
+		ctx,
+		uuid.UUID(trace.EngineRunID.Bytes),
+		normalizedProjectionState(trace.EngineProjectionState),
+		trace.EngineLastProjectedHistoryID,
+	)
+}
+
+func (s *engineControlService) effectiveProjectionState(
+	ctx context.Context,
+	runID uuid.UUID,
+	state string,
+	lastProjectedHistoryID *int64,
+) (string, error) {
+	stale, err := s.traceProjectionCheckpointStale(ctx, runID, lastProjectedHistoryID)
+	if err != nil {
+		return "", err
+	}
+	if stale && state == publicprojection.StateUpToDate.String() {
+		return publicprojection.StateCatchingUp.String(), nil
+	}
+	return state, nil
+}
+
+func (s *engineControlService) traceProjectionCheckpointStale(
+	ctx context.Context,
+	runID uuid.UUID,
+	lastProjectedHistoryID *int64,
+) (bool, error) {
+	latestHistoryID, err := s.engine.GetLatestHistoryIDByRun(ctx, runID)
+	if err != nil {
+		return false, err
+	}
+	return latestHistoryID > derefInt64(lastProjectedHistoryID), nil
 }
 
 func (req *engineStartRunRequest) TraceUserID() string {
@@ -888,6 +1164,8 @@ func syncProjectedTraceSummary(
 		return err
 	}
 
+	// Projected pending inbox counts intentionally exclude cancel rows to match
+	// GET /pending-work and the live engine run summary.
 	pendingInboxItems, err := engineTx.CountOpenInboxByRun(ctx, pgtype.UUID{Bytes: run.ID, Valid: true})
 	if err != nil {
 		return err
@@ -908,11 +1186,44 @@ func isTerminalEngineRun(status enginedb.EngineRunLifecycleStatus) bool {
 	switch status {
 	case enginedb.EngineRunLifecycleStatusCompleted,
 		enginedb.EngineRunLifecycleStatusFailed,
-		enginedb.EngineRunLifecycleStatusCancelled:
+		enginedb.EngineRunLifecycleStatusCancelled,
+		enginedb.EngineRunLifecycleStatusTerminated:
 		return true
 	default:
 		return false
 	}
+}
+
+func terminalRunSummaryFromRun(run *enginedb.EngineRun) engineRunSummary {
+	if run == nil {
+		return engineRunSummary{}
+	}
+
+	return engineRunSummary{
+		RunID:                run.ID,
+		Status:               run.Status,
+		Result:               cloneRaw(run.Result),
+		LastErrorCode:        run.LastErrorCode,
+		LastErrorMessage:     run.LastErrorMessage,
+		PendingActivityTasks: 0,
+		PendingInboxItems:    0,
+	}
+}
+
+func decodePendingTimerKey(raw json.RawMessage) (string, error) {
+	var payload publichistory.TimerScheduledPayload
+	if err := publichistory.UnmarshalPayload(raw, &payload); err != nil {
+		return "", fmt.Errorf("decode timer payload: %w", err)
+	}
+	return payload.TimerKey, nil
+}
+
+func decodePendingSignalName(raw json.RawMessage) (string, error) {
+	var payload publichistory.SignalReceivedPayload
+	if err := publichistory.UnmarshalPayload(raw, &payload); err != nil {
+		return "", fmt.Errorf("decode signal payload: %w", err)
+	}
+	return payload.SignalName, nil
 }
 
 func pgTimePtr(value pgtype.Timestamptz) *time.Time {

--- a/internal/api/engine_handlers.go
+++ b/internal/api/engine_handlers.go
@@ -98,6 +98,25 @@ func (s *Server) CancelEngineRun(w http.ResponseWriter, r *http.Request, runID o
 	writeJSON(w, http.StatusOK, engineControlResponseToAPI(&result))
 }
 
+func (s *Server) TerminateEngineRun(w http.ResponseWriter, r *http.Request, runID openapi_types.UUID, _ TerminateEngineRunParams) {
+	projectID, ok := projectIDOrUnauthorized(w, r)
+	if !ok {
+		return
+	}
+	if s.engineControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	result, err := s.engineControl.TerminateRun(r.Context(), projectID, runID)
+	if err != nil {
+		writeEngineError(w, err, "Failed to terminate engine run")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, engineRunResultResponseToAPI(&result))
+}
+
 func (s *Server) GetEngineRunHistory(w http.ResponseWriter, r *http.Request, runID openapi_types.UUID, params GetEngineRunHistoryParams) {
 	projectID, ok := projectIDOrUnauthorized(w, r)
 	if !ok {
@@ -143,6 +162,25 @@ func (s *Server) GetEngineRunResult(w http.ResponseWriter, r *http.Request, runI
 	}
 
 	writeJSON(w, http.StatusOK, engineRunResultResponseToAPI(&result))
+}
+
+func (s *Server) GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runID openapi_types.UUID) {
+	projectID, ok := projectIDOrUnauthorized(w, r)
+	if !ok {
+		return
+	}
+	if s.engineControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	result, err := s.engineControl.GetRunPendingWork(r.Context(), projectID, runID)
+	if err != nil {
+		writeEngineError(w, err, "Failed to get engine pending work")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, enginePendingWorkResponseToAPI(&result))
 }
 
 func (s *Server) SignalEngineRun(w http.ResponseWriter, r *http.Request, runID openapi_types.UUID, _ SignalEngineRunParams) {

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -627,7 +629,6 @@ func TestTerminateEngineRun_ReturnsTerminatedSummaryAndIsIdempotent(t *testing.T
 		ID:        runID,
 	})
 	require.NoError(t, err)
-	setEngineRunWaiting(t, ctx, platformStore, runID, "approval", map[string]any{"step": "waiting"})
 	assert.Equal(t, enginedb.EngineRunLifecycleStatusTerminated, run.Status)
 
 	instance, err := engineQueries.GetInstance(ctx, run.InstanceID)
@@ -799,7 +800,7 @@ func TestTerminateEngineRun_ProjectorEventuallyProjectsTerminalCleanup(t *testin
 	})
 	require.NoError(t, err)
 
-	setEngineRunWaiting(t, ctx, platformStore, start.RunId, "approval", map[string]any{"step": "waiting"})
+	setEngineRunWaiting(t, ctx, platformStore, start.RunId, map[string]any{"step": "waiting"})
 	setProjectedEngineSummary(t, ctx, platformStore, trace.ID, projectedEngineSummaryUpdate{
 		RunStatus:            string(enginedb.EngineRunLifecycleStatusWaiting),
 		CustomStatus:         []byte(`{"step":"projected"}`),
@@ -1016,7 +1017,7 @@ func TestGetEngineRunPendingWork_ReturnsPureSignalWaitWithoutPreviewHeader(t *te
 		RequestKey:        "req-pending-wait",
 	}))
 
-	setEngineRunWaiting(t, ctx, platformStore, start.RunId, "approval", map[string]any{"step": "waiting"})
+	setEngineRunWaiting(t, ctx, platformStore, start.RunId, map[string]any{"step": "waiting"})
 
 	rec := invokeGetEngineRunPendingWork(t, server, projectID, start.RunId)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1254,7 +1255,7 @@ func TestGetTrace_UsesLiveFallbackForNonCurrentProjectionStatesAndStaleCheckpoin
 			})
 			require.NoError(t, err)
 
-			setEngineRunWaiting(t, ctx, platformStore, runID, "approval", map[string]any{"step": "live"})
+			setEngineRunWaiting(t, ctx, platformStore, runID, map[string]any{"step": "live"})
 			createPendingWorkForRun(t, ctx, engineQueries, projectID, runID)
 			if tc.seedStaleHistory {
 				appendEngineHistoryEvent(t, ctx, engineQueries, projectID, run.InstanceID, runID, 2, publichistory.EventCustomStatusUpdated, publichistory.CustomStatusUpdatedPayload{
@@ -1360,6 +1361,15 @@ func TestGetTrace_LiveFallbackFailureReturns500(t *testing.T) {
 		TraceID:   start.TraceId,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, restoreErr := platformStore.Pool().Exec(ctx, `
+			UPDATE traces
+			SET engine_run_id = $2,
+			    updated_at = NOW()
+			WHERE id = $1
+		`, trace.ID, start.RunId)
+		require.NoError(t, restoreErr)
+	})
 
 	setTraceProjectionState(t, ctx, platformStore, trace.ID, publicprojection.StateCatchingUp.String())
 	_, err = platformStore.Pool().Exec(ctx, `
@@ -1529,6 +1539,7 @@ func assertJSONFieldNull(t *testing.T, body []byte, field string) {
 	assert.Equal(t, "null", string(bytes.TrimSpace(value)))
 }
 
+//nolint:revive // Keep testing.T first in test helper signatures.
 func appendEngineHistoryEvent(
 	t *testing.T,
 	ctx context.Context,
@@ -1561,12 +1572,11 @@ func setEngineRunWaiting(
 	ctx context.Context,
 	platformStore *store.Store,
 	runID uuid.UUID,
-	signalName string,
 	customStatus map[string]any,
 ) {
 	t.Helper()
 
-	waitingFor, err := json.Marshal(map[string]any{"kind": "signal", "signal_name": signalName})
+	waitingFor, err := json.Marshal(map[string]any{"kind": "signal", "signal_name": "approval"})
 	require.NoError(t, err)
 	customStatusRaw, err := json.Marshal(customStatus)
 	require.NoError(t, err)
@@ -1699,8 +1709,25 @@ type externalEngineServeProcess struct {
 	cancel context.CancelFunc
 	cmd    *exec.Cmd
 	done   chan error
-	stdout bytes.Buffer
-	stderr bytes.Buffer
+	stdout lockedBuffer
+	stderr lockedBuffer
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func startExternalEngineServeProcess(t *testing.T) *externalEngineServeProcess {
@@ -1709,6 +1736,7 @@ func startExternalEngineServeProcess(t *testing.T) *externalEngineServeProcess {
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, "go", "run", "./cmd/continua-engine", "serve")
 	cmd.Dir = filepath.Join(apiTestRepoRoot(t), "engine")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Env = append(os.Environ(),
 		"ENGINE_DATABASE_URL="+apiTestDatabaseURL(),
 		"DATABASE_URL=",
@@ -1742,16 +1770,54 @@ func (p *externalEngineServeProcess) stop(t *testing.T) {
 		return
 	}
 
-	p.cancel()
 	select {
 	case err := <-p.done:
 		if err != nil && !errors.Is(err, context.Canceled) {
-			t.Fatalf("engine serve process exited with error: %v\nstdout=%s\nstderr=%s", err, p.stdout.String(), p.stderr.String())
+			t.Fatalf("engine serve process exited unexpectedly: %v\nstdout=%s\nstderr=%s", err, p.stdout.String(), p.stderr.String())
 		}
-	case <-time.After(10 * time.Second):
-		_ = p.cmd.Process.Kill()
+		return
+	default:
+	}
+
+	p.cancel()
+
+	stopped, err := waitExternalEngineServeProcess(p.done, 2*time.Second)
+	if !stopped {
+		_ = signalProcessGroup(p.cmd.Process.Pid, syscall.SIGTERM)
+		stopped, err = waitExternalEngineServeProcess(p.done, 2*time.Second)
+	}
+
+	if !stopped {
+		_ = signalProcessGroup(p.cmd.Process.Pid, syscall.SIGKILL)
+		stopped, err = waitExternalEngineServeProcess(p.done, 5*time.Second)
+	}
+
+	if !stopped {
 		t.Fatalf("engine serve process did not stop\nstdout=%s\nstderr=%s", p.stdout.String(), p.stderr.String())
 	}
+
+	if err != nil && !errors.Is(err, context.Canceled) {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("engine serve process exited with error: %v\nstdout=%s\nstderr=%s", err, p.stdout.String(), p.stderr.String())
+		}
+	}
+}
+
+func waitExternalEngineServeProcess(done <-chan error, timeout time.Duration) (bool, error) {
+	select {
+	case err := <-done:
+		return true, err
+	case <-time.After(timeout):
+		return false, nil
+	}
+}
+
+func signalProcessGroup(pid int, sig syscall.Signal) error {
+	if pid <= 0 {
+		return nil
+	}
+	return syscall.Kill(-pid, sig)
 }
 
 func waitForProjectedTraceTerminalSummary(t *testing.T, pool *pgxpool.Pool, traceID uuid.UUID) (string, string, []byte) {
@@ -1777,6 +1843,7 @@ func waitForProjectedTraceTerminalSummary(t *testing.T, pool *pgxpool.Pool, trac
 	return "", "", nil
 }
 
+//nolint:revive // Keep testing.T first in test helper signatures.
 func waitForProjectedTracePendingInboxItems(
 	t *testing.T,
 	ctx context.Context,

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -9,11 +9,17 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -581,6 +587,7 @@ func TestGetEngineRunResult_ReturnsCancelledFailureSummary(t *testing.T) {
 
 	rec := invokeGetEngineRunResult(t, server, projectID, runID)
 	require.Equal(t, http.StatusOK, rec.Code)
+	body := append([]byte(nil), rec.Body.Bytes()...)
 
 	resp := decodeJSONBody[EngineRunResultResponse](t, rec)
 	assert.Equal(t, EngineRunStatusCANCELLED, resp.Status)
@@ -588,44 +595,634 @@ func TestGetEngineRunResult_ReturnsCancelledFailureSummary(t *testing.T) {
 	assert.Equal(t, "cancelled", resp.Failure.ErrorCode)
 	assert.Equal(t, "workflow cancelled", resp.Failure.ErrorMessage)
 	assert.Nil(t, resp.Result)
+	assertJSONFieldNull(t, body, "result")
 }
 
-func TestGetTrace_UsesLiveFallbackOnlyForNonCurrentProjectionStates(t *testing.T) {
+func TestTerminateEngineRun_ReturnsTerminatedSummaryAndIsIdempotent(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-terminated-result",
+		RequestKey:        "req-terminated-result",
+	}))
+
+	runID := start.RunId
+	rec := invokeTerminateEngineRun(t, server, projectID, runID)
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := append([]byte(nil), rec.Body.Bytes()...)
+
+	resp := decodeJSONBody[EngineRunResultResponse](t, rec)
+	assert.Equal(t, EngineRunStatusTERMINATED, resp.Status)
+	require.NotNil(t, resp.Failure)
+	assert.Equal(t, "terminated", resp.Failure.ErrorCode)
+	assert.Equal(t, "run terminated by operator", resp.Failure.ErrorMessage)
+	assert.Nil(t, resp.Result)
+	assertJSONFieldNull(t, body, "result")
+
+	run, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        runID,
+	})
+	require.NoError(t, err)
+	setEngineRunWaiting(t, ctx, platformStore, runID, "approval", map[string]any{"step": "waiting"})
+	assert.Equal(t, enginedb.EngineRunLifecycleStatusTerminated, run.Status)
+
+	instance, err := engineQueries.GetInstance(ctx, run.InstanceID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineInstanceLifecycleStatusTerminated, instance.Status)
+
+	historyRows, err := engineQueries.GetHistoryByRun(ctx, runID)
+	require.NoError(t, err)
+	require.Len(t, historyRows, 2)
+	assert.Equal(t, publichistory.EventWorkflowTerminated, historyRows[1].EventType)
+	decoded, err := publichistory.DecodePayload(historyRows[1].EventType, historyRows[1].Payload)
+	require.NoError(t, err)
+	terminatedPayload, ok := decoded.(*publichistory.WorkflowTerminatedPayload)
+	require.True(t, ok)
+	assert.Equal(t, "terminated", terminatedPayload.ErrorCode)
+	assert.Equal(t, "run terminated by operator", terminatedPayload.ErrorMessage)
+
+	resultRec := invokeGetEngineRunResult(t, server, projectID, runID)
+	require.Equal(t, http.StatusOK, resultRec.Code)
+	resultResp := decodeJSONBody[EngineRunResultResponse](t, resultRec)
+	assert.Equal(t, EngineRunStatusTERMINATED, resultResp.Status)
+	require.NotNil(t, resultResp.Failure)
+	assert.Equal(t, "terminated", resultResp.Failure.ErrorCode)
+	assert.Equal(t, "run terminated by operator", resultResp.Failure.ErrorMessage)
+	assert.Nil(t, resultResp.Result)
+
+	signalRec := invokeSignalEngineRun(t, server, projectID, runID, EngineSignalRunRequest{SignalName: "ignored"})
+	require.Equal(t, http.StatusConflict, signalRec.Code)
+	assert.Equal(t, "run_terminal", decodeJSONBody[Error](t, signalRec).Code)
+
+	cancelRec := invokeCancelEngineRun(t, server, projectID, runID)
+	require.Equal(t, http.StatusConflict, cancelRec.Code)
+	assert.Equal(t, "run_terminal", decodeJSONBody[Error](t, cancelRec).Code)
+
+	replayedTerminate := invokeTerminateEngineRun(t, server, projectID, runID)
+	require.Equal(t, http.StatusOK, replayedTerminate.Code)
+	replayedResp := decodeJSONBody[EngineRunResultResponse](t, replayedTerminate)
+	assert.Equal(t, resp, replayedResp)
+
+	historyAfterReplay, err := engineQueries.GetHistoryByRun(ctx, runID)
+	require.NoError(t, err)
+	assert.Len(t, historyAfterReplay, len(historyRows))
+
+	otherProjectID := testutil.CreateTestProject(t, ctx, platformStore.Queries())
+	notFoundRec := invokeTerminateEngineRun(t, server, otherProjectID, runID)
+	require.Equal(t, http.StatusNotFound, notFoundRec.Code)
+	assert.Equal(t, "not_found", decodeJSONBody[Error](t, notFoundRec).Code)
+
+	missingRunRec := invokeTerminateEngineRun(t, server, projectID, uuid.New())
+	require.Equal(t, http.StatusNotFound, missingRunRec.Code)
+	assert.Equal(t, "not_found", decodeJSONBody[Error](t, missingRunRec).Code)
+}
+
+func TestTerminateEngineRun_ReturnsExistingTerminalStateWhenActivationWinsRowLock(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-terminate-race-completed",
+		RequestKey:        "req-terminate-race-completed",
+	}))
+
+	runID := start.RunId
+	_, err := platformStore.Pool().Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'running',
+		    claimed_by = 'worker-a',
+		    claimed_at = NOW(),
+		    lease_expires_at = NOW() + INTERVAL '1 minute',
+		    updated_at = NOW()
+		WHERE id = $1
+	`, runID)
+	require.NoError(t, err)
+
+	tx, err := platformStore.Pool().BeginTx(ctx, pgx.TxOptions{})
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	engineTx := enginedb.New(tx)
+	lockedRun, err := engineTx.GetRunByProjectAndIDForUpdate(ctx, enginedb.GetRunByProjectAndIDForUpdateParams{
+		ProjectID: projectID,
+		ID:        runID,
+	})
+	require.NoError(t, err)
+
+	terminateDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		terminateDone <- invokeTerminateEngineRun(t, server, projectID, runID)
+	}()
+
+	waitForEngineRunLockWaiter(t, platformStore.Pool())
+
+	historyRows, err := engineTx.GetHistoryByRun(ctx, runID)
+	require.NoError(t, err)
+	payload, err := publichistory.MarshalPayload(publichistory.WorkflowCompletedPayload{
+		Result: []byte(`{"ok":true}`),
+	})
+	require.NoError(t, err)
+	_, err = engineTx.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: lockedRun.InstanceID,
+		RunID:      lockedRun.ID,
+		SequenceNo: historyRows[len(historyRows)-1].SequenceNo + 1,
+		EventType:  publichistory.EventWorkflowCompleted,
+		Payload:    payload,
+	})
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'completed',
+		    result = $2,
+		    waiting_for = NULL,
+		    completed_at = NOW(),
+		    last_error_code = NULL,
+		    last_error_message = NULL,
+		    claimed_by = NULL,
+		    claimed_at = NULL,
+		    lease_expires_at = NULL,
+		    updated_at = NOW()
+		WHERE id = $1
+	`, runID, []byte(`{"ok":true}`))
+	require.NoError(t, err)
+	_, err = engineTx.UpdateInstanceStatus(ctx, enginedb.UpdateInstanceStatusParams{
+		ID:     lockedRun.InstanceID,
+		Status: enginedb.EngineInstanceLifecycleStatusCompleted,
+	})
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	var terminateRec *httptest.ResponseRecorder
+	select {
+	case terminateRec = <-terminateDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("terminate handler did not finish after activation commit")
+	}
+
+	require.Equal(t, http.StatusOK, terminateRec.Code)
+	resp := decodeJSONBody[EngineRunResultResponse](t, terminateRec)
+	assert.Equal(t, EngineRunStatusCOMPLETED, resp.Status)
+	require.NotNil(t, resp.Result)
+	result, ok := resp.Result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, result["ok"])
+	assert.Nil(t, resp.Failure)
+
+	historyAfter, err := engineQueries.GetHistoryByRun(ctx, runID)
+	require.NoError(t, err)
+	require.Len(t, historyAfter, 2)
+	assert.Equal(t, publichistory.EventWorkflowCompleted, historyAfter[1].EventType)
+}
+
+func TestTerminateEngineRun_ProjectorEventuallyProjectsTerminalCleanup(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-terminate-projector",
+		RequestKey:        "req-terminate-projector",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	setEngineRunWaiting(t, ctx, platformStore, start.RunId, "approval", map[string]any{"step": "waiting"})
+	setProjectedEngineSummary(t, ctx, platformStore, trace.ID, projectedEngineSummaryUpdate{
+		RunStatus:            string(enginedb.EngineRunLifecycleStatusWaiting),
+		CustomStatus:         []byte(`{"step":"projected"}`),
+		WaitState:            []byte(`{"kind":"signal","signal_name":"approval"}`),
+		PendingActivityTasks: 0,
+		PendingInboxItems:    0,
+	})
+
+	rec := invokeTerminateEngineRun(t, server, projectID, start.RunId)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var beforeRunStatus string
+	var beforeWaitState []byte
+	err = platformStore.Pool().QueryRow(ctx, `
+		SELECT engine_run_status, engine_wait_state
+		FROM public.traces
+		WHERE id = $1
+	`, trace.ID).Scan(&beforeRunStatus, &beforeWaitState)
+	require.NoError(t, err)
+	assert.Equal(t, string(enginedb.EngineRunLifecycleStatusWaiting), beforeRunStatus)
+	require.NotEmpty(t, beforeWaitState)
+
+	engineServe := startExternalEngineServeProcess(t)
+	defer engineServe.stop(t)
+
+	traceStatus, runStatus, waitState := waitForProjectedTraceTerminalSummary(t, platformStore.Pool(), trace.ID)
+	assert.Equal(t, "failed", traceStatus)
+	assert.Equal(t, string(enginedb.EngineRunLifecycleStatusTerminated), runStatus)
+	assert.Len(t, waitState, 0)
+}
+
+func TestTerminateEngineRun_RouterEnforcesPreviewHeaderAndAvailability(t *testing.T) {
+	ctx := context.Background()
+	platformStore := store.New(testutil.TestDB(t))
+	engineQueries := enginedb.New(platformStore.Pool())
+
+	apiKey := "engine-terminate-" + uuid.NewString()
+	project, err := platformStore.Queries().CreateProject(ctx, platformdb.CreateProjectParams{
+		Name:       "terminate-router-" + uuid.NewString()[:8],
+		ApiKeyHash: hashTestAPIKey(apiKey),
+	})
+	require.NoError(t, err)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	server := NewServer(platformStore, nil)
+	server.engineControl = newEngineControlService(platformStore)
+	server.enginePublicAPIEnabled = true
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, project.ID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "terminate-router-instance",
+		RequestKey:        "terminate-router-request",
+	}))
+
+	router := NewRouter(server, platformStore)
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/runs/"+start.RunId.String()+"/terminate", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "preview_header_required", decodeJSONBody[Error](t, rec).Code)
+
+	server.enginePublicAPIEnabled = false
+	router = NewRouter(server, platformStore)
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/engine/runs/"+start.RunId.String()+"/terminate", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set(enginePreviewHeader, "1")
+	rec = httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestGetEngineRunPendingWork_ReturnsTypedOpenWorkAndExcludesCancelRows(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-pending-work",
+		RequestKey:        "req-pending-work",
+	}))
+
+	runID := start.RunId
+	run, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        runID,
+	})
+	require.NoError(t, err)
+
+	baseTime := time.Now().UTC().Round(time.Microsecond)
+	activityHistoryA := appendEngineHistoryEvent(t, ctx, engineQueries, projectID, run.InstanceID, runID, 2, publichistory.EventActivityScheduled, publichistory.ActivityScheduledPayload{
+		ActivityKey:  "approval-a",
+		ActivityType: "demo.activity",
+		Input:        []byte(`{"step":"a"}`),
+	})
+	activityHistoryB := appendEngineHistoryEvent(t, ctx, engineQueries, projectID, run.InstanceID, runID, 3, publichistory.EventActivityScheduled, publichistory.ActivityScheduledPayload{
+		ActivityKey:  "approval-b",
+		ActivityType: "demo.activity",
+		Input:        []byte(`{"step":"b"}`),
+	})
+	timerHistory := appendEngineHistoryEvent(t, ctx, engineQueries, projectID, run.InstanceID, runID, 4, publichistory.EventTimerScheduled, publichistory.TimerScheduledPayload{
+		TimerKey: "deadline",
+		DueAt:    baseTime.Add(3 * time.Minute),
+	})
+
+	_, err = engineQueries.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:    projectID,
+		InstanceID:   run.InstanceID,
+		RunID:        runID,
+		HistoryID:    &activityHistoryB.ID,
+		ActivityKey:  "approval-b",
+		ActivityType: "demo.activity",
+		Input:        []byte(`{"step":"b"}`),
+		AvailableAt:  baseTime.Add(2 * time.Minute),
+	})
+	require.NoError(t, err)
+	_, err = engineQueries.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:    projectID,
+		InstanceID:   run.InstanceID,
+		RunID:        runID,
+		HistoryID:    &activityHistoryA.ID,
+		ActivityKey:  "approval-a",
+		ActivityType: "demo.activity",
+		Input:        []byte(`{"step":"a"}`),
+		AvailableAt:  baseTime.Add(1 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	timerPayload, err := publichistory.MarshalPayload(publichistory.TimerScheduledPayload{
+		TimerKey: "deadline",
+		DueAt:    baseTime.Add(3 * time.Minute),
+	})
+	require.NoError(t, err)
+	_, err = engineQueries.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   projectID,
+		InstanceID:  run.InstanceID,
+		RunID:       pgtype.UUID{Bytes: runID, Valid: true},
+		HistoryID:   &timerHistory.ID,
+		Kind:        "timer",
+		Payload:     timerPayload,
+		AvailableAt: baseTime.Add(3 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	signalPayload, err := publichistory.MarshalPayload(publichistory.SignalReceivedPayload{
+		SignalName: "approval",
+		Payload:    []byte(`{"approved":true}`),
+	})
+	require.NoError(t, err)
+	_, err = engineQueries.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   projectID,
+		InstanceID:  run.InstanceID,
+		RunID:       pgtype.UUID{Bytes: runID, Valid: true},
+		Kind:        "signal",
+		Payload:     signalPayload,
+		AvailableAt: baseTime.Add(4 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	cancelPayload, err := publichistory.MarshalPayload(publichistory.CancelRequestedPayload{})
+	require.NoError(t, err)
+	_, err = engineQueries.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   projectID,
+		InstanceID:  run.InstanceID,
+		RunID:       pgtype.UUID{Bytes: runID, Valid: true},
+		Kind:        "cancel",
+		Payload:     cancelPayload,
+		AvailableAt: baseTime.Add(5 * time.Minute),
+		DedupeKey:   testutil.StrPtr("cancel:" + runID.String()),
+	})
+	require.NoError(t, err)
+
+	rec := invokeGetEngineRunPendingWork(t, server, projectID, runID)
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := append([]byte(nil), rec.Body.Bytes()...)
+
+	resp := decodeJSONBody[EnginePendingWorkResponse](t, rec)
+	assert.Equal(t, runID, resp.RunId)
+	assert.Nil(t, resp.CurrentWait)
+	assert.Len(t, resp.Activities, 2)
+	assert.Equal(t, "approval-a", resp.Activities[0].ActivityKey)
+	assert.Equal(t, "approval-b", resp.Activities[1].ActivityKey)
+	assert.Equal(t, "deadline", resp.Timers[0].TimerKey)
+	assert.Equal(t, "approval", resp.Signals[0].SignalName)
+	assert.EqualValues(t, 2, resp.PendingActivityTasks)
+	assert.EqualValues(t, 2, resp.PendingInboxItems)
+	assertJSONFieldNull(t, body, "current_wait")
+
+	openInbox, err := engineQueries.CountOpenInboxByRun(ctx, pgtype.UUID{Bytes: runID, Valid: true})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, openInbox)
+
+	otherProjectID := testutil.CreateTestProject(t, ctx, platformStore.Queries())
+	notFound := invokeGetEngineRunPendingWork(t, server, otherProjectID, runID)
+	require.Equal(t, http.StatusNotFound, notFound.Code)
+	assert.Equal(t, "not_found", decodeJSONBody[Error](t, notFound).Code)
+}
+
+func TestGetEngineRunPendingWork_ReturnsPureSignalWaitWithoutPreviewHeader(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-pending-wait",
+		RequestKey:        "req-pending-wait",
+	}))
+
+	setEngineRunWaiting(t, ctx, platformStore, start.RunId, "approval", map[string]any{"step": "waiting"})
+
+	rec := invokeGetEngineRunPendingWork(t, server, projectID, start.RunId)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[EnginePendingWorkResponse](t, rec)
+	require.NotNil(t, resp.CurrentWait)
+	require.NotNil(t, resp.CurrentWait.SignalName)
+	assert.Equal(t, "approval", *resp.CurrentWait.SignalName)
+	assert.Empty(t, resp.Activities)
+	assert.Empty(t, resp.Timers)
+	assert.Empty(t, resp.Signals)
+	assert.EqualValues(t, 0, resp.PendingActivityTasks)
+	assert.EqualValues(t, 0, resp.PendingInboxItems)
+
+	apiKey := "engine-pending-work-" + uuid.NewString()
+	project, err := platformStore.Queries().CreateProject(ctx, platformdb.CreateProjectParams{
+		Name:       "pending-router-" + uuid.NewString()[:8],
+		ApiKeyHash: hashTestAPIKey(apiKey),
+	})
+	require.NoError(t, err)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	routerServer := NewServer(platformStore, nil)
+	routerServer.engineControl = newEngineControlService(platformStore)
+	routerServer.enginePublicAPIEnabled = true
+	routerStart := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, routerServer, project.ID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "pending-router-instance",
+		RequestKey:        "pending-router-request",
+	}))
+
+	router := NewRouter(routerServer, platformStore)
+	req := httptest.NewRequest(http.MethodGet, "/v1/engine/runs/"+routerStart.RunId.String()+"/pending-work", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+}
+
+func TestEngineRunPendingWorkCountsStayConsistentAcrossRunReadAndProjectedSummary(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-pending-count-consistency",
+		RequestKey:        "req-pending-count-consistency",
+	}))
+
+	runID := start.RunId
+	run, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        runID,
+	})
+	require.NoError(t, err)
+
+	baseTime := time.Now().UTC().Round(time.Microsecond)
+	timerHistory := appendEngineHistoryEvent(t, ctx, engineQueries, projectID, run.InstanceID, runID, 2, publichistory.EventTimerScheduled, publichistory.TimerScheduledPayload{
+		TimerKey: "deadline",
+		DueAt:    baseTime.Add(3 * time.Minute),
+	})
+	timerPayload, err := publichistory.MarshalPayload(publichistory.TimerScheduledPayload{
+		TimerKey: "deadline",
+		DueAt:    baseTime.Add(3 * time.Minute),
+	})
+	require.NoError(t, err)
+	_, err = engineQueries.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   projectID,
+		InstanceID:  run.InstanceID,
+		RunID:       pgtype.UUID{Bytes: runID, Valid: true},
+		HistoryID:   &timerHistory.ID,
+		Kind:        "timer",
+		Payload:     timerPayload,
+		AvailableAt: baseTime.Add(3 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	signalPayload, err := publichistory.MarshalPayload(publichistory.SignalReceivedPayload{
+		SignalName: "approval",
+		Payload:    []byte(`{"approved":true}`),
+	})
+	require.NoError(t, err)
+	_, err = engineQueries.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   projectID,
+		InstanceID:  run.InstanceID,
+		RunID:       pgtype.UUID{Bytes: runID, Valid: true},
+		Kind:        "signal",
+		Payload:     signalPayload,
+		AvailableAt: baseTime.Add(4 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	cancelPayload, err := publichistory.MarshalPayload(publichistory.CancelRequestedPayload{})
+	require.NoError(t, err)
+	_, err = engineQueries.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   projectID,
+		InstanceID:  run.InstanceID,
+		RunID:       pgtype.UUID{Bytes: runID, Valid: true},
+		Kind:        "cancel",
+		Payload:     cancelPayload,
+		AvailableAt: baseTime.Add(5 * time.Minute),
+		DedupeKey:   testutil.StrPtr("cancel:" + runID.String()),
+	})
+	require.NoError(t, err)
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	engineServe := startExternalEngineServeProcess(t)
+	defer engineServe.stop(t)
+	waitForProjectedTracePendingInboxItems(t, ctx, platformStore.Pool(), trace.ID, timerHistory.ID, 2)
+
+	openInbox, err := engineQueries.CountOpenInboxByRun(ctx, pgtype.UUID{Bytes: runID, Valid: true})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, openInbox)
+
+	runRec := invokeGetEngineRun(t, server, projectID, runID)
+	require.Equal(t, http.StatusOK, runRec.Code)
+	runResp := decodeJSONBody[EngineRunResponse](t, runRec)
+	assert.EqualValues(t, 2, runResp.PendingWork.PendingInboxItems)
+
+	pendingRec := invokeGetEngineRunPendingWork(t, server, projectID, runID)
+	require.Equal(t, http.StatusOK, pendingRec.Code)
+	pendingResp := decodeJSONBody[EnginePendingWorkResponse](t, pendingRec)
+	assert.EqualValues(t, 2, pendingResp.PendingInboxItems)
+	assert.Len(t, pendingResp.Timers, 1)
+	assert.Len(t, pendingResp.Signals, 1)
+
+	var projectedPendingInboxItems int64
+	err = platformStore.Pool().QueryRow(ctx, `
+		SELECT engine_pending_inbox_items
+		FROM public.traces
+		WHERE id = $1
+	`, trace.ID).Scan(&projectedPendingInboxItems)
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, projectedPendingInboxItems)
+}
+
+func TestGetTrace_UsesLiveFallbackForNonCurrentProjectionStatesAndStaleCheckpoints(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
 
 	testCases := []struct {
-		name            string
-		projectionState string
-		wantStatus      EngineRunStatus
-		wantWaitState   bool
-		projectedOnly   bool
+		name                 string
+		projectionState      string
+		wantStatus           EngineRunStatus
+		wantProjectionState  EngineProjectionState
+		wantWaitState        bool
+		projectedOnly        bool
+		disableEngineControl bool
+		seedStaleHistory     bool
 	}{
 		{
-			name:            "up_to_date serves projected summary only",
-			projectionState: publicprojection.StateUpToDate.String(),
-			wantStatus:      EngineRunStatusWAITING,
-			wantWaitState:   true,
-			projectedOnly:   true,
+			name:                 "up_to_date serves projected summary only",
+			projectionState:      publicprojection.StateUpToDate.String(),
+			wantStatus:           EngineRunStatusWAITING,
+			wantProjectionState:  UpToDate,
+			wantWaitState:        true,
+			projectedOnly:        true,
+			disableEngineControl: true,
 		},
 		{
-			name:            "catching_up supplements from live engine summary",
-			projectionState: publicprojection.StateCatchingUp.String(),
-			wantStatus:      EngineRunStatusWAITING,
-			wantWaitState:   true,
+			name:                "catching_up supplements from live engine summary",
+			projectionState:     publicprojection.StateCatchingUp.String(),
+			wantStatus:          EngineRunStatusWAITING,
+			wantProjectionState: CatchingUp,
+			wantWaitState:       true,
 		},
 		{
-			name:            "summary_only supplements from live engine summary",
-			projectionState: publicprojection.StateSummaryOnly.String(),
-			wantStatus:      EngineRunStatusWAITING,
-			wantWaitState:   true,
+			name:                "summary_only supplements from live engine summary",
+			projectionState:     publicprojection.StateSummaryOnly.String(),
+			wantStatus:          EngineRunStatusWAITING,
+			wantProjectionState: SummaryOnly,
+			wantWaitState:       true,
 		},
 		{
-			name:            "journal_expired stays on projected summary shell",
-			projectionState: publicprojection.StateJournalExpired.String(),
-			wantStatus:      EngineRunStatusWAITING,
-			wantWaitState:   true,
-			projectedOnly:   true,
+			name:                "journal_expired stays on projected summary shell",
+			projectionState:     publicprojection.StateJournalExpired.String(),
+			wantStatus:          EngineRunStatusWAITING,
+			wantProjectionState: JournalExpired,
+			wantWaitState:       true,
+			projectedOnly:       true,
+		},
+		{
+			name:                "journal_expired ignores stale checkpoint and stays on projected summary shell",
+			projectionState:     publicprojection.StateJournalExpired.String(),
+			wantStatus:          EngineRunStatusWAITING,
+			wantProjectionState: JournalExpired,
+			wantWaitState:       true,
+			projectedOnly:       true,
+			seedStaleHistory:    true,
+		},
+		{
+			name:                "up_to_date falls back live when history checkpoint is stale",
+			projectionState:     publicprojection.StateUpToDate.String(),
+			wantStatus:          EngineRunStatusWAITING,
+			wantProjectionState: CatchingUp,
+			wantWaitState:       true,
+			seedStaleHistory:    true,
 		},
 	}
 
@@ -651,9 +1248,19 @@ func TestGetTrace_UsesLiveFallbackOnlyForNonCurrentProjectionStates(t *testing.T
 				TraceID:   start.TraceId,
 			})
 			require.NoError(t, err)
+			run, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+				ProjectID: projectID,
+				ID:        runID,
+			})
+			require.NoError(t, err)
 
 			setEngineRunWaiting(t, ctx, platformStore, runID, "approval", map[string]any{"step": "live"})
 			createPendingWorkForRun(t, ctx, engineQueries, projectID, runID)
+			if tc.seedStaleHistory {
+				appendEngineHistoryEvent(t, ctx, engineQueries, projectID, run.InstanceID, runID, 2, publichistory.EventCustomStatusUpdated, publichistory.CustomStatusUpdatedPayload{
+					Status: []byte(`{"step":"live"}`),
+				})
+			}
 			setTraceProjectionState(t, ctx, platformStore, trace.ID, tc.projectionState)
 			setProjectedEngineSummary(t, ctx, platformStore, trace.ID, projectedEngineSummaryUpdate{
 				RunStatus:            string(enginedb.EngineRunLifecycleStatusWaiting),
@@ -664,7 +1271,7 @@ func TestGetTrace_UsesLiveFallbackOnlyForNonCurrentProjectionStates(t *testing.T
 			})
 
 			originalEngineControl := server.engineControl
-			if tc.projectedOnly {
+			if tc.disableEngineControl {
 				server.engineControl = nil
 			} else {
 				server.engineControl = originalEngineControl
@@ -676,7 +1283,7 @@ func TestGetTrace_UsesLiveFallbackOnlyForNonCurrentProjectionStates(t *testing.T
 			detail := decodeJSONBody[TraceDetail](t, invokeGetTrace(t, server, projectID, trace.ID))
 			require.NotNil(t, detail.Engine)
 			assert.Equal(t, instanceKey, detail.Engine.InstanceKey)
-			assert.Equal(t, engineProjectionStateFromString(tc.projectionState), detail.Engine.ProjectionState)
+			assert.Equal(t, tc.wantProjectionState, detail.Engine.ProjectionState)
 			assert.Equal(t, tc.wantStatus, detail.Engine.Status)
 			require.NotNil(t, detail.Engine.CustomStatus)
 
@@ -699,6 +1306,42 @@ func TestGetTrace_UsesLiveFallbackOnlyForNonCurrentProjectionStates(t *testing.T
 			}
 		})
 	}
+}
+
+func TestTraceMetadataReadSurfacesReportCatchingUpWhenHistoryCheckpointIsStale(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-trace-projection-stale",
+		RequestKey:        "req-trace-projection-stale",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+	run, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        start.RunId,
+	})
+	require.NoError(t, err)
+
+	appendEngineHistoryEvent(t, ctx, engineQueries, projectID, run.InstanceID, run.ID, 2, publichistory.EventCustomStatusUpdated, publichistory.CustomStatusUpdatedPayload{
+		Status: []byte(`{"step":"stale"}`),
+	})
+
+	traceList := decodeJSONBody[TraceList](t, invokeListTraces(t, server, projectID, ListTracesParams{}))
+	require.Len(t, traceList.Traces, 1)
+	require.NotNil(t, traceList.Traces[0].Engine)
+	assert.Equal(t, CatchingUp, traceList.Traces[0].Engine.ProjectionState)
+
+	timeline := decodeJSONBody[TimelineResponse](t, invokeGetTraceEvents(t, server, projectID, trace.ID, GetTraceEventsParams{}))
+	require.NotNil(t, timeline.Engine)
+	assert.Equal(t, CatchingUp, timeline.Engine.ProjectionState)
 }
 
 func TestGetTrace_LiveFallbackFailureReturns500(t *testing.T) {
@@ -767,7 +1410,7 @@ func invokeStartEngineRun(t *testing.T, server *Server, projectID uuid.UUID, req
 	httpReq = httpReq.WithContext(context.WithValue(httpReq.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.StartEngineRun(rec, httpReq, StartEngineRunParams{XContinuaEnginePreview: testutil.StrPtr("1")})
+	server.StartEngineRun(rec, httpReq, StartEngineRunParams{XContinuaEnginePreview: "1"})
 	return rec
 }
 
@@ -836,7 +1479,7 @@ func invokeSignalEngineRun(
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.SignalEngineRun(rec, req, runID, SignalEngineRunParams{XContinuaEnginePreview: testutil.StrPtr("1")})
+	server.SignalEngineRun(rec, req, runID, SignalEngineRunParams{XContinuaEnginePreview: "1"})
 	return rec
 }
 
@@ -848,8 +1491,68 @@ func invokeCancelEngineRun(t *testing.T, server *Server, projectID, runID uuid.U
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.CancelEngineRun(rec, req, runID, CancelEngineRunParams{XContinuaEnginePreview: testutil.StrPtr("1")})
+	server.CancelEngineRun(rec, req, runID, CancelEngineRunParams{XContinuaEnginePreview: "1"})
 	return rec
+}
+
+func invokeGetEngineRunPendingWork(t *testing.T, server *Server, projectID, runID uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/engine/runs/"+runID.String()+"/pending-work", nil)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	rec := httptest.NewRecorder()
+
+	server.GetEngineRunPendingWork(rec, req, runID)
+	return rec
+}
+
+func invokeTerminateEngineRun(t *testing.T, server *Server, projectID, runID uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/runs/"+runID.String()+"/terminate", nil)
+	req.Header.Set(enginePreviewHeader, "1")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	rec := httptest.NewRecorder()
+
+	server.TerminateEngineRun(rec, req, runID, TerminateEngineRunParams{XContinuaEnginePreview: "1"})
+	return rec
+}
+
+func assertJSONFieldNull(t *testing.T, body []byte, field string) {
+	t.Helper()
+
+	var payload map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &payload))
+
+	value, ok := payload[field]
+	require.True(t, ok, "expected field %q to be present in %s", field, string(body))
+	assert.Equal(t, "null", string(bytes.TrimSpace(value)))
+}
+
+func appendEngineHistoryEvent(
+	t *testing.T,
+	ctx context.Context,
+	engineQueries *enginedb.Queries,
+	projectID, instanceID, runID uuid.UUID,
+	sequence int32,
+	eventType string,
+	payload any,
+) enginedb.EngineHistory {
+	t.Helper()
+
+	raw, err := publichistory.MarshalPayload(payload)
+	require.NoError(t, err)
+
+	row, err := engineQueries.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instanceID,
+		RunID:      runID,
+		SequenceNo: sequence,
+		EventType:  eventType,
+		Payload:    raw,
+	})
+	require.NoError(t, err)
+	return row
 }
 
 //nolint:revive // Keep testing.T first in test helper signatures.
@@ -963,6 +1666,182 @@ func setTraceProjectionState(t *testing.T, ctx context.Context, platformStore *s
 		WHERE id = $1
 	`, traceID, projectionState)
 	require.NoError(t, err)
+}
+
+func waitForEngineRunLockWaiter(t *testing.T, pool interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var waiting bool
+		err := pool.QueryRow(context.Background(), `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity
+				WHERE datname = current_database()
+				  AND wait_event_type = 'Lock'
+				  AND query LIKE '%FROM engine.runs%'
+				  AND query LIKE '%FOR UPDATE%'
+			)
+		`).Scan(&waiting)
+		require.NoError(t, err)
+		if waiting {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for terminate transaction to block on engine.runs row lock")
+}
+
+type externalEngineServeProcess struct {
+	cancel context.CancelFunc
+	cmd    *exec.Cmd
+	done   chan error
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+}
+
+func startExternalEngineServeProcess(t *testing.T) *externalEngineServeProcess {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "go", "run", "./cmd/continua-engine", "serve")
+	cmd.Dir = filepath.Join(apiTestRepoRoot(t), "engine")
+	cmd.Env = append(os.Environ(),
+		"ENGINE_DATABASE_URL="+apiTestDatabaseURL(),
+		"DATABASE_URL=",
+		"ENGINE_WORKFLOW_POLL_INTERVAL=50ms",
+		"ENGINE_ACTIVITY_POLL_INTERVAL=5s",
+		"ENGINE_MAINTENANCE_POLL_INTERVAL=5s",
+		"ENGINE_RUN_LEASE_TTL=500ms",
+		"ENGINE_ACTIVITY_LEASE_TTL=500ms",
+		"ENGINE_REQUEST_DEDUPE_TTL=2s",
+	)
+
+	process := &externalEngineServeProcess{
+		cancel: cancel,
+		cmd:    cmd,
+		done:   make(chan error, 1),
+	}
+	cmd.Stdout = &process.stdout
+	cmd.Stderr = &process.stderr
+
+	require.NoError(t, cmd.Start())
+	go func() {
+		process.done <- cmd.Wait()
+	}()
+	return process
+}
+
+func (p *externalEngineServeProcess) stop(t *testing.T) {
+	t.Helper()
+
+	if p == nil || p.cmd == nil || p.cmd.Process == nil {
+		return
+	}
+
+	p.cancel()
+	select {
+	case err := <-p.done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("engine serve process exited with error: %v\nstdout=%s\nstderr=%s", err, p.stdout.String(), p.stderr.String())
+		}
+	case <-time.After(10 * time.Second):
+		_ = p.cmd.Process.Kill()
+		t.Fatalf("engine serve process did not stop\nstdout=%s\nstderr=%s", p.stdout.String(), p.stderr.String())
+	}
+}
+
+func waitForProjectedTraceTerminalSummary(t *testing.T, pool *pgxpool.Pool, traceID uuid.UUID) (string, string, []byte) {
+	t.Helper()
+
+	deadline := time.Now().Add(20 * time.Second)
+	var lastTraceStatus string
+	var lastRunStatus string
+	var lastWaitState []byte
+	for time.Now().Before(deadline) {
+		err := pool.QueryRow(context.Background(), `
+			SELECT status, engine_run_status, engine_wait_state
+			FROM public.traces
+			WHERE id = $1
+		`, traceID).Scan(&lastTraceStatus, &lastRunStatus, &lastWaitState)
+		require.NoError(t, err)
+		if lastTraceStatus == "failed" && lastRunStatus == string(enginedb.EngineRunLifecycleStatusTerminated) && len(lastWaitState) == 0 {
+			return lastTraceStatus, lastRunStatus, lastWaitState
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for projected terminated trace summary, last trace=%q run=%q wait_state=%s", lastTraceStatus, lastRunStatus, string(lastWaitState))
+	return "", "", nil
+}
+
+func waitForProjectedTracePendingInboxItems(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	traceID uuid.UUID,
+	expectedHistoryID int64,
+	expectedPendingInboxItems int64,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(20 * time.Second)
+	var lastPendingInboxItems int64
+	var lastLatestHistoryID int64
+	var lastProjectedHistoryID int64
+	for time.Now().Before(deadline) {
+		err := pool.QueryRow(ctx, `
+			SELECT engine_pending_inbox_items,
+			       engine_latest_history_id,
+			       engine_last_projected_history_id
+			FROM public.traces
+			WHERE id = $1
+		`, traceID).Scan(&lastPendingInboxItems, &lastLatestHistoryID, &lastProjectedHistoryID)
+		require.NoError(t, err)
+		if lastPendingInboxItems == expectedPendingInboxItems &&
+			lastLatestHistoryID >= expectedHistoryID &&
+			lastProjectedHistoryID >= expectedHistoryID {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf(
+		"timed out waiting for projected pending inbox count=%d at history id %d, last pending=%d latest=%d projected=%d",
+		expectedPendingInboxItems,
+		expectedHistoryID,
+		lastPendingInboxItems,
+		lastLatestHistoryID,
+		lastProjectedHistoryID,
+	)
+}
+
+func apiTestDatabaseURL() string {
+	if value := os.Getenv("TEST_DATABASE_URL"); value != "" {
+		return value
+	}
+	return testutil.DefaultTestDBURL
+}
+
+func apiTestRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller() failed")
+
+	dir := filepath.Dir(currentFile)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("repo root not found")
+		}
+		dir = parent
+	}
 }
 
 func hashTestAPIKey(apiKey string) string {

--- a/internal/api/engine_mapper.go
+++ b/internal/api/engine_mapper.go
@@ -44,9 +44,15 @@ func engineRunResponseToAPI(summary *engineRunSummary) EngineRunResponse {
 }
 
 func engineRunResultResponseToAPI(summary *engineRunSummary) EngineRunResultResponse {
+	result := parseOptionalJSONValueRaw(summary.Result)
+	if summary.Status == enginedb.EngineRunLifecycleStatusCancelled ||
+		summary.Status == enginedb.EngineRunLifecycleStatusTerminated {
+		result = nil
+	}
+
 	return EngineRunResultResponse{
 		Failure: engineFailureSummaryToAPI(summary.Status, summary.LastErrorCode, summary.LastErrorMessage),
-		Result:  parseOptionalJSONValueRaw(summary.Result),
+		Result:  result,
 		RunId:   summary.RunID,
 		Status:  engineRunStatusToAPI(summary.Status),
 	}
@@ -103,6 +109,55 @@ func engineControlResponseToAPI(result *engineControlResult) EngineControlRespon
 	}
 }
 
+func enginePendingWorkResponseToAPI(result *enginePendingWorkResult) EnginePendingWorkResponse {
+	response := EnginePendingWorkResponse{
+		Activities:           make([]EnginePendingActivityItem, 0, len(result.Activities)),
+		PendingActivityTasks: int64(len(result.Activities)),
+		PendingInboxItems:    int64(len(result.Timers) + len(result.Signals)),
+		RunId:                result.RunID,
+		Signals:              make([]EnginePendingSignalItem, 0, len(result.Signals)),
+		Timers:               make([]EnginePendingTimerItem, 0, len(result.Timers)),
+	}
+
+	if waitState := parseOptionalWaitState(result.CurrentWait); waitState != nil {
+		response.CurrentWait = waitState
+	}
+
+	for i := range result.Activities {
+		item := result.Activities[i]
+		response.Activities = append(response.Activities, EnginePendingActivityItem{
+			ActivityKey:  item.ActivityKey,
+			ActivityType: item.ActivityType,
+			AttemptCount: item.AttemptCount,
+			AvailableAt:  item.AvailableAt,
+			Status:       item.Status,
+			TaskId:       item.TaskID,
+		})
+	}
+
+	for i := range result.Timers {
+		item := result.Timers[i]
+		response.Timers = append(response.Timers, EnginePendingTimerItem{
+			AvailableAt: item.AvailableAt,
+			InboxId:     item.InboxID,
+			Status:      item.Status,
+			TimerKey:    item.TimerKey,
+		})
+	}
+
+	for i := range result.Signals {
+		item := result.Signals[i]
+		response.Signals = append(response.Signals, EnginePendingSignalItem{
+			AvailableAt: item.AvailableAt,
+			InboxId:     item.InboxID,
+			SignalName:  item.SignalName,
+			Status:      item.Status,
+		})
+	}
+
+	return response
+}
+
 func projectedEngineRunSummaryFromTrace(trace *store.TraceRead) *EngineRunSummary {
 	info := engineTraceInfoFromTrace(trace)
 	if info == nil {
@@ -133,7 +188,7 @@ func projectedEngineRunSummaryFromTrace(trace *store.TraceRead) *EngineRunSummar
 	switch summary.Status {
 	case EngineRunStatusCOMPLETED:
 		summary.Result = parseOptionalJSONValueRaw(trace.Output)
-	case EngineRunStatusFAILED, EngineRunStatusCANCELLED:
+	case EngineRunStatusFAILED, EngineRunStatusCANCELLED, EngineRunStatusTERMINATED:
 		summary.Failure = projectedEngineFailureSummary(trace.Status, trace.Output)
 	}
 
@@ -184,6 +239,8 @@ func projectedEngineRunStatusFromTrace(trace *store.TraceRead) EngineRunStatus {
 		return EngineRunStatusFAILED
 	case string(enginedb.EngineRunLifecycleStatusCancelled):
 		return EngineRunStatusCANCELLED
+	case string(enginedb.EngineRunLifecycleStatusTerminated):
+		return EngineRunStatusTERMINATED
 	case string(enginedb.EngineRunLifecycleStatusRunning):
 		return EngineRunStatusRUNNING
 	default:
@@ -258,7 +315,9 @@ func engineFailureSummaryToAPI(
 	errorMessage *string,
 ) *EngineFailureSummary {
 	if strings.TrimSpace(derefString(errorCode)) == "" && strings.TrimSpace(derefString(errorMessage)) == "" &&
-		status != enginedb.EngineRunLifecycleStatusFailed && status != enginedb.EngineRunLifecycleStatusCancelled {
+		status != enginedb.EngineRunLifecycleStatusFailed &&
+		status != enginedb.EngineRunLifecycleStatusCancelled &&
+		status != enginedb.EngineRunLifecycleStatusTerminated {
 		return nil
 	}
 
@@ -337,6 +396,8 @@ func engineRunStatusToAPI(status enginedb.EngineRunLifecycleStatus) EngineRunSta
 		return EngineRunStatusFAILED
 	case enginedb.EngineRunLifecycleStatusCancelled:
 		return EngineRunStatusCANCELLED
+	case enginedb.EngineRunLifecycleStatusTerminated:
+		return EngineRunStatusTERMINATED
 	case enginedb.EngineRunLifecycleStatusWaiting:
 		return EngineRunStatusWAITING
 	default:

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -82,12 +82,13 @@ const (
 
 // Defines values for EngineRunStatus.
 const (
-	EngineRunStatusCANCELLED EngineRunStatus = "CANCELLED"
-	EngineRunStatusCOMPLETED EngineRunStatus = "COMPLETED"
-	EngineRunStatusFAILED    EngineRunStatus = "FAILED"
-	EngineRunStatusQUEUED    EngineRunStatus = "QUEUED"
-	EngineRunStatusRUNNING   EngineRunStatus = "RUNNING"
-	EngineRunStatusWAITING   EngineRunStatus = "WAITING"
+	EngineRunStatusCANCELLED  EngineRunStatus = "CANCELLED"
+	EngineRunStatusCOMPLETED  EngineRunStatus = "COMPLETED"
+	EngineRunStatusFAILED     EngineRunStatus = "FAILED"
+	EngineRunStatusQUEUED     EngineRunStatus = "QUEUED"
+	EngineRunStatusRUNNING    EngineRunStatus = "RUNNING"
+	EngineRunStatusTERMINATED EngineRunStatus = "TERMINATED"
+	EngineRunStatusWAITING    EngineRunStatus = "WAITING"
 )
 
 // Defines values for IngestEventLevel.
@@ -427,10 +428,49 @@ type EngineInstanceResponse struct {
 	Status         string             `json:"status"`
 }
 
+// EnginePendingActivityItem defines model for EnginePendingActivityItem.
+type EnginePendingActivityItem struct {
+	ActivityKey  string             `json:"activity_key"`
+	ActivityType string             `json:"activity_type"`
+	AttemptCount int32              `json:"attempt_count"`
+	AvailableAt  time.Time          `json:"available_at"`
+	Status       string             `json:"status"`
+	TaskId       openapi_types.UUID `json:"task_id"`
+}
+
+// EnginePendingSignalItem defines model for EnginePendingSignalItem.
+type EnginePendingSignalItem struct {
+	AvailableAt time.Time          `json:"available_at"`
+	InboxId     openapi_types.UUID `json:"inbox_id"`
+	SignalName  string             `json:"signal_name"`
+	Status      string             `json:"status"`
+}
+
+// EnginePendingTimerItem defines model for EnginePendingTimerItem.
+type EnginePendingTimerItem struct {
+	AvailableAt time.Time          `json:"available_at"`
+	InboxId     openapi_types.UUID `json:"inbox_id"`
+	Status      string             `json:"status"`
+	TimerKey    string             `json:"timer_key"`
+}
+
 // EnginePendingWork defines model for EnginePendingWork.
 type EnginePendingWork struct {
 	PendingActivityTasks int64 `json:"pending_activity_tasks"`
 	PendingInboxItems    int64 `json:"pending_inbox_items"`
+}
+
+// EnginePendingWorkResponse defines model for EnginePendingWorkResponse.
+type EnginePendingWorkResponse struct {
+	Activities []EnginePendingActivityItem `json:"activities"`
+
+	// CurrentWait Current synthesized wait state from the run row when present.
+	CurrentWait          *EngineWaitState           `json:"current_wait"`
+	PendingActivityTasks int64                     `json:"pending_activity_tasks"`
+	PendingInboxItems    int64                     `json:"pending_inbox_items"`
+	RunId                openapi_types.UUID        `json:"run_id"`
+	Signals              []EnginePendingSignalItem `json:"signals"`
+	Timers               []EnginePendingTimerItem  `json:"timers"`
 }
 
 // EngineProjectionState defines model for EngineProjectionState.
@@ -469,7 +509,7 @@ type EngineRunResultResponse struct {
 	Failure *EngineFailureSummary `json:"failure,omitempty"`
 
 	// Result Terminal workflow result payload when available.
-	Result interface{}        `json:"result,omitempty"`
+	Result interface{}        `json:"result"`
 	RunId  openapi_types.UUID `json:"run_id"`
 	Status EngineRunStatus    `json:"status"`
 }
@@ -1088,13 +1128,13 @@ type GetTraceEventsParams struct {
 // StartEngineRunParams defines parameters for StartEngineRun.
 type StartEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
 }
 
 // CancelEngineRunParams defines parameters for CancelEngineRun.
 type CancelEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
 }
 
 // GetEngineRunHistoryParams defines parameters for GetEngineRunHistory.
@@ -1106,7 +1146,13 @@ type GetEngineRunHistoryParams struct {
 // SignalEngineRunParams defines parameters for SignalEngineRun.
 type SignalEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// TerminateEngineRunParams defines parameters for TerminateEngineRun.
+type TerminateEngineRunParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
 }
 
 // IngestParams defines parameters for Ingest.
@@ -1313,12 +1359,18 @@ type ServerInterface interface {
 	// Get engine run history
 	// (GET /v1/engine/runs/{run_id}/history)
 	GetEngineRunHistory(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params GetEngineRunHistoryParams)
+	// Get the durable pending work held by an engine run
+	// (GET /v1/engine/runs/{run_id}/pending-work)
+	GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
 	// Get the terminal result for an engine run
 	// (GET /v1/engine/runs/{run_id}/result)
 	GetEngineRunResult(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
 	// Deliver a signal to an engine run
 	// (POST /v1/engine/runs/{run_id}/signal)
 	SignalEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params SignalEngineRunParams)
+	// Forcefully terminate an engine run
+	// (POST /v1/engine/runs/{run_id}/terminate)
+	TerminateEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params TerminateEngineRunParams)
 	// Ingest traces, spans, and events
 	// (POST /v1/ingest)
 	Ingest(w http.ResponseWriter, r *http.Request, params IngestParams)
@@ -1409,6 +1461,12 @@ func (_ Unimplemented) GetEngineRunHistory(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Get the durable pending work held by an engine run
+// (GET /v1/engine/runs/{run_id}/pending-work)
+func (_ Unimplemented) GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Get the terminal result for an engine run
 // (GET /v1/engine/runs/{run_id}/result)
 func (_ Unimplemented) GetEngineRunResult(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID) {
@@ -1418,6 +1476,12 @@ func (_ Unimplemented) GetEngineRunResult(w http.ResponseWriter, r *http.Request
 // Deliver a signal to an engine run
 // (POST /v1/engine/runs/{run_id}/signal)
 func (_ Unimplemented) SignalEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params SignalEngineRunParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Forcefully terminate an engine run
+// (POST /v1/engine/runs/{run_id}/terminate)
+func (_ Unimplemented) TerminateEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params TerminateEngineRunParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1921,7 +1985,7 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -1930,14 +1994,18 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = &XContinuaEnginePreview
+		params.XContinuaEnginePreview = XContinuaEnginePreview
 
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2007,7 +2075,7 @@ func (siw *ServerInterfaceWrapper) CancelEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2016,14 +2084,18 @@ func (siw *ServerInterfaceWrapper) CancelEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = &XContinuaEnginePreview
+		params.XContinuaEnginePreview = XContinuaEnginePreview
 
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2078,6 +2150,37 @@ func (siw *ServerInterfaceWrapper) GetEngineRunHistory(w http.ResponseWriter, r 
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetEngineRunHistory(w, r, runId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetEngineRunPendingWork operation middleware
+func (siw *ServerInterfaceWrapper) GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "run_id" -------------
+	var runId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "run_id", chi.URLParam(r, "run_id"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "run_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetEngineRunPendingWork(w, r, runId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2143,7 +2246,7 @@ func (siw *ServerInterfaceWrapper) SignalEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2152,18 +2255,81 @@ func (siw *ServerInterfaceWrapper) SignalEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = &XContinuaEnginePreview
+		params.XContinuaEnginePreview = XContinuaEnginePreview
 
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.SignalEngineRun(w, r, runId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// TerminateEngineRun operation middleware
+func (siw *ServerInterfaceWrapper) TerminateEngineRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "run_id" -------------
+	var runId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "run_id", chi.URLParam(r, "run_id"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "run_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params TerminateEngineRunParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.TerminateEngineRun(w, r, runId, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2411,10 +2577,16 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/history", wrapper.GetEngineRunHistory)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/pending-work", wrapper.GetEngineRunPendingWork)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/result", wrapper.GetEngineRunResult)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/engine/runs/{run_id}/signal", wrapper.SignalEngineRun)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/runs/{run_id}/terminate", wrapper.TerminateEngineRun)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/ingest", wrapper.Ingest)

--- a/internal/api/session_compare_integration_test.go
+++ b/internal/api/session_compare_integration_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/continua-ai/continua/db/gen/go/platform"
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	publichistory "github.com/continua-ai/continua/engine/pkg/history"
 	"github.com/continua-ai/continua/internal/api/middleware"
 	"github.com/continua-ai/continua/internal/store"
 	"github.com/continua-ai/continua/internal/testutil"
@@ -274,6 +276,81 @@ func TestGetSessionCompare_EmptyComparisonReturns200(t *testing.T) {
 	assert.Equal(t, 0, resp.Summary.TotalSpansCandidate)
 	assert.Equal(t, 0, resp.Summary.TotalSemanticBaseline)
 	assert.Equal(t, 0, resp.Summary.TotalSemanticCandidate)
+}
+
+func TestGetSessionCompare_ReportsCatchingUpProjectionStateWhenHistoryCheckpointIsStale(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	sessionKey := "compare-engine-stale-" + uuid.NewString()[:8]
+	baselineStart := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "compare-baseline-" + uuid.NewString()[:8],
+		RequestKey:        "req-compare-baseline-" + uuid.NewString()[:8],
+		Session: &EngineStartSession{
+			Key: testutil.StrPtr(sessionKey),
+		},
+	}))
+	candidateStart := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "compare-candidate-" + uuid.NewString()[:8],
+		RequestKey:        "req-compare-candidate-" + uuid.NewString()[:8],
+		Session: &EngineStartSession{
+			Key: testutil.StrPtr(sessionKey),
+		},
+	}))
+
+	baselineTrace, err := platformStore.Queries().GetTraceByExternalID(ctx, platform.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   baselineStart.TraceId,
+	})
+	require.NoError(t, err)
+	candidateTrace, err := platformStore.Queries().GetTraceByExternalID(ctx, platform.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   candidateStart.TraceId,
+	})
+	require.NoError(t, err)
+	require.True(t, baselineTrace.SessionID.Valid)
+	require.Equal(t, baselineTrace.SessionID.Bytes, candidateTrace.SessionID.Bytes)
+
+	baselineRun, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        baselineStart.RunId,
+	})
+	require.NoError(t, err)
+	candidateRun, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        candidateStart.RunId,
+	})
+	require.NoError(t, err)
+
+	appendEngineHistoryEvent(t, ctx, engineQueries, projectID, baselineRun.InstanceID, baselineRun.ID, 2, publichistory.EventCustomStatusUpdated, publichistory.CustomStatusUpdatedPayload{
+		Status: []byte(`{"step":"baseline-stale"}`),
+	})
+	appendEngineHistoryEvent(t, ctx, engineQueries, projectID, candidateRun.InstanceID, candidateRun.ID, 2, publichistory.EventCustomStatusUpdated, publichistory.CustomStatusUpdatedPayload{
+		Status: []byte(`{"step":"candidate-stale"}`),
+	})
+
+	endedAt := time.Now().UTC()
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE traces
+		SET status = 'completed',
+		    end_time = $2,
+		    updated_at = NOW()
+		WHERE id IN ($1, $3)
+	`, baselineTrace.ID, endedAt, candidateTrace.ID)
+	require.NoError(t, err)
+
+	rec := invokeGetSessionCompare(t, server, projectID, baselineTrace.SessionID.Bytes, baselineTrace.ID, candidateTrace.ID)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[SessionCompareResponse](t, rec)
+	require.NotNil(t, resp.Baseline.Engine)
+	require.NotNil(t, resp.Candidate.Engine)
+	assert.Equal(t, CatchingUp, resp.Baseline.Engine.ProjectionState)
+	assert.Equal(t, CatchingUp, resp.Candidate.Engine.ProjectionState)
 }
 
 func invokeGetSessionCompare(

--- a/internal/api/sessions_handlers.go
+++ b/internal/api/sessions_handlers.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
+	"github.com/google/uuid"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/continua-ai/continua/internal/store"
@@ -153,5 +155,41 @@ func (s *Server) GetSessionCompare(w http.ResponseWriter, r *http.Request, id op
 		return
 	}
 
+	if err := s.normalizeComparisonProjectionState(r.Context(), projectID, &comparison); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to get session comparison")
+		return
+	}
+
 	writeJSON(w, http.StatusOK, sessionCompareToAPI(&comparison))
+}
+
+func (s *Server) normalizeComparisonProjectionState(
+	ctx context.Context,
+	projectID uuid.UUID,
+	comparison *store.SessionComparison,
+) error {
+	if s.engineControl == nil || comparison == nil {
+		return nil
+	}
+	if err := s.normalizeCompareTraceProjectionState(ctx, projectID, &comparison.Baseline); err != nil {
+		return err
+	}
+	return s.normalizeCompareTraceProjectionState(ctx, projectID, &comparison.Candidate)
+}
+
+func (s *Server) normalizeCompareTraceProjectionState(
+	ctx context.Context,
+	projectID uuid.UUID,
+	header *store.SessionCompareTraceHeader,
+) error {
+	if s.engineControl == nil || header == nil || header.EngineRunID == nil {
+		return nil
+	}
+
+	projectionState, err := s.engineControl.projectionStateForRun(ctx, projectID, *header.EngineRunID)
+	if err != nil {
+		return err
+	}
+	header.EngineProjectionState = &projectionState
+	return nil
 }

--- a/internal/api/traces_handlers.go
+++ b/internal/api/traces_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -58,6 +59,11 @@ func (s *Server) ListTraces(w http.ResponseWriter, r *http.Request, params ListT
 		}
 	}
 
+	if err := s.normalizeTraceProjectionStates(r.Context(), traces); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list traces")
+		return
+	}
+
 	apiTraces := make([]Trace, len(traces))
 	for i := range traces {
 		apiTraces[i] = traceToAPI(&traces[i])
@@ -83,7 +89,17 @@ func (s *Server) GetTrace(w http.ResponseWriter, r *http.Request, id openapi_typ
 	}
 
 	var engineSummary *EngineRunSummary
-	if shouldReadLiveEngineSummary(&trace) {
+	readLiveEngineSummary := shouldReadLiveEngineSummary(&trace)
+	if !readLiveEngineSummary && s.engineControl != nil {
+		needsLiveSummary, err := s.engineControl.shouldReadLiveTraceSummary(r.Context(), &trace)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to read engine summary")
+			return
+		}
+		readLiveEngineSummary = needsLiveSummary
+	}
+
+	if readLiveEngineSummary {
 		if s.engineControl == nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to read engine summary")
 			return
@@ -143,6 +159,11 @@ func (s *Server) GetTraceEvents(w http.ResponseWriter, r *http.Request, id opena
 		return
 	}
 
+	if err := s.normalizeTraceProjectionState(r.Context(), &trace); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list timeline events")
+		return
+	}
+
 	explicitEvents, err := s.store.ListSpanEventsByTrace(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list timeline events")
@@ -183,4 +204,29 @@ func (s *Server) GetTraceEvents(w http.ResponseWriter, r *http.Request, id opena
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) normalizeTraceProjectionStates(ctx context.Context, traces []store.TraceRead) error {
+	if s.engineControl == nil {
+		return nil
+	}
+	for i := range traces {
+		if err := s.normalizeTraceProjectionState(ctx, &traces[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) normalizeTraceProjectionState(ctx context.Context, trace *store.TraceRead) error {
+	if s.engineControl == nil || trace == nil || !trace.EngineRunID.Valid {
+		return nil
+	}
+
+	projectionState, err := s.engineControl.projectionStateForTrace(ctx, trace)
+	if err != nil {
+		return err
+	}
+	trace.EngineProjectionState = &projectionState
+	return nil
 }

--- a/openspec/changes/add-engine-operational-hardening-core/design.md
+++ b/openspec/changes/add-engine-operational-hardening-core/design.md
@@ -1,0 +1,154 @@
+# Design: Engine Operational Hardening Core
+
+## Context
+
+Continua's engine has two active in-flight proposals that, together, ship the Phase 11 dark-launch runtime and the Phase 12 public surface:
+
+- `add-engine-dark-launch-core` (dark launch): three worker loops, activation transaction, replay, CAS transitions, at-least-once activities, inbox consumption
+- `add-engine-public-surface` (public surface): `/v1/engine/*` REST API, trace linkage columns, projection state machine, projector loop, debugger integration
+
+Both ship cancel and lifecycle semantics that are correct for happy-path flows but under-specify how the system behaves when:
+
+- a workflow is actively waiting on an activity, timer, or pure signal at the moment it terminates
+- an operator needs to stop a run that is not cooperating with `CancellationRequested()`
+- history consumers need to distinguish "workflow cancelled itself in response to cancel" from "generic failure"
+- the platform debugger needs to reconcile its projected open waits/spans with a terminal engine state
+- `engine.instances.status` needs to reflect the latest run outcome for retention, filtering, and operator tooling
+
+This change does not restructure the happy path, but it does touch the existing `completed` and `failed` terminal commits in one specific way: every terminal activation transaction must also write the owning instance's status via the existing `UpdateInstanceStatus` query, so `engine.instances.status` stays authoritative going forward. Implementers should treat this as a required same-transaction write on the happy path, not an optional cleanup. Everything else in the `completed`/`failed` paths is unchanged.
+
+## Goals / Non-Goals
+
+### Goals
+- Introduce a forceful terminate path with unambiguous semantics
+- Give cancel an explicit cooperative contract that can reach a `CANCELLED` terminal outcome
+- Make the engine history contract durable enough that history consumers see distinct events for cancelled vs terminated outcomes
+- Ensure the debugger never shows open waits or running spans for a run that is terminal in the engine
+- Make `engine.instances.status` authoritative going forward and fix pre-existing drift in one backfill
+- Give operators a single read endpoint for the durable work a run is still holding
+
+### Non-Goals
+- activity retries / retry policy surface
+- `ActivityWithOptions(...)` or similar per-call overrides
+- retention, purge, or repair tooling
+- Python or TypeScript control SDK expansion
+- ContinueAsNew
+- suspend/resume
+- activity heartbeats
+
+## Decisions
+
+### 1. Cancel stays cooperative; terminate is the forceful path
+**Decision:** `POST /cancel` only requests cancellation and signals the workflow. The workflow decides how to react. Terminate is a separate, preview-gated endpoint that stops the run directly and idempotently.
+
+**Why:** Cancel has to remain replayable and integrated with activation. Forceful preemption during activation would break replay. Terminate lives outside activation, operates on the run row under lock, and has no replay implications.
+
+**Alternatives considered:**
+- Making cancel forceful: rejected — breaks Phase 11's observational cancellation guarantee and leaks into replay
+- Inbox-mediated terminate: rejected — terminate must work on runs that are not being activated, including `queued` runs that have no inbox consumer scheduled soon
+
+### 2. `workflow.ErrCancelled` is the explicit sentinel
+**Decision:** Treat the already-exported `workflow.ErrCancelled` in `engine/pkg/workflow` as the explicit cancelled sentinel. When workflow code returns it, replay produces `decisionCancelled` and the run becomes `CANCELLED`, not `FAILED`. Returning `nil` after cancel remains valid and produces `COMPLETED`.
+
+**Why:** Today, `cancellation_requested` can only surface as a generic failure or as normal completion. Distinguishing `CANCELLED` from `FAILED` is required for operator tooling, history readers, and the debugger, and users already reach for a sentinel pattern in Go. Replay must check `errors.Is(runErr, workflow.ErrCancelled)` before generic failure handling, otherwise replay-recorded `workflow.cancelled` will never match the re-run.
+
+**Alternatives considered:**
+- Encoding cancel via an error code string: rejected — fragile across Go/SDK boundaries and not discoverable
+- Auto-treating any error after cancel as cancelled: rejected — masks real failures and is not explicit
+
+### 3. Terminal sealing is rows-returned, not pre-read snapshot
+**Decision:** `CancelOpenActivityTasksByRun` and `DiscardOpenInboxItemsByRun` use `UPDATE ... RETURNING *` inside the terminal transaction. The transition from open to sealed is the engine's authoritative state change. The projector later re-reads those sealed rows through explicit sqlc read queries (by status) when it processes the terminal history row and performs debugger cleanup (activity-span closure + synthetic activity/timer wait-resolution events). Those synthetic events reuse the existing `wait` event model with payload `{wait_kind, phase="resolved", wait_id, resolution}`, where `resolution` is `cancelled` or `terminated`. Signal-wait cleanup is handled by clearing the existing `engine_wait_state` projection column, not by inventing a signal-wait timeline event.
+
+**Why:** Between a pre-read snapshot and sealing, an activity can complete or a timer can fire. Using the rows actually mutated avoids racing with those completion paths and avoids synthesizing "cancelled" events for work that actually finished. Today's projector does not emit `wait_kind='signal'` events (only `activity` and `timer`), so pure-signal-wait cleanup does not need its own synthetic event — clearing `engine_wait_state` is sufficient and scope-honest for operational hardening.
+
+**Alternatives considered:**
+- Pre-read snapshot alone: rejected — race with late completions, double-close possible
+- Emit synthetic `wait_kind='signal'` `phase='resolved'` events for pure signal waits: rejected — that would introduce a new signal-wait timeline model on top of lifecycle hardening
+
+### 4. Terminal debugger cleanup is projection-only
+**Decision:** Terminal sealing does not append per-primitive cancel/terminate rows to `engine.history`. The engine history stays minimal. The projector writes synthetic wait-resolution events into `public.span_events` and closes `public.spans` rows (on processing the terminal history row — see Decision 5), all anchored to the terminal history row ID with deterministic `VariantKey`s so re-projection is upsert/do-nothing.
+
+**Why:** Engine history is replay fuel, not a debugger log. Adding per-primitive terminal-stop events would expand the replay contract for no runtime benefit. The debugger is a projection consumer, so projection is the correct place for cleanup.
+
+**Alternatives considered:**
+- Per-primitive terminal-stop history rows: rejected — pollutes replay and history readers with events that have no replay meaning
+- No cleanup at all, just mark the trace terminal: rejected — open activity spans and "waiting for signal" markers stay visible forever in the debugger
+
+### 5. Projector owns terminal debugger cleanup (projector-as-writer)
+**Decision:** Terminal debugger cleanup (closing open activity spans, emitting synthetic wait-resolution events, clearing `engine_wait_state`) lives in the projector and fires when the projector processes a `workflow.cancelled` or `workflow.terminated` history row. Neither the engine-side `decisionCancelled` activation transaction nor the root-side terminate transaction writes to projection tables. The engine transactions still perform their own state mutations (append terminal history row, transition run, update instance status, seal activity_tasks and inbox via `UPDATE ... RETURNING`), but they stop at the engine schema boundary. For activity spans, cleanup uses the existing projected failure equivalent (`status='failed'`) rather than introducing a new span status.
+
+**Why:** The projector is already the single writer for projection tables. Adding a second writer (a shared helper called from two different transactions) would race with the projector's own forward progress. Concretely, if the terminal transaction commits cleanup for activity A, but the projector has not yet processed the earlier `activity.scheduled` event for A, the projector's later `projectActivityScheduled` would overwrite cleanup state with `status='running'`. Putting cleanup inside the projector sidesteps this race entirely: history is processed in order, the terminal row is the last event for the run, and after it there are no further projection writes for the run to race against. This also removes the need for a cross-binary shared helper, simplifying the import boundary.
+
+**Alternatives considered:**
+- Shared public helper called from both terminal transactions: rejected — creates a second writer to projection tables and races with projector forward progress
+- Duplicate cleanup logic root-side and engine-side: rejected — drift risk on top of the race
+- Block the terminal transaction until the projector catches up: rejected — couples operator control-plane latency to projection lag
+
+### 6. Terminal transition queries are non-CAS on `claimed_by`
+**Decision:** `TransitionRunToTerminated` guards on `status IN ('queued','running','waiting')`; `TransitionRunToCancelled` remains narrower on `status = 'running'`. Neither transition checks `claimed_by`. Zero rows after a locked read is an invariant failure, not a stale-claim condition.
+
+**Why:** Terminate and `decisionCancelled` both take the run row lock first. Once locked, `claimed_by` is whatever it is; the caller is not a workflow worker defending its claim, it's an operator or a decision that has already won. `TransitionRunToCancelled` stays `running`-only because it is only reachable from inside activation. Applying a CAS on `claimed_by` would make terminate race with the current worker, which is exactly what we need to avoid.
+
+**Alternatives considered:**
+- Keep CAS on `claimed_by`: rejected — makes terminate unreliable and injects a race against the same worker that may still be holding the row post-commit
+- Drop the status guard too: rejected — we still need to ensure we're not "terminating" a run that is already terminal
+
+### 7. Activation-vs-terminate race is resolved by row lock ordering
+**Decision:** Terminate locks the run row before transitioning. Activation also takes a row lock at the start of its transaction. Whichever commits first wins. If activation commits first, terminate reads terminal state and returns it unchanged. If terminate commits first, activation exits via its existing stale-claim path.
+
+**Why:** This is the simplest model and reuses the existing stale-claim machinery. No new coordination primitive is needed.
+
+**Alternatives considered:**
+- Cancel inbox interrupt for terminate: rejected — terminate must succeed even when activation is not running
+- Dedicated coordination channel: rejected — adds infrastructure for a race the DB can already resolve
+
+### 8. `engine.instances.status` becomes authoritative again via backfill + runtime writes
+**Decision:** A one-time backfill recomputes `engine.instances.status` from each instance's latest run. Going forward, every terminal run transition writes the matching instance status in the same transaction.
+
+**Why:** `engine.instances.status` is already part of the schema and is surfaced in operator read paths, but it currently drifts. Fixing it end-to-end requires both a snapshot fix and a durable write path.
+
+**Alternatives considered:**
+- Compute instance status on read: rejected — pushes cost to every read, and breaks filtering by instance state
+- Keep only the runtime writes: rejected — leaves pre-existing drift in place
+
+### 9. Pending-work endpoint returns exact durable rows plus current wait
+**Decision:** `GET /pending-work` returns `current_wait` from `runs.waiting_for`, plus arrays derived from `engine.activity_tasks` (statuses `queued`/`claimed`) and `engine.inbox` (split by `kind='timer'` and `kind='signal'`, statuses `pending`/`claimed`). `cancel` inbox rows are excluded. No `available_at <= NOW()` filter — future and claimed work both appear. Each item exposes only the operational identifiers and scheduling fields needed by clients: activities return `task_id`, `activity_key`, `activity_type`, `status`, `available_at`, `attempt_count`; timers return `inbox_id`, `timer_key`, `status`, `available_at`; signals return `inbox_id`, `signal_name`, `status`, `available_at`.
+
+**Why:** Operators need to see what a run is holding regardless of whether it is immediately runnable. This endpoint is diagnostic, not a work queue view. Separating `current_wait` from the durable arrays reflects the reality that a pure signal wait is in `waiting_for` with no row to point at.
+
+**Alternatives considered:**
+- Filter by `available_at <= NOW()`: rejected — hides scheduled future timers and delivered-but-unconsumed signals
+- Fold `current_wait` into one of the arrays: rejected — pure signal waits have no row and would get dropped
+
+## Risks / Trade-offs
+
+- **Risk:** Projector-as-writer cleanup lags behind the terminal transaction. **Mitigation:** this is by design — the projector catches up in its own loop, and the engine summary status for the run still becomes `terminated`/`cancelled` as soon as the projector processes the terminal history row. Debugger consumers already tolerate projection lag elsewhere (e.g., `projection_status='catching_up'`).
+- **Risk:** Backfill recomputes thousands of instance rows in one migration. **Mitigation:** the backfill is a single `UPDATE ... FROM (SELECT latest run per instance)`; size is bounded by total instance count and is not intended to run during peak traffic.
+- **Risk:** Idempotency of synthetic cleanup events regresses if `VariantKey` derivation shifts. **Mitigation:** pin `VariantKey` derivation to `terminal_reason + ":" + wait_id` and add tests that re-project the same terminal history row twice.
+- **Risk:** Ordering mistakes in `decisionCancelled` cause double-resolution. **Mitigation:** explicit test covering consumed-inbox-then-seal ordering, plus a test where an activity finishes after cancel was enqueued but before workflow returned `ErrCancelled`.
+- **Trade-off:** Keeping history minimal (projection-only terminal cleanup) means history readers that reconstruct wait timelines from history alone will not see the terminal resolution. **Rationale:** history is for replay; wait-timeline reconstruction is a debugger/projection concern.
+
+## Migration Plan
+
+1. Apply engine migration adding `terminated` to `engine.run_lifecycle_status` and `engine.instance_lifecycle_status` enums.
+2. Apply engine migration defining `TransitionRunToTerminated`, `TransitionRunToCancelled` (non-CAS guard), `CancelOpenActivityTasksByRun`, `DiscardOpenInboxItemsByRun`.
+3. Apply engine data backfill recomputing `engine.instances.status` from each instance's latest run.
+4. Apply platform migration dropping and recreating `traces_engine_run_status_check` to accept `'terminated'`.
+5. Run `make generate` to regenerate sqlc query bindings.
+6. Deploy engine runtime with updated activation (ErrCancelled + decisionCancelled ordering) and projector (terminated mapping).
+7. Deploy platform server with terminate handler, pending-work handler, updated cancel handler, and EngineRunStatus enum.
+8. Update OpenAPI, run `make generate` for TypeScript client.
+
+### Rollback
+
+- Endpoints are preview-gated and additive; disabling `ENGINE_PUBLIC_API_ENABLED` turns them all off.
+- The `terminated` enum values cannot be dropped if any row uses them, so rollback requires first re-transitioning `terminated` runs to `failed`. The down migration MUST guard this explicitly (mirror the `waiting` enum down migration pattern).
+- CHECK-constraint rollback reinstates the original constraint, which will then reject existing `'terminated'` rows — rollback must be paired with a data fix.
+
+## Open Questions
+
+None at this time. Prior tentative items are resolved:
+
+- **Where does terminal cleanup live?** Resolved (Decision 5): inside the projector as projector-as-writer. No shared cross-binary helper.
+- **Does terminate need a body field for audit?** Resolved: no for this change. Audit lives in request logs and history. Can be added later without a spec break.
+- **Does `pending-work` expose `history_id` per row?** Resolved: no. `pending-work` returns only engine durable-row identifiers and scheduling metadata (activity `task_id`/`activity_key`, timer or signal `inbox_id`, plus the per-item status and availability fields). Debugger cross-referencing to history is the debugger's job via projected spans/events, not this operational endpoint.

--- a/openspec/changes/add-engine-operational-hardening-core/proposal.md
+++ b/openspec/changes/add-engine-operational-hardening-core/proposal.md
@@ -1,0 +1,82 @@
+# Change: Add Engine Operational Hardening Core
+
+## Why
+
+The engine dark-launch runtime (Phase 11) and public engine surface (Phase 12) ship cancel, signal, and terminal-state handling that work for happy-path flows but leave operators and the debugger exposed in several narrow scenarios:
+
+- cancel is purely cooperative and has no way to distinguish "workflow chose to end cleanly" from "operator intent to cancel"
+- there is no forceful terminate path, so a stuck or misbehaving run cannot be stopped from the outside
+- when a run ends while it had open activity tasks, timer inbox rows, or a pure signal wait, the debugger can still show those waits and spans as live
+- `engine.instances.status` can stay `active` after the latest run has reached a terminal state, because the runtime does not currently rewrite it on terminal transitions
+- operators have no read endpoint to see, at a glance, the durable work a run is still holding onto
+- the public history contract has no events that explicitly represent "this run was cancelled" or "this run was terminated by an operator", so history consumers cannot tell those outcomes apart from a generic failure
+
+This change hardens the existing lifecycle and control surface for these cases without changing the Phase 11 worker-loop topology or happy-path ingest, start, and signal flows. It does tighten terminal commit behavior inside the workflow worker path so cancelled/completed/failed instance-status writes stay authoritative.
+
+## What Changes
+
+### API surface (extends `engine-public-api`)
+- Extend `EngineRunStatus` with `TERMINATED`
+- Add `POST /v1/engine/runs/{run_id}/terminate` (preview-header gated, forceful)
+- Add `GET /v1/engine/runs/{run_id}/pending-work` with exact row/status semantics and explicit per-item schemas
+- Make `POST /v1/engine/runs/{run_id}/cancel` contract explicit as cooperative
+- Define `GET /v1/engine/runs/{run_id}/result` terminal response explicitly for `CANCELLED` and `TERMINATED`
+
+### History contract (extends `engine-history-events`)
+- Add `workflow.cancelled` event type (empty payload)
+- Add `workflow.terminated` event type with payload `error_code`, `error_message`
+- Register both in decode/output paths for history readers
+
+### Runtime (extends `engine-runtime-execution`)
+- Adopt the already-exported public sentinel `workflow.ErrCancelled` as the explicit cancelled replay signal
+- Replay consults `workflow.ErrCancelled` before generic failure, producing `decisionCancelled`
+- `decisionCancelled` processes already-consumed inbox rows first, then seals the rest
+- Add forceful terminate path that is direct (not inbox-mediated), idempotent, and locks the run row first
+- Terminal transactions (engine-side `decisionCancelled` and root-side terminate) write only to engine schema — projection-table writes are owned exclusively by the projector
+- Sealing is driven by rows actually returned from `UPDATE ... RETURNING`, not only a pre-read snapshot
+- After any terminal transition, `engine.instances.status` is written to match the run's terminal state
+
+### Schema (extends `engine-schema-runtime-delta`)
+- Add engine migration: `terminated` added to `engine.run_lifecycle_status`
+- Add engine migration: `terminated` added to `engine.instance_lifecycle_status`
+- Update `TransitionRunToCancelled` to drop the `claimed_by` CAS while keeping scope narrowly guarded on `status='running'` (only `decisionCancelled` calls it, only from inside activation)
+- Add `TransitionRunToTerminated` non-CAS guarded transition (used by the operator terminate handler for `queued`/`running`/`waiting`)
+- Add `CancelOpenActivityTasksByRun :many` using `UPDATE ... RETURNING`
+- Add `DiscardOpenInboxItemsByRun :many` using `UPDATE ... RETURNING`
+- Update `CountOpenInboxByRun` to exclude `kind='cancel'` so all pending-inbox counts (run summary, pending-work, projected `engine_pending_inbox_items`) agree on the operator-visible definition
+- Add one-time data backfill that recomputes `engine.instances.status` from the latest run
+
+### Platform projection (extends `engine-trace-projection`)
+- Add platform migration that drops and recreates `traces_engine_run_status_check` so `public.traces.engine_run_status` accepts `'terminated'`
+- Define `terminated` projection mapping: raw trace status `failed`, root span status `failed`, engine summary `TERMINATED`
+- Projector performs terminal debugger cleanup when processing `workflow.cancelled` / `workflow.terminated` history rows: closes still-running activity spans, emits synthetic wait-resolution events for activity/timer rows, writes terminal trace/root-span state, and clears the existing `engine_wait_state` projection column (signal-wait visibility is cleared via `engine_wait_state` only — no new signal-wait timeline event is introduced)
+- Projector remains the single writer for projection tables — terminal transactions do not touch `public.*`
+- Synthetic terminal cleanup events are projection-only, idempotent, and anchored to the terminal history row
+
+## Impact
+
+- Affected specs:
+  - `engine-public-api` (ADDED: terminate endpoint, pending-work endpoint, terminated status, cancel contract, terminal result response)
+  - `engine-runtime-execution` (ADDED: documented ErrCancelled semantics, decisionCancelled ordering, terminate handler, shared sealing, instance status authority, terminal transactions stay inside engine schema)
+  - `engine-history-events` (ADDED: workflow.cancelled, workflow.terminated)
+  - `engine-schema-runtime-delta` (ADDED: terminated enums, narrowed `TransitionRunToCancelled`, new `TransitionRunToTerminated`, RETURNING sealing queries, `CountOpenInboxByRun` cancel-excluding fix, instance status backfill, instance status updates reuse existing query)
+  - `engine-trace-projection` (ADDED: CHECK-constraint migration, terminated mapping, projector-owned terminal debugger cleanup, wait-state clearing on terminal)
+- Affected code:
+  - `engine/db/migrations/postgres/` — new migration for `terminated` enums, backfill
+  - `engine/db/queries/runs.sql`, `activity_tasks.sql`, `inbox.sql` — new transitions and sealing queries
+  - `engine/pkg/workflow/` — existing `ErrCancelled` sentinel with documented replay contract
+  - `engine/pkg/history/` — new `workflow.cancelled` and `workflow.terminated` constants and payload structs
+  - `engine/internal/workflow/` — `decisionCancelled` ordering, `workflow.ErrCancelled` replay handling, sealing via `UPDATE ... RETURNING`
+  - `engine/internal/projector/` — terminated mapping, terminal cleanup on `workflow.cancelled`/`workflow.terminated` history rows
+  - `internal/api/engine_control.go` — terminate handler, pending-work handler, cancel handler doc, instance status write on terminal (engine-schema only, no projection writes)
+  - `contracts/openapi/openapi.yaml` — terminate route, pending-work route, status and response schema updates
+  - `db/platform/migrations/postgres/` — new migration updating `traces_engine_run_status_check`
+- No changes to happy-path ingest, non-engine traces, sessions, or the overall Phase 11 worker-loop topology
+- API surface is additive for existing engine API consumers (`TERMINATED` and new routes are additive), but pending-work/run-summary inbox counts are intentionally corrected to exclude `kind='cancel'`
+
+## Assumptions
+
+- `add-engine-dark-launch-core` and `add-engine-public-surface` represent the baseline this change extends; their requirements are not rewritten here
+- Terminal debugger cleanup is projection-only; the engine history does not gain per-primitive terminal-stop history rows
+- The Phase 11 single-primitive-wait assumption still holds
+- Activity retries, `ActivityWithOptions(...)`, retention/purge, repair, Python control SDK, ContinueAsNew, suspend/resume, and heartbeats remain out of scope for this change

--- a/openspec/changes/add-engine-operational-hardening-core/specs/engine-history-events/spec.md
+++ b/openspec/changes/add-engine-operational-hardening-core/specs/engine-history-events/spec.md
@@ -1,0 +1,113 @@
+# Capability: engine-history-events
+
+Operational hardening additions to the public engine history contract: introduces `workflow.cancelled` and `workflow.terminated` as first-class event types with distinct payloads and replay semantics, so history consumers can distinguish cancelled and terminated outcomes from generic failures.
+
+Related capabilities: [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-trace-projection](../engine-trace-projection/spec.md)
+
+## ADDED Requirements
+
+### Requirement: workflow.cancelled event type
+
+The history package MUST define `workflow.cancelled` as a canonical terminal event type with an empty payload, distinct from `workflow.failed`.
+
+#### Scenario: Event type constant is registered
+- **WHEN** the history event type registry is loaded
+- **THEN** it includes `workflow.cancelled` as a canonical event type constant
+- **THEN** the constant is exported from the public engine history package
+
+#### Scenario: Payload struct is empty
+- **WHEN** a `workflow.cancelled` event is created
+- **THEN** its payload struct has no required fields
+- **THEN** the JSON payload serializes as an empty object `{}`
+
+#### Scenario: Decode surface recognizes workflow.cancelled
+- **WHEN** a history reader decodes a row with event type `workflow.cancelled`
+- **THEN** `DecodePayload` returns the empty cancelled payload struct without error
+- **THEN** no "unknown event type" error is produced
+
+#### Scenario: workflow.cancelled is terminal
+- **WHEN** activation appends `workflow.cancelled`
+- **THEN** the run transitions to terminal status `cancelled` in the same transaction
+- **THEN** no further history rows for that run are appended by activation
+
+#### Scenario: workflow.cancelled is replay-driving
+- **WHEN** replay encounters a recorded `workflow.cancelled` row
+- **THEN** replay treats it as the terminal decision and does not re-execute workflow code past the cancellation point
+- **THEN** any trailing events after `workflow.cancelled` are treated as a replay mismatch
+
+---
+
+### Requirement: workflow.terminated event type
+
+The history package MUST define `workflow.terminated` as a canonical terminal event type with an operator-facing error payload, distinct from `workflow.failed` and `workflow.cancelled`.
+
+#### Scenario: Event type constant is registered
+- **WHEN** the history event type registry is loaded
+- **THEN** it includes `workflow.terminated` as a canonical event type constant
+- **THEN** the constant is exported from the public engine history package
+
+#### Scenario: Payload struct carries error fields
+- **WHEN** a `workflow.terminated` event is created
+- **THEN** its payload struct includes `error_code` and `error_message` fields with canonical JSON tag names
+- **THEN** the struct is exported from the public engine history package
+
+#### Scenario: Canonical payload values for operator terminate
+- **WHEN** the platform terminate handler appends `workflow.terminated`
+- **THEN** the payload has `error_code="terminated"` and `error_message="run terminated by operator"`
+
+#### Scenario: Decode surface recognizes workflow.terminated
+- **WHEN** a history reader decodes a row with event type `workflow.terminated`
+- **THEN** `DecodePayload` returns the typed terminated payload struct without error
+- **THEN** the returned struct contains the original `error_code` and `error_message` values
+
+#### Scenario: workflow.terminated is terminal
+- **WHEN** the terminate handler appends `workflow.terminated`
+- **THEN** the run transitions to terminal status `terminated` in the same transaction
+- **THEN** no further history rows for that run are appended after termination
+
+#### Scenario: workflow.terminated is not replay-driving
+- **WHEN** a terminated run exists
+- **THEN** the engine does not reactivate or replay the run
+- **THEN** `workflow.terminated` is decode-supported for history and projector consumers but never consulted by an activation transaction
+
+---
+
+### Requirement: History output includes cancelled and terminated
+
+The history reader API surfaces (engine history endpoint, projector journal reads) MUST include `workflow.cancelled` and `workflow.terminated` as fully-typed events.
+
+#### Scenario: History endpoint returns cancelled event
+- **WHEN** a history reader fetches events for a run that ended with `CANCELLED`
+- **THEN** the response contains a `workflow.cancelled` event as the terminal row
+- **THEN** the event appears after any activity, timer, signal, or cancel events that preceded it
+
+#### Scenario: History endpoint returns terminated event
+- **WHEN** a history reader fetches events for a run that ended with `TERMINATED`
+- **THEN** the response contains a `workflow.terminated` event as the terminal row
+- **THEN** the event payload carries `error_code` and `error_message`
+
+#### Scenario: Projector journal consumes both events
+- **WHEN** the projector catches up on history for a terminal run
+- **THEN** it reads `workflow.cancelled` or `workflow.terminated` via the same decode path as other events
+- **THEN** it maps them to the appropriate projected engine summary status
+
+---
+
+### Requirement: Distinction between cancelled, terminated, and failed
+
+History consumers MUST be able to differentiate `workflow.cancelled`, `workflow.terminated`, and `workflow.failed` outcomes by event type alone, without parsing error codes.
+
+#### Scenario: Generic failure remains workflow.failed
+- **WHEN** a workflow returns a non-nil error that is NOT `workflow.ErrCancelled`
+- **THEN** replay produces `workflow.failed` with the error code and message from the returned error
+- **THEN** the event type is `workflow.failed`, not `workflow.cancelled`
+
+#### Scenario: Cancelled is never encoded as workflow.failed
+- **WHEN** a workflow returns `workflow.ErrCancelled`
+- **THEN** the terminal history event type is `workflow.cancelled`
+- **THEN** no `workflow.failed` row is appended for the same run
+
+#### Scenario: Terminated is never encoded as workflow.failed
+- **WHEN** the operator terminate handler stops a run
+- **THEN** the terminal history event type is `workflow.terminated`
+- **THEN** no `workflow.failed` row is appended for the same run

--- a/openspec/changes/add-engine-operational-hardening-core/specs/engine-public-api/spec.md
+++ b/openspec/changes/add-engine-operational-hardening-core/specs/engine-public-api/spec.md
@@ -1,0 +1,200 @@
+# Capability: engine-public-api
+
+Operational hardening layer on top of the existing engine public API: introduces a forceful terminate endpoint, an exact pending-work read endpoint, an explicit cooperative cancel contract, and adds `TERMINATED` to the run status enum.
+
+Related capabilities: [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-history-events](../engine-history-events/spec.md), [engine-trace-projection](../engine-trace-projection/spec.md)
+
+## ADDED Requirements
+
+### Requirement: EngineRunStatus includes TERMINATED
+
+The `EngineRunStatus` enum returned by engine API responses MUST include `TERMINATED` as an additive terminal value.
+
+#### Scenario: Enum values
+- **WHEN** the engine API returns `EngineRunStatus` in any response
+- **THEN** the enum values are `QUEUED`, `RUNNING`, `WAITING`, `COMPLETED`, `FAILED`, `CANCELLED`, `TERMINATED`
+
+#### Scenario: Terminal status classification
+- **WHEN** API handlers check whether a run is terminal
+- **THEN** `COMPLETED`, `FAILED`, `CANCELLED`, and `TERMINATED` are all classified as terminal
+- **THEN** terminal-guarded endpoints (`cancel`, `signal`, `terminate`) uniformly reject `TERMINATED` the same way they reject other terminal statuses
+
+#### Scenario: Additive change for existing clients
+- **WHEN** an existing client receives a response that contains `TERMINATED`
+- **THEN** the change is additive; the client sees a new enum value but no existing value changes meaning
+
+---
+
+### Requirement: Terminate engine run
+
+`POST /v1/engine/runs/{run_id}/terminate` MUST forcefully stop an active run and is not inbox-mediated.
+
+#### Scenario: Terminate route registration and gating
+- **WHEN** `ENGINE_PUBLIC_API_ENABLED=true`
+- **THEN** `POST /v1/engine/runs/{run_id}/terminate` is registered
+- **WHEN** a terminate request lacks the `X-Continua-Engine-Preview: 1` header
+- **THEN** the server returns 400 with a message indicating the preview header is required
+- **WHEN** `ENGINE_PUBLIC_API_ENABLED` is not set or is `false`
+- **THEN** the route returns 404
+
+#### Scenario: Terminate authentication and project scoping
+- **WHEN** a terminate request arrives with a valid API key
+- **THEN** `project_id` is taken from the API key and all engine operations are scoped to that project
+- **WHEN** no valid API key is provided
+- **THEN** the server returns 401
+
+#### Scenario: Terminate response schema
+- **WHEN** a terminate request returns HTTP 200
+- **THEN** the response body conforms to the existing `EngineRunResultResponse` schema: `{run_id, status, result, failure}`
+- **THEN** a new schema is NOT introduced for terminate responses
+
+#### Scenario: Terminate active run
+- **WHEN** a terminate request targets a run with status `queued`, `running`, or `waiting`
+- **THEN** the handler locks the run row, appends `workflow.terminated` to history, transitions the run to `terminated`, seals open activity tasks and inbox items, and responds with the new terminal state
+- **THEN** the response body is an `EngineRunResultResponse` with `status=TERMINATED`, `result=null`, and `failure={error_code:"terminated", error_message:"run terminated by operator"}`
+
+#### Scenario: Terminate on already-terminal run (idempotent)
+- **WHEN** a terminate request targets a run whose status is already `completed`, `failed`, `cancelled`, or `terminated`
+- **THEN** no new history rows, transitions, or cleanup are produced
+- **THEN** the response returns the existing terminal `EngineRunResultResponse` with HTTP 200 (same shape as `GET /result` returns for the same run)
+
+#### Scenario: Terminate on missing or cross-project run
+- **WHEN** the `run_id` does not exist or belongs to a different project
+- **THEN** the server returns 404
+
+#### Scenario: Terminate is not inbox-mediated
+- **WHEN** a terminate request is processed
+- **THEN** no `cancel` inbox row is created and no activation is required for the transition to take effect
+
+#### Scenario: Terminate races with activation
+- **WHEN** terminate and an activation both target the same run
+- **WHEN** activation commits first
+- **THEN** terminate observes a terminal status under lock and returns it unchanged
+- **WHEN** terminate commits first
+- **THEN** the subsequent activation exits via the existing stale-claim path and does not revive the run
+
+---
+
+### Requirement: Pending-work read endpoint
+
+`GET /v1/engine/runs/{run_id}/pending-work` MUST return the run's current wait and the durable rows the run is still holding.
+
+#### Scenario: Endpoint authentication and gating
+- **WHEN** `ENGINE_PUBLIC_API_ENABLED=true`
+- **THEN** `GET /v1/engine/runs/{run_id}/pending-work` is registered
+- **THEN** the preview header is NOT required for this GET route
+- **WHEN** no valid API key is provided
+- **THEN** the server returns 401
+
+#### Scenario: Response shape
+- **WHEN** the endpoint returns a successful response
+- **THEN** the body is an `EnginePendingWorkResponse` with all of: `run_id` (uuid), `current_wait` (nullable), `activities` (array of `EnginePendingActivityItem`), `timers` (array of `EnginePendingTimerItem`), `signals` (array of `EnginePendingSignalItem`), `pending_activity_tasks` (integer), `pending_inbox_items` (integer)
+- **THEN** these seven fields are the complete response body; no additional wrapping envelope is added
+
+#### Scenario: current_wait synthesis
+- **WHEN** `runs.waiting_for` is populated
+- **THEN** `current_wait` is derived directly from `runs.waiting_for` and may overlap with a durable activity or timer row
+- **WHEN** `runs.waiting_for` is NULL
+- **THEN** `current_wait` is null
+
+#### Scenario: activities array
+- **WHEN** the endpoint reads `engine.activity_tasks` for the run
+- **THEN** the returned array includes rows with status `queued` or `claimed`
+- **THEN** there is no `available_at <= NOW()` filter; future and claimed rows both appear
+- **THEN** rows are ordered by `available_at ASC, id ASC`
+
+#### Scenario: activities item schema
+- **WHEN** an activity row appears in `activities`
+- **THEN** each item exposes `task_id`, `activity_key`, `activity_type`, `status`, `available_at`, and `attempt_count`
+- **THEN** `status` mirrors the durable activity-task row state (`queued` or `claimed`)
+- **THEN** this endpoint does NOT require `history_id`, raw `input`, or raw `output` fields for activities
+
+#### Scenario: timers array
+- **WHEN** the endpoint reads `engine.inbox` for the run
+- **THEN** the returned `timers` array includes rows with `kind = 'timer'` and status `pending` or `claimed`
+- **THEN** there is no `available_at <= NOW()` filter
+- **THEN** rows are ordered by `available_at ASC, id ASC`
+
+#### Scenario: timers item schema
+- **WHEN** a timer inbox row appears in `timers`
+- **THEN** each item exposes `inbox_id`, `timer_key`, `status`, and `available_at`
+- **THEN** `status` mirrors the durable inbox row state (`pending` or `claimed`)
+- **THEN** `timer_key` is decoded from the row payload using the existing `timer.scheduled` payload contract
+- **THEN** this endpoint does NOT require `history_id` or raw timer payload fields
+
+#### Scenario: signals array
+- **WHEN** the endpoint reads `engine.inbox` for the run
+- **THEN** the returned `signals` array includes rows with `kind = 'signal'` and status `pending` or `claimed`
+- **THEN** delivered-but-unconsumed signals appear here
+- **THEN** rows are ordered by `available_at ASC, id ASC`
+
+#### Scenario: signals item schema
+- **WHEN** a signal inbox row appears in `signals`
+- **THEN** each item exposes `inbox_id`, `signal_name`, `status`, and `available_at`
+- **THEN** `status` mirrors the durable inbox row state (`pending` or `claimed`)
+- **THEN** `signal_name` is decoded from the row payload using the existing `signal.received` payload contract
+- **THEN** this endpoint does NOT require `history_id` or raw signal payload fields
+
+#### Scenario: cancel inbox rows are excluded
+- **WHEN** the endpoint reads `engine.inbox` for the run
+- **THEN** rows with `kind = 'cancel'` are not included in any array
+
+#### Scenario: Pure signal wait with no inbox rows
+- **WHEN** a run is waiting on a signal and no matching inbox row has been delivered yet
+- **THEN** `current_wait` is populated from `runs.waiting_for`
+- **THEN** `activities`, `timers`, and `signals` arrays are empty
+- **THEN** the summary counts `pending_activity_tasks` and `pending_inbox_items` are zero
+
+#### Scenario: Summary counts match durable rows
+- **WHEN** the endpoint returns the response
+- **THEN** `pending_activity_tasks` equals the number of rows in the `activities` array
+- **THEN** `pending_inbox_items` equals the combined number of rows in the `timers` and `signals` arrays (cancel inbox rows are never counted)
+- **THEN** these counts match what existing run-summary responses return for the same run at the same moment, because `CountOpenInboxByRun` is updated in this change to also exclude `kind='cancel'` (see engine-schema-runtime-delta)
+
+#### Scenario: Run not found or cross-project
+- **WHEN** the `run_id` does not exist or belongs to a different project
+- **THEN** the server returns 404
+
+---
+
+### Requirement: Cancel contract is explicit and cooperative
+
+`POST /v1/engine/runs/{run_id}/cancel` MUST be documented and behave as purely cooperative; its success does not guarantee the run becomes `CANCELLED`.
+
+#### Scenario: Cancel request alone remains cooperative
+- **WHEN** a cancel request is accepted for an active run
+- **THEN** the handler creates a `cancel` inbox row and optionally wakes the run, and the final terminal outcome is determined by the workflow code on the next activation
+
+#### Scenario: Cancel + workflow returning nil
+- **WHEN** a workflow observes cancellation and returns `nil` (no error)
+- **THEN** the run may still end with terminal status `COMPLETED`
+- **THEN** the run is not forcibly moved to `CANCELLED`
+
+#### Scenario: Cancel + workflow returning workflow.ErrCancelled
+- **WHEN** a workflow observes cancellation and returns `workflow.ErrCancelled`
+- **THEN** the run ends with terminal status `CANCELLED`
+- **THEN** `workflow.cancelled` is appended to history as the terminal event
+
+#### Scenario: Cancel is not a terminate shortcut
+- **WHEN** a caller needs to guarantee a forceful stop
+- **THEN** the caller MUST use `POST /terminate`, not `POST /cancel`
+
+---
+
+### Requirement: Terminal result response for cancelled and terminated
+
+`GET /v1/engine/runs/{run_id}/result` MUST return explicit, documented shapes for `CANCELLED` and `TERMINATED` runs.
+
+#### Scenario: Cancelled terminal response
+- **WHEN** a run has status `CANCELLED`
+- **THEN** the endpoint returns HTTP 200
+- **THEN** the response body has `result=null` and a populated `failure` object with `error_code=cancelled` and `error_message=workflow cancelled`
+
+#### Scenario: Terminated terminal response
+- **WHEN** a run has status `TERMINATED`
+- **THEN** the endpoint returns HTTP 200
+- **THEN** the response body has `result=null` and a populated `failure` object with `error_code=terminated` and `error_message=run terminated by operator`
+
+#### Scenario: Non-terminal run response unchanged
+- **WHEN** a run is not yet terminal
+- **THEN** the endpoint returns HTTP 409 as before

--- a/openspec/changes/add-engine-operational-hardening-core/specs/engine-runtime-execution/spec.md
+++ b/openspec/changes/add-engine-operational-hardening-core/specs/engine-runtime-execution/spec.md
@@ -1,0 +1,184 @@
+# Capability: engine-runtime-execution
+
+Operational hardening of the activation transaction and control-plane handlers: documents the existing `workflow.ErrCancelled` sentinel with explicit replay semantics, imposes ordering guarantees on `decisionCancelled`, introduces a direct terminate path outside activation, defines shared terminal sealing via `UPDATE ... RETURNING`, and makes `engine.instances.status` authoritative going forward.
+
+Related capabilities: [engine-history-events](../engine-history-events/spec.md), [engine-schema-runtime-delta](../engine-schema-runtime-delta/spec.md), [engine-trace-projection](../engine-trace-projection/spec.md)
+
+## ADDED Requirements
+
+### Requirement: workflow.ErrCancelled replay contract
+
+The public engine workflow package's already-exported sentinel error `workflow.ErrCancelled` MUST be the explicit cancelled signal that replay consults.
+
+#### Scenario: Sentinel is exported
+- **WHEN** workflow authors import `engine/pkg/workflow`
+- **THEN** they see an exported `ErrCancelled` sentinel
+- **THEN** they can return it from workflow code to signal an explicit cancelled terminal outcome
+
+#### Scenario: Replay checks ErrCancelled before generic failure
+- **WHEN** a workflow definition's `Run(...)` returns a non-nil error
+- **THEN** replay uses `errors.Is(runErr, workflow.ErrCancelled)` to branch into the cancelled path before any generic failure handling
+
+#### Scenario: ErrCancelled produces decisionCancelled
+- **WHEN** replay identifies `workflow.ErrCancelled`
+- **THEN** replay produces `decisionCancelled`, not `decisionFailed`
+- **THEN** activation records a terminal `workflow.cancelled` history event (appended or matched during replay)
+
+#### Scenario: Replay mismatch after cancelled
+- **WHEN** replay has advanced past `workflow.cancelled` and recorded history contains any further events
+- **THEN** replay treats the trailing events as a replay mismatch
+
+#### Scenario: Workflow returns nil after cancel
+- **WHEN** the workflow observes cancellation via `CancellationRequested()` and returns `nil`
+- **THEN** the run completes normally with `COMPLETED` and `workflow.completed` in history
+- **THEN** cancelled is NOT inferred from the cancel request alone
+
+---
+
+### Requirement: decisionCancelled ordering and sealing
+
+When activation produces `decisionCancelled`, the commit phase MUST process consumed inbox rows before sealing remaining open work.
+
+#### Scenario: Consumed inbox is processed first
+- **WHEN** `decisionCancelled` commits
+- **THEN** every inbox row listed in `decision.ConsumedInboxIDs` is marked `processed` before any sealing query runs
+
+#### Scenario: Terminal history append
+- **WHEN** `decisionCancelled` commits
+- **THEN** `workflow.cancelled` is appended to history as the terminal event before the run transition
+
+#### Scenario: Run transition guard
+- **WHEN** `decisionCancelled` commits
+- **THEN** the transition calls `TransitionRunToCancelled` guarded on `status = 'running'` (no `claimed_by` CAS, because the activation holds the row)
+- **THEN** the transition clears `claimed_by`, `claimed_at`, `lease_expires_at`, `waiting_for`, `result`
+- **THEN** the transition sets `completed_at = NOW()`, `last_error_code='cancelled'`, `last_error_message='workflow cancelled'`
+
+#### Scenario: Sealing remaining open work
+- **WHEN** the transition succeeds
+- **THEN** the commit calls `CancelOpenActivityTasksByRun` RETURNING the rows actually cancelled
+- **THEN** the commit calls `DiscardOpenInboxItemsByRun` RETURNING the rows actually discarded
+- **THEN** inbox rows already marked `processed` earlier in the same transaction are not re-discarded
+
+#### Scenario: Terminal projection cleanup is deferred to projector
+- **WHEN** the activation transaction commits with `workflow.cancelled` and the sealed row results
+- **THEN** the activation transaction does NOT write to `public.spans`, `public.span_events`, or `public.traces`
+- **THEN** debugger cleanup is performed by the projector when it later processes the terminal history row (see engine-trace-projection)
+- **THEN** the projector is the single writer for projection tables, preserving the single-writer invariant
+
+#### Scenario: Instance status update
+- **WHEN** `decisionCancelled` commits
+- **THEN** the same transaction updates `engine.instances.status` for the run's instance to `cancelled`
+
+---
+
+### Requirement: Terminate handler semantics
+
+The platform-side terminate handler MUST stop a run forcefully, idempotently, and directly (not inbox-mediated).
+
+#### Scenario: Terminate locks the run row first
+- **WHEN** a terminate request enters the handler
+- **THEN** the handler opens a transaction and locks the target run row (`SELECT ... FOR UPDATE`) before any writes
+
+#### Scenario: Idempotency on already-terminal runs
+- **WHEN** the locked run row already has a terminal status (`completed`, `failed`, `cancelled`, `terminated`)
+- **THEN** the handler commits without appending history or sealing work and returns the current terminal state
+
+#### Scenario: Terminate active run
+- **WHEN** the locked run row has status `queued`, `running`, or `waiting`
+- **THEN** the same transaction appends `workflow.terminated` to history (payload includes `error_code=terminated`, `error_message=run terminated by operator`)
+- **THEN** the same transaction calls `TransitionRunToTerminated` guarded on `status IN ('queued','running','waiting')`
+- **THEN** the transition clears `claimed_by`, `claimed_at`, `lease_expires_at`, `waiting_for`, `result`, sets `completed_at = NOW()`, sets `last_error_code='terminated'`, `last_error_message='run terminated by operator'`
+- **THEN** the same transaction calls `CancelOpenActivityTasksByRun` RETURNING the mutated rows
+- **THEN** the same transaction calls `DiscardOpenInboxItemsByRun` RETURNING the mutated rows
+- **THEN** the same transaction updates `engine.instances.status` to `terminated`
+- **THEN** the terminate transaction does NOT write to `public.spans`, `public.span_events`, or `public.traces`
+- **THEN** debugger cleanup is performed by the projector when it later processes the `workflow.terminated` history row (see engine-trace-projection)
+
+#### Scenario: Zero rows from transition is invariant failure
+- **WHEN** `TransitionRunToTerminated` returns zero rows under an active-status lock
+- **THEN** this is treated as an invariant failure, not a stale-claim condition
+- **THEN** the handler rolls back the transaction and returns an internal error
+
+#### Scenario: Terminate does not use the cancel inbox
+- **WHEN** terminate commits
+- **THEN** no `cancel` inbox row is created for the run
+- **THEN** terminate does not depend on activation running
+
+---
+
+### Requirement: Shared terminal sealing contract
+
+Terminal sealing for any direct terminal stop (terminate, decisionCancelled) MUST be driven by the rows actually returned from `UPDATE ... RETURNING`, not only a pre-read snapshot.
+
+#### Scenario: CancelOpenActivityTasksByRun is the source of truth
+- **WHEN** open activity tasks are sealed
+- **THEN** `CancelOpenActivityTasksByRun RETURNING *` returns the exact set of rows transitioned to `cancelled`
+- **THEN** no other pre-read set is used to synthesize activity cleanup
+
+#### Scenario: DiscardOpenInboxItemsByRun is the source of truth
+- **WHEN** open inbox rows are sealed
+- **THEN** `DiscardOpenInboxItemsByRun RETURNING *` returns the exact set of inbox rows transitioned to `discarded`
+- **THEN** rows already `processed` by earlier steps in the same transaction are not included
+
+#### Scenario: Projector reconstructs wait state from prior projected inputs
+- **WHEN** the projector performs terminal cleanup
+- **THEN** it reconstructs the run's current wait state from the prior history events and projected wait markers it has already processed (activity.scheduled, timer.scheduled, signal.received, and the existing projected `engine_wait_state`)
+- **THEN** no pre-transition `waiting_for` snapshot is carried across transaction boundaries — the terminal transaction is not responsible for passing wait state to the projector
+- **THEN** pure signal waits are cleared by nulling the existing `engine_wait_state` projection column, not by emitting a synthetic `span_events` row
+
+#### Scenario: Late activity completion does not lose to terminate
+- **WHEN** an activity completes before sealing's row lock
+- **THEN** the activity row is not in status `queued` or `claimed` and is not returned by `CancelOpenActivityTasksByRun`
+- **THEN** no synthetic cancellation is emitted for that activity
+
+#### Scenario: Late activity completion loses to terminate
+- **WHEN** terminate's row lock wins and seals before the activity completion commits
+- **THEN** the activity completion path returns a stale-claim or no-op result and does not revive the run
+
+---
+
+### Requirement: Instance status authority after terminal transitions
+
+Every terminal run transition MUST write the matching value to `engine.instances.status` in the same transaction.
+
+#### Scenario: Completed run updates instance status
+- **WHEN** a run transitions to `completed`
+- **THEN** the same transaction sets the owning instance's `status` to `completed`
+
+#### Scenario: Failed run updates instance status
+- **WHEN** a run transitions to `failed`
+- **THEN** the same transaction sets the owning instance's `status` to `failed`
+
+#### Scenario: Cancelled run updates instance status
+- **WHEN** a run transitions to `cancelled`
+- **THEN** the same transaction sets the owning instance's `status` to `cancelled`
+
+#### Scenario: Terminated run updates instance status
+- **WHEN** a run transitions to `terminated`
+- **THEN** the same transaction sets the owning instance's `status` to `terminated`
+
+#### Scenario: Active instance while latest run is non-terminal
+- **WHEN** the latest run for an instance is in a non-terminal state (`queued`, `running`, `waiting`)
+- **THEN** the owning instance's status is `active`
+
+---
+
+### Requirement: Terminal transactions do not touch projection tables
+
+The engine-side `decisionCancelled` activation transaction and the root-side terminate transaction MUST NOT write to `public.spans`, `public.span_events`, `public.traces`, or other projection tables. Projection cleanup is owned by the projector alone (see engine-trace-projection).
+
+#### Scenario: decisionCancelled commit touches only engine schema
+- **WHEN** `decisionCancelled` commits
+- **THEN** all writes land in `engine.*` tables (history, runs, instances, activity_tasks, inbox)
+- **THEN** no write lands in `public.*` projection tables
+
+#### Scenario: Terminate commit touches only engine schema
+- **WHEN** the terminate handler commits
+- **THEN** all writes land in `engine.*` tables (history, runs, instances, activity_tasks, inbox)
+- **THEN** no write lands in `public.*` projection tables
+
+#### Scenario: Import boundary preserved by design
+- **WHEN** root-side code (`internal/api/engine_control.go`) implements terminate
+- **THEN** it imports only `engine/db/gen/go` generated sqlc types and public engine packages
+- **THEN** it does NOT import any `engine/internal/*` package
+- **THEN** no shared projection helper is needed because the projector owns projection writes

--- a/openspec/changes/add-engine-operational-hardening-core/specs/engine-schema-runtime-delta/spec.md
+++ b/openspec/changes/add-engine-operational-hardening-core/specs/engine-schema-runtime-delta/spec.md
@@ -1,0 +1,267 @@
+# Capability: engine-schema-runtime-delta
+
+Operational hardening additions to the engine schema: adds `terminated` to the run and instance lifecycle enums, introduces non-CAS guarded terminal transitions (`TransitionRunToTerminated` for operator terminate, a narrowed `TransitionRunToCancelled` for `decisionCancelled`), adds row-returning sealing queries, aligns `CountOpenInboxByRun` with the operator-visible definition (excludes `kind='cancel'`), and backfills `engine.instances.status` to match each instance's latest run.
+
+Related capabilities: [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-trace-projection](../engine-trace-projection/spec.md)
+
+## ADDED Requirements
+
+### Requirement: terminated enum values
+
+The engine MUST extend `engine.run_lifecycle_status` and `engine.instance_lifecycle_status` to include `terminated`.
+
+#### Scenario: run_lifecycle_status gains terminated
+- **WHEN** the up migration runs
+- **THEN** `engine.run_lifecycle_status` includes the value `terminated`
+- **THEN** existing enum values (`queued`, `running`, `waiting`, `completed`, `failed`, `cancelled`) remain unchanged
+
+#### Scenario: instance_lifecycle_status gains terminated
+- **WHEN** the up migration runs
+- **THEN** `engine.instance_lifecycle_status` includes the value `terminated`
+- **THEN** existing enum values (`active`, `completed`, `failed`, `cancelled`) remain unchanged
+
+#### Scenario: Down migration safety guard
+- **WHEN** the down migration runs and any row has `status = 'terminated'` in either enum
+- **THEN** the down migration fails with an explicit error rather than silently dropping data
+- **THEN** the error message names the table(s) that still contain `terminated` rows
+
+#### Scenario: Down migration enum replacement pattern
+- **WHEN** the down migration runs and no row uses `terminated`
+- **THEN** the old enum is renamed, a replacement enum without `terminated` is created, the column is altered with an explicit cast to the new type, and the old enum is dropped
+- **THEN** the pattern mirrors the existing `waiting` enum down migration
+
+---
+
+### Requirement: TransitionRunToTerminated query
+
+The engine MUST provide a status-guarded (non-CAS on `claimed_by`) transition query that moves a run from an active status to `terminated` and clears claim and wait fields in one update.
+
+#### Scenario: Active run transitions to terminated
+- **WHEN** `TransitionRunToTerminated` runs with a run whose `status IN ('queued','running','waiting')`
+- **THEN** the row is updated to `status = 'terminated'` and the updated row is returned
+- **THEN** `claimed_by`, `claimed_at`, `lease_expires_at`, `waiting_for`, `result` are set to NULL
+- **THEN** `completed_at = NOW()`
+- **THEN** `last_error_code = 'terminated'` and `last_error_message = 'run terminated by operator'`
+
+#### Scenario: Non-CAS on claimed_by
+- **WHEN** the query's WHERE clause is evaluated
+- **THEN** it matches on `id = $1 AND status IN ('queued','running','waiting')`
+- **THEN** it does NOT include `claimed_by` in the predicate
+
+#### Scenario: Terminal run is not re-terminated
+- **WHEN** `TransitionRunToTerminated` runs against a run whose status is already terminal
+- **THEN** zero rows are affected and zero rows are returned
+- **THEN** the caller treats zero rows under an active-status lock as an invariant failure (see engine-runtime-execution)
+
+#### Scenario: Query returns full updated row
+- **WHEN** the query matches
+- **THEN** the query returns all columns needed by the caller (including the pre-update `waiting_for` if captured upstream via SELECT ... FOR UPDATE)
+
+---
+
+### Requirement: TransitionRunToCancelled query (running-only, non-CAS)
+
+The engine MUST update `TransitionRunToCancelled` to drop the `claimed_by` CAS while keeping its scope narrowly guarded on `status = 'running'`. `decisionCancelled` is the only caller and it only fires inside activation on a claimed, running run.
+
+#### Scenario: Status-guarded transition on running only
+- **WHEN** `TransitionRunToCancelled` runs with a run whose `status = 'running'`
+- **THEN** the row is updated to `status = 'cancelled'` and the updated row is returned
+- **THEN** `claimed_by`, `claimed_at`, `lease_expires_at`, `waiting_for`, `result` are set to NULL
+- **THEN** `completed_at = NOW()`
+- **THEN** `last_error_code = 'cancelled'` and `last_error_message = 'workflow cancelled'`
+
+#### Scenario: No CAS on claimed_by
+- **WHEN** the query's WHERE clause is evaluated
+- **THEN** it matches on `id = $1 AND status = 'running'`
+- **THEN** it does NOT include `claimed_by` in the predicate
+- **THEN** the activation transaction (which already validated ownership at load time and holds the row in-transaction) can commit the transition without re-asserting claim identity
+
+#### Scenario: No widening for operator terminate
+- **WHEN** operator terminate stops a non-running active run (`queued` or `waiting`)
+- **THEN** the terminate path uses `TransitionRunToTerminated`, NOT `TransitionRunToCancelled`
+- **THEN** `TransitionRunToCancelled` is never broadened to accept `queued` or `waiting`
+
+#### Scenario: Zero rows under active-status lock is invariant failure
+- **WHEN** `TransitionRunToCancelled` is called inside an activation that has already verified `status = 'running'` under lock
+- **THEN** zero rows is treated as an invariant failure by the caller
+- **THEN** the caller rolls back and returns an internal error (see engine-runtime-execution)
+
+---
+
+### Requirement: CancelOpenActivityTasksByRun query
+
+The engine MUST provide a `UPDATE ... RETURNING *` query that transitions every open activity task for a given run to `cancelled` and returns the exact set of rows mutated.
+
+#### Scenario: Sealing open activity tasks
+- **WHEN** `CancelOpenActivityTasksByRun` runs with a `run_id`
+- **THEN** activity rows with `status IN ('queued','claimed')` for that run transition to `status = 'cancelled'`
+- **THEN** `completed_at = NOW()` is set on each mutated row
+- **THEN** the query returns every mutated row via `RETURNING *`
+
+#### Scenario: Late completion is not re-cancelled
+- **WHEN** an activity row has already transitioned to `completed` or `failed` before the query runs
+- **THEN** that row is not matched by the WHERE clause
+- **THEN** that row is not included in the returned set
+
+#### Scenario: Rows returned are the source of truth
+- **WHEN** the caller uses the returned rows to drive debugger cleanup
+- **THEN** the rows exactly represent the activity tasks that this transaction just cancelled
+- **THEN** no additional pre-read set is needed to know what was cancelled
+
+#### Scenario: sqlc annotation
+- **WHEN** the query is declared in the engine query files
+- **THEN** it is annotated `:many` so sqlc generates a slice return
+- **THEN** the return type carries the full row (matching the `activity_tasks` table shape)
+
+---
+
+### Requirement: DiscardOpenInboxItemsByRun query
+
+The engine MUST provide a `UPDATE ... RETURNING *` query that transitions every open inbox row for a given run to `discarded` and returns the exact set of rows mutated.
+
+#### Scenario: Sealing open inbox rows
+- **WHEN** `DiscardOpenInboxItemsByRun` runs with a `run_id`
+- **THEN** inbox rows with `status IN ('pending','claimed')` for that run transition to `status = 'discarded'`
+- **THEN** `resolved_at = NOW()` is set on each mutated row
+- **THEN** the query returns every mutated row via `RETURNING *`
+
+#### Scenario: Already-processed rows are not re-discarded
+- **WHEN** an inbox row has status `processed` before the query runs (e.g., consumed earlier in the same transaction)
+- **THEN** that row is not matched by the WHERE clause
+- **THEN** that row is not included in the returned set
+
+#### Scenario: Returned rows include kind
+- **WHEN** the caller uses the returned rows to drive debugger cleanup
+- **THEN** the returned rows carry `kind` (`timer`, `signal`, `cancel`) so the caller can route cleanup by primitive
+- **THEN** the rows exactly represent the inbox rows that this transaction just discarded
+
+#### Scenario: sqlc annotation
+- **WHEN** the query is declared in the engine query files
+- **THEN** it is annotated `:many` so sqlc generates a slice return
+- **THEN** the return type carries the full row (matching the `inbox` table shape)
+
+---
+
+### Requirement: Ordered read query for pending-work activity rows
+
+The engine MUST provide a read query for the pending-work endpoint that returns only open activity-task rows for a run in deterministic scheduling order.
+
+#### Scenario: Open activity-task rows for pending-work
+- **WHEN** the pending-work activity query runs with a `run_id`
+- **THEN** it returns rows from `engine.activity_tasks` with `run_id = $1` and `status IN ('queued','claimed')`
+- **THEN** it does NOT apply `available_at <= NOW()`
+- **THEN** rows are ordered by `available_at ASC, id ASC`
+
+#### Scenario: Query returns full row for API mapping
+- **WHEN** the caller maps activity items for `GET /pending-work`
+- **THEN** the query returns the full task row so `task_id`, `activity_key`, `activity_type`, `status`, `available_at`, and `attempt_count` can be derived without handwritten SQL
+
+---
+
+### Requirement: Ordered read query for pending-work inbox rows by kind
+
+The engine MUST provide a read query for the pending-work endpoint that returns only open inbox rows for a run and a specific kind in deterministic scheduling order.
+
+#### Scenario: Open timer or signal inbox rows for pending-work
+- **WHEN** the pending-work inbox query runs with `run_id` and `kind`
+- **THEN** it returns rows from `engine.inbox` with `run_id = $1`, `kind = $2`, and `status IN ('pending','claimed')`
+- **THEN** it does NOT apply `available_at <= NOW()`
+- **THEN** rows are ordered by `available_at ASC, id ASC`
+
+#### Scenario: Used only for timer and signal arrays
+- **WHEN** the pending-work endpoint calls the query
+- **THEN** it uses `kind='timer'` for the `timers` array and `kind='signal'` for the `signals` array
+- **THEN** `kind='cancel'` is never used for an operator-visible array
+
+---
+
+### Requirement: Ordered read queries for projector terminal cleanup inputs
+
+The engine MUST provide read queries that let the projector re-read sealed engine rows for terminal cleanup without handwritten SQL.
+
+#### Scenario: Cancelled activity-task rows for projector cleanup
+- **WHEN** the projector needs activity cleanup inputs for a terminal run
+- **THEN** it uses a query that returns `engine.activity_tasks` rows with `run_id = $1` and `status = 'cancelled'`
+- **THEN** rows are ordered by `available_at ASC, id ASC`
+
+#### Scenario: Discarded timer inbox rows for projector cleanup
+- **WHEN** the projector needs timer cleanup inputs for a terminal run
+- **THEN** it uses a query that returns `engine.inbox` rows with `run_id = $1`, `status = 'discarded'`, and `kind = 'timer'`
+- **THEN** rows are ordered by `available_at ASC, id ASC`
+
+---
+
+### Requirement: Instance status backfill migration
+
+The engine MUST ship a one-time data backfill that recomputes `engine.instances.status` from each instance's latest run.
+
+#### Scenario: Backfill computes from latest run
+- **WHEN** the data backfill migration runs
+- **THEN** for each instance, it reads the latest run (by `created_at DESC, id DESC`)
+- **THEN** if the latest run is in a terminal state, `engine.instances.status` is set to match (`completed`, `failed`, `cancelled`, `terminated`)
+- **THEN** if the latest run is non-terminal (`queued`, `running`, `waiting`), `engine.instances.status` is set to `active`
+
+#### Scenario: Backfill is a single UPDATE ... FROM
+- **WHEN** the backfill runs
+- **THEN** it executes as a single `UPDATE engine.instances SET status = ... FROM (SELECT latest run per instance)` statement
+- **THEN** it does not iterate per-instance in application code
+
+#### Scenario: Backfill is idempotent
+- **WHEN** the backfill is re-applied
+- **THEN** rows already at the correct status are not changed in meaning
+- **THEN** the backfill can safely run again without error
+
+#### Scenario: Backfill does not touch instances with no runs
+- **WHEN** an instance has zero associated run rows
+- **THEN** the backfill leaves its status unchanged
+
+---
+
+### Requirement: Runtime instance status updates reuse existing query
+
+Terminal transitions MUST call the existing `UpdateInstanceStatus(id, status)` query (`engine/db/queries/instances.sql`) inside the same transaction as the run transition. No new instance-status writer is introduced.
+
+#### Scenario: Existing query is the writer
+- **WHEN** a terminal run transition needs to update the owning instance
+- **THEN** the caller invokes the existing `UpdateInstanceStatus` query with `(instance_id, status)`
+- **THEN** no new query shape (run-keyed or otherwise) is added for this purpose
+
+#### Scenario: Instance ID is already available
+- **WHEN** the runtime reaches a terminal transition
+- **THEN** the caller already holds the `instance_id` from the locked run/instance read earlier in the same transaction
+- **THEN** the caller passes that `instance_id` to `UpdateInstanceStatus` directly
+
+#### Scenario: Called inside the terminal transaction
+- **WHEN** any terminal run transition commits (`completed`, `failed`, `cancelled`, `terminated`)
+- **THEN** the `UpdateInstanceStatus` call runs in the same transaction as the run transition
+- **THEN** a failure here fails the entire terminal transition
+
+#### Scenario: Accepts terminated value
+- **WHEN** the caller passes `status='terminated'` to `UpdateInstanceStatus`
+- **THEN** the query succeeds because `engine.instance_lifecycle_status` now includes `terminated` (see "terminated enum values")
+
+---
+
+### Requirement: CountOpenInboxByRun excludes cancel inbox rows
+
+The engine `CountOpenInboxByRun` query MUST exclude rows with `kind = 'cancel'` so the reported count reflects only operator-visible pending work (timer and signal rows), matching the semantic used by the `pending-work` endpoint and by projected `engine_pending_inbox_items` counts.
+
+#### Scenario: Query filter excludes cancel kind
+- **WHEN** `CountOpenInboxByRun` runs for a run
+- **THEN** the WHERE clause is `run_id = $1 AND status IN ('pending','claimed') AND kind <> 'cancel'`
+- **THEN** cancel inbox rows are not counted
+
+#### Scenario: Consistent count across read paths
+- **WHEN** the same run is read via the engine run-summary endpoint (which uses `CountOpenInboxByRun`), via the pending-work endpoint, and via the projected `engine_pending_inbox_items` column
+- **THEN** all three surfaces return the same number of pending inbox items
+- **THEN** cancel inbox rows never contribute to that count in any surface
+
+#### Scenario: Rationale — cancel is engine-internal control
+- **WHEN** an operator or history consumer reads pending work
+- **THEN** cancel inbox rows are not exposed, because they are an internal control primitive used by `POST /cancel` to wake the run, not a user-observable pending wait
+- **THEN** this matches the existing semantic that the projector does not emit `wait_kind='cancel'` events
+
+#### Scenario: Existing callers see the updated semantic
+- **WHEN** any caller of `CountOpenInboxByRun` runs against a database with cancel rows
+- **THEN** the returned count drops by the number of cancel rows for that run compared to the pre-change behavior
+- **THEN** existing callers (e.g., `GetRunResult` summary) inherit the corrected semantic without a new query being introduced

--- a/openspec/changes/add-engine-operational-hardening-core/specs/engine-trace-projection/spec.md
+++ b/openspec/changes/add-engine-operational-hardening-core/specs/engine-trace-projection/spec.md
@@ -1,0 +1,162 @@
+# Capability: engine-trace-projection
+
+Operational hardening additions to the engine trace projection: extends the `public.traces.engine_run_status` CHECK constraint to accept `terminated`, defines the projection mapping for terminated runs, and specifies that the projector itself performs terminal debugger cleanup (closing open activity spans, emitting synthetic wait-resolution events, clearing `engine_wait_state`) when it processes `workflow.cancelled`/`workflow.terminated` history rows, so the debugger never shows a terminal run as still waiting.
+
+Related capabilities: [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-history-events](../engine-history-events/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Platform CHECK-constraint migration accepts terminated
+
+The platform database MUST ship a migration that drops and recreates `traces_engine_run_status_check` so `public.traces.engine_run_status` accepts the value `'terminated'`.
+
+#### Scenario: Up migration replaces the CHECK constraint
+- **WHEN** the up migration runs
+- **THEN** `traces_engine_run_status_check` is dropped and recreated
+- **THEN** the recreated constraint accepts the values `('queued','running','waiting','completed','failed','cancelled','terminated')`
+- **THEN** rows already in the table are not altered
+
+#### Scenario: Down migration requires data fix
+- **WHEN** the down migration runs while any row has `engine_run_status = 'terminated'`
+- **THEN** the down migration fails with an explicit error naming the offending rows
+- **THEN** rollback must first re-transition those rows away from `terminated`
+
+#### Scenario: Down migration restores original constraint
+- **WHEN** the down migration runs and no row has `engine_run_status = 'terminated'`
+- **THEN** the CHECK constraint is recreated with the original value set (no `terminated`)
+
+---
+
+### Requirement: Terminated projection mapping
+
+The projector MUST map the engine's `terminated` run status to a clear projected triple.
+
+#### Scenario: Raw trace status mapping
+- **WHEN** the projector projects a terminal `terminated` run
+- **THEN** the raw `public.traces.status` is set to `failed`
+- **THEN** this uses an existing allowed value so no additional trace status enum migration is required
+
+#### Scenario: Root span status mapping
+- **WHEN** the projector closes the root span for a `terminated` run
+- **THEN** the root span `status` is set to `failed`
+
+#### Scenario: Engine summary status mapping
+- **WHEN** the projector writes the projected engine summary for a `terminated` run
+- **THEN** `public.traces.engine_run_status` is set to `terminated`
+- **THEN** read endpoints returning `EngineRunStatus` return `TERMINATED` for that trace
+
+#### Scenario: Failure details on terminated
+- **WHEN** the projector writes the projected engine summary for a `terminated` run
+- **THEN** the summary includes `error_code = 'terminated'` and `error_message = 'run terminated by operator'`
+
+---
+
+### Requirement: Projector performs terminal cleanup on terminal history rows
+
+The projector MUST perform debugger cleanup (close open activity spans, emit synthetic wait-resolution events, clear `engine_wait_state`) as part of processing `workflow.cancelled` and `workflow.terminated` history rows. Terminal cleanup is NOT performed inside the engine-side activation transaction or the operator terminate transaction.
+
+#### Scenario: Projector is the single writer for terminal cleanup
+- **WHEN** the projector processes a `workflow.cancelled` or `workflow.terminated` history row
+- **THEN** the projector performs all debugger cleanup writes to `public.spans`, `public.span_events`, and `public.traces`
+- **THEN** no other code path writes terminal cleanup to projection tables
+- **THEN** this preserves the single-writer invariant for projection tables and avoids any race between the terminal transaction and concurrent projection progress
+
+#### Scenario: Cleanup inputs are read from engine state
+- **WHEN** the projector performs terminal cleanup
+- **THEN** the activity-task rows to close are loaded through the explicit cancelled-activity read query (`run_id = ? AND status = 'cancelled'`)
+- **THEN** the inbox rows whose waits should be resolved are loaded through the explicit discarded-timer read query (`run_id = ? AND status = 'discarded' AND kind = 'timer'`)
+- **THEN** the current wait state is reconstructed from prior projected state: activity/timer waits come from earlier projected history handling, and pure signal waits come from the existing projected `engine_wait_state` column rather than a dedicated signal-wait history event
+- **THEN** no pre-transition `waiting_for` snapshot is carried across the terminal transaction
+
+#### Scenario: Close still-running activity spans
+- **WHEN** the projector processes terminal cleanup and finds cancelled activity-task rows
+- **THEN** for each projected activity span that is still open, it sets the span `status` to `failed` and sets `end_time` derived from the terminal history row timestamp
+- **THEN** `status_message` is set to the terminal reason message (`workflow cancelled` or `run terminated by operator`)
+- **THEN** if an activity span is already closed (already `completed` or `failed`), it is not re-closed
+
+#### Scenario: Synthetic wait-resolution for activity waits
+- **WHEN** the projector processes cancelled activity-task rows during terminal cleanup
+- **THEN** for each cancelled activity, it emits a synthetic `EventType="wait"` event into `public.span_events` anchored to the terminal history row
+- **THEN** the payload uses the existing wait shape `{wait_kind:"activity", phase:"resolved", wait_id:"activity:<activity_key>", resolution:<terminal_reason>}`
+- **THEN** `<terminal_reason>` is `cancelled` for `workflow.cancelled` and `terminated` for `workflow.terminated`
+
+#### Scenario: Synthetic wait-resolution for timer waits
+- **WHEN** the projector processes discarded inbox rows with `kind = 'timer'` during terminal cleanup
+- **THEN** for each timer row, it emits a synthetic `EventType="wait"` event into `public.span_events` anchored to the terminal history row
+- **THEN** the payload uses the existing wait shape `{wait_kind:"timer", phase:"resolved", wait_id:"timer:<timer_key>", resolution:<terminal_reason>}`
+- **THEN** `<terminal_reason>` is `cancelled` for `workflow.cancelled` and `terminated` for `workflow.terminated`
+
+#### Scenario: Signal waits are cleared via engine_wait_state only
+- **WHEN** the projector finds from its reconstructed state that the run was on a signal wait at terminal
+- **THEN** the projector does NOT emit a synthetic `wait_kind='signal'` `phase='resolved'` event into `public.span_events`
+- **THEN** signal-wait visibility is cleared by nulling the existing `engine_wait_state` column on the projected trace (see "Engine summary wait state is cleared on terminal")
+- **THEN** the projector does not invent a new signal-wait timeline model as part of terminal hardening
+
+#### Scenario: Cancel inbox rows do not emit wait-resolution
+- **WHEN** the projector processes discarded inbox rows with `kind = 'cancel'` during terminal cleanup
+- **THEN** no synthetic wait-resolution event is emitted for those rows
+- **THEN** cancel inbox rows are not treated as a user-observable wait
+
+#### Scenario: Idempotency via VariantKey
+- **WHEN** the projector emits a synthetic event during terminal cleanup
+- **THEN** the event's `VariantKey` is derived deterministically from `terminal_reason + ":" + wait_id`
+- **THEN** re-projecting the same terminal history row produces no new rows (upsert/do-nothing)
+
+#### Scenario: Anchored to terminal history row
+- **WHEN** the projector writes synthetic events or closes spans during terminal cleanup
+- **THEN** every write is tagged with the terminal history row ID for traceability
+- **THEN** terminal cleanup can be reconstructed from the terminal history row alone
+
+#### Scenario: Synthetic cleanup sequence offsets use the terminal row base
+- **WHEN** the projector emits synthetic cleanup events for a terminal history row with sequence number `N`
+- **THEN** the terminal history row keeps its normal projected base sequence `N*10`
+- **THEN** synthetic cleanup wait events use monotonically increasing sequence offsets starting at `N*10 + 1`
+- **THEN** activity cleanup events are assigned first in query order, followed by timer cleanup events in query order
+- **THEN** because the terminal history row is the last row for the run, these offsets do not collide with later projected history events
+
+#### Scenario: No race with earlier scheduling events
+- **WHEN** the projector processes history in order for a run
+- **THEN** all `activity.scheduled` / `timer.scheduled` / `signal.received` events relevant to the run's current projected wait state are processed before the terminal history row
+- **THEN** terminal cleanup writes are the last projection writes for the run
+- **THEN** no later projection write for the run can overwrite cleanup state, because the run is terminal and no further history rows will be appended
+
+---
+
+### Requirement: Engine summary wait state is cleared on terminal
+
+The existing projected engine summary column `engine_wait_state` (Go type `EngineWaitState`) MUST be cleared when a run reaches any terminal status.
+
+#### Scenario: engine_wait_state is cleared on terminal
+- **WHEN** a run transitions to `completed`, `failed`, `cancelled`, or `terminated`
+- **THEN** the projector writes NULL to `public.traces.engine_wait_state` for the run's projected trace
+- **THEN** no new projection column is introduced; this uses the existing `engine_wait_state` storage and `EngineWaitState` mapper
+
+#### Scenario: engine_pending_activity_tasks count on terminal
+- **WHEN** the projector syncs the summary after terminal sealing
+- **THEN** `engine_pending_activity_tasks` reflects the actual open activity rows (zero after sealing)
+- **THEN** terminated runs do not display lingering open activities
+
+#### Scenario: engine_pending_inbox_items count on terminal
+- **WHEN** the projector syncs the summary after terminal sealing
+- **THEN** `engine_pending_inbox_items` reflects the actual open inbox rows (zero after sealing, excluding `cancel` rows per existing semantics)
+
+---
+
+### Requirement: Synthetic cleanup events are projection-only
+
+Synthetic terminal cleanup events MUST live in the projection layer and never be mirrored back into `engine.history`.
+
+#### Scenario: No engine.history rows are appended
+- **WHEN** the projector emits synthetic wait-resolution events during terminal cleanup
+- **THEN** no new rows are appended to `engine.history` for those events
+- **THEN** only the terminal history row (`workflow.cancelled` or `workflow.terminated`) remains in engine history
+
+#### Scenario: Synthetic events go only to public.span_events
+- **WHEN** the projector emits synthetic events during terminal cleanup
+- **THEN** the rows are written to `public.span_events` with a recognizable kind/tag for debugger consumers
+- **THEN** no other projection table receives duplicate rows for the same synthetic event
+
+#### Scenario: Replay is unaffected
+- **WHEN** a run with synthetic cleanup events is read for replay
+- **THEN** replay consumes only `engine.history`
+- **THEN** synthetic cleanup events do not alter replay's event sequence or decisions

--- a/openspec/changes/add-engine-operational-hardening-core/tasks.md
+++ b/openspec/changes/add-engine-operational-hardening-core/tasks.md
@@ -1,0 +1,199 @@
+## 1. Engine Schema Migrations
+
+- [x] 1.1 Create `engine/db/migrations/postgres/NNNN_terminated_lifecycle.up.sql` with: `ALTER TYPE engine.run_lifecycle_status ADD VALUE 'terminated'`, `ALTER TYPE engine.instance_lifecycle_status ADD VALUE 'terminated'`
+- [x] 1.2 Create matching down migration that fails explicitly if any row uses `terminated`, otherwise renames the old enums, creates replacements without `terminated`, alters the columns with explicit casts, and drops the old enums (mirror the `waiting` down migration pattern)
+- [x] 1.3 Create `engine/db/migrations/postgres/NNNN_backfill_instance_status.up.sql` with a single `UPDATE engine.instances SET status = ... FROM (SELECT latest run per instance)` statement that sets each instance's status to its latest run's terminal status or `active` for non-terminal latest runs
+- [x] 1.4 Create matching down migration that is a safe no-op (the backfill is idempotent and advisory)
+
+**Validation:** Migrations up/down round-trip on a database with and without `terminated` rows
+
+## 2. Engine Query Additions
+
+- [x] 2.1 Update `TransitionRunToCancelled` in `engine/db/queries/runs.sql` to drop the `claimed_by` CAS while keeping status scoped to `running` only: `WHERE id = $1 AND status = 'running'`, clearing `claimed_by`, `claimed_at`, `lease_expires_at`, `waiting_for`, `result`, setting `completed_at = NOW()`, `last_error_code='cancelled'`, `last_error_message='workflow cancelled'`, with `RETURNING *` (this query is called only from `decisionCancelled` inside activation, which already holds the row lock)
+- [x] 2.2 Add `TransitionRunToTerminated` in `engine/db/queries/runs.sql` with the same non-CAS status guard, setting `status='terminated'`, `last_error_code='terminated'`, `last_error_message='run terminated by operator'`, with `RETURNING *`
+- [x] 2.3 Verify the existing `UpdateInstanceStatus` query in `engine/db/queries/instances.sql` accepts the new `terminated` enum value (no query changes needed beyond the enum migration in Task 1.1); callers will reuse this query with `(instance_id, status)` from the already-held instance ID
+- [x] 2.4 Add `CancelOpenActivityTasksByRun :many` in `engine/db/queries/activity_tasks.sql`: `UPDATE engine.activity_tasks SET status='cancelled', completed_at=NOW() WHERE run_id=$1 AND status IN ('queued','claimed') RETURNING *`
+- [x] 2.5 Add `DiscardOpenInboxItemsByRun :many` in `engine/db/queries/inbox.sql`: `UPDATE engine.inbox SET status='discarded', resolved_at=NOW() WHERE run_id=$1 AND status IN ('pending','claimed') RETURNING *`
+- [x] 2.6 Update `CountOpenInboxByRun` in `engine/db/queries/inbox.sql` to exclude cancel inbox rows: add `AND kind <> 'cancel'` to the WHERE clause so the count reflects only operator-visible pending work (timers + signals) and matches the semantic used by `pending-work` and by projected `engine_pending_inbox_items`
+- [x] 2.7 Add `ListOpenActivityTasksByRun :many` in `engine/db/queries/activity_tasks.sql`: `SELECT * FROM engine.activity_tasks WHERE run_id=$1 AND status IN ('queued','claimed') ORDER BY available_at ASC, id ASC`
+- [x] 2.8 Add `ListOpenInboxItemsByRunAndKind :many` in `engine/db/queries/inbox.sql`: `SELECT * FROM engine.inbox WHERE run_id=$1 AND kind=$2 AND status IN ('pending','claimed') ORDER BY available_at ASC, id ASC`
+- [x] 2.9 Add `ListCancelledActivityTasksByRun :many` in `engine/db/queries/activity_tasks.sql`: `SELECT * FROM engine.activity_tasks WHERE run_id=$1 AND status='cancelled' ORDER BY available_at ASC, id ASC`
+- [x] 2.10 Add `ListDiscardedTimerInboxItemsByRun :many` in `engine/db/queries/inbox.sql`: `SELECT * FROM engine.inbox WHERE run_id=$1 AND kind='timer' AND status='discarded' ORDER BY available_at ASC, id ASC`
+- [x] 2.11 Run `make generate` and verify new queries produce correct Go signatures in `engine/db/gen/go`
+
+**Validation:** `make generate` succeeds; generated `:many` queries return ordered row slices with all columns needed by handlers/projector
+
+## 3. Store Layer Updates
+
+- [x] 3.1 Update the store wrapper for `TransitionRunToCancelled` to treat zero rows under an active-status lock as an invariant failure (not `ErrStaleClaim`), returning an explicit internal error
+- [x] 3.2 Add store wrapper for `TransitionRunToTerminated` with the same invariant-failure semantics
+- [x] 3.3 Confirm the existing `UpdateInstanceStatus` store wrapper handles the new `terminated` value (no new wrapper needed)
+- [x] 3.4 Add store wrappers for `CancelOpenActivityTasksByRun` and `DiscardOpenInboxItemsByRun` that return the slices of returned rows directly
+- [x] 3.5 Add store wrappers for `ListOpenActivityTasksByRun`, `ListOpenInboxItemsByRunAndKind`, `ListCancelledActivityTasksByRun`, and `ListDiscardedTimerInboxItemsByRun`, preserving DB order for handler/projector consumers
+- [x] 3.6 Review all callers of the old `TransitionRunToCancelled` CAS behaviour and update call sites to the new signature
+- [x] 3.7 Grep callers of `CountOpenInboxByRun` (at minimum: `GetRunResult` in `internal/api/engine_control.go`) and confirm each caller's expected semantic is "operator-visible pending work" — document in a code comment on any caller that was previously relying on cancel rows being included
+
+**Validation:** Store package compiles; wrappers match new query signatures; callers/projector compile with the new behavior; `CountOpenInboxByRun` callers are audited
+
+## 4. History Event Package
+
+- [x] 4.1 Add `EventWorkflowCancelled = "workflow.cancelled"` and `EventWorkflowTerminated = "workflow.terminated"` constants to `engine/pkg/history/history.go`
+- [x] 4.2 Add `WorkflowCancelledPayload struct{}` and `WorkflowTerminatedPayload struct { ErrorCode string; ErrorMessage string }` with canonical JSON tags (`error_code`, `error_message`)
+- [x] 4.3 Register both event types in `payloadTarget` (decode switch) so `DecodePayload` returns the typed structs
+- [x] 4.4 Add a round-trip test covering marshal/unmarshal of both payload types
+
+**Validation:** Package compiles; decode returns typed payload for both event types; terminated payload preserves error fields
+
+## 5. Public Workflow Sentinel Documentation
+
+- [x] 5.1 Add a Go doc comment on the already-exported `workflow.ErrCancelled` in `engine/pkg/workflow/context.go` stating: returning it produces terminal `CANCELLED` with a `workflow.cancelled` history row; returning `nil` after observing cancellation produces `COMPLETED`; it participates in replay via `errors.Is`
+
+**Validation:** `go doc engine/pkg/workflow ErrCancelled` shows the new comment
+
+## 6. Terminal Cleanup Lives in the Projector
+
+This change deliberately does NOT introduce a shared cross-binary helper. Terminal debugger cleanup is owned by the projector (projector-as-writer) and fires when the projector processes a `workflow.cancelled` or `workflow.terminated` history row. Implementation tasks live in Section 8 (Engine Projector Updates). This placeholder section exists only to make that architectural choice visible in the task list.
+
+- [x] 6.1 (Doc-only) Record in `engine/internal/projector/` package doc that terminal debugger cleanup (closing activity spans, emitting synthetic wait-resolution events, clearing `engine_wait_state`) fires when the projector processes `workflow.cancelled` / `workflow.terminated` history rows, and that no other code path writes projection tables for terminal cleanup
+
+**Validation:** Package doc is added; grep confirms no cross-binary helper is created
+
+## 7. Engine-Side Runtime Updates
+
+- [x] 7.1 In `engine/internal/workflow/replay.go`, reorder error handling so `errors.Is(runErr, publicworkflow.ErrCancelled)` is checked BEFORE generic failure and produces `decisionCancelled`
+- [x] 7.2 Make `decisionCancelled` append `workflow.cancelled` to history (with empty payload) instead of any `workflow.failed` encoding
+- [x] 7.3 In `engine/internal/workflow/activation.go`, restructure the `decisionCancelled` commit ordering: mark consumed inbox rows `processed` first, append `workflow.cancelled`, call `TransitionRunToCancelled`, then call `CancelOpenActivityTasksByRun` and `DiscardOpenInboxItemsByRun` to seal remaining open work
+- [x] 7.4 Ensure the activation transaction writes ONLY to `engine.*` schema (history, runs, instances, activity_tasks, inbox) — no writes to `public.*` projection tables occur from activation, even on terminal
+- [x] 7.5 Update the instance status in the same activation transaction to `cancelled` via the existing `UpdateInstanceStatus(instance_id, 'cancelled')` query (and, as part of the same restructuring, also ensure `completed` and `failed` terminal activation paths call `UpdateInstanceStatus` with the matching status so the instance authority invariant holds for every terminal)
+- [x] 7.6 Add engine-side tests: workflow returning `ErrCancelled` ends as `CANCELLED` with `workflow.cancelled` history; workflow returning `nil` after observing cancellation ends as `COMPLETED`
+
+**Validation:** Engine tests pass for the cancelled path; replay detects trailing events after `workflow.cancelled` as a mismatch
+
+## 8. Engine Projector Updates (includes terminal cleanup)
+
+- [x] 8.1 Extend the projector's terminal mapping in `engine/internal/projector/projector.go` so `terminated` runs project to raw trace status `failed`, root span status `failed`, engine summary status `TERMINATED`, with failure details `error_code='terminated'`, `error_message='run terminated by operator'`
+- [x] 8.2 Ensure the projector consumes `workflow.cancelled` and `workflow.terminated` via the existing `DecodePayload` path without falling through to an unknown-event-type error
+- [x] 8.3 When the projector processes a `workflow.cancelled` or `workflow.terminated` history row, run terminal cleanup INSIDE the projector's own transaction using the new `engine/internal/store` wrappers around the sqlc read queries: load `ListCancelledActivityTasksByRun` and `ListDiscardedTimerInboxItemsByRun` to drive activity/timer cleanup directly, and use the existing projected `engine_wait_state` only to determine whether a pure signal wait must be cleared
+- [x] 8.4 Close still-open projected activity spans for each cancelled activity using the existing failure equivalent: set `status='failed'`, set `status_message` to `workflow cancelled` or `run terminated by operator`, and set `end_time` from the terminal history row timestamp
+- [x] 8.5 Emit synthetic terminal cleanup events with the existing wait-event model only: `EventType="wait"` and payload `{wait_kind, phase:"resolved", wait_id, resolution}`, where `wait_id` is `activity:<activity_key>` or `timer:<timer_key>` and `resolution` is `cancelled` or `terminated` from the terminal reason
+- [x] 8.6 Assign synthetic cleanup event sequences from the terminal row base: keep the terminal row's normal projected sequence, then assign cleanup waits starting at `sequence_no*10 + 1` with activities first in query order and timers second in query order
+- [x] 8.7 Derive idempotent `VariantKey` for synthetic events as `terminal_reason + ":" + wait_id` so re-projecting the same terminal history row is a no-op
+- [x] 8.8 Exclude `kind='cancel'` inbox rows from synthetic wait-resolution emission
+- [x] 8.9 Anchor every synthetic event and span close to the terminal history row ID for traceability
+- [x] 8.10 Do NOT emit `wait_kind='signal'` synthetic events — signal waits are cleared via `engine_wait_state` only
+
+**Validation:** Projector tests cover the terminated mapping, terminal cleanup on `workflow.cancelled`/`workflow.terminated`, exact wait payloads/resolutions, deterministic sequence offsets, idempotency on re-projection, and cleared wait state on every terminal
+
+## 9. Platform Schema Migration
+
+- [x] 9.1 Create `db/platform/migrations/postgres/NNNN_engine_run_status_terminated.up.sql` that drops `traces_engine_run_status_check` and recreates it with values `('queued','running','waiting','completed','failed','cancelled','terminated')`
+- [x] 9.2 Create matching down migration that fails if any row has `engine_run_status='terminated'`, otherwise restores the original constraint (without `terminated`)
+
+**Validation:** Migration applies on a database containing `completed`/`failed`/`cancelled` rows without errors; down fails safely when `terminated` rows exist
+
+## 10. OpenAPI + TypeScript Client
+
+- [x] 10.1 Extend `EngineRunStatus` in `contracts/openapi/openapi.yaml` to include `TERMINATED`
+- [x] 10.2 Add `POST /v1/engine/runs/{run_id}/terminate` route definition with preview-header requirement; response schema reuses the existing `EngineRunResultResponse` (so `200 OK` returns `{run_id, status, result=null, failure}`)
+- [x] 10.3 Add `GET /v1/engine/runs/{run_id}/pending-work` route definition with a new `EnginePendingWorkResponse` schema containing: `run_id` (uuid), `current_wait` (nullable), `activities` (array of `EnginePendingActivityItem` with `task_id`, `activity_key`, `activity_type`, `status`, `available_at`, `attempt_count`), `timers` (array of `EnginePendingTimerItem` with `inbox_id`, `timer_key`, `status`, `available_at`), `signals` (array of `EnginePendingSignalItem` with `inbox_id`, `signal_name`, `status`, `available_at`), `pending_activity_tasks` (int), `pending_inbox_items` (int)
+- [x] 10.4 Update `GET /v1/engine/runs/{run_id}/result` description to explicitly document `CANCELLED` and `TERMINATED` terminal response shapes
+- [x] 10.5 Update the description on `POST /v1/engine/runs/{run_id}/cancel` to reflect its cooperative contract: success does NOT guarantee terminal `CANCELLED`; the workflow decides between `COMPLETED` and `CANCELLED` via `workflow.ErrCancelled`
+- [x] 10.6 Run `make generate` and verify Go server bindings + TypeScript client regenerate without drift
+
+**Validation:** `make generate` succeeds; generated bindings include `TERMINATED`, terminate route reusing `EngineRunResultResponse`, and the new `EnginePendingWorkResponse`
+
+## 11. Platform Mapper + Status Classification
+
+- [x] 11.1 Update `engineRunStatusToAPI` in `internal/api/engine_mapper.go` to map `terminated` engine status to `EngineRunStatusTerminated`
+- [x] 11.2 Update `isTerminalEngineRun` (or equivalent) to classify `TERMINATED` as terminal so `cancel`, `signal`, and `terminate` routes all reject it uniformly
+- [x] 11.3 Update `GetRunResult` to return the documented `result=null` + populated `failure` shape for `CANCELLED` and `TERMINATED`
+
+**Validation:** Mapper and classification tests cover the new terminal value
+
+## 12. Platform Terminate Handler
+
+- [x] 12.1 In `internal/api/engine_control.go`, add a `TerminateRun` service method that opens a transaction, locks the run row (`SELECT ... FOR UPDATE`), returns the current terminal state if already terminal (idempotent), otherwise appends `workflow.terminated` to history, calls `TransitionRunToTerminated`, calls `CancelOpenActivityTasksByRun` and `DiscardOpenInboxItemsByRun`, calls the existing `UpdateInstanceStatus(instance_id, 'terminated')`, commits the transaction, and returns the new terminal state mapped through `EngineRunResultResponse`. The handler writes ONLY to `engine.*` schema; projection cleanup is handled by the projector when it later processes the `workflow.terminated` history row
+- [x] 12.2 Treat zero rows from `TransitionRunToTerminated` under the active-status lock as an invariant failure (rollback and return internal error)
+- [x] 12.3 Verify that only `engine/db/gen/go` and public engine packages (like `engine/pkg/history`) are imported — NO `engine/internal/*` imports from the handler file, and NO writes to `public.*` projection tables
+- [x] 12.4 Wire the HTTP route to enforce `ENGINE_PUBLIC_API_ENABLED=true` gating, `X-Continua-Engine-Preview: 1` preview header, API key authentication, and project scoping
+- [x] 12.5 Add handler unit tests covering: active-run terminate, already-terminal idempotency, missing-run 404, cross-project 404, missing preview header 400, disabled-gate 404
+
+**Validation:** Handler compiles with import boundary preserved; terminate route tests pass
+
+## 13. Platform Pending-Work Handler
+
+- [x] 13.1 In `internal/api/engine_control.go`, add a `GetRunPendingWork` service method that loads the run's `waiting_for`, lists open activity tasks (`status IN ('queued','claimed')`) ordered by `available_at ASC, id ASC`, lists open timer inbox rows (`kind='timer'`, `status IN ('pending','claimed')`) ordered by `available_at ASC, id ASC`, lists open signal inbox rows (`kind='signal'`, `status IN ('pending','claimed')`) ordered the same way, and excludes `kind='cancel'` rows
+- [x] 13.2 Implement `GetRunPendingWork` with the new generated `*enginedb.Queries` methods (`ListOpenActivityTasksByRun`, `ListOpenInboxItemsByRunAndKind`) in `internal/api/engine_control.go` rather than handwritten SQL or the existing due-now/all-status queries
+- [x] 13.3 Synthesize `current_wait` from `runs.waiting_for` (nullable) and return it alongside the three typed arrays plus `pending_activity_tasks` and `pending_inbox_items` counts in the `EnginePendingWorkResponse` body; populate activity items from durable task columns, and decode `timer_key` / `signal_name` from the existing inbox payload contracts without exposing `history_id` or raw payload blobs
+- [x] 13.4 Wire the HTTP route with `ENGINE_PUBLIC_API_ENABLED=true` gating and API key authentication; the preview header is NOT required for this GET route
+- [x] 13.5 Add handler unit tests covering: run with activities, run with timers, run waiting on pure signal (empty arrays + populated current_wait), run with cancel inbox rows (not shown), cross-project 404
+**Validation:** Handler tests pass; response shape matches spec; cancel rows are excluded
+
+## 14. Cancel Handler Documentation
+
+- [x] 14.1 Add a top-of-function comment on `CancelRun` in `internal/api/engine_control.go` documenting its explicit cooperative contract: success does NOT guarantee terminal `CANCELLED`; workflow code decides via `workflow.ErrCancelled`
+- [x] 14.2 Confirm the OpenAPI description of `POST /v1/engine/runs/{run_id}/cancel` (updated in Task 10.5) is reflected in the regenerated client docs
+
+**Validation:** Comment renders; OpenAPI description includes the cooperative contract
+
+## 15. Integration Tests
+
+- [x] 15.1 Integration test: `ErrCancelled` path — start run, send cancel, workflow returns `ErrCancelled`, assert terminal `CANCELLED`, `workflow.cancelled` history, instance status `cancelled`, projected summary `CANCELLED`
+- [x] 15.2 Integration test: `nil`-after-cancel path — start run, send cancel, workflow returns `nil`, assert terminal `COMPLETED` and NOT `CANCELLED`
+- [x] 15.3 Integration test: operator terminate path — start run, terminate while `waiting`, assert terminal `TERMINATED`, `workflow.terminated` history, instance status `terminated`, projected summary `TERMINATED`, `engine_wait_state` cleared to NULL
+- [x] 15.4 Integration test: terminate idempotency — terminate an already-terminal run twice, assert second call returns the existing terminal state unchanged with no new history rows
+- [x] 15.5 Integration test: terminate-vs-activation race — when activation commits first, terminate observes terminal status under lock and returns it; when terminate commits first, subsequent activation exits stale-claim without reviving the run
+- [x] 15.6 Integration test: decisionCancelled ordering — consumed inbox rows are marked `processed` before `CancelOpenActivityTasksByRun`/`DiscardOpenInboxItemsByRun` run, and already-processed rows do not appear in the discarded set
+- [x] 15.7 Integration test: late activity completion vs terminate — activity completes just before terminate's row lock, assert no synthetic cancellation is emitted for that activity; when terminate wins, activity completion path returns no-op without reviving the run
+- [x] 15.8 Integration test: pending-work endpoint — run with activities, timers, signals (delivered but unconsumed), and pure signal wait; assert response shape and ordering
+- [x] 15.9 Integration test: pending-work excludes cancel inbox rows
+- [x] 15.10 Integration test: debugger terminal cleanup — after terminate, the projector eventually closes open activity spans, emits synthetic activity/timer wait-resolution events, and clears `engine_wait_state` to NULL (including the pure-signal-wait case); re-projecting the same terminal history row produces no duplicates
+- [x] 15.11 Integration test: pending-work/run-read/projected-count consistency — create a run with 1 timer inbox row, 1 signal inbox row, and 1 cancel inbox row; wait for projector catch-up, then assert `GET /v1/engine/runs/{run_id}` (via `CountOpenInboxByRun`), `GET /pending-work`, and the projected `engine_pending_inbox_items` column all report 2 (not 3)
+
+**Validation:** All integration tests pass against a real Postgres
+
+## 16. Projector Tests
+
+- [x] 16.1 Projector test: `terminated` run projects to raw trace `failed`, root span `failed`, engine summary `TERMINATED`, with failure details
+- [x] 16.2 Projector test: existing `engine_wait_state` column is cleared to NULL on every terminal transition (completed, failed, cancelled, terminated)
+- [x] 16.3 Projector test: `engine_pending_activity_tasks` and `engine_pending_inbox_items` counts are zero after terminal sealing
+- [x] 16.4 Projector test: synthetic terminal cleanup emits `wait` events with `resolution=cancelled|terminated`, `wait_id` values `activity:<activity_key>` / `timer:<timer_key>`, and deterministic terminal-row-based sequence offsets
+
+**Validation:** Projector tests pass
+
+## 17. Instance Status Authority Tests
+
+- [x] 17.1 Test: run `completed` writes instance `completed` in the same transaction
+- [x] 17.2 Test: run `failed` writes instance `failed` in the same transaction
+- [x] 17.3 Test: run `cancelled` writes instance `cancelled` in the same transaction
+- [x] 17.4 Test: run `terminated` writes instance `terminated` in the same transaction
+- [x] 17.5 Test: backfill migration correctly recomputes instance statuses from latest runs (mix of terminal and non-terminal)
+
+**Validation:** Instance status tests pass; backfill is idempotent
+
+## 18. Regression Guard
+
+- [x] 18.1 Run `make generate` and verify no drift
+- [x] 18.2 Run `cd engine && go test ./...` — all engine tests pass (including new replay/activation/projector tests)
+- [x] 18.3 Run `go test ./internal/api/... ./internal/ingest/... ./internal/store/... ./internal/jobs/...`
+- [x] 18.4 Run `pnpm --filter web test` to confirm the web app compiles against the regenerated TypeScript client
+- [x] 18.5 Confirm existing Phase 11/12 happy-path gate tests still pass without modification
+
+**Validation:** Engine, root Go, and web regressions pass; no generated-code drift
+
+---
+
+### Parallelization Notes
+
+- Tasks 1, 4, 5, 6, 9 can run in parallel (engine migration, history events, public sentinel doc, projector-placement doc, platform migration are independent)
+- Task 2 depends on Task 1 (queries reference the `terminated` enum value)
+- Task 3 depends on Task 2 (store wraps new queries)
+- Task 7 depends on Tasks 3+4 (activation uses store wrappers and history constants)
+- Task 8 depends on Tasks 3+4 (projector uses `engine/internal/store` wrappers around the new read queries and decodes new event types for terminal cleanup)
+- **Task 10 (OpenAPI + regenerate) must precede Tasks 11–13**; the generated server interfaces and client types define the handler signatures and request/response shapes
+- Task 11 depends on Task 10 (mapper references the regenerated `EngineRunStatus` values)
+- Task 12 depends on Tasks 2+4+9+10+11 (terminate handler uses generated engine sqlc queries directly in `internal/api/engine_control.go`, plus history events, the updated CHECK constraint, the generated server interface, and the mapper — but does NOT depend on Task 8 because projection cleanup is decoupled and happens asynchronously)
+- Task 13 depends on Tasks 2+10+11 (pending-work handler uses generated engine sqlc queries directly in `internal/api/engine_control.go`, the generated `EnginePendingWorkResponse` schema, and the mapper)
+- Task 14 depends on Task 10 (cancel comment references the regenerated OpenAPI text)
+- Tasks 15–17 depend on everything that came before them
+- Task 18 is the final regression guard

--- a/openspec/changes/update-engine-projection-freshness-contract/proposal.md
+++ b/openspec/changes/update-engine-projection-freshness-contract/proposal.md
@@ -1,0 +1,24 @@
+# Change: Reconcile engine projection freshness contract
+
+## Why
+The older `add-engine-public-surface` OpenSpec text defines engine projection freshness as a fully stored state machine on `public.traces`. The later `add-engine-operational-hardening-core` change explicitly forbids `decisionCancelled` and root-side terminate from writing `public.*` projection tables. Those two requirements conflict for terminal cancel/terminate paths and have caused review churn even though the runtime already implements a deliberate reconciliation.
+
+## What Changes
+- Modify `engine-trace-projection` to distinguish:
+  - stored freshness transitions for start and non-terminal activation progress
+  - the terminal cancel/terminate exception where the transaction stays engine-only and the stored projection shell may lag until projector catch-up
+- Modify `engine-debugger-integration` to define read-side freshness in terms of an effective per-trace state:
+  - stale stored `up_to_date` shells may be exposed as `catching_up`
+  - `journal_expired` remains summary-shell-only with no live supplementation for freshness normalization
+- Clarify that the read path may normalize freshness without rewriting `public.traces`
+- No code, schema, API, or migration behavior changes are introduced by this change
+
+## Impact
+- Affected specs:
+  - `engine-trace-projection`
+  - `engine-debugger-integration`
+- Affected code: none; this change documents the existing reconciliation already implemented in:
+  - `engine/internal/workflow/activation.go`
+  - `internal/api/engine_control.go`
+  - `internal/api/traces_handlers.go`
+  - `internal/api/sessions_handlers.go`

--- a/openspec/changes/update-engine-projection-freshness-contract/specs/engine-debugger-integration/spec.md
+++ b/openspec/changes/update-engine-projection-freshness-contract/specs/engine-debugger-integration/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Trace detail engine fallback read
+The trace detail read path MUST determine freshness from the effective per-trace projection state, not only the raw stored enum value, so engine-only terminal cancel/terminate transactions can remain projection-write-free without surfacing stale `up_to_date` detail.
+
+#### Scenario: Effective projection up to date
+- **WHEN** an engine-backed trace has stored `engine_projection_state = up_to_date`
+- **AND** the run's live history frontier is not ahead of `engine_last_projected_history_id`
+- **THEN** the trace detail is served entirely from projected platform rows
+- **THEN** no engine-side read is performed
+
+#### Scenario: Projection catching up from stored state
+- **WHEN** an engine-backed trace has stored `engine_projection_state = catching_up`
+- **THEN** the trace detail read path MUST call a root-side engine-read helper keyed by `traces.engine_run_id`
+- **THEN** the helper supplements projected data with current engine run summary (status, custom status, wait state, pending counts)
+
+#### Scenario: Projection catching up from stale stored shell
+- **WHEN** an engine-backed trace has stored `engine_projection_state = up_to_date`
+- **AND** the run's live history frontier is ahead of `engine_last_projected_history_id`
+- **THEN** the trace detail read path treats the trace as effectively `catching_up`
+- **THEN** the helper supplements projected data with current engine run summary (status, custom status, wait state, pending counts)
+- **THEN** the read path does not rewrite `public.traces`
+
+#### Scenario: Summary only fallback
+- **WHEN** an engine-backed trace has `engine_projection_state = summary_only`
+- **THEN** the trace detail read path MUST call the root-side engine-read helper to supplement the retained summary shell with current engine run state
+- **THEN** span and event detail is not available (projected detail rows were cleaned up)
+
+#### Scenario: Journal expired fallback
+- **WHEN** an engine-backed trace has `engine_projection_state = journal_expired`
+- **THEN** the trace detail is served from the retained summary shell only
+- **THEN** no engine-side read is performed (raw history is no longer available)
+
+## ADDED Requirements
+
+### Requirement: Read metadata exposes effective projection state
+Debugger read surfaces that expose engine projection state MUST report the effective per-trace freshness state rather than blindly echoing a stale stored `up_to_date` shell.
+
+#### Scenario: Trace, timeline, and compare metadata normalize stale up_to_date
+- **WHEN** trace detail, trace list, timeline metadata, or compare headers expose `projection_state` for an engine-backed trace
+- **AND** the stored state is `up_to_date` but the run's live history frontier is ahead of `engine_last_projected_history_id`
+- **THEN** those surfaces expose `catching_up`
+- **THEN** this normalization does not write back to `public.traces`
+
+#### Scenario: Journal expired metadata remains unchanged
+- **WHEN** a read surface exposes `projection_state` for a trace whose stored state is `journal_expired`
+- **THEN** it continues to expose `journal_expired`
+- **THEN** it does not downgrade or supplement the trace solely to normalize freshness

--- a/openspec/changes/update-engine-projection-freshness-contract/specs/engine-trace-projection/spec.md
+++ b/openspec/changes/update-engine-projection-freshness-contract/specs/engine-trace-projection/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Projection state machine
+Each engine-backed trace MUST track its projection freshness through a four-state machine stored in `engine_projection_state`, with stored checkpoint columns on `public.traces` remaining the steady-state source of truth and a narrow exception for engine-only terminal cancel/terminate transactions introduced by operational hardening.
+
+#### Scenario: State definitions
+- **WHEN** a trace has `engine_projection_state` set
+- **THEN** the value is one of: `up_to_date`, `catching_up`, `summary_only`, `journal_expired`
+
+#### Scenario: Initial state on start
+- **WHEN** the start handler creates an engine run and its projected trace shell in one transaction
+- **THEN** `engine_latest_history_id` and `engine_last_projected_history_id` are both set to the `workflow.started` history event ID
+- **THEN** `engine_projection_state` is set to `up_to_date`
+
+#### Scenario: Transition to catching_up on non-terminal activation progress
+- **WHEN** a non-terminal activation appends history events that advance `engine_latest_history_id` beyond `engine_last_projected_history_id`
+- **THEN** activation updates the stored `engine_latest_history_id`
+- **THEN** `engine_projection_state` transitions to `catching_up`
+
+#### Scenario: Terminal cancel and terminate do not advance stored freshness in-band
+- **WHEN** `decisionCancelled` or the root-side terminate handler appends terminal history
+- **THEN** those transactions do NOT write `public.traces`
+- **THEN** the stored `engine_latest_history_id` and `engine_projection_state` MAY remain behind until the projector catches up
+- **THEN** this exception exists to preserve the single-writer projection invariant defined by operational hardening
+
+#### Scenario: Transition back to up_to_date
+- **WHEN** the async projector advances `engine_last_projected_history_id` to equal `engine_latest_history_id`
+- **THEN** `engine_projection_state` transitions to `up_to_date`
+
+#### Scenario: Retention cleanup transitions
+- **WHEN** retention cleanup deletes projected detail rows from a terminal trace but raw engine history remains
+- **THEN** `engine_projection_state` transitions to `summary_only`
+- **WHEN** raw engine history is also no longer available
+- **THEN** `engine_projection_state` transitions to `journal_expired`
+
+#### Scenario: Per-trace frontier check
+- **WHEN** a read path checks projection freshness
+- **THEN** it uses the trace's stored `engine_last_projected_history_id` together with the run's live history frontier
+- **THEN** it does not infer freshness from a project-wide checkpoint alone
+
+#### Scenario: Effective catching_up for stale stored shells
+- **WHEN** a read surface sees stored `engine_projection_state = up_to_date` but the run's live history frontier is ahead of `engine_last_projected_history_id`
+- **THEN** the surface MAY expose an effective `catching_up` state until the projector catches up
+- **THEN** the read path does not rewrite `public.traces` just to normalize freshness
+
+#### Scenario: Journal expired remains shell-only
+- **WHEN** stored `engine_projection_state = journal_expired`
+- **THEN** read paths do not perform live summary supplementation solely to normalize freshness
+- **THEN** the retained summary shell remains the only source for that trace

--- a/openspec/changes/update-engine-projection-freshness-contract/tasks.md
+++ b/openspec/changes/update-engine-projection-freshness-contract/tasks.md
@@ -1,0 +1,6 @@
+## 1. Spec Reconciliation
+- [x] 1.1 Update `engine-trace-projection` to clarify that stored checkpoint transitions remain authoritative for start and non-terminal activation progress, while `decisionCancelled` and root-side terminate stay engine-only and may leave stored projection metadata behind until projector catch-up.
+- [x] 1.2 Update `engine-debugger-integration` to define effective projection-state reporting and live fallback behavior for stale stored `up_to_date` shells, while preserving `journal_expired` as summary-shell-only.
+
+## 2. Validation
+- [x] 2.1 Run `openspec validate update-engine-projection-freshness-contract --strict`

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -39,6 +39,7 @@ class EngineRunStatus(Enum):
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
     CANCELLED = "CANCELLED"
+    TERMINATED = "TERMINATED"
 
 
 class EngineTraceInfo(BaseModel):
@@ -61,6 +62,41 @@ class EngineWaitState(BaseModel):
 
 
 class EnginePendingWork(BaseModel):
+    pending_activity_tasks: int
+    pending_inbox_items: int
+
+
+class EnginePendingActivityItem(BaseModel):
+    task_id: UUID
+    activity_key: str
+    activity_type: str
+    status: str
+    available_at: AwareDatetime
+    attempt_count: int
+
+
+class EnginePendingTimerItem(BaseModel):
+    inbox_id: UUID
+    timer_key: str
+    status: str
+    available_at: AwareDatetime
+
+
+class EnginePendingSignalItem(BaseModel):
+    inbox_id: UUID
+    signal_name: str
+    status: str
+    available_at: AwareDatetime
+
+
+class EnginePendingWorkResponse(BaseModel):
+    run_id: UUID
+    current_wait: EngineWaitState | None = Field(
+        ..., description="Current synthesized wait state from the run row when present."
+    )
+    activities: list[EnginePendingActivityItem]
+    timers: list[EnginePendingTimerItem]
+    signals: list[EnginePendingSignalItem]
     pending_activity_tasks: int
     pending_inbox_items: int
 
@@ -171,8 +207,8 @@ class EngineRunResponse(EngineRunSummary):
 class EngineRunResultResponse(BaseModel):
     run_id: UUID
     status: EngineRunStatus
-    result: Any | None = Field(
-        None, description="Terminal workflow result payload when available."
+    result: Any = Field(
+        ..., description="Terminal workflow result payload when available."
     )
     failure: EngineFailureSummary | None = None
 


### PR DESCRIPTION
## What changed
- harden the engine runtime around terminal lifecycle transitions, including `workflow.cancelled` / `workflow.terminated`, non-CAS sealing, authoritative instance status, and exact pending-work semantics
- add the public engine terminate and pending-work surfaces, update the OpenAPI/codegen outputs, and extend the platform migration guard for `terminated`
- move terminal debugger cleanup fully into the projector, including span closeout, synthetic wait-resolution events, wait-state clearing, and catch-up consistency behavior
- add the OpenSpec hardening package plus a follow-up OpenSpec reconciliation for projection freshness semantics

## Why
The engine public surface needed an explicit operator terminate path, exact operator-visible pending-work reads, stronger terminal-state semantics, and a single-writer projection model for terminal cleanup. The follow-up OpenSpec change documents the approved reconciliation between stored projection checkpoints and engine-only terminal transactions.

## Validation
- `cd engine && go test ./...`
- `go test ./internal/api/... ./internal/ingest/... ./internal/store/... ./internal/jobs/...`
- `openspec validate add-engine-operational-hardening-core --strict`
- `openspec validate update-engine-projection-freshness-contract --strict`

## Commit structure
1. `feat(engine): harden terminal lifecycle semantics`
2. `feat(api): add engine terminate and pending-work surfaces`
3. `feat(projector): own terminal cleanup and catch-up behavior`
4. `docs(openspec): capture engine hardening and freshness contracts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POST /v1/engine/runs/{run_id}/terminate — forceful terminate (preview header required).
  * GET /v1/engine/runs/{run_id}/pending-work — returns current_wait plus activities, timers, signals and counts.

* **Schema Updates**
  * EngineRunStatus adds TERMINATED.
  * Run result responses: result field required (nullable) and explicitly null for CANCELLED/TERMINATED.
  * New history event types: workflow.cancelled and workflow.terminated.

* **Client SDK**
  * Python types/models updated to reflect above API/schema changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->