### PR TITLE
Implement engine retention, repair, and control SDK

### DIFF
--- a/.codex/references/decisions.md
+++ b/.codex/references/decisions.md
@@ -81,6 +81,7 @@ Important caveat: `openspec/specs/` is currently empty, so OpenSpec is not a com
 - Engine foundation state lives in the dedicated Postgres `engine` schema.
 - Engine migrations use their own migration bookkeeping table so they can coexist with platform migrations in the same physical database.
 - Engine foundation does not add cross-schema foreign keys to `public.projects`.
+- The repo is still pre-production, so platform and engine migrations may be rewritten or squashed until the first production release. After the first production release, migration history becomes immutable.
 
 ## Config reality
 - Runtime config is env-only via `internal/config/config.go`.

--- a/.codex/references/guardrails.md
+++ b/.codex/references/guardrails.md
@@ -17,8 +17,10 @@ These rules are adapted from the project's Claude hooks so Codex sessions keep t
 - Do not treat `config.example.yaml` as the live config contract; runtime config is env-only in `internal/config/config.go`.
 
 ## Migration safety
-- Existing SQL migrations under `db/platform/migrations/` and `engine/db/migrations/` are treated as immutable.
-- Create a new migration with `make migrate-create name=<description>` instead of modifying an old one.
+- This repo is still pre-production. Until the first production release, SQL migrations under `db/platform/migrations/` and `engine/db/migrations/` may be rewritten, renumbered, or squashed when that keeps the pre-release schema history cleaner.
+- After the first production release, treat existing SQL migrations under `db/platform/migrations/` and `engine/db/migrations/` as immutable.
+- If a pre-production migration is rewritten, also update any dependent down migrations, migration smoke tests, generated code, and docs that reference the old numbering or behavior.
+- When a new step is clearer than rewriting history, still prefer `make migrate-create name=<description>`.
 
 ## Command safety
 - Avoid destructive shell commands unless the user explicitly asks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,9 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 ## Database And Migration Rules
 - Postgres is the real platform runtime database.
 - SQLite exists only as an early bootstrap scaffold under `db/platform/migrations/sqlite/`; do not assume full parity with Postgres behavior.
-- Existing migrations under `db/platform/migrations/` and `engine/db/migrations/` are immutable.
+- This repo is still pre-production. Until the first production release, migrations under `db/platform/migrations/` and `engine/db/migrations/` may be rewritten, renumbered, or squashed if that keeps the pre-release schema history cleaner.
+- After the first production release, treat existing migrations under `db/platform/migrations/` and `engine/db/migrations/` as immutable.
+- If you rewrite a pre-production migration, update any dependent down migrations, migration smoke tests, generated code, and docs that reference the old numbering or behavior.
 - Create new migrations with `make migrate-create name=<description>`.
 - Current important platform tables include `projects`, `ingest_batches`, `ingest_batch_payloads`, `sessions`, `traces`, `spans`, and `span_events`.
 
@@ -155,7 +157,7 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 ### Codex guardrails
 - Do not edit generated files directly; change the source inputs and run `make generate`.
-- Treat migrations as immutable.
+- Follow the repo's pre-production migration policy: migration rewrites are allowed until the first production release, but become immutable after that point.
 - Avoid direct `.env*` reads or writes.
 - Avoid broad staging commands like `git add .`, `git add -A`, or wildcard staging.
 - Format edited Go files with `gofmt` and `goimports` when available.

--- a/cmd/continua/main.go
+++ b/cmd/continua/main.go
@@ -20,6 +20,7 @@ import (
 	pgmigrations "github.com/continua-ai/continua/db/platform/migrations/postgres"
 	"github.com/continua-ai/continua/internal/api"
 	"github.com/continua-ai/continua/internal/config"
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/ingest"
 	"github.com/continua-ai/continua/internal/jobs"
 	"github.com/continua-ai/continua/internal/store"
@@ -59,12 +60,21 @@ func serveCmd() *cobra.Command {
 }
 
 func runServer() error {
-	app := fx.New(
+	app := newServerApp()
+	app.Run()
+	return nil
+}
+
+func newServerApp() *fx.App {
+	return fx.New(
 		// Provide configuration
 		config.Module,
 
 		// Provide database access
 		store.Module,
+
+		// Provide shared engine control orchestration
+		enginecontrol.Module,
 
 		// Provide async job processing (River)
 		jobs.Module,
@@ -78,9 +88,6 @@ func runServer() error {
 		// Start HTTP server
 		fx.Invoke(startHTTPServer),
 	)
-
-	app.Run()
-	return nil
 }
 
 func migrateCmd() *cobra.Command {

--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -80,6 +80,21 @@ const (
 	UpToDate       EngineProjectionState = "up_to_date"
 )
 
+// Defines values for EnginePurgeMode.
+const (
+	Full           EnginePurgeMode = "full"
+	ProjectionOnly EnginePurgeMode = "projection_only"
+)
+
+// Defines values for EngineRepairReason.
+const (
+	AlreadyCatchingUp EngineRepairReason = "already_catching_up"
+	AlreadyUpToDate   EngineRepairReason = "already_up_to_date"
+	HistoryExpired    EngineRepairReason = "history_expired"
+	NoEventsToProject EngineRepairReason = "no_events_to_project"
+	RepairRequested   EngineRepairReason = "repair_requested"
+)
+
 // Defines values for EngineRunStatus.
 const (
 	EngineRunStatusCANCELLED  EngineRunStatus = "CANCELLED"
@@ -265,9 +280,20 @@ const (
 
 // Defines values for ListTracesParamsStatus.
 const (
-	Completed ListTracesParamsStatus = "completed"
-	Failed    ListTracesParamsStatus = "failed"
-	Running   ListTracesParamsStatus = "running"
+	ListTracesParamsStatusCompleted ListTracesParamsStatus = "completed"
+	ListTracesParamsStatusFailed    ListTracesParamsStatus = "failed"
+	ListTracesParamsStatusRunning   ListTracesParamsStatus = "running"
+)
+
+// Defines values for ListTracesParamsEngineRunStatus.
+const (
+	ListTracesParamsEngineRunStatusCancelled  ListTracesParamsEngineRunStatus = "cancelled"
+	ListTracesParamsEngineRunStatusCompleted  ListTracesParamsEngineRunStatus = "completed"
+	ListTracesParamsEngineRunStatusFailed     ListTracesParamsEngineRunStatus = "failed"
+	ListTracesParamsEngineRunStatusQueued     ListTracesParamsEngineRunStatus = "queued"
+	ListTracesParamsEngineRunStatusRunning    ListTracesParamsEngineRunStatus = "running"
+	ListTracesParamsEngineRunStatusTerminated ListTracesParamsEngineRunStatus = "terminated"
+	ListTracesParamsEngineRunStatusWaiting    ListTracesParamsEngineRunStatus = "waiting"
 )
 
 // BatchStatusResponse defines model for BatchStatusResponse.
@@ -476,11 +502,42 @@ type EnginePendingWorkResponse struct {
 // EngineProjectionState defines model for EngineProjectionState.
 type EngineProjectionState string
 
+// EnginePurgeMode defines model for EnginePurgeMode.
+type EnginePurgeMode string
+
+// EnginePurgeRequest defines model for EnginePurgeRequest.
+type EnginePurgeRequest struct {
+	Mode EnginePurgeMode `json:"mode"`
+}
+
+// EnginePurgeResponse defines model for EnginePurgeResponse.
+type EnginePurgeResponse struct {
+	// Deleted True when purge deleted projection detail and/or history rows.
+	Deleted         bool                  `json:"deleted"`
+	Mode            EnginePurgeMode       `json:"mode"`
+	ProjectionState EngineProjectionState `json:"projection_state"`
+	RunId           openapi_types.UUID    `json:"run_id"`
+}
+
+// EngineRepairReason defines model for EngineRepairReason.
+type EngineRepairReason string
+
+// EngineRepairResponse defines model for EngineRepairResponse.
+type EngineRepairResponse struct {
+	Accepted        bool                  `json:"accepted"`
+	ProjectionState EngineProjectionState `json:"projection_state"`
+	Reason          EngineRepairReason    `json:"reason"`
+	RunId           openapi_types.UUID    `json:"run_id"`
+}
+
 // EngineRunHistoryResponse defines model for EngineRunHistoryResponse.
 type EngineRunHistoryResponse struct {
-	Events    []EngineHistoryEvent `json:"events"`
-	HasMore   bool                 `json:"has_more"`
-	NextAfter *int                 `json:"next_after,omitempty"`
+	Events []EngineHistoryEvent `json:"events"`
+
+	// Expired True when retained engine history for the run has been purged.
+	Expired   *bool `json:"expired,omitempty"`
+	HasMore   bool  `json:"has_more"`
+	NextAfter *int  `json:"next_after,omitempty"`
 }
 
 // EngineRunResponse defines model for EngineRunResponse.
@@ -508,7 +565,8 @@ type EngineRunResponse struct {
 type EngineRunResultResponse struct {
 	Failure *EngineFailureSummary `json:"failure,omitempty"`
 
-	// Result Terminal workflow result payload when available.
+	// Result Terminal workflow result payload when available. `summary_only` and
+	// `journal_expired` runs continue to return the retained terminal shell.
 	Result interface{}        `json:"result"`
 	RunId  openapi_types.UUID `json:"run_id"`
 	Status EngineRunStatus    `json:"status"`
@@ -1100,6 +1158,18 @@ type ListTracesParams struct {
 	// UserId Filter by user ID
 	UserId *string `form:"user_id,omitempty" json:"user_id,omitempty"`
 
+	// EngineInstanceKey Filter by engine instance key
+	EngineInstanceKey *string `form:"engine_instance_key,omitempty" json:"engine_instance_key,omitempty"`
+
+	// EngineDefinitionName Filter by engine definition name
+	EngineDefinitionName *string `form:"engine_definition_name,omitempty" json:"engine_definition_name,omitempty"`
+
+	// EngineRunStatus Filter by engine run lifecycle status
+	EngineRunStatus *ListTracesParamsEngineRunStatus `form:"engine_run_status,omitempty" json:"engine_run_status,omitempty"`
+
+	// EngineProjectionState Filter by engine projection state
+	EngineProjectionState *EngineProjectionState `form:"engine_projection_state,omitempty" json:"engine_projection_state,omitempty"`
+
 	// HasErrors Filter traces with errors (error_count > 0)
 	HasErrors *bool `form:"has_errors,omitempty" json:"has_errors,omitempty"`
 
@@ -1115,6 +1185,9 @@ type ListTracesParamsSortDir string
 
 // ListTracesParamsStatus defines parameters for ListTraces.
 type ListTracesParamsStatus string
+
+// ListTracesParamsEngineRunStatus defines parameters for ListTraces.
+type ListTracesParamsEngineRunStatus string
 
 // GetTraceEventsParams defines parameters for GetTraceEvents.
 type GetTraceEventsParams struct {
@@ -1143,6 +1216,18 @@ type GetEngineRunHistoryParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// PurgeEngineRunParams defines parameters for PurgeEngineRun.
+type PurgeEngineRunParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// RepairEngineRunParams defines parameters for RepairEngineRun.
+type RepairEngineRunParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
 // SignalEngineRunParams defines parameters for SignalEngineRun.
 type SignalEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
@@ -1168,6 +1253,9 @@ type IngestParams struct {
 
 // StartEngineRunJSONRequestBody defines body for StartEngineRun for application/json ContentType.
 type StartEngineRunJSONRequestBody = EngineStartRunRequest
+
+// PurgeEngineRunJSONRequestBody defines body for PurgeEngineRun for application/json ContentType.
+type PurgeEngineRunJSONRequestBody = EnginePurgeRequest
 
 // SignalEngineRunJSONRequestBody defines body for SignalEngineRun for application/json ContentType.
 type SignalEngineRunJSONRequestBody = EngineSignalRunRequest
@@ -1362,6 +1450,12 @@ type ServerInterface interface {
 	// Get the durable pending work held by an engine run
 	// (GET /v1/engine/runs/{run_id}/pending-work)
 	GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
+	// Purge projected detail and optionally retained history for an engine run
+	// (POST /v1/engine/runs/{run_id}/purge)
+	PurgeEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params PurgeEngineRunParams)
+	// Request projection repair for an engine run
+	// (POST /v1/engine/runs/{run_id}/repair)
+	RepairEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params RepairEngineRunParams)
 	// Get the terminal result for an engine run
 	// (GET /v1/engine/runs/{run_id}/result)
 	GetEngineRunResult(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
@@ -1464,6 +1558,18 @@ func (_ Unimplemented) GetEngineRunHistory(w http.ResponseWriter, r *http.Reques
 // Get the durable pending work held by an engine run
 // (GET /v1/engine/runs/{run_id}/pending-work)
 func (_ Unimplemented) GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Purge projected detail and optionally retained history for an engine run
+// (POST /v1/engine/runs/{run_id}/purge)
+func (_ Unimplemented) PurgeEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params PurgeEngineRunParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Request projection repair for an engine run
+// (POST /v1/engine/runs/{run_id}/repair)
+func (_ Unimplemented) RepairEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params RepairEngineRunParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1796,6 +1902,38 @@ func (siw *ServerInterfaceWrapper) ListTraces(w http.ResponseWriter, r *http.Req
 	err = runtime.BindQueryParameter("form", true, false, "user_id", r.URL.Query(), &params.UserId)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "user_id", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "engine_instance_key" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_instance_key", r.URL.Query(), &params.EngineInstanceKey)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_instance_key", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "engine_definition_name" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_definition_name", r.URL.Query(), &params.EngineDefinitionName)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_definition_name", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "engine_run_status" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_run_status", r.URL.Query(), &params.EngineRunStatus)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_run_status", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "engine_projection_state" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_projection_state", r.URL.Query(), &params.EngineProjectionState)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_projection_state", Err: err})
 		return
 	}
 
@@ -2181,6 +2319,124 @@ func (siw *ServerInterfaceWrapper) GetEngineRunPendingWork(w http.ResponseWriter
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetEngineRunPendingWork(w, r, runId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PurgeEngineRun operation middleware
+func (siw *ServerInterfaceWrapper) PurgeEngineRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "run_id" -------------
+	var runId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "run_id", chi.URLParam(r, "run_id"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "run_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PurgeEngineRunParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PurgeEngineRun(w, r, runId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RepairEngineRun operation middleware
+func (siw *ServerInterfaceWrapper) RepairEngineRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "run_id" -------------
+	var runId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "run_id", chi.URLParam(r, "run_id"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "run_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params RepairEngineRunParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RepairEngineRun(w, r, runId, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2578,6 +2834,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/pending-work", wrapper.GetEngineRunPendingWork)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/runs/{run_id}/purge", wrapper.PurgeEngineRun)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/runs/{run_id}/repair", wrapper.RepairEngineRun)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/result", wrapper.GetEngineRunResult)

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -110,6 +110,8 @@ export interface paths {
          * @description Returns the terminal result shape for the run.
          *     `COMPLETED` returns the workflow result payload.
          *     `CANCELLED` and `TERMINATED` return `result=null` with a populated `failure` object.
+         *     Purged runs in `summary_only` and `journal_expired` continue to return the
+         *     retained terminal shell instead of becoming `404`.
          *
          */
         get: operations["getEngineRunResult"];
@@ -145,10 +147,56 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get engine run history */
+        /**
+         * Get engine run history
+         * @description Returns the durable engine history page for the run.
+         *     Purged runs continue to return `200`; `journal_expired` runs include
+         *     `expired=true` so clients can distinguish purged-empty from never-had-events.
+         *
+         */
         get: operations["getEngineRunHistory"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/engine/runs/{run_id}/purge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Purge projected detail and optionally retained history for an engine run */
+        post: operations["purgeEngineRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/engine/runs/{run_id}/repair": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request projection repair for an engine run
+         * @description Repair is asynchronous. Accepted repair requests only reopen projection by
+         *     returning the run to `catching_up`; the separate `continua-engine`
+         *     projector loop performs the rebuild later.
+         *
+         */
+        post: operations["repairEngineRun"];
         delete?: never;
         options?: never;
         head?: never;
@@ -364,6 +412,10 @@ export interface components {
         /** @enum {string} */
         EngineProjectionState: "up_to_date" | "catching_up" | "summary_only" | "journal_expired";
         /** @enum {string} */
+        EnginePurgeMode: "projection_only" | "full";
+        /** @enum {string} */
+        EngineRepairReason: "already_up_to_date" | "history_expired" | "no_events_to_project" | "repair_requested" | "already_catching_up";
+        /** @enum {string} */
         EngineRunStatus: "QUEUED" | "RUNNING" | "WAITING" | "COMPLETED" | "FAILED" | "CANCELLED" | "TERMINATED";
         EngineTraceInfo: {
             /** Format: uuid */
@@ -520,6 +572,10 @@ export interface components {
             status: string;
             current_run: components["schemas"]["EngineRunSummary"];
         };
+        /** @description Engine run detail. Clients can identify `definition_version_mismatch`
+         *     from the existing `definition_name`, `definition_version`, and
+         *     `failure.error_code` fields without a dedicated mismatch endpoint.
+         *      */
         EngineRunResponse: components["schemas"]["EngineRunSummary"] & {
             /** Format: uuid */
             instance_id: string;
@@ -528,7 +584,9 @@ export interface components {
             /** Format: uuid */
             run_id: string;
             status: components["schemas"]["EngineRunStatus"];
-            /** @description Terminal workflow result payload when available. */
+            /** @description Terminal workflow result payload when available. `summary_only` and
+             *     `journal_expired` runs continue to return the retained terminal shell.
+             *      */
             result: unknown | null;
             failure?: components["schemas"]["EngineFailureSummary"];
         };
@@ -546,6 +604,26 @@ export interface components {
             events: components["schemas"]["EngineHistoryEvent"][];
             has_more: boolean;
             next_after?: number;
+            /** @description True when retained engine history for the run has been purged. */
+            expired?: boolean;
+        };
+        EnginePurgeRequest: {
+            mode: components["schemas"]["EnginePurgeMode"];
+        };
+        EnginePurgeResponse: {
+            /** Format: uuid */
+            run_id: string;
+            mode: components["schemas"]["EnginePurgeMode"];
+            projection_state: components["schemas"]["EngineProjectionState"];
+            /** @description True when purge deleted projection detail and/or history rows. */
+            deleted: boolean;
+        };
+        EngineRepairResponse: {
+            /** Format: uuid */
+            run_id: string;
+            accepted: boolean;
+            reason: components["schemas"]["EngineRepairReason"];
+            projection_state: components["schemas"]["EngineProjectionState"];
         };
         EngineSignalRunRequest: {
             signal_name: string;
@@ -1417,6 +1495,123 @@ export interface operations {
             };
         };
     };
+    purgeEngineRun: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required preview header for mutating engine routes. */
+                "X-Continua-Engine-Preview": string;
+            };
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnginePurgeRequest"];
+            };
+        };
+        responses: {
+            /** @description Purge applied or already satisfied */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnginePurgeResponse"];
+                };
+            };
+            /** @description Invalid request body or missing preview header */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Run not found or engine API disabled */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Run not terminal (`run_not_terminal`) */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    repairEngineRun: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required preview header for mutating engine routes. */
+                "X-Continua-Engine-Preview": string;
+            };
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Repair accepted or current state reported */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EngineRepairResponse"];
+                };
+            };
+            /** @description Missing preview header */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Run not found or engine API disabled */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     signalEngineRun: {
         parameters: {
             query?: never;
@@ -1615,6 +1810,14 @@ export interface operations {
                 start_time_to?: string;
                 /** @description Filter by user ID */
                 user_id?: string;
+                /** @description Filter by engine instance key */
+                engine_instance_key?: string;
+                /** @description Filter by engine definition name */
+                engine_definition_name?: string;
+                /** @description Filter by engine run lifecycle status */
+                engine_run_status?: "queued" | "running" | "waiting" | "completed" | "failed" | "cancelled" | "terminated";
+                /** @description Filter by engine projection state */
+                engine_projection_state?: components["schemas"]["EngineProjectionState"];
                 /** @description Filter traces with errors (error_count > 0) */
                 has_errors?: boolean;
                 /** @description Filter traces with duration >= this value in milliseconds */

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -228,6 +228,8 @@ paths:
         Returns the terminal result shape for the run.
         `COMPLETED` returns the workflow result payload.
         `CANCELLED` and `TERMINATED` return `result=null` with a populated `failure` object.
+        Purged runs in `summary_only` and `journal_expired` continue to return the
+        retained terminal shell instead of becoming `404`.
       tags:
         - Engine
       parameters:
@@ -298,6 +300,10 @@ paths:
     get:
       operationId: getEngineRunHistory
       summary: Get engine run history
+      description: |
+        Returns the durable engine history page for the run.
+        Purged runs continue to return `200`; `journal_expired` runs include
+        `expired=true` so clients can distinguish purged-empty from never-had-events.
       tags:
         - Engine
       parameters:
@@ -325,6 +331,110 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EngineRunHistoryResponse'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Run not found or engine API disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/engine/runs/{run_id}/purge:
+    post:
+      operationId: purgeEngineRun
+      summary: Purge projected detail and optionally retained history for an engine run
+      tags:
+        - Engine
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnginePurgeRequest'
+      responses:
+        '200':
+          description: Purge applied or already satisfied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnginePurgeResponse'
+        '400':
+          description: Invalid request body or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Run not found or engine API disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Run not terminal (`run_not_terminal`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/engine/runs/{run_id}/repair:
+    post:
+      operationId: repairEngineRun
+      summary: Request projection repair for an engine run
+      description: |
+        Repair is asynchronous. Accepted repair requests only reopen projection by
+        returning the run to `catching_up`; the separate `continua-engine`
+        projector loop performs the rebuild later.
+      tags:
+        - Engine
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Repair accepted or current state reported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineRepairResponse'
+        '400':
+          description: Missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized - missing or invalid API key
           content:
@@ -559,6 +669,34 @@ paths:
           description: Filter by user ID
           schema:
             type: string
+        - name: engine_instance_key
+          in: query
+          description: Filter by engine instance key
+          schema:
+            type: string
+        - name: engine_definition_name
+          in: query
+          description: Filter by engine definition name
+          schema:
+            type: string
+        - name: engine_run_status
+          in: query
+          description: Filter by engine run lifecycle status
+          schema:
+            type: string
+            enum:
+              - queued
+              - running
+              - waiting
+              - completed
+              - failed
+              - cancelled
+              - terminated
+        - name: engine_projection_state
+          in: query
+          description: Filter by engine projection state
+          schema:
+            $ref: '#/components/schemas/EngineProjectionState'
         - name: has_errors
           in: query
           description: Filter traces with errors (error_count > 0)
@@ -908,6 +1046,19 @@ components:
         - catching_up
         - summary_only
         - journal_expired
+    EnginePurgeMode:
+      type: string
+      enum:
+        - projection_only
+        - full
+    EngineRepairReason:
+      type: string
+      enum:
+        - already_up_to_date
+        - history_expired
+        - no_events_to_project
+        - repair_requested
+        - already_catching_up
     EngineRunStatus:
       type: string
       enum:
@@ -1258,6 +1409,10 @@ components:
         current_run:
           $ref: '#/components/schemas/EngineRunSummary'
     EngineRunResponse:
+      description: |
+        Engine run detail. Clients can identify `definition_version_mismatch`
+        from the existing `definition_name`, `definition_version`, and
+        `failure.error_code` fields without a dedicated mismatch endpoint.
       allOf:
         - $ref: '#/components/schemas/EngineRunSummary'
         - type: object
@@ -1280,7 +1435,9 @@ components:
         status:
           $ref: '#/components/schemas/EngineRunStatus'
         result:
-          description: Terminal workflow result payload when available.
+          description: |
+            Terminal workflow result payload when available. `summary_only` and
+            `journal_expired` runs continue to return the retained terminal shell.
           x-nullable: true
         failure:
           $ref: '#/components/schemas/EngineFailureSummary'
@@ -1319,6 +1476,51 @@ components:
           type: boolean
         next_after:
           type: integer
+        expired:
+          type: boolean
+          description: True when retained engine history for the run has been purged.
+    EnginePurgeRequest:
+      type: object
+      required:
+        - mode
+      properties:
+        mode:
+          $ref: '#/components/schemas/EnginePurgeMode'
+    EnginePurgeResponse:
+      type: object
+      required:
+        - run_id
+        - mode
+        - projection_state
+        - deleted
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        mode:
+          $ref: '#/components/schemas/EnginePurgeMode'
+        projection_state:
+          $ref: '#/components/schemas/EngineProjectionState'
+        deleted:
+          type: boolean
+          description: True when purge deleted projection detail and/or history rows.
+    EngineRepairResponse:
+      type: object
+      required:
+        - run_id
+        - accepted
+        - reason
+        - projection_state
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        accepted:
+          type: boolean
+        reason:
+          $ref: '#/components/schemas/EngineRepairReason'
+        projection_state:
+          $ref: '#/components/schemas/EngineProjectionState'
     EngineSignalRunRequest:
       type: object
       required:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -234,6 +234,8 @@ paths:
         Returns the terminal result shape for the run.
         `COMPLETED` returns the workflow result payload.
         `CANCELLED` and `TERMINATED` return `result=null` with a populated `failure` object.
+        Purged runs in `summary_only` and `journal_expired` continue to return the
+        retained terminal shell instead of becoming `404`.
       tags: [Engine]
       parameters:
         - name: run_id
@@ -304,6 +306,10 @@ paths:
     get:
       operationId: getEngineRunHistory
       summary: Get engine run history
+      description: |
+        Returns the durable engine history page for the run.
+        Purged runs continue to return `200`; `journal_expired` runs include
+        `expired=true` so clients can distinguish purged-empty from never-had-events.
       tags: [Engine]
       parameters:
         - name: run_id
@@ -330,6 +336,110 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EngineRunHistoryResponse'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Run not found or engine API disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/engine/runs/{run_id}/purge:
+    post:
+      operationId: purgeEngineRun
+      summary: Purge projected detail and optionally retained history for an engine run
+      tags: [Engine]
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnginePurgeRequest'
+      responses:
+        '200':
+          description: Purge applied or already satisfied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnginePurgeResponse'
+        '400':
+          description: Invalid request body or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Run not found or engine API disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Run not terminal (`run_not_terminal`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/engine/runs/{run_id}/repair:
+    post:
+      operationId: repairEngineRun
+      summary: Request projection repair for an engine run
+      description: |
+        Repair is asynchronous. Accepted repair requests only reopen projection by
+        returning the run to `catching_up`; the separate `continua-engine`
+        projector loop performs the rebuild later.
+      tags: [Engine]
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Repair accepted or current state reported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineRepairResponse'
+        '400':
+          description: Missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized - missing or invalid API key
           content:
@@ -558,6 +668,27 @@ paths:
           description: Filter by user ID
           schema:
             type: string
+        - name: engine_instance_key
+          in: query
+          description: Filter by engine instance key
+          schema:
+            type: string
+        - name: engine_definition_name
+          in: query
+          description: Filter by engine definition name
+          schema:
+            type: string
+        - name: engine_run_status
+          in: query
+          description: Filter by engine run lifecycle status
+          schema:
+            type: string
+            enum: [queued, running, waiting, completed, failed, cancelled, terminated]
+        - name: engine_projection_state
+          in: query
+          description: Filter by engine projection state
+          schema:
+            $ref: '#/components/schemas/EngineProjectionState'
         - name: has_errors
           in: query
           description: Filter traces with errors (error_count > 0)
@@ -901,6 +1032,19 @@ components:
       type: string
       enum: [up_to_date, catching_up, summary_only, journal_expired]
 
+    EnginePurgeMode:
+      type: string
+      enum: [projection_only, full]
+
+    EngineRepairReason:
+      type: string
+      enum:
+        - already_up_to_date
+        - history_expired
+        - no_events_to_project
+        - repair_requested
+        - already_catching_up
+
     EngineRunStatus:
       type: string
       enum: [QUEUED, RUNNING, WAITING, COMPLETED, FAILED, CANCELLED, TERMINATED]
@@ -1207,6 +1351,10 @@ components:
           $ref: '#/components/schemas/EngineRunSummary'
 
     EngineRunResponse:
+      description: |
+        Engine run detail. Clients can identify `definition_version_mismatch`
+        from the existing `definition_name`, `definition_version`, and
+        `failure.error_code` fields without a dedicated mismatch endpoint.
       allOf:
         - $ref: '#/components/schemas/EngineRunSummary'
         - type: object
@@ -1226,7 +1374,9 @@ components:
         status:
           $ref: '#/components/schemas/EngineRunStatus'
         result:
-          description: Terminal workflow result payload when available.
+          description: |
+            Terminal workflow result payload when available. `summary_only` and
+            `journal_expired` runs continue to return the retained terminal shell.
           x-nullable: true
         failure:
           $ref: '#/components/schemas/EngineFailureSummary'
@@ -1261,6 +1411,45 @@ components:
           type: boolean
         next_after:
           type: integer
+        expired:
+          type: boolean
+          description: True when retained engine history for the run has been purged.
+
+    EnginePurgeRequest:
+      type: object
+      required: [mode]
+      properties:
+        mode:
+          $ref: '#/components/schemas/EnginePurgeMode'
+
+    EnginePurgeResponse:
+      type: object
+      required: [run_id, mode, projection_state, deleted]
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        mode:
+          $ref: '#/components/schemas/EnginePurgeMode'
+        projection_state:
+          $ref: '#/components/schemas/EngineProjectionState'
+        deleted:
+          type: boolean
+          description: True when purge deleted projection detail and/or history rows.
+
+    EngineRepairResponse:
+      type: object
+      required: [run_id, accepted, reason, projection_state]
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        accepted:
+          type: boolean
+        reason:
+          $ref: '#/components/schemas/EngineRepairReason'
+        projection_state:
+          $ref: '#/components/schemas/EngineProjectionState'
 
     EngineSignalRunRequest:
       type: object

--- a/db/gen/go/platform/spans.sql.go
+++ b/db/gen/go/platform/spans.sql.go
@@ -149,6 +149,27 @@ func (q *Queries) CreateSpan(ctx context.Context, arg CreateSpanParams) (Span, e
 	return i, err
 }
 
+const deleteNonRootSpansByTrace = `-- name: DeleteNonRootSpansByTrace :exec
+DELETE FROM spans
+WHERE trace_id = $1
+  AND parent_span_id IS NOT NULL
+`
+
+func (q *Queries) DeleteNonRootSpansByTrace(ctx context.Context, traceID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteNonRootSpansByTrace, traceID)
+	return err
+}
+
+const deleteSpanEventsByTrace = `-- name: DeleteSpanEventsByTrace :exec
+DELETE FROM span_events
+WHERE trace_id = $1
+`
+
+func (q *Queries) DeleteSpanEventsByTrace(ctx context.Context, traceID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteSpanEventsByTrace, traceID)
+	return err
+}
+
 const getSpan = `-- name: GetSpan :one
 SELECT id, project_id, trace_id, span_id, parent_span_id, name, type, status, status_message, level, start_time, end_time, server_received_at, duration_ms, input, input_truncated, input_original_size_bytes, input_truncation_reason, output, output_truncated, output_original_size_bytes, output_truncation_reason, thinking, thinking_truncated, model, provider, prompt_tokens, completion_tokens, total_tokens, total_cost, metadata, sequence, depth, version, created_at, updated_at, search_vector FROM spans WHERE id = $1
 `

--- a/db/gen/go/platform/traces.sql.go
+++ b/db/gen/go/platform/traces.sql.go
@@ -257,6 +257,60 @@ func (q *Queries) CreateTrace(ctx context.Context, arg CreateTraceParams) (Trace
 	return i, err
 }
 
+const flipProjectionStateToCatchingUp = `-- name: FlipProjectionStateToCatchingUp :execrows
+UPDATE traces
+SET engine_projection_state = 'catching_up',
+    engine_projection_updated_at = NOW(),
+    updated_at = NOW(),
+    version = COALESCE(version, 1) + 1
+WHERE engine_run_id = $1
+  AND COALESCE(engine_projection_state, 'up_to_date') = 'summary_only'
+`
+
+func (q *Queries) FlipProjectionStateToCatchingUp(ctx context.Context, engineRunID pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, flipProjectionStateToCatchingUp, engineRunID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const flipProjectionStateToJournalExpired = `-- name: FlipProjectionStateToJournalExpired :execrows
+UPDATE traces
+SET engine_projection_state = 'journal_expired',
+    engine_projection_updated_at = NOW(),
+    updated_at = NOW(),
+    version = COALESCE(version, 1) + 1
+WHERE engine_run_id = $1
+  AND COALESCE(engine_projection_state, 'up_to_date') IN ('up_to_date', 'catching_up', 'summary_only')
+`
+
+func (q *Queries) FlipProjectionStateToJournalExpired(ctx context.Context, engineRunID pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, flipProjectionStateToJournalExpired, engineRunID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const flipProjectionStateToSummaryOnly = `-- name: FlipProjectionStateToSummaryOnly :execrows
+UPDATE traces
+SET engine_projection_state = 'summary_only',
+    engine_projection_updated_at = NOW(),
+    updated_at = NOW(),
+    version = COALESCE(version, 1) + 1
+WHERE engine_run_id = $1
+  AND COALESCE(engine_projection_state, 'up_to_date') IN ('up_to_date', 'catching_up')
+`
+
+func (q *Queries) FlipProjectionStateToSummaryOnly(ctx context.Context, engineRunID pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, flipProjectionStateToSummaryOnly, engineRunID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getTrace = `-- name: GetTrace :one
 SELECT t.id, t.project_id, t.session_id, t.trace_id, t.name, t.user_id, t.tags, t.environment, t.release, t.metadata, t.input, t.output, t.status, t.start_time, t.end_time, t.server_received_at, t.duration_ms, t.total_spans, t.total_cost, t.error_count, t.version, t.created_at, t.updated_at, t.search_vector, t.total_tokens_in, t.total_tokens_out, t.engine_run_id, t.engine_definition_name, t.engine_definition_version, t.engine_projection_state, t.engine_latest_history_id, t.engine_last_projected_history_id, t.engine_projection_updated_at, t.engine_instance_key, t.engine_run_status, t.engine_custom_status, t.engine_wait_state, t.engine_pending_activity_tasks, t.engine_pending_inbox_items, s.external_id AS session_external_id
 FROM traces t
@@ -328,6 +382,66 @@ type GetTraceByExternalIDParams struct {
 
 func (q *Queries) GetTraceByExternalID(ctx context.Context, arg GetTraceByExternalIDParams) (Trace, error) {
 	row := q.db.QueryRow(ctx, getTraceByExternalID, arg.ProjectID, arg.TraceID)
+	var i Trace
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.SessionID,
+		&i.TraceID,
+		&i.Name,
+		&i.UserID,
+		&i.Tags,
+		&i.Environment,
+		&i.Release,
+		&i.Metadata,
+		&i.Input,
+		&i.Output,
+		&i.Status,
+		&i.StartTime,
+		&i.EndTime,
+		&i.ServerReceivedAt,
+		&i.DurationMs,
+		&i.TotalSpans,
+		&i.TotalCost,
+		&i.ErrorCount,
+		&i.Version,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.SearchVector,
+		&i.TotalTokensIn,
+		&i.TotalTokensOut,
+		&i.EngineRunID,
+		&i.EngineDefinitionName,
+		&i.EngineDefinitionVersion,
+		&i.EngineProjectionState,
+		&i.EngineLatestHistoryID,
+		&i.EngineLastProjectedHistoryID,
+		&i.EngineProjectionUpdatedAt,
+		&i.EngineInstanceKey,
+		&i.EngineRunStatus,
+		&i.EngineCustomStatus,
+		&i.EngineWaitState,
+		&i.EnginePendingActivityTasks,
+		&i.EnginePendingInboxItems,
+	)
+	return i, err
+}
+
+const getTraceByProjectAndEngineRunIDForUpdate = `-- name: GetTraceByProjectAndEngineRunIDForUpdate :one
+SELECT id, project_id, session_id, trace_id, name, user_id, tags, environment, release, metadata, input, output, status, start_time, end_time, server_received_at, duration_ms, total_spans, total_cost, error_count, version, created_at, updated_at, search_vector, total_tokens_in, total_tokens_out, engine_run_id, engine_definition_name, engine_definition_version, engine_projection_state, engine_latest_history_id, engine_last_projected_history_id, engine_projection_updated_at, engine_instance_key, engine_run_status, engine_custom_status, engine_wait_state, engine_pending_activity_tasks, engine_pending_inbox_items
+FROM traces
+WHERE project_id = $1
+  AND engine_run_id = $2
+FOR UPDATE
+`
+
+type GetTraceByProjectAndEngineRunIDForUpdateParams struct {
+	ProjectID   uuid.UUID   `json:"project_id"`
+	EngineRunID pgtype.UUID `json:"engine_run_id"`
+}
+
+func (q *Queries) GetTraceByProjectAndEngineRunIDForUpdate(ctx context.Context, arg GetTraceByProjectAndEngineRunIDForUpdateParams) (Trace, error) {
+	row := q.db.QueryRow(ctx, getTraceByProjectAndEngineRunIDForUpdate, arg.ProjectID, arg.EngineRunID)
 	var i Trace
 	err := row.Scan(
 		&i.ID,

--- a/db/platform/migrations/postgres/000018_engine_trace_filter_indexes.down.sql
+++ b/db/platform/migrations/postgres/000018_engine_trace_filter_indexes.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_traces_engine_projection_state_project;
+DROP INDEX IF EXISTS idx_traces_engine_run_status_project;
+DROP INDEX IF EXISTS idx_traces_engine_definition_name_project;
+DROP INDEX IF EXISTS idx_traces_engine_instance_key_project;

--- a/db/platform/migrations/postgres/000018_engine_trace_filter_indexes.up.sql
+++ b/db/platform/migrations/postgres/000018_engine_trace_filter_indexes.up.sql
@@ -1,0 +1,15 @@
+CREATE INDEX idx_traces_engine_instance_key_project
+    ON traces(project_id, engine_instance_key)
+    WHERE engine_run_id IS NOT NULL;
+
+CREATE INDEX idx_traces_engine_definition_name_project
+    ON traces(project_id, engine_definition_name)
+    WHERE engine_run_id IS NOT NULL;
+
+CREATE INDEX idx_traces_engine_run_status_project
+    ON traces(project_id, engine_run_status)
+    WHERE engine_run_id IS NOT NULL;
+
+CREATE INDEX idx_traces_engine_projection_state_project
+    ON traces(project_id, engine_projection_state)
+    WHERE engine_run_id IS NOT NULL;

--- a/db/platform/queries/spans.sql
+++ b/db/platform/queries/spans.sql
@@ -198,3 +198,12 @@ SET prompt_tokens = $2, completion_tokens = $3, total_tokens = $4,
     total_cost = $5, updated_at = NOW(), version = version + 1
 WHERE id = $1
 RETURNING *;
+
+-- name: DeleteSpanEventsByTrace :exec
+DELETE FROM span_events
+WHERE trace_id = $1;
+
+-- name: DeleteNonRootSpansByTrace :exec
+DELETE FROM spans
+WHERE trace_id = $1
+  AND parent_span_id IS NOT NULL;

--- a/db/platform/queries/traces.sql
+++ b/db/platform/queries/traces.sql
@@ -11,6 +11,13 @@ SELECT version FROM traces WHERE id = $1;
 -- name: GetTraceByExternalID :one
 SELECT * FROM traces WHERE project_id = $1 AND trace_id = $2;
 
+-- name: GetTraceByProjectAndEngineRunIDForUpdate :one
+SELECT *
+FROM traces
+WHERE project_id = $1
+  AND engine_run_id = $2
+FOR UPDATE;
+
 -- name: GetTraceUUID :one
 SELECT id FROM traces WHERE project_id = $1 AND trace_id = $2;
 
@@ -95,6 +102,33 @@ SET engine_run_status = $2,
     version = COALESCE(version, 1) + 1
 WHERE engine_run_id = $1
 RETURNING *;
+
+-- name: FlipProjectionStateToSummaryOnly :execrows
+UPDATE traces
+SET engine_projection_state = 'summary_only',
+    engine_projection_updated_at = NOW(),
+    updated_at = NOW(),
+    version = COALESCE(version, 1) + 1
+WHERE engine_run_id = $1
+  AND COALESCE(engine_projection_state, 'up_to_date') IN ('up_to_date', 'catching_up');
+
+-- name: FlipProjectionStateToJournalExpired :execrows
+UPDATE traces
+SET engine_projection_state = 'journal_expired',
+    engine_projection_updated_at = NOW(),
+    updated_at = NOW(),
+    version = COALESCE(version, 1) + 1
+WHERE engine_run_id = $1
+  AND COALESCE(engine_projection_state, 'up_to_date') IN ('up_to_date', 'catching_up', 'summary_only');
+
+-- name: FlipProjectionStateToCatchingUp :execrows
+UPDATE traces
+SET engine_projection_state = 'catching_up',
+    engine_projection_updated_at = NOW(),
+    updated_at = NOW(),
+    version = COALESCE(version, 1) + 1
+WHERE engine_run_id = $1
+  AND COALESCE(engine_projection_state, 'up_to_date') = 'summary_only';
 
 -- name: UpsertTrace :one
 -- Upsert trace with patch semantics: NULL values don't overwrite existing.

--- a/docs/architecture/RULES.md
+++ b/docs/architecture/RULES.md
@@ -36,6 +36,8 @@ Change the source inputs, not:
 
 `db/platform/migrations/postgres/` is the real platform schema. SQLite under `db/platform/migrations/sqlite/` is bootstrap-only scaffolding.
 
+This repo is still pre-production, so platform and engine migrations may be rewritten, renumbered, or squashed until the first production release. After the first production release, migration history becomes immutable.
+
 ### 6. Runtime config is env-only
 
 `internal/config/config.go` is the live config contract. `config.example.yaml` is future-state drift, not runtime truth.

--- a/engine/cmd/continua-engine/main_test.go
+++ b/engine/cmd/continua-engine/main_test.go
@@ -44,27 +44,27 @@ func TestMigrateCommandsRoundTrip(t *testing.T) {
 	t.Setenv("ENGINE_DATABASE_URL", db.DatabaseURL)
 	t.Setenv("DATABASE_URL", "")
 
-	stdout, stderr, err := executeCommand(t, "migrate", "down", "4")
+	stdout, stderr, err := executeCommand(t, "migrate", "down", "5")
 	if err != nil {
-		t.Fatalf("execute migrate down 4: %v", err)
+		t.Fatalf("execute migrate down 5: %v", err)
 	}
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, "Rolled back 4 engine migration step(s)") {
+	if !strings.Contains(stdout, "Rolled back 5 engine migration step(s)") {
 		t.Fatalf("unexpected migrate down output: %q", stdout)
 	}
 
 	if !schemaExists(t, db.DatabaseURL, "engine") {
-		t.Fatal("expected engine schema to remain after rolling back only the runtime migration")
+		t.Fatal("expected engine schema to remain after rolling back the runtime migration stack")
 	}
 	for _, column := range []string{"result", "custom_status", "waiting_for", "completed_at"} {
 		if columnExists(t, db.DatabaseURL, "engine", "runs", column) {
-			t.Fatalf("expected engine.runs.%s to be removed after migrate down 4", column)
+			t.Fatalf("expected engine.runs.%s to be removed after migrate down 5", column)
 		}
 	}
 	if enumLabelExists(t, db.DatabaseURL, "engine", "run_lifecycle_status", "waiting") {
-		t.Fatal("expected waiting enum label to be removed after migrate down 4")
+		t.Fatal("expected waiting enum label to be removed after migrate down 5")
 	}
 
 	stdout, stderr, err = executeCommand(t, "migrate", "up")
@@ -143,9 +143,9 @@ func TestMigrateDownRejectsWaitingRuns(t *testing.T) {
 		t.Fatalf("TransitionRunToWaiting() error = %v", err)
 	}
 
-	stdout, stderr, err := executeCommand(t, "migrate", "down", "4")
+	stdout, stderr, err := executeCommand(t, "migrate", "down", "5")
 	if err == nil {
-		t.Fatal("expected migrate down 4 to fail when waiting rows exist")
+		t.Fatal("expected migrate down 5 to fail when waiting rows exist")
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout on failed rollback, got %q", stdout)
@@ -261,8 +261,8 @@ func TestBackfillMigrationRecomputesInstanceStatusesFromLatestRun(t *testing.T) 
 		t.Fatalf("corrupt instance statuses: %v", err)
 	}
 
-	if stdout, stderr, err := executeCommand(t, "migrate", "down", "1"); err != nil {
-		t.Fatalf("execute migrate down 1: %v (stdout=%q stderr=%q)", err, stdout, stderr)
+	if stdout, stderr, err := executeCommand(t, "migrate", "down", "2"); err != nil {
+		t.Fatalf("execute migrate down 2: %v (stdout=%q stderr=%q)", err, stdout, stderr)
 	}
 	if stdout, stderr, err := executeCommand(t, "migrate", "up"); err != nil {
 		t.Fatalf("execute migrate up after backfill rollback: %v (stdout=%q stderr=%q)", err, stdout, stderr)

--- a/engine/db/gen/go/history.sql.go
+++ b/engine/db/gen/go/history.sql.go
@@ -56,6 +56,16 @@ func (q *Queries) AppendHistory(ctx context.Context, arg AppendHistoryParams) (E
 	return i, err
 }
 
+const deleteHistoryByRun = `-- name: DeleteHistoryByRun :exec
+DELETE FROM engine.history
+WHERE run_id = $1
+`
+
+func (q *Queries) DeleteHistoryByRun(ctx context.Context, runID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteHistoryByRun, runID)
+	return err
+}
+
 const getHistoryByInstance = `-- name: GetHistoryByInstance :many
 SELECT id, project_id, instance_id, run_id, sequence_no, event_type, payload, created_at
 FROM engine.history

--- a/engine/db/migrations/postgres/000002_runtime_columns.down.sql
+++ b/engine/db/migrations/postgres/000002_runtime_columns.down.sql
@@ -35,6 +35,11 @@ ALTER TABLE engine.runs
     DROP COLUMN custom_status,
     DROP COLUMN result;
 
-CREATE INDEX idx_engine_runs_claim
-    ON engine.runs(status, ready_at, lease_expires_at)
-    WHERE status IN ('queued', 'running');
+DO $$
+BEGIN
+    EXECUTE $sql$
+        CREATE INDEX idx_engine_runs_claim
+            ON engine.runs(status, ready_at, lease_expires_at)
+            WHERE status IN ('queued', 'running')
+    $sql$;
+END $$;

--- a/engine/db/migrations/postgres/000004_terminated_lifecycle.down.sql
+++ b/engine/db/migrations/postgres/000004_terminated_lifecycle.down.sql
@@ -67,9 +67,14 @@ DROP TYPE engine.instance_lifecycle_status_old;
 ALTER TABLE engine.instances
     ALTER COLUMN status SET DEFAULT 'active';
 
-CREATE INDEX idx_engine_runs_claim
-    ON engine.runs(status, ready_at, lease_expires_at)
-    WHERE status IN ('queued', 'running');
+DO $$
+BEGIN
+    EXECUTE $sql$
+        CREATE INDEX idx_engine_runs_claim
+            ON engine.runs(status, ready_at, lease_expires_at)
+            WHERE status IN ('queued', 'running')
+    $sql$;
+END $$;
 
 CREATE INDEX idx_engine_instances_status_updated
     ON engine.instances(project_id, status, updated_at DESC);

--- a/engine/db/migrations/postgres/000006_run_completion_retention_index.down.sql
+++ b/engine/db/migrations/postgres/000006_run_completion_retention_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS engine.idx_engine_runs_retention_completed_at;

--- a/engine/db/migrations/postgres/000006_run_completion_retention_index.up.sql
+++ b/engine/db/migrations/postgres/000006_run_completion_retention_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_engine_runs_retention_completed_at
+    ON engine.runs (completed_at, id)
+    WHERE status IN ('completed', 'failed', 'cancelled', 'terminated');

--- a/engine/db/queries/history.sql
+++ b/engine/db/queries/history.sql
@@ -42,3 +42,7 @@ SELECT *
 FROM engine.history
 WHERE instance_id = $1
 ORDER BY id ASC;
+
+-- name: DeleteHistoryByRun :exec
+DELETE FROM engine.history
+WHERE run_id = $1;

--- a/engine/internal/projector/projector.go
+++ b/engine/internal/projector/projector.go
@@ -1,7 +1,8 @@
 // Package projector owns all cross-schema writes from engine history into the
 // platform debugger tables, including terminal debugger cleanup when
-// workflow.cancelled or workflow.terminated history rows are projected. No
-// other code path writes projection tables for terminal cleanup.
+// workflow.cancelled or workflow.terminated history rows are projected. Purge
+// is the only coordinated co-writer for engine projection state, and it must
+// go through the platform-side CAS helpers before deleting detail rows.
 //
 // Authoritative platform dependencies:
 // - db/platform/migrations/postgres/000001_initial_schema.up.sql
@@ -71,56 +72,16 @@ func New(store *enginestore.Store) *Projector {
 }
 
 func (p *Projector) PollOnce(ctx context.Context, _ string) error {
-	tx, err := p.store.BeginTx(ctx, pgx.TxOptions{})
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = tx.Rollback(ctx)
-	}()
-
-	target, err := selectProjectionTarget(ctx, tx.Tx())
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil
-		}
-		return err
-	}
-
-	historyRows, err := tx.ListHistoryByRunAfterID(ctx, enginedb.ListHistoryByRunAfterIDParams{
-		RunID: target.RunID,
-		ID:    target.LastProjectedHistoryID,
-		Limit: defaultProjectorBatchSize,
-	})
-	if err != nil {
-		return err
-	}
-	if len(historyRows) == 0 {
-		if err := advanceProjectionCheckpoint(ctx, tx.Tx(), target.TraceID, target.RunID, target.LastProjectedHistoryID); err != nil {
+	for processed := 0; processed < int(defaultProjectorBatchSize); processed++ {
+		more, err := p.pollSingleHistoryRow(ctx)
+		if err != nil {
 			return err
 		}
-		return tx.Commit(ctx)
+		if !more {
+			return nil
+		}
 	}
-
-	lastProjectedID, err := p.projectHistoryRows(ctx, tx, &target, historyRows)
-	if err != nil {
-		return err
-	}
-	if err := refreshTraceCounters(ctx, tx.Tx(), target.TraceID); err != nil {
-		return err
-	}
-	if err := advanceProjectionCheckpoint(ctx, tx.Tx(), target.TraceID, target.RunID, lastProjectedID); err != nil {
-		return err
-	}
-	run, err := tx.GetRun(ctx, target.RunID)
-	if err != nil {
-		return err
-	}
-	if err := SyncProjectedRunSummary(ctx, tx.Tx(), &run); err != nil {
-		return err
-	}
-
-	return tx.Commit(ctx)
+	return nil
 }
 
 func UpdateLatestHistory(
@@ -163,8 +124,8 @@ func WriteTerminalSummary(
 	errorMessage *string,
 	latestHistoryID int64,
 ) error {
-	traceStatus, spanStatus := terminalStatuses(runStatus)
-	outputPayload, err := terminalOutputPayload(runStatus, result, errorCode, errorMessage)
+	traceStatus, spanStatus := publicprojection.TerminalStatuses(string(runStatus))
+	outputPayload, err := publicprojection.TerminalOutputPayload(string(runStatus), result, errorCode, errorMessage)
 	if err != nil {
 		return err
 	}
@@ -271,19 +232,25 @@ func (p *Projector) projectHistoryRows(
 	tx *enginestore.Tx,
 	target *projectionTarget,
 	rows []enginedb.EngineHistory,
-) (int64, error) {
+) (int64, bool, error) {
 	if target == nil {
-		return 0, errors.New("projection target is required")
+		return 0, false, errors.New("projection target is required")
 	}
 	lastProjectedID := target.LastProjectedHistoryID
 	for i := range rows {
 		row := &rows[i]
-		if err := projectHistoryRow(ctx, tx, target, row); err != nil {
-			return lastProjectedID, err
+		applied, err := withProjectionBarrier(ctx, tx.Tx(), target, func() error {
+			return projectHistoryRow(ctx, tx, target, row)
+		})
+		if err != nil {
+			return lastProjectedID, false, err
+		}
+		if !applied {
+			return lastProjectedID, true, nil
 		}
 		lastProjectedID = row.ID
 	}
-	return lastProjectedID, nil
+	return lastProjectedID, false, nil
 }
 
 func projectHistoryRow(
@@ -404,9 +371,9 @@ func writeTerminalProjection(
 		return errors.New("projection target is required")
 	}
 
-	traceStatus, spanStatus := terminalStatuses(projection.RunStatus)
-	outputPayload, err := terminalOutputPayload(
-		projection.RunStatus,
+	traceStatus, spanStatus := publicprojection.TerminalStatuses(string(projection.RunStatus))
+	outputPayload, err := publicprojection.TerminalOutputPayload(
+		string(projection.RunStatus),
 		projection.Result,
 		stringPtr(projection.ErrorCode),
 		stringPtr(projection.ErrorMessage),
@@ -918,7 +885,8 @@ func selectProjectionTarget(ctx context.Context, tx pgx.Tx) (projectionTarget, e
 		           t.engine_projection_updated_at,
 		           t.updated_at
 		    FROM public.traces AS t
-		    WHERE t.engine_run_id IS NOT NULL
+		WHERE t.engine_run_id IS NOT NULL
+		  AND COALESCE(t.engine_projection_state, '') NOT IN ('summary_only', 'journal_expired')
 		)
 		SELECT id,
 		       project_id,
@@ -989,6 +957,126 @@ func advanceProjectionCheckpoint(
 	return nil
 }
 
+func advanceProjectionCheckpointWithBarrier(
+	ctx context.Context,
+	tx pgx.Tx,
+	target *projectionTarget,
+	lastProjectedHistoryID int64,
+) (bool, error) {
+	if target == nil {
+		return false, errors.New("projection target is required")
+	}
+	return withProjectionBarrier(ctx, tx, target, func() error {
+		return advanceProjectionCheckpoint(ctx, tx, target.TraceID, target.RunID, lastProjectedHistoryID)
+	})
+}
+
+func (p *Projector) pollSingleHistoryRow(ctx context.Context) (bool, error) {
+	tx, err := p.store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	target, err := selectProjectionTarget(ctx, tx.Tx())
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	historyRows, err := tx.ListHistoryByRunAfterID(ctx, enginedb.ListHistoryByRunAfterIDParams{
+		RunID: target.RunID,
+		ID:    target.LastProjectedHistoryID,
+		Limit: 1,
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(historyRows) == 0 {
+		if _, err := advanceProjectionCheckpointWithBarrier(ctx, tx.Tx(), &target, target.LastProjectedHistoryID); err != nil {
+			return false, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	lastProjectedID, blocked, err := p.projectHistoryRows(ctx, tx, &target, historyRows)
+	if err != nil {
+		return false, err
+	}
+	if blocked {
+		if err := tx.Commit(ctx); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if err := refreshTraceCounters(ctx, tx.Tx(), target.TraceID); err != nil {
+		return false, err
+	}
+	applied, err := advanceProjectionCheckpointWithBarrier(ctx, tx.Tx(), &target, lastProjectedID)
+	if err != nil {
+		return false, err
+	}
+	if !applied {
+		if err := tx.Commit(ctx); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	run, err := tx.GetRun(ctx, target.RunID)
+	if err != nil {
+		return false, err
+	}
+	if err := SyncProjectedRunSummary(ctx, tx.Tx(), &run); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func withProjectionBarrier(
+	ctx context.Context,
+	tx pgx.Tx,
+	target *projectionTarget,
+	write func() error,
+) (bool, error) {
+	if target == nil {
+		return false, errors.New("projection target is required")
+	}
+	if write == nil {
+		return false, errors.New("projection write is required")
+	}
+
+	var projectionState string
+	err := tx.QueryRow(ctx, `
+		SELECT COALESCE(engine_projection_state, $3)
+		FROM public.traces
+		WHERE id = $1
+		  AND engine_run_id = $2
+		FOR UPDATE
+	`, target.TraceID, target.RunID, publicprojection.StateUpToDate.String()).Scan(&projectionState)
+	if err != nil {
+		return false, err
+	}
+	if projectionState == publicprojection.StateSummaryOnly.String() ||
+		projectionState == publicprojection.StateJournalExpired.String() {
+		return false, nil
+	}
+
+	if err := write(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func refreshTraceCounters(ctx context.Context, tx pgx.Tx, traceID uuid.UUID) error {
 	_, err := tx.Exec(ctx, `
 		WITH counts AS (
@@ -1005,35 +1093,6 @@ func refreshTraceCounters(ctx context.Context, tx pgx.Tx, traceID uuid.UUID) err
 		WHERE public.traces.id = $1
 	`, traceID)
 	return err
-}
-
-func terminalStatuses(status enginedb.EngineRunLifecycleStatus) (traceStatus, spanStatus string) {
-	switch status {
-	case enginedb.EngineRunLifecycleStatusCompleted:
-		return "completed", "completed"
-	case enginedb.EngineRunLifecycleStatusCancelled:
-		return "cancelled", "failed"
-	case enginedb.EngineRunLifecycleStatusTerminated:
-		return "failed", "failed"
-	default:
-		return "failed", "failed"
-	}
-}
-
-func terminalOutputPayload(
-	status enginedb.EngineRunLifecycleStatus,
-	result json.RawMessage,
-	errorCode *string,
-	errorMessage *string,
-) (json.RawMessage, error) {
-	if status == enginedb.EngineRunLifecycleStatusCompleted {
-		return cloneRaw(result), nil
-	}
-	return json.Marshal(map[string]any{
-		"error_code":    derefString(errorCode),
-		"error_message": derefString(errorMessage),
-		"status":        string(status),
-	})
 }
 
 func mergeOriginalEventType(raw json.RawMessage, originalEventType string) (json.RawMessage, error) {

--- a/engine/internal/projector/projector.go
+++ b/engine/internal/projector/projector.go
@@ -232,11 +232,11 @@ func (p *Projector) projectHistoryRows(
 	tx *enginestore.Tx,
 	target *projectionTarget,
 	rows []enginedb.EngineHistory,
-) (int64, bool, error) {
+) (lastProjectedID int64, blocked bool, err error) {
 	if target == nil {
 		return 0, false, errors.New("projection target is required")
 	}
-	lastProjectedID := target.LastProjectedHistoryID
+	lastProjectedID = target.LastProjectedHistoryID
 	for i := range rows {
 		row := &rows[i]
 		applied, err := withProjectionBarrier(ctx, tx.Tx(), target, func() error {
@@ -1152,13 +1152,6 @@ func nullableText(value *string) pgtype.Text {
 		return pgtype.Text{}
 	}
 	return pgtype.Text{String: *value, Valid: true}
-}
-
-func derefString(value *string) string {
-	if value == nil {
-		return ""
-	}
-	return *value
 }
 
 type pgtypeTimestamptz struct {

--- a/engine/internal/projector/projector_test.go
+++ b/engine/internal/projector/projector_test.go
@@ -297,6 +297,134 @@ func TestAdvanceProjectionCheckpoint_IsMonotonicForStaleUpdates(t *testing.T) {
 	}
 }
 
+func TestProjectorBarrier_ConcurrentPurgeToSummaryOnlySkipsDetailWrites(t *testing.T) {
+	fixture := newProjectorFixture(t)
+
+	activityHistory := fixture.appendHistoryEvent(2, publichistory.EventActivityScheduled, publichistory.ActivityScheduledPayload{
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+	})
+	fixture.setTraceProjection(activityHistory.ID, fixture.startedHistory.ID, publicprojection.StateCatchingUp.String())
+
+	tx, err := fixture.store.BeginTx(fixture.ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback(fixture.ctx) }()
+
+	target, err := selectProjectionTarget(fixture.ctx, tx.Tx())
+	if err != nil {
+		t.Fatalf("selectProjectionTarget() error = %v", err)
+	}
+	rows, err := tx.ListHistoryByRunAfterID(fixture.ctx, enginedb.ListHistoryByRunAfterIDParams{
+		RunID: fixture.run.ID,
+		ID:    fixture.startedHistory.ID,
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("ListHistoryByRunAfterID() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected one pending history row, got %d", len(rows))
+	}
+
+	fixture.setTraceProjection(activityHistory.ID, fixture.startedHistory.ID, publicprojection.StateSummaryOnly.String())
+
+	lastProjectedID, blocked, err := fixture.projector.projectHistoryRows(fixture.ctx, tx, &target, rows)
+	if err != nil {
+		t.Fatalf("projectHistoryRows() error = %v", err)
+	}
+	if !blocked {
+		t.Fatal("expected projection barrier to block detail writes after purge flips state to summary_only")
+	}
+	if lastProjectedID != fixture.startedHistory.ID {
+		t.Fatalf("expected checkpoint to remain at %d, got %d", fixture.startedHistory.ID, lastProjectedID)
+	}
+	if err := tx.Commit(fixture.ctx); err != nil {
+		t.Fatalf("tx.Commit() error = %v", err)
+	}
+
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-summary-only-barrier"); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+
+	assertProjectedDetailState(t, fixture, publicprojection.StateSummaryOnly.String(), fixture.startedHistory.ID, 0, 0)
+}
+
+func TestProjectorBarrier_JournalExpiredSkipsReprojection(t *testing.T) {
+	fixture := newProjectorFixture(t)
+
+	activityHistory := fixture.appendHistoryEvent(2, publichistory.EventActivityScheduled, publichistory.ActivityScheduledPayload{
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+	})
+	fixture.setTraceProjection(activityHistory.ID, fixture.startedHistory.ID, publicprojection.StateJournalExpired.String())
+
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-journal-expired-noop"); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+
+	assertProjectedDetailState(t, fixture, publicprojection.StateJournalExpired.String(), fixture.startedHistory.ID, 0, 0)
+}
+
+func TestProjectorBarrier_ConcurrentFullPurgeBlocksCheckpointWithoutHistoryRows(t *testing.T) {
+	fixture := newProjectorFixture(t)
+
+	activityHistory := fixture.appendHistoryEvent(2, publichistory.EventActivityScheduled, publichistory.ActivityScheduledPayload{
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+	})
+	fixture.setTraceProjection(activityHistory.ID, fixture.startedHistory.ID, publicprojection.StateCatchingUp.String())
+
+	tx, err := fixture.store.BeginTx(fixture.ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback(fixture.ctx) }()
+
+	target, err := selectProjectionTarget(fixture.ctx, tx.Tx())
+	if err != nil {
+		t.Fatalf("selectProjectionTarget() error = %v", err)
+	}
+
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		DELETE FROM engine.history
+		WHERE run_id = $1
+		  AND id = $2
+	`, fixture.run.ID, activityHistory.ID); err != nil {
+		t.Fatalf("delete projected history during concurrent purge: %v", err)
+	}
+	fixture.setTraceProjection(activityHistory.ID, fixture.startedHistory.ID, publicprojection.StateJournalExpired.String())
+
+	rows, err := tx.ListHistoryByRunAfterID(fixture.ctx, enginedb.ListHistoryByRunAfterIDParams{
+		RunID: fixture.run.ID,
+		ID:    fixture.startedHistory.ID,
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("ListHistoryByRunAfterID() error = %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected zero remaining history rows after purge, got %d", len(rows))
+	}
+
+	applied, err := advanceProjectionCheckpointWithBarrier(fixture.ctx, tx.Tx(), &target, target.LastProjectedHistoryID)
+	if err != nil {
+		t.Fatalf("advanceProjectionCheckpointWithBarrier() error = %v", err)
+	}
+	if applied {
+		t.Fatal("expected checkpoint advance to be blocked by journal_expired barrier")
+	}
+	if err := tx.Commit(fixture.ctx); err != nil {
+		t.Fatalf("tx.Commit() error = %v", err)
+	}
+
+	assertProjectedDetailState(t, fixture, publicprojection.StateJournalExpired.String(), fixture.startedHistory.ID, 0, 0)
+}
+
 func TestProjectionStateAdvancesAcrossStartActivationAndProjector(t *testing.T) {
 	fixture := newProjectorFixture(t)
 
@@ -374,6 +502,41 @@ func TestProjectionStateAdvancesAcrossStartActivationAndProjector(t *testing.T) 
 	}
 	if traceState != publicprojection.StateUpToDate.String() {
 		t.Fatalf("expected projector to restore up_to_date, got %q", traceState)
+	}
+}
+
+func TestProjectorPollOnce_RepairFromSummaryOnlyRebuildsDetailFromCheckpoint(t *testing.T) {
+	fixture := newProjectorFixture(t)
+
+	activityHistory := fixture.appendHistoryEvent(2, publichistory.EventActivityScheduled, publichistory.ActivityScheduledPayload{
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+	})
+
+	// Simulate a purged shell that still has retained history after an operator-triggered repair
+	// flips the trace back to catching_up.
+	fixture.setTraceProjection(activityHistory.ID, fixture.startedHistory.ID, publicprojection.StateSummaryOnly.String())
+	assertProjectedDetailState(t, fixture, publicprojection.StateSummaryOnly.String(), fixture.startedHistory.ID, 0, 0)
+	fixture.setTraceProjection(activityHistory.ID, fixture.startedHistory.ID, publicprojection.StateCatchingUp.String())
+
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-repair-catch-up"); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+
+	assertProjectedDetailState(t, fixture, publicprojection.StateUpToDate.String(), activityHistory.ID, 1, 2)
+
+	var activitySpanCount int
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT COUNT(*)
+		FROM public.spans
+		WHERE trace_id = $1
+		  AND span_id = $2
+	`, fixture.traceID, activitySpanExternalID(fixture.run.ID, "ship-order")).Scan(&activitySpanCount); err != nil {
+		t.Fatalf("count activity spans: %v", err)
+	}
+	if activitySpanCount != 1 {
+		t.Fatalf("expected exactly one repaired activity span, got %d", activitySpanCount)
 	}
 }
 
@@ -1180,4 +1343,57 @@ func queryResolvedWaitEvents(t *testing.T, fixture *projectorFixture, resolution
 	}
 
 	return resolved
+}
+
+func assertProjectedDetailState(
+	t *testing.T,
+	fixture *projectorFixture,
+	wantProjectionState string,
+	wantLastProjectedHistoryID int64,
+	wantActivitySpans int,
+	wantSpanEvents int,
+) {
+	t.Helper()
+
+	var projectionState string
+	var lastProjectedHistoryID int64
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT engine_projection_state,
+		       engine_last_projected_history_id
+		FROM public.traces
+		WHERE id = $1
+	`, fixture.traceID).Scan(&projectionState, &lastProjectedHistoryID); err != nil {
+		t.Fatalf("query trace projection state: %v", err)
+	}
+	if projectionState != wantProjectionState {
+		t.Fatalf("expected projection state %q, got %q", wantProjectionState, projectionState)
+	}
+	if lastProjectedHistoryID != wantLastProjectedHistoryID {
+		t.Fatalf("expected last projected history id %d, got %d", wantLastProjectedHistoryID, lastProjectedHistoryID)
+	}
+
+	var activitySpanCount int
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT COUNT(*)
+		FROM public.spans
+		WHERE trace_id = $1
+		  AND span_id LIKE 'engine:activity:%'
+	`, fixture.traceID).Scan(&activitySpanCount); err != nil {
+		t.Fatalf("count activity spans: %v", err)
+	}
+	if activitySpanCount != wantActivitySpans {
+		t.Fatalf("expected %d activity spans, got %d", wantActivitySpans, activitySpanCount)
+	}
+
+	var spanEventCount int
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT COUNT(*)
+		FROM public.span_events
+		WHERE trace_id = $1
+	`, fixture.traceID).Scan(&spanEventCount); err != nil {
+		t.Fatalf("count span events: %v", err)
+	}
+	if spanEventCount != wantSpanEvents {
+		t.Fatalf("expected %d span events, got %d", wantSpanEvents, spanEventCount)
+	}
 }

--- a/engine/internal/store/history.go
+++ b/engine/internal/store/history.go
@@ -41,3 +41,7 @@ func (o *storeOps) GetHistoryByInstance(
 ) ([]enginedb.EngineHistory, error) {
 	return o.q.GetHistoryByInstance(ctx, instanceID)
 }
+
+func (o *storeOps) DeleteHistoryByRun(ctx context.Context, runID uuid.UUID) error {
+	return o.q.DeleteHistoryByRun(ctx, runID)
+}

--- a/engine/pkg/projection/terminal.go
+++ b/engine/pkg/projection/terminal.go
@@ -1,0 +1,46 @@
+package projection
+
+import "encoding/json"
+
+func TerminalStatuses(runStatus string) (traceStatus, spanStatus string) {
+	switch runStatus {
+	case "completed":
+		return "completed", "completed"
+	case "cancelled":
+		return "cancelled", "failed"
+	case "terminated":
+		return "failed", "failed"
+	default:
+		return "failed", "failed"
+	}
+}
+
+func TerminalOutputPayload(
+	runStatus string,
+	result json.RawMessage,
+	errorCode *string,
+	errorMessage *string,
+) (json.RawMessage, error) {
+	if runStatus == "completed" {
+		return cloneRaw(result), nil
+	}
+	return json.Marshal(map[string]any{
+		"error_code":    derefString(errorCode),
+		"error_message": derefString(errorMessage),
+		"status":        runStatus,
+	})
+}
+
+func cloneRaw(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/engine/pkg/projection/terminal_test.go
+++ b/engine/pkg/projection/terminal_test.go
@@ -1,0 +1,59 @@
+package projection
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTerminalStatuses(t *testing.T) {
+	testCases := []struct {
+		name      string
+		runStatus string
+		wantTrace string
+		wantSpan  string
+	}{
+		{name: "completed", runStatus: "completed", wantTrace: "completed", wantSpan: "completed"},
+		{name: "cancelled", runStatus: "cancelled", wantTrace: "cancelled", wantSpan: "failed"},
+		{name: "terminated", runStatus: "terminated", wantTrace: "failed", wantSpan: "failed"},
+		{name: "failed", runStatus: "failed", wantTrace: "failed", wantSpan: "failed"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTrace, gotSpan := TerminalStatuses(tc.runStatus)
+			if gotTrace != tc.wantTrace || gotSpan != tc.wantSpan {
+				t.Fatalf("TerminalStatuses(%q) = (%q, %q), want (%q, %q)", tc.runStatus, gotTrace, gotSpan, tc.wantTrace, tc.wantSpan)
+			}
+		})
+	}
+}
+
+func TestTerminalOutputPayload(t *testing.T) {
+	t.Run("completed returns result", func(t *testing.T) {
+		result := json.RawMessage(`{"ok":true}`)
+		got, err := TerminalOutputPayload("completed", result, nil, nil)
+		if err != nil {
+			t.Fatalf("TerminalOutputPayload() error = %v", err)
+		}
+		if string(got) != string(result) {
+			t.Fatalf("TerminalOutputPayload() = %s, want %s", got, result)
+		}
+	})
+
+	t.Run("terminal failure returns structured payload", func(t *testing.T) {
+		errorCode := "terminated"
+		errorMessage := "run terminated by operator"
+		got, err := TerminalOutputPayload("terminated", nil, &errorCode, &errorMessage)
+		if err != nil {
+			t.Fatalf("TerminalOutputPayload() error = %v", err)
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal(got, &payload); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		if payload["error_code"] != errorCode || payload["error_message"] != errorMessage || payload["status"] != "terminated" {
+			t.Fatalf("unexpected payload: %+v", payload)
+		}
+	})
+}

--- a/internal/api/engine_control.go
+++ b/internal/api/engine_control.go
@@ -90,6 +90,7 @@ type engineRunSummary struct {
 
 type engineHistoryPage struct {
 	Events    []enginedb.EngineHistory
+	Expired   bool
 	HasMore   bool
 	NextAfter *int
 }
@@ -612,6 +613,11 @@ func (s *engineControlService) GetRunHistory(
 	page := engineHistoryPage{
 		Events: rows,
 	}
+	projectionState, err := s.projectionStateForRun(ctx, projectID, runID)
+	if err != nil {
+		return engineHistoryPage{}, err
+	}
+	page.Expired = projectionState == publicprojection.StateJournalExpired.String()
 	if len(rows) > limit {
 		page.HasMore = true
 		page.Events = rows[:limit]

--- a/internal/api/engine_handlers.go
+++ b/internal/api/engine_handlers.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"github.com/continua-ai/continua/internal/enginecontrol"
 )
 
 func (s *Server) GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string) {
@@ -162,6 +164,49 @@ func (s *Server) GetEngineRunResult(w http.ResponseWriter, r *http.Request, runI
 	}
 
 	writeJSON(w, http.StatusOK, engineRunResultResponseToAPI(&result))
+}
+
+func (s *Server) PurgeEngineRun(w http.ResponseWriter, r *http.Request, runID openapi_types.UUID, _ PurgeEngineRunParams) {
+	projectID, ok := projectIDOrUnauthorized(w, r)
+	if !ok {
+		return
+	}
+	if s.engineSharedControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var req EnginePurgeRequest
+	if !decodeJSONRequest(w, r, &req) {
+		return
+	}
+
+	result, err := s.engineSharedControl.PurgeRun(r.Context(), projectID, runID, enginecontrol.PurgeMode(req.Mode))
+	if err != nil {
+		writeEngineError(w, err, "Failed to purge engine run")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, enginePurgeResponseToAPI(&result))
+}
+
+func (s *Server) RepairEngineRun(w http.ResponseWriter, r *http.Request, runID openapi_types.UUID, _ RepairEngineRunParams) {
+	projectID, ok := projectIDOrUnauthorized(w, r)
+	if !ok {
+		return
+	}
+	if s.engineSharedControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	result, err := s.engineSharedControl.RepairRun(r.Context(), projectID, runID)
+	if err != nil {
+		writeEngineError(w, err, "Failed to repair engine run")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, engineRepairResponseToAPI(&result))
 }
 
 func (s *Server) GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runID openapi_types.UUID) {

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -2465,6 +2465,7 @@ func waitForProjectedTraceTerminalSummary(t *testing.T, pool *pgxpool.Pool, trac
 	return "", "", nil
 }
 
+//nolint:revive // Keep testing.T first in test helper signatures.
 func waitForProjectedTraceCaughtUp(
 	t *testing.T,
 	ctx context.Context,

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -30,6 +30,7 @@ import (
 	publichistory "github.com/continua-ai/continua/engine/pkg/history"
 	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
 	"github.com/continua-ai/continua/internal/api/middleware"
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/store"
 	"github.com/continua-ai/continua/internal/testutil"
 )
@@ -600,6 +601,40 @@ func TestGetEngineRunResult_ReturnsCancelledFailureSummary(t *testing.T) {
 	assertJSONFieldNull(t, body, "result")
 }
 
+func TestGetEngineRun_IncludesDefinitionMismatchFailureContext(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-definition-mismatch",
+		RequestKey:        "req-definition-mismatch",
+	}))
+
+	_, err := platformStore.Pool().Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'failed',
+		    waiting_for = NULL,
+		    completed_at = NOW(),
+		    last_error_code = 'definition_version_mismatch',
+		    last_error_message = 'requested definition version is not registered',
+		    updated_at = NOW()
+		WHERE id = $1
+	`, start.RunId)
+	require.NoError(t, err)
+
+	rec := invokeGetEngineRun(t, server, projectID, start.RunId)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[EngineRunResponse](t, rec)
+	assert.Equal(t, "checkout", resp.DefinitionName)
+	assert.Equal(t, "v1", resp.DefinitionVersion)
+	require.NotNil(t, resp.Failure)
+	assert.Equal(t, "definition_version_mismatch", resp.Failure.ErrorCode)
+	assert.Equal(t, "requested definition version is not registered", resp.Failure.ErrorMessage)
+}
+
 func TestTerminateEngineRun_ReturnsTerminatedSummaryAndIsIdempotent(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
@@ -877,6 +912,452 @@ func TestTerminateEngineRun_RouterEnforcesPreviewHeaderAndAvailability(t *testin
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestPurgeEngineRun_ProjectionOnlyThenFullPreservesShell(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-purge",
+		RequestKey:        "req-purge",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+	markEngineRunCompleted(t, ctx, platformStore, start.RunId, trace.ID)
+
+	now := time.Now().UTC()
+	_, err = platformStore.Queries().CreateSpan(ctx, platformdb.CreateSpanParams{
+		ProjectID:    projectID,
+		TraceID:      trace.ID,
+		SpanID:       "engine:activity:" + start.RunId.String() + ":ship-order",
+		ParentSpanID: testutil.StrPtr("engine:root:" + start.RunId.String()),
+		Name:         "ship-order",
+		Type:         "tool",
+		Status:       "completed",
+		Level:        "default",
+		StartTime:    now.Add(-time.Minute),
+		EndTime:      testutil.PgtypeTimestamptz(now),
+		Depth:        testutil.Int32Ptr(1),
+	})
+	require.NoError(t, err)
+	_, err = platformStore.Queries().InsertSpanEvent(ctx, platformdb.InsertSpanEventParams{
+		ProjectID: projectID,
+		TraceID:   trace.ID,
+		SpanID:    "engine:root:" + start.RunId.String(),
+		EventType: "custom",
+		Level:     "info",
+		EventTs:   testutil.PgtypeTimestamptz(now),
+		Message:   testutil.StrPtr("projected detail"),
+		Payload:   []byte(`{"detail":true}`),
+	})
+	require.NoError(t, err)
+
+	projectionOnly := decodeJSONBody[EnginePurgeResponse](t, invokePurgeEngineRun(
+		t,
+		server,
+		projectID,
+		start.RunId,
+		ProjectionOnly,
+	))
+	assert.True(t, projectionOnly.Deleted)
+	assert.Equal(t, SummaryOnly, projectionOnly.ProjectionState)
+
+	idempotentProjectionOnly := decodeJSONBody[EnginePurgeResponse](t, invokePurgeEngineRun(
+		t,
+		server,
+		projectID,
+		start.RunId,
+		ProjectionOnly,
+	))
+	assert.False(t, idempotentProjectionOnly.Deleted)
+	assert.Equal(t, SummaryOnly, idempotentProjectionOnly.ProjectionState)
+
+	remainingSpans, err := platformStore.ListSpansByTrace(ctx, trace.ID)
+	require.NoError(t, err)
+	require.Len(t, remainingSpans, 1)
+	assert.Equal(t, "engine:root:"+start.RunId.String(), remainingSpans[0].SpanID)
+
+	events, err := platformStore.ListSpanEventsByTrace(ctx, trace.ID)
+	require.NoError(t, err)
+	assert.Empty(t, events)
+
+	resultRec := invokeGetEngineRunResult(t, server, projectID, start.RunId)
+	require.Equal(t, http.StatusOK, resultRec.Code)
+	resultResp := decodeJSONBody[EngineRunResultResponse](t, resultRec)
+	assert.Equal(t, EngineRunStatusCOMPLETED, resultResp.Status)
+	require.NotNil(t, resultResp.Result)
+
+	full := decodeJSONBody[EnginePurgeResponse](t, invokePurgeEngineRun(
+		t,
+		server,
+		projectID,
+		start.RunId,
+		Full,
+	))
+	assert.True(t, full.Deleted)
+	assert.Equal(t, JournalExpired, full.ProjectionState)
+
+	historyRows, err := engineQueries.GetHistoryByRun(ctx, start.RunId)
+	require.NoError(t, err)
+	assert.Empty(t, historyRows)
+
+	historyRec := invokeGetEngineRunHistory(t, server, projectID, start.RunId, GetEngineRunHistoryParams{})
+	require.Equal(t, http.StatusOK, historyRec.Code)
+	historyResp := decodeJSONBody[EngineRunHistoryResponse](t, historyRec)
+	require.NotNil(t, historyResp.Expired)
+	assert.True(t, *historyResp.Expired)
+	assert.Empty(t, historyResp.Events)
+
+	journalExpiredResultRec := invokeGetEngineRunResult(t, server, projectID, start.RunId)
+	require.Equal(t, http.StatusOK, journalExpiredResultRec.Code)
+	journalExpiredResult := decodeJSONBody[EngineRunResultResponse](t, journalExpiredResultRec)
+	assert.Equal(t, EngineRunStatusCOMPLETED, journalExpiredResult.Status)
+	require.NotNil(t, journalExpiredResult.Result)
+
+	idempotentFull := decodeJSONBody[EnginePurgeResponse](t, invokePurgeEngineRun(
+		t,
+		server,
+		projectID,
+		start.RunId,
+		Full,
+	))
+	assert.False(t, idempotentFull.Deleted)
+	assert.Equal(t, JournalExpired, idempotentFull.ProjectionState)
+}
+
+func TestPurgeEngineRun_SynthesizesTerminalShellBeforeBarrier(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-purge-terminal-shell-race",
+		RequestKey:        "req-purge-terminal-shell-race",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+	run, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        start.RunId,
+	})
+	require.NoError(t, err)
+
+	startHistory, err := engineQueries.GetHistoryByRun(ctx, start.RunId)
+	require.NoError(t, err)
+	require.Len(t, startHistory, 1)
+
+	terminalHistory := appendEngineHistoryEvent(
+		t,
+		ctx,
+		engineQueries,
+		projectID,
+		run.InstanceID,
+		start.RunId,
+		2,
+		publichistory.EventWorkflowCompleted,
+		publichistory.WorkflowCompletedPayload{Result: []byte(`{"ok":true}`)},
+	)
+	markEngineRunCompletedEngineOnly(t, ctx, platformStore, start.RunId)
+	setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "catching_up", terminalHistory.ID, startHistory[0].ID)
+
+	purge := decodeJSONBody[EnginePurgeResponse](t, invokePurgeEngineRun(
+		t,
+		server,
+		projectID,
+		start.RunId,
+		ProjectionOnly,
+	))
+	assert.True(t, purge.Deleted)
+	assert.Equal(t, SummaryOnly, purge.ProjectionState)
+
+	var traceStatus string
+	var traceOutput []byte
+	var runStatus string
+	if err := platformStore.Pool().QueryRow(ctx, `
+		SELECT status, output, engine_run_status
+		FROM traces
+		WHERE id = $1
+	`, trace.ID).Scan(&traceStatus, &traceOutput, &runStatus); err != nil {
+		t.Fatalf("query synthesized terminal trace shell: %v", err)
+	}
+	assert.Equal(t, "completed", traceStatus)
+	assert.Equal(t, string(enginedb.EngineRunLifecycleStatusCompleted), runStatus)
+	assert.JSONEq(t, `{"ok":true}`, string(traceOutput))
+
+	var rootSpanStatus string
+	var rootSpanOutput []byte
+	if err := platformStore.Pool().QueryRow(ctx, `
+		SELECT status, output
+		FROM spans
+		WHERE trace_id = $1
+		  AND span_id = $2
+	`, trace.ID, "engine:root:"+start.RunId.String()).Scan(&rootSpanStatus, &rootSpanOutput); err != nil {
+		t.Fatalf("query synthesized terminal root span shell: %v", err)
+	}
+	assert.Equal(t, "completed", rootSpanStatus)
+	assert.JSONEq(t, `{"ok":true}`, string(rootSpanOutput))
+}
+
+func TestPurgeEngineRun_RejectsNonTerminalRun(t *testing.T) {
+	ctx, _, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-purge-nonterminal",
+		RequestKey:        "req-purge-nonterminal",
+	}))
+
+	rec := invokePurgeEngineRun(t, server, projectID, start.RunId, ProjectionOnly)
+	require.Equal(t, http.StatusConflict, rec.Code)
+	assert.Equal(t, "run_not_terminal", decodeJSONBody[Error](t, rec).Code)
+}
+
+func TestPurgeEngineRun_ReturnsNotFoundForMissingRunAndCrossProject(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-purge-scope",
+		RequestKey:        "req-purge-scope",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+	markEngineRunCompleted(t, ctx, platformStore, start.RunId, trace.ID)
+
+	otherProjectID := testutil.CreateTestProject(t, ctx, platformStore.Queries())
+	crossProject := invokePurgeEngineRun(t, server, otherProjectID, start.RunId, ProjectionOnly)
+	require.Equal(t, http.StatusNotFound, crossProject.Code)
+	assert.Equal(t, "not_found", decodeJSONBody[Error](t, crossProject).Code)
+
+	missing := invokePurgeEngineRun(t, server, projectID, uuid.New(), ProjectionOnly)
+	require.Equal(t, http.StatusNotFound, missing.Code)
+	assert.Equal(t, "not_found", decodeJSONBody[Error](t, missing).Code)
+}
+
+func TestRepairEngineRun_ReturnsExpectedReasons(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-repair",
+		RequestKey:        "req-repair",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	t.Run("up_to_date", func(t *testing.T) {
+		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "up_to_date", 5, 5)
+		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
+		assert.False(t, resp.Accepted)
+		assert.Equal(t, AlreadyUpToDate, resp.Reason)
+		assert.Equal(t, UpToDate, resp.ProjectionState)
+	})
+
+	t.Run("summary_only with retained history", func(t *testing.T) {
+		latestHistoryID, err := engineQueries.GetLatestHistoryIDByRun(ctx, start.RunId)
+		require.NoError(t, err)
+		require.Greater(t, latestHistoryID, int64(0))
+		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", latestHistoryID, latestHistoryID-1)
+		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, RepairRequested, resp.Reason)
+		assert.Equal(t, CatchingUp, resp.ProjectionState)
+	})
+
+	t.Run("summary_only no events", func(t *testing.T) {
+		latestHistoryID, err := engineQueries.GetLatestHistoryIDByRun(ctx, start.RunId)
+		require.NoError(t, err)
+		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", latestHistoryID, latestHistoryID)
+		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
+		assert.False(t, resp.Accepted)
+		assert.Equal(t, NoEventsToProject, resp.Reason)
+		assert.Equal(t, SummaryOnly, resp.ProjectionState)
+	})
+
+	t.Run("summary_only uses retained history instead of stale trace latest id", func(t *testing.T) {
+		run, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+			ProjectID: projectID,
+			ID:        start.RunId,
+		})
+		require.NoError(t, err)
+		retainedHistory := appendEngineHistoryEvent(
+			t,
+			ctx,
+			engineQueries,
+			projectID,
+			run.InstanceID,
+			start.RunId,
+			2,
+			publichistory.EventActivityScheduled,
+			publichistory.ActivityScheduledPayload{
+				ActivityKey:  "ship-order",
+				ActivityType: "demo.ship",
+				Input:        []byte(`{"order_id":"ord-123"}`),
+			},
+		)
+		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", 1, 1)
+
+		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, RepairRequested, resp.Reason)
+		assert.Equal(t, CatchingUp, resp.ProjectionState)
+
+		var latestHistoryID int64
+		if err := platformStore.Pool().QueryRow(ctx, `
+			SELECT engine_latest_history_id
+			FROM traces
+			WHERE id = $1
+		`, trace.ID).Scan(&latestHistoryID); err != nil {
+			t.Fatalf("query trace latest history id: %v", err)
+		}
+		assert.NotEqual(t, retainedHistory.ID, latestHistoryID)
+	})
+
+	t.Run("journal_expired", func(t *testing.T) {
+		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "journal_expired", 9, 3)
+		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
+		assert.False(t, resp.Accepted)
+		assert.Equal(t, HistoryExpired, resp.Reason)
+		assert.Equal(t, JournalExpired, resp.ProjectionState)
+	})
+
+	t.Run("catching_up", func(t *testing.T) {
+		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "catching_up", 9, 3)
+		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
+		assert.True(t, resp.Accepted)
+		assert.Equal(t, AlreadyCatchingUp, resp.Reason)
+		assert.Equal(t, CatchingUp, resp.ProjectionState)
+	})
+}
+
+func TestRepairEngineRun_ReturnsNotFoundForMissingRunAndCrossProject(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-repair-scope",
+		RequestKey:        "req-repair-scope",
+	}))
+
+	otherProjectID := testutil.CreateTestProject(t, ctx, platformStore.Queries())
+	crossProject := invokeRepairEngineRun(t, server, otherProjectID, start.RunId)
+	require.Equal(t, http.StatusNotFound, crossProject.Code)
+	assert.Equal(t, "not_found", decodeJSONBody[Error](t, crossProject).Code)
+
+	missing := invokeRepairEngineRun(t, server, projectID, uuid.New())
+	require.Equal(t, http.StatusNotFound, missing.Code)
+	assert.Equal(t, "not_found", decodeJSONBody[Error](t, missing).Code)
+}
+
+func TestRepairEngineRun_ProjectorEventuallyRebuildsPurgedDetail(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-repair-projector",
+		RequestKey:        "req-repair-projector",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	run, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        start.RunId,
+	})
+	require.NoError(t, err)
+
+	historyBefore, err := engineQueries.GetHistoryByRun(ctx, start.RunId)
+	require.NoError(t, err)
+	require.Len(t, historyBefore, 1)
+
+	activityHistory := appendEngineHistoryEvent(
+		t,
+		ctx,
+		engineQueries,
+		projectID,
+		run.InstanceID,
+		start.RunId,
+		2,
+		publichistory.EventActivityScheduled,
+		publichistory.ActivityScheduledPayload{
+			ActivityKey:  "ship-order",
+			ActivityType: "demo.ship",
+			Input:        []byte(`{"order_id":"ord-123"}`),
+		},
+	)
+
+	markEngineRunCompleted(t, ctx, platformStore, start.RunId, trace.ID)
+	setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", activityHistory.ID, historyBefore[0].ID)
+
+	spansBefore, err := platformStore.ListSpansByTrace(ctx, trace.ID)
+	require.NoError(t, err)
+	require.Len(t, spansBefore, 1)
+
+	eventsBefore, err := platformStore.ListSpanEventsByTrace(ctx, trace.ID)
+	require.NoError(t, err)
+	assert.Empty(t, eventsBefore)
+
+	repair := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
+	assert.True(t, repair.Accepted)
+	assert.Equal(t, RepairRequested, repair.Reason)
+	assert.Equal(t, CatchingUp, repair.ProjectionState)
+
+	engineServe := startExternalEngineServeProcess(t)
+	defer engineServe.stop(t)
+
+	waitForProjectedTraceCaughtUp(t, ctx, platformStore.Pool(), trace.ID, activityHistory.ID)
+
+	spansAfter, err := platformStore.ListSpansByTrace(ctx, trace.ID)
+	require.NoError(t, err)
+	require.Len(t, spansAfter, 2)
+
+	var activitySpanCount int
+	for _, span := range spansAfter {
+		if span.SpanID == "engine:activity:"+start.RunId.String()+":ship-order" {
+			activitySpanCount++
+		}
+	}
+	assert.Equal(t, 1, activitySpanCount)
+
+	eventsAfter, err := platformStore.ListSpanEventsByTrace(ctx, trace.ID)
+	require.NoError(t, err)
+	require.Len(t, eventsAfter, 2)
+	assert.Equal(t, "effect", eventsAfter[0].EventType)
+	assert.Equal(t, "wait", eventsAfter[1].EventType)
 }
 
 func TestGetEngineRunPendingWork_ReturnsTypedOpenWorkAndExcludesCancelRows(t *testing.T) {
@@ -1395,6 +1876,7 @@ func setupEngineHandlerTest(t *testing.T) (context.Context, *store.Store, *engin
 	platformStore := store.New(pool)
 	server := NewServer(platformStore, nil)
 	server.engineControl = newEngineControlService(platformStore)
+	server.engineSharedControl = enginecontrol.NewService(platformStore)
 	server.enginePublicAPIEnabled = true
 
 	projectID := testutil.CreateTestProject(t, ctx, platformStore.Queries())
@@ -1470,6 +1952,38 @@ func invokeGetEngineRunResult(t *testing.T, server *Server, projectID, runID uui
 	rec := httptest.NewRecorder()
 
 	server.GetEngineRunResult(rec, req, runID)
+	return rec
+}
+
+func invokePurgeEngineRun(
+	t *testing.T,
+	server *Server,
+	projectID, runID uuid.UUID,
+	mode EnginePurgeMode,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(EnginePurgeRequest{Mode: mode})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/runs/"+runID.String()+"/purge", bytes.NewReader(body))
+	req.Header.Set(enginePreviewHeader, "1")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	rec := httptest.NewRecorder()
+
+	server.PurgeEngineRun(rec, req, runID, PurgeEngineRunParams{XContinuaEnginePreview: "1"})
+	return rec
+}
+
+func invokeRepairEngineRun(t *testing.T, server *Server, projectID, runID uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/runs/"+runID.String()+"/repair", nil)
+	req.Header.Set(enginePreviewHeader, "1")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	rec := httptest.NewRecorder()
+
+	server.RepairEngineRun(rec, req, runID, RepairEngineRunParams{XContinuaEnginePreview: "1"})
 	return rec
 }
 
@@ -1624,6 +2138,90 @@ func setProjectedEngineSummary(
 }
 
 //nolint:revive // Keep testing.T first in test helper signatures.
+func markEngineRunCompleted(
+	t *testing.T,
+	ctx context.Context,
+	platformStore *store.Store,
+	runID uuid.UUID,
+	traceID uuid.UUID,
+) {
+	t.Helper()
+
+	completedAt := time.Now().UTC().Round(time.Microsecond)
+	result := []byte(`{"ok":true}`)
+
+	_, err := platformStore.Pool().Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'completed',
+		    waiting_for = NULL,
+		    result = $2,
+		    completed_at = $3,
+		    updated_at = $3
+		WHERE id = $1
+	`, runID, result, completedAt)
+	require.NoError(t, err)
+
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE engine.instances
+		SET status = 'completed',
+		    updated_at = $2
+		WHERE id = (
+		    SELECT instance_id
+		    FROM engine.runs
+		    WHERE id = $1
+		)
+	`, runID, completedAt)
+	require.NoError(t, err)
+
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE traces
+		SET status = 'completed',
+		    end_time = $2,
+		    output = $3::jsonb,
+		    engine_run_status = 'completed',
+		    updated_at = $2
+		WHERE id = $1
+	`, traceID, completedAt, result)
+	require.NoError(t, err)
+}
+
+//nolint:revive // Keep testing.T first in test helper signatures.
+func markEngineRunCompletedEngineOnly(
+	t *testing.T,
+	ctx context.Context,
+	platformStore *store.Store,
+	runID uuid.UUID,
+) {
+	t.Helper()
+
+	completedAt := time.Now().UTC().Round(time.Microsecond)
+	result := []byte(`{"ok":true}`)
+
+	_, err := platformStore.Pool().Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'completed',
+		    waiting_for = NULL,
+		    result = $2,
+		    completed_at = $3,
+		    updated_at = $3
+		WHERE id = $1
+	`, runID, result, completedAt)
+	require.NoError(t, err)
+
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE engine.instances
+		SET status = 'completed',
+		    updated_at = $2
+		WHERE id = (
+		    SELECT instance_id
+		    FROM engine.runs
+		    WHERE id = $1
+		)
+	`, runID, completedAt)
+	require.NoError(t, err)
+}
+
+//nolint:revive // Keep testing.T first in test helper signatures.
 func createPendingWorkForRun(
 	t *testing.T,
 	ctx context.Context,
@@ -1662,6 +2260,30 @@ func createPendingWorkForRun(
 		Payload:     []byte(`{"signal_name":"approval"}`),
 		AvailableAt: history[0].CreatedAt,
 	})
+	require.NoError(t, err)
+}
+
+//nolint:revive // Keep testing.T first in test helper signatures.
+func setEngineProjectionCheckpoint(
+	t *testing.T,
+	ctx context.Context,
+	platformStore *store.Store,
+	traceID uuid.UUID,
+	projectionState string,
+	latestHistoryID int64,
+	lastProjectedHistoryID int64,
+) {
+	t.Helper()
+
+	_, err := platformStore.Pool().Exec(ctx, `
+		UPDATE traces
+		SET engine_projection_state = $2,
+		    engine_latest_history_id = $3,
+		    engine_last_projected_history_id = $4,
+		    engine_projection_updated_at = NOW(),
+		    updated_at = NOW()
+		WHERE id = $1
+	`, traceID, projectionState, latestHistoryID, lastProjectedHistoryID)
 	require.NoError(t, err)
 }
 
@@ -1841,6 +2463,45 @@ func waitForProjectedTraceTerminalSummary(t *testing.T, pool *pgxpool.Pool, trac
 	}
 	t.Fatalf("timed out waiting for projected terminated trace summary, last trace=%q run=%q wait_state=%s", lastTraceStatus, lastRunStatus, string(lastWaitState))
 	return "", "", nil
+}
+
+func waitForProjectedTraceCaughtUp(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	traceID uuid.UUID,
+	expectedHistoryID int64,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(20 * time.Second)
+	var lastProjectionState string
+	var lastLatestHistoryID int64
+	var lastProjectedHistoryID int64
+	for time.Now().Before(deadline) {
+		err := pool.QueryRow(ctx, `
+			SELECT engine_projection_state,
+			       engine_latest_history_id,
+			       engine_last_projected_history_id
+			FROM public.traces
+			WHERE id = $1
+		`, traceID).Scan(&lastProjectionState, &lastLatestHistoryID, &lastProjectedHistoryID)
+		require.NoError(t, err)
+		if lastProjectionState == publicprojection.StateUpToDate.String() &&
+			lastLatestHistoryID >= expectedHistoryID &&
+			lastProjectedHistoryID >= expectedHistoryID {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf(
+		"timed out waiting for projected trace to catch up to history id %d, last state=%q latest=%d projected=%d",
+		expectedHistoryID,
+		lastProjectionState,
+		lastLatestHistoryID,
+		lastProjectedHistoryID,
+	)
 }
 
 //nolint:revive // Keep testing.T first in test helper signatures.

--- a/internal/api/engine_mapper.go
+++ b/internal/api/engine_mapper.go
@@ -10,6 +10,7 @@ import (
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/store"
 )
 
@@ -83,11 +84,15 @@ func engineHistoryPageToAPI(page *engineHistoryPage) EngineRunHistoryResponse {
 		events[i] = engineHistoryEventToAPI(&page.Events[i])
 	}
 
-	return EngineRunHistoryResponse{
+	resp := EngineRunHistoryResponse{
 		Events:    events,
 		HasMore:   page.HasMore,
 		NextAfter: page.NextAfter,
 	}
+	if page.Expired {
+		resp.Expired = boolPtr(true)
+	}
+	return resp
 }
 
 func engineHistoryEventToAPI(event *enginedb.EngineHistory) EngineHistoryEvent {
@@ -106,6 +111,24 @@ func engineControlResponseToAPI(result *engineControlResult) EngineControlRespon
 		InstanceKey: result.InstanceKey,
 		RunId:       result.RunID,
 		WakeApplied: result.WakeApplied,
+	}
+}
+
+func enginePurgeResponseToAPI(result *enginecontrol.PurgeResult) EnginePurgeResponse {
+	return EnginePurgeResponse{
+		Deleted:         result.Deleted,
+		Mode:            EnginePurgeMode(result.Mode),
+		ProjectionState: engineProjectionStateFromString(result.ProjectionState),
+		RunId:           result.RunID,
+	}
+}
+
+func engineRepairResponseToAPI(result *enginecontrol.RepairResult) EngineRepairResponse {
+	return EngineRepairResponse{
+		Accepted:        result.Accepted,
+		ProjectionState: engineProjectionStateFromString(result.ProjectionState),
+		Reason:          EngineRepairReason(result.Reason),
+		RunId:           result.RunID,
 	}
 }
 
@@ -204,6 +227,10 @@ func cloneTraceJSON(raw []byte) json.RawMessage {
 		return nil
 	}
 	return append(json.RawMessage(nil), raw...)
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func shouldReadLiveEngineSummary(trace *store.TraceRead) bool {

--- a/internal/api/ingest_handlers_test.go
+++ b/internal/api/ingest_handlers_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/continua-ai/continua/db/gen/go/platform"
 	"github.com/continua-ai/continua/internal/api/middleware"
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/ingest"
 	"github.com/continua-ai/continua/internal/jobs"
 	"github.com/continua-ai/continua/internal/store"
@@ -25,7 +26,7 @@ func newAsyncIngestServer(t *testing.T) (*Server, *store.Store, *platform.Querie
 
 	pool := testutil.TestDB(t)
 	s := store.New(pool)
-	client, err := jobs.NewClient(pool, s, ingest.NewProcessor(s, nil), nil)
+	client, err := jobs.NewClient(pool, s, ingest.NewProcessor(s, nil), enginecontrol.NewService(s), nil)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/config"
 	"github.com/continua-ai/continua/internal/ingest"
 	"github.com/continua-ai/continua/internal/store"
@@ -19,6 +20,7 @@ type Server struct {
 	store                  *store.Store
 	ingestService          *ingest.Service
 	engineControl          *engineControlService
+	engineSharedControl    *enginecontrol.Service
 	enginePublicAPIEnabled bool
 }
 
@@ -30,9 +32,15 @@ func NewServer(s *store.Store, ingestService *ingest.Service) *Server {
 	}
 }
 
-func newConfiguredServer(s *store.Store, ingestService *ingest.Service, cfg *config.Config) *Server {
+func newConfiguredServer(
+	s *store.Store,
+	ingestService *ingest.Service,
+	shared *enginecontrol.Service,
+	cfg *config.Config,
+) *Server {
 	server := NewServer(s, ingestService)
 	server.engineControl = newEngineControlService(s)
+	server.engineSharedControl = shared
 	if cfg != nil {
 		server.enginePublicAPIEnabled = cfg.Engine.PublicAPIEnabled
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,8 +1,8 @@
 package api
 
 import (
-	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/config"
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/ingest"
 	"github.com/continua-ai/continua/internal/store"
 )

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -80,6 +80,21 @@ const (
 	UpToDate       EngineProjectionState = "up_to_date"
 )
 
+// Defines values for EnginePurgeMode.
+const (
+	Full           EnginePurgeMode = "full"
+	ProjectionOnly EnginePurgeMode = "projection_only"
+)
+
+// Defines values for EngineRepairReason.
+const (
+	AlreadyCatchingUp EngineRepairReason = "already_catching_up"
+	AlreadyUpToDate   EngineRepairReason = "already_up_to_date"
+	HistoryExpired    EngineRepairReason = "history_expired"
+	NoEventsToProject EngineRepairReason = "no_events_to_project"
+	RepairRequested   EngineRepairReason = "repair_requested"
+)
+
 // Defines values for EngineRunStatus.
 const (
 	EngineRunStatusCANCELLED  EngineRunStatus = "CANCELLED"
@@ -265,9 +280,20 @@ const (
 
 // Defines values for ListTracesParamsStatus.
 const (
-	Completed ListTracesParamsStatus = "completed"
-	Failed    ListTracesParamsStatus = "failed"
-	Running   ListTracesParamsStatus = "running"
+	ListTracesParamsStatusCompleted ListTracesParamsStatus = "completed"
+	ListTracesParamsStatusFailed    ListTracesParamsStatus = "failed"
+	ListTracesParamsStatusRunning   ListTracesParamsStatus = "running"
+)
+
+// Defines values for ListTracesParamsEngineRunStatus.
+const (
+	ListTracesParamsEngineRunStatusCancelled  ListTracesParamsEngineRunStatus = "cancelled"
+	ListTracesParamsEngineRunStatusCompleted  ListTracesParamsEngineRunStatus = "completed"
+	ListTracesParamsEngineRunStatusFailed     ListTracesParamsEngineRunStatus = "failed"
+	ListTracesParamsEngineRunStatusQueued     ListTracesParamsEngineRunStatus = "queued"
+	ListTracesParamsEngineRunStatusRunning    ListTracesParamsEngineRunStatus = "running"
+	ListTracesParamsEngineRunStatusTerminated ListTracesParamsEngineRunStatus = "terminated"
+	ListTracesParamsEngineRunStatusWaiting    ListTracesParamsEngineRunStatus = "waiting"
 )
 
 // BatchStatusResponse defines model for BatchStatusResponse.
@@ -476,11 +502,42 @@ type EnginePendingWorkResponse struct {
 // EngineProjectionState defines model for EngineProjectionState.
 type EngineProjectionState string
 
+// EnginePurgeMode defines model for EnginePurgeMode.
+type EnginePurgeMode string
+
+// EnginePurgeRequest defines model for EnginePurgeRequest.
+type EnginePurgeRequest struct {
+	Mode EnginePurgeMode `json:"mode"`
+}
+
+// EnginePurgeResponse defines model for EnginePurgeResponse.
+type EnginePurgeResponse struct {
+	// Deleted True when purge deleted projection detail and/or history rows.
+	Deleted         bool                  `json:"deleted"`
+	Mode            EnginePurgeMode       `json:"mode"`
+	ProjectionState EngineProjectionState `json:"projection_state"`
+	RunId           openapi_types.UUID    `json:"run_id"`
+}
+
+// EngineRepairReason defines model for EngineRepairReason.
+type EngineRepairReason string
+
+// EngineRepairResponse defines model for EngineRepairResponse.
+type EngineRepairResponse struct {
+	Accepted        bool                  `json:"accepted"`
+	ProjectionState EngineProjectionState `json:"projection_state"`
+	Reason          EngineRepairReason    `json:"reason"`
+	RunId           openapi_types.UUID    `json:"run_id"`
+}
+
 // EngineRunHistoryResponse defines model for EngineRunHistoryResponse.
 type EngineRunHistoryResponse struct {
-	Events    []EngineHistoryEvent `json:"events"`
-	HasMore   bool                 `json:"has_more"`
-	NextAfter *int                 `json:"next_after,omitempty"`
+	Events []EngineHistoryEvent `json:"events"`
+
+	// Expired True when retained engine history for the run has been purged.
+	Expired   *bool `json:"expired,omitempty"`
+	HasMore   bool  `json:"has_more"`
+	NextAfter *int  `json:"next_after,omitempty"`
 }
 
 // EngineRunResponse defines model for EngineRunResponse.
@@ -508,7 +565,8 @@ type EngineRunResponse struct {
 type EngineRunResultResponse struct {
 	Failure *EngineFailureSummary `json:"failure,omitempty"`
 
-	// Result Terminal workflow result payload when available.
+	// Result Terminal workflow result payload when available. `summary_only` and
+	// `journal_expired` runs continue to return the retained terminal shell.
 	Result interface{}        `json:"result"`
 	RunId  openapi_types.UUID `json:"run_id"`
 	Status EngineRunStatus    `json:"status"`
@@ -1100,6 +1158,18 @@ type ListTracesParams struct {
 	// UserId Filter by user ID
 	UserId *string `form:"user_id,omitempty" json:"user_id,omitempty"`
 
+	// EngineInstanceKey Filter by engine instance key
+	EngineInstanceKey *string `form:"engine_instance_key,omitempty" json:"engine_instance_key,omitempty"`
+
+	// EngineDefinitionName Filter by engine definition name
+	EngineDefinitionName *string `form:"engine_definition_name,omitempty" json:"engine_definition_name,omitempty"`
+
+	// EngineRunStatus Filter by engine run lifecycle status
+	EngineRunStatus *ListTracesParamsEngineRunStatus `form:"engine_run_status,omitempty" json:"engine_run_status,omitempty"`
+
+	// EngineProjectionState Filter by engine projection state
+	EngineProjectionState *EngineProjectionState `form:"engine_projection_state,omitempty" json:"engine_projection_state,omitempty"`
+
 	// HasErrors Filter traces with errors (error_count > 0)
 	HasErrors *bool `form:"has_errors,omitempty" json:"has_errors,omitempty"`
 
@@ -1115,6 +1185,9 @@ type ListTracesParamsSortDir string
 
 // ListTracesParamsStatus defines parameters for ListTraces.
 type ListTracesParamsStatus string
+
+// ListTracesParamsEngineRunStatus defines parameters for ListTraces.
+type ListTracesParamsEngineRunStatus string
 
 // GetTraceEventsParams defines parameters for GetTraceEvents.
 type GetTraceEventsParams struct {
@@ -1143,6 +1216,18 @@ type GetEngineRunHistoryParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// PurgeEngineRunParams defines parameters for PurgeEngineRun.
+type PurgeEngineRunParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// RepairEngineRunParams defines parameters for RepairEngineRun.
+type RepairEngineRunParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
 // SignalEngineRunParams defines parameters for SignalEngineRun.
 type SignalEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
@@ -1168,6 +1253,9 @@ type IngestParams struct {
 
 // StartEngineRunJSONRequestBody defines body for StartEngineRun for application/json ContentType.
 type StartEngineRunJSONRequestBody = EngineStartRunRequest
+
+// PurgeEngineRunJSONRequestBody defines body for PurgeEngineRun for application/json ContentType.
+type PurgeEngineRunJSONRequestBody = EnginePurgeRequest
 
 // SignalEngineRunJSONRequestBody defines body for SignalEngineRun for application/json ContentType.
 type SignalEngineRunJSONRequestBody = EngineSignalRunRequest
@@ -1362,6 +1450,12 @@ type ServerInterface interface {
 	// Get the durable pending work held by an engine run
 	// (GET /v1/engine/runs/{run_id}/pending-work)
 	GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
+	// Purge projected detail and optionally retained history for an engine run
+	// (POST /v1/engine/runs/{run_id}/purge)
+	PurgeEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params PurgeEngineRunParams)
+	// Request projection repair for an engine run
+	// (POST /v1/engine/runs/{run_id}/repair)
+	RepairEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params RepairEngineRunParams)
 	// Get the terminal result for an engine run
 	// (GET /v1/engine/runs/{run_id}/result)
 	GetEngineRunResult(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
@@ -1464,6 +1558,18 @@ func (_ Unimplemented) GetEngineRunHistory(w http.ResponseWriter, r *http.Reques
 // Get the durable pending work held by an engine run
 // (GET /v1/engine/runs/{run_id}/pending-work)
 func (_ Unimplemented) GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Purge projected detail and optionally retained history for an engine run
+// (POST /v1/engine/runs/{run_id}/purge)
+func (_ Unimplemented) PurgeEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params PurgeEngineRunParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Request projection repair for an engine run
+// (POST /v1/engine/runs/{run_id}/repair)
+func (_ Unimplemented) RepairEngineRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID, params RepairEngineRunParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1796,6 +1902,38 @@ func (siw *ServerInterfaceWrapper) ListTraces(w http.ResponseWriter, r *http.Req
 	err = runtime.BindQueryParameter("form", true, false, "user_id", r.URL.Query(), &params.UserId)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "user_id", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "engine_instance_key" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_instance_key", r.URL.Query(), &params.EngineInstanceKey)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_instance_key", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "engine_definition_name" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_definition_name", r.URL.Query(), &params.EngineDefinitionName)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_definition_name", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "engine_run_status" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_run_status", r.URL.Query(), &params.EngineRunStatus)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_run_status", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "engine_projection_state" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_projection_state", r.URL.Query(), &params.EngineProjectionState)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_projection_state", Err: err})
 		return
 	}
 
@@ -2181,6 +2319,124 @@ func (siw *ServerInterfaceWrapper) GetEngineRunPendingWork(w http.ResponseWriter
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetEngineRunPendingWork(w, r, runId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PurgeEngineRun operation middleware
+func (siw *ServerInterfaceWrapper) PurgeEngineRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "run_id" -------------
+	var runId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "run_id", chi.URLParam(r, "run_id"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "run_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PurgeEngineRunParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PurgeEngineRun(w, r, runId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RepairEngineRun operation middleware
+func (siw *ServerInterfaceWrapper) RepairEngineRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "run_id" -------------
+	var runId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "run_id", chi.URLParam(r, "run_id"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "run_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params RepairEngineRunParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RepairEngineRun(w, r, runId, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2578,6 +2834,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/pending-work", wrapper.GetEngineRunPendingWork)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/runs/{run_id}/purge", wrapper.PurgeEngineRun)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/runs/{run_id}/repair", wrapper.RepairEngineRun)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/runs/{run_id}/result", wrapper.GetEngineRunResult)

--- a/internal/api/server_helpers.go
+++ b/internal/api/server_helpers.go
@@ -11,6 +11,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/continua-ai/continua/internal/api/middleware"
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/ingest"
 	"github.com/continua-ai/continua/internal/store"
 )
@@ -33,6 +34,11 @@ func writeEngineError(w http.ResponseWriter, err error, fallbackMessage string) 
 	var apiErr *engineAPIError
 	if errors.As(err, &apiErr) {
 		writeError(w, apiErr.HTTPStatus, apiErr.Code, apiErr.Message)
+		return
+	}
+	var sharedErr *enginecontrol.APIError
+	if errors.As(err, &sharedErr) {
+		writeError(w, sharedErr.HTTPStatus, sharedErr.Code, sharedErr.Message)
 		return
 	}
 
@@ -140,6 +146,18 @@ func traceFilterFromParams(projectID uuid.UUID, params *ListTracesParams, limit,
 	if params.UserId != nil {
 		filter.UserID = *params.UserId
 	}
+	if params.EngineInstanceKey != nil {
+		filter.EngineInstanceKey = *params.EngineInstanceKey
+	}
+	if params.EngineDefinitionName != nil {
+		filter.EngineDefinitionName = *params.EngineDefinitionName
+	}
+	if params.EngineRunStatus != nil {
+		filter.EngineRunStatus = string(*params.EngineRunStatus)
+	}
+	if params.EngineProjectionState != nil {
+		filter.EngineProjectionState = string(*params.EngineProjectionState)
+	}
 	if params.SessionId != nil {
 		id := *params.SessionId
 		filter.SessionID = &id
@@ -164,6 +182,10 @@ func traceNeedsDynamicQuery(filter *store.TraceFilter) bool {
 		filter.StartTimeFrom != nil ||
 		filter.StartTimeTo != nil ||
 		filter.UserID != "" ||
+		filter.EngineInstanceKey != "" ||
+		filter.EngineDefinitionName != "" ||
+		filter.EngineRunStatus != "" ||
+		filter.EngineProjectionState != "" ||
 		filter.HasErrors != nil ||
 		filter.MinDurationMs != nil
 }

--- a/internal/api/traces_handlers.go
+++ b/internal/api/traces_handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -30,6 +31,11 @@ func (s *Server) ListTraces(w http.ResponseWriter, r *http.Request, params ListT
 	case traceNeedsDynamicQuery(&filter):
 		result, err := s.store.ListTracesFiltered(r.Context(), filter)
 		if err != nil {
+			var filterErr *store.TraceFilterValidationError
+			if errors.As(err, &filterErr) {
+				writeError(w, http.StatusBadRequest, "invalid_request", filterErr.Error())
+				return
+			}
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to search traces")
 			return
 		}

--- a/internal/api/traces_handlers_test.go
+++ b/internal/api/traces_handlers_test.go
@@ -795,6 +795,29 @@ func TestListTraces_SearchOverridesSortParams(t *testing.T) {
 	assert.Equal(t, []uuid.UUID{nameMatch.ID, spanOnlyMatch.ID}, apiTraceIDs(resp.Traces))
 }
 
+func TestListTraces_InvalidEngineFiltersReturn400(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+
+	projectID := testutil.CreateTestProject(t, ctx, s.Queries())
+	invalidRunStatus := ListTracesParamsEngineRunStatus("not-a-status")
+	invalidProjectionState := EngineProjectionState("not-a-state")
+
+	runStatusRec := invokeListTraces(t, server, projectID, ListTracesParams{
+		EngineRunStatus: &invalidRunStatus,
+	})
+	require.Equal(t, http.StatusBadRequest, runStatusRec.Code)
+	assert.Equal(t, "invalid_request", decodeJSONBody[Error](t, runStatusRec).Code)
+
+	projectionStateRec := invokeListTraces(t, server, projectID, ListTracesParams{
+		EngineProjectionState: &invalidProjectionState,
+	})
+	require.Equal(t, http.StatusBadRequest, projectionStateRec.Code)
+	assert.Equal(t, "invalid_request", decodeJSONBody[Error](t, projectionStateRec).Code)
+}
+
 func TestGetTrace_ProjectScopingReturns404(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ctx := context.Background()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,9 @@ type JobsConfig struct {
 
 // EngineConfig holds public engine API rollout settings.
 type EngineConfig struct {
-	PublicAPIEnabled bool
+	PublicAPIEnabled             bool
+	ProjectionRetentionAfter     time.Duration
+	HistoryRetentionAfter        time.Duration
 }
 
 // Address returns the server address in host:port format.
@@ -80,6 +82,20 @@ func Load() (*Config, error) {
 	enginePublicAPIEnabled, err := loadBool("ENGINE_PUBLIC_API_ENABLED", false)
 	if err != nil {
 		return nil, err
+	}
+	engineProjectionRetentionAfter, err := loadOptionalDuration("ENGINE_PROJECTION_RETENTION_AFTER")
+	if err != nil {
+		return nil, err
+	}
+	engineHistoryRetentionAfter, err := loadOptionalDuration("ENGINE_HISTORY_RETENTION_AFTER")
+	if err != nil {
+		return nil, err
+	}
+	if engineHistoryRetentionAfter > 0 && engineProjectionRetentionAfter <= 0 {
+		return nil, errors.New("ENGINE_HISTORY_RETENTION_AFTER requires ENGINE_PROJECTION_RETENTION_AFTER to be set and greater than zero")
+	}
+	if engineHistoryRetentionAfter > 0 && engineHistoryRetentionAfter <= engineProjectionRetentionAfter {
+		return nil, errors.New("ENGINE_HISTORY_RETENTION_AFTER must be greater than ENGINE_PROJECTION_RETENTION_AFTER")
 	}
 	dependencyRetryWindow, err := loadDuration("INGEST_DEPENDENCY_RETRY_WINDOW", 15*time.Minute)
 	if err != nil {
@@ -121,7 +137,9 @@ func Load() (*Config, error) {
 			FailedPayloadRetention: failedPayloadRetention,
 		},
 		Engine: EngineConfig{
-			PublicAPIEnabled: enginePublicAPIEnabled,
+			PublicAPIEnabled:         enginePublicAPIEnabled,
+			ProjectionRetentionAfter: engineProjectionRetentionAfter,
+			HistoryRetentionAfter:    engineHistoryRetentionAfter,
 		},
 		Jobs: JobsConfig{
 			IngestWorkers:      ingestWorkers,
@@ -173,6 +191,25 @@ func loadDuration(key string, defaultValue time.Duration) (time.Duration, error)
 	}
 	if value < 0 {
 		return 0, errors.New(key + " must be non-negative")
+	}
+	return value, nil
+}
+
+func loadOptionalDuration(key string) (time.Duration, error) {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return 0, nil
+	}
+
+	value, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, errors.New(key + " must be a valid duration")
+	}
+	if value < 0 {
+		return 0, errors.New(key + " must be non-negative")
+	}
+	if value == 0 {
+		return 0, nil
 	}
 	return value, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,9 +46,9 @@ type JobsConfig struct {
 
 // EngineConfig holds public engine API rollout settings.
 type EngineConfig struct {
-	PublicAPIEnabled             bool
-	ProjectionRetentionAfter     time.Duration
-	HistoryRetentionAfter        time.Duration
+	PublicAPIEnabled         bool
+	ProjectionRetentionAfter time.Duration
+	HistoryRetentionAfter    time.Duration
 }
 
 // Address returns the server address in host:port format.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,4 +28,48 @@ func TestLoad_RejectsInvalidWorkerCount(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "RIVER_QUEUE_INGEST_WORKERS")
+}
+
+func TestLoad_RejectsHistoryRetentionWithoutProjectionRetention(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("ENGINE_HISTORY_RETENTION_AFTER", "720h")
+
+	cfg, err := config.Load()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "ENGINE_HISTORY_RETENTION_AFTER")
+	assert.Contains(t, err.Error(), "ENGINE_PROJECTION_RETENTION_AFTER")
+}
+
+func TestLoad_RejectsHistoryRetentionNotGreaterThanProjectionRetention(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("ENGINE_PROJECTION_RETENTION_AFTER", "168h")
+	t.Setenv("ENGINE_HISTORY_RETENTION_AFTER", "168h")
+
+	cfg, err := config.Load()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "ENGINE_HISTORY_RETENTION_AFTER")
+}
+
+func TestLoad_AllowsProjectionOnlyRetentionAndZeroDisable(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("ENGINE_PROJECTION_RETENTION_AFTER", "168h")
+	t.Setenv("ENGINE_HISTORY_RETENTION_AFTER", "0")
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, 168*time.Hour, cfg.Engine.ProjectionRetentionAfter)
+	assert.Zero(t, cfg.Engine.HistoryRetentionAfter)
+}
+
+func TestLoad_RejectsUnparseableRetentionDuration(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("ENGINE_PROJECTION_RETENTION_AFTER", "not-a-duration")
+
+	cfg, err := config.Load()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "ENGINE_PROJECTION_RETENTION_AFTER")
 }

--- a/internal/enginecontrol/module.go
+++ b/internal/enginecontrol/module.go
@@ -1,0 +1,7 @@
+package enginecontrol
+
+import "go.uber.org/fx"
+
+var Module = fx.Module("enginecontrol",
+	fx.Provide(NewService),
+)

--- a/internal/enginecontrol/service.go
+++ b/internal/enginecontrol/service.go
@@ -107,7 +107,7 @@ func (s *Service) PurgeRun(
 			HTTPStatus: 409,
 		}
 	}
-	if err := ensureTerminalShell(ctx, tx, trace, run); err != nil {
+	if err := ensureTerminalShell(ctx, tx, &trace, &run); err != nil {
 		return PurgeResult{}, err
 	}
 
@@ -282,9 +282,12 @@ func isTerminalRun(status enginedb.EngineRunLifecycleStatus) bool {
 func ensureTerminalShell(
 	ctx context.Context,
 	tx *store.Tx,
-	trace platformdb.Trace,
-	run enginedb.EngineRun,
+	trace *platformdb.Trace,
+	run *enginedb.EngineRun,
 ) error {
+	if trace == nil || run == nil {
+		return errors.New("terminal shell requires trace and run")
+	}
 	completedAt := terminalCompletedAt(run)
 	traceStatus, spanStatus := publicprojection.TerminalStatuses(string(run.Status))
 	outputPayload, err := publicprojection.TerminalOutputPayload(
@@ -324,7 +327,10 @@ func ensureTerminalShell(
 	return nil
 }
 
-func terminalCompletedAt(run enginedb.EngineRun) time.Time {
+func terminalCompletedAt(run *enginedb.EngineRun) time.Time {
+	if run == nil {
+		return time.Time{}
+	}
 	if run.CompletedAt.Valid {
 		return run.CompletedAt.Time
 	}

--- a/internal/enginecontrol/service.go
+++ b/internal/enginecontrol/service.go
@@ -1,0 +1,372 @@
+package enginecontrol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	platformdb "github.com/continua-ai/continua/db/gen/go/platform"
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
+	"github.com/continua-ai/continua/internal/store"
+)
+
+const engineRootSpanPrefix = "engine:root:"
+
+type APIError struct {
+	Code       string
+	Message    string
+	HTTPStatus int
+}
+
+func (e *APIError) Error() string {
+	return e.Code + ": " + e.Message
+}
+
+type PurgeMode string
+
+const (
+	PurgeModeProjectionOnly PurgeMode = "projection_only"
+	PurgeModeFull           PurgeMode = "full"
+)
+
+type RepairReason string
+
+const (
+	RepairReasonAlreadyUpToDate   RepairReason = "already_up_to_date"
+	RepairReasonHistoryExpired    RepairReason = "history_expired"
+	RepairReasonNoEventsToProject RepairReason = "no_events_to_project"
+	RepairReasonRequested         RepairReason = "repair_requested"
+	RepairReasonAlreadyCatchingUp RepairReason = "already_catching_up"
+)
+
+type PurgeResult struct {
+	RunID           uuid.UUID
+	Mode            PurgeMode
+	ProjectionState string
+	Deleted         bool
+}
+
+type RepairResult struct {
+	RunID           uuid.UUID
+	Accepted        bool
+	Reason          RepairReason
+	ProjectionState string
+}
+
+type Service struct {
+	platform *store.Store
+}
+
+func NewService(platformStore *store.Store) *Service {
+	if platformStore == nil {
+		return nil
+	}
+	return &Service{platform: platformStore}
+}
+
+func (s *Service) PurgeRun(
+	ctx context.Context,
+	projectID uuid.UUID,
+	runID uuid.UUID,
+	mode PurgeMode,
+) (PurgeResult, error) {
+	if s == nil || s.platform == nil {
+		return PurgeResult{}, errors.New("engine control service is not configured")
+	}
+	if mode != PurgeModeProjectionOnly && mode != PurgeModeFull {
+		return PurgeResult{}, &APIError{
+			Code:       "invalid_request",
+			Message:    "mode must be projection_only or full",
+			HTTPStatus: 400,
+		}
+	}
+
+	tx, err := s.platform.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return PurgeResult{}, err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	trace, run, projectionState, err := loadLockedRunTrace(ctx, tx, projectID, runID)
+	if err != nil {
+		return PurgeResult{}, err
+	}
+	if !isTerminalRun(run.Status) {
+		return PurgeResult{}, &APIError{
+			Code:       "run_not_terminal",
+			Message:    "run has not reached a terminal state",
+			HTTPStatus: 409,
+		}
+	}
+	if err := ensureTerminalShell(ctx, tx, trace, run); err != nil {
+		return PurgeResult{}, err
+	}
+
+	result := PurgeResult{
+		RunID:           runID,
+		Mode:            mode,
+		ProjectionState: projectionState,
+	}
+
+	switch mode {
+	case PurgeModeProjectionOnly:
+		if projectionState == publicprojection.StateSummaryOnly.String() ||
+			projectionState == publicprojection.StateJournalExpired.String() {
+			if err := tx.Commit(ctx); err != nil {
+				return PurgeResult{}, err
+			}
+			return result, nil
+		}
+		if err := tx.DeleteSpanEventsByTrace(ctx, trace.ID); err != nil {
+			return PurgeResult{}, err
+		}
+		if err := tx.DeleteNonRootSpansByTrace(ctx, trace.ID); err != nil {
+			return PurgeResult{}, err
+		}
+		if mutated, err := tx.FlipProjectionStateToSummaryOnly(ctx, runID); err != nil {
+			return PurgeResult{}, err
+		} else if mutated == 0 {
+			return PurgeResult{}, fmt.Errorf("flip projection state to summary_only matched zero rows for run %s", runID)
+		}
+		result.ProjectionState = publicprojection.StateSummaryOnly.String()
+		result.Deleted = true
+	case PurgeModeFull:
+		if projectionState == publicprojection.StateJournalExpired.String() {
+			if err := tx.Commit(ctx); err != nil {
+				return PurgeResult{}, err
+			}
+			return result, nil
+		}
+		if err := tx.DeleteSpanEventsByTrace(ctx, trace.ID); err != nil {
+			return PurgeResult{}, err
+		}
+		if err := tx.DeleteNonRootSpansByTrace(ctx, trace.ID); err != nil {
+			return PurgeResult{}, err
+		}
+		if err := enginedb.New(tx.Tx()).DeleteHistoryByRun(ctx, runID); err != nil {
+			return PurgeResult{}, err
+		}
+		if mutated, err := tx.FlipProjectionStateToJournalExpired(ctx, runID); err != nil {
+			return PurgeResult{}, err
+		} else if mutated == 0 {
+			return PurgeResult{}, fmt.Errorf("flip projection state to journal_expired matched zero rows for run %s", runID)
+		}
+		result.ProjectionState = publicprojection.StateJournalExpired.String()
+		result.Deleted = true
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return PurgeResult{}, err
+	}
+	return result, nil
+}
+
+func (s *Service) RepairRun(
+	ctx context.Context,
+	projectID uuid.UUID,
+	runID uuid.UUID,
+) (RepairResult, error) {
+	if s == nil || s.platform == nil {
+		return RepairResult{}, errors.New("engine control service is not configured")
+	}
+
+	tx, err := s.platform.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return RepairResult{}, err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	trace, _, projectionState, err := loadLockedRunTrace(ctx, tx, projectID, runID)
+	if err != nil {
+		return RepairResult{}, err
+	}
+
+	result := RepairResult{
+		RunID:           runID,
+		ProjectionState: projectionState,
+	}
+
+	switch projectionState {
+	case publicprojection.StateJournalExpired.String():
+		result.Reason = RepairReasonHistoryExpired
+	case publicprojection.StateSummaryOnly.String():
+		lastProjected := derefInt64(trace.EngineLastProjectedHistoryID)
+		latest, err := enginedb.New(tx.Tx()).GetLatestHistoryIDByRun(ctx, runID)
+		if err != nil {
+			return RepairResult{}, err
+		}
+		if lastProjected >= latest {
+			result.Reason = RepairReasonNoEventsToProject
+			break
+		}
+		if mutated, err := tx.FlipProjectionStateToCatchingUp(ctx, runID); err != nil {
+			return RepairResult{}, err
+		} else if mutated == 0 {
+			return RepairResult{}, fmt.Errorf("flip projection state to catching_up matched zero rows for run %s", runID)
+		}
+		result.Accepted = true
+		result.Reason = RepairReasonRequested
+		result.ProjectionState = publicprojection.StateCatchingUp.String()
+	case publicprojection.StateCatchingUp.String():
+		result.Accepted = true
+		result.Reason = RepairReasonAlreadyCatchingUp
+	default:
+		result.Reason = RepairReasonAlreadyUpToDate
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return RepairResult{}, err
+	}
+	return result, nil
+}
+
+func loadLockedRunTrace(
+	ctx context.Context,
+	tx *store.Tx,
+	projectID uuid.UUID,
+	runID uuid.UUID,
+) (platformdb.Trace, enginedb.EngineRun, string, error) {
+	trace, err := tx.GetTraceByProjectAndEngineRunIDForUpdate(ctx, projectID, runID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return platformdb.Trace{}, enginedb.EngineRun{}, "", notFoundError("engine run")
+		}
+		return platformdb.Trace{}, enginedb.EngineRun{}, "", err
+	}
+
+	run, err := enginedb.New(tx.Tx()).GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        runID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return platformdb.Trace{}, enginedb.EngineRun{}, "", notFoundError("engine run")
+		}
+		return platformdb.Trace{}, enginedb.EngineRun{}, "", err
+	}
+
+	return trace, run, normalizedProjectionState(trace.EngineProjectionState), nil
+}
+
+func normalizedProjectionState(value *string) string {
+	state := strings.TrimSpace(derefString(value))
+	if state == "" {
+		return publicprojection.StateUpToDate.String()
+	}
+	return state
+}
+
+func isTerminalRun(status enginedb.EngineRunLifecycleStatus) bool {
+	switch status {
+	case enginedb.EngineRunLifecycleStatusCompleted,
+		enginedb.EngineRunLifecycleStatusFailed,
+		enginedb.EngineRunLifecycleStatusCancelled,
+		enginedb.EngineRunLifecycleStatusTerminated:
+		return true
+	default:
+		return false
+	}
+}
+
+func ensureTerminalShell(
+	ctx context.Context,
+	tx *store.Tx,
+	trace platformdb.Trace,
+	run enginedb.EngineRun,
+) error {
+	completedAt := terminalCompletedAt(run)
+	traceStatus, spanStatus := publicprojection.TerminalStatuses(string(run.Status))
+	outputPayload, err := publicprojection.TerminalOutputPayload(
+		string(run.Status),
+		run.Result,
+		run.LastErrorCode,
+		run.LastErrorMessage,
+	)
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.UpdateEngineTraceSummary(ctx, &platformdb.UpdateEngineTraceSummaryParams{
+		EngineRunID:                pgtype.UUID{Bytes: run.ID, Valid: true},
+		EngineRunStatus:            stringPtr(string(run.Status)),
+		EngineCustomStatus:         cloneRaw(run.CustomStatus),
+		EngineWaitState:            cloneRaw(run.WaitingFor),
+		EnginePendingActivityTasks: int64Ptr(0),
+		EnginePendingInboxItems:    int64Ptr(0),
+	}); err != nil {
+		return err
+	}
+	if err := tx.EnsureTerminalTraceShell(ctx, trace.ID, traceStatus, completedAt, outputPayload); err != nil {
+		return err
+	}
+	if err := tx.EnsureTerminalRootSpanShell(
+		ctx,
+		trace.ID,
+		engineRootSpanPrefix+run.ID.String(),
+		spanStatus,
+		completedAt,
+		outputPayload,
+		run.LastErrorMessage,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func terminalCompletedAt(run enginedb.EngineRun) time.Time {
+	if run.CompletedAt.Valid {
+		return run.CompletedAt.Time
+	}
+	return run.UpdatedAt
+}
+
+func notFoundError(resource string) error {
+	return &APIError{
+		Code:       "not_found",
+		Message:    resource + " not found",
+		HTTPStatus: 404,
+	}
+}
+
+func derefInt64(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func stringPtr(value string) *string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return &value
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
+}
+
+func cloneRaw(raw []byte) []byte {
+	if len(raw) == 0 {
+		return nil
+	}
+	return append([]byte(nil), raw...)
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/ingest"
 	"github.com/continua-ai/continua/internal/jobs"
 	"github.com/continua-ai/continua/internal/store"
@@ -25,7 +26,7 @@ func newTestService(s *store.Store) *ingest.Service {
 func newAsyncTestService(t *testing.T, s *store.Store) *ingest.Service {
 	t.Helper()
 
-	client, err := jobs.NewClient(testutil.TestDB(t), s, ingest.NewProcessor(s, nil), nil)
+	client, err := jobs.NewClient(testutil.TestDB(t), s, ingest.NewProcessor(s, nil), enginecontrol.NewService(s), nil)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/jobargs/jobargs.go
+++ b/internal/jobargs/jobargs.go
@@ -86,3 +86,25 @@ func (CleanupArgs) InsertOpts() river.InsertOpts {
 
 // CleanupInterval is the cadence for payload cleanup jobs.
 const CleanupInterval = 24 * time.Hour
+
+// RetentionArgs contains the arguments for the engine retention maintenance job.
+type RetentionArgs struct{}
+
+// Kind returns the River job kind.
+func (RetentionArgs) Kind() string {
+	return "engine_retention_maintenance"
+}
+
+// InsertOpts routes retention jobs to the maintenance queue with active-state uniqueness.
+func (RetentionArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue: QueueMaintenance,
+		UniqueOpts: river.UniqueOpts{
+			ByArgs:  true,
+			ByState: ActiveUniqueStates(),
+		},
+	}
+}
+
+// RetentionInterval is the cadence for engine retention jobs.
+const RetentionInterval = 24 * time.Hour

--- a/internal/jobs/ingest_batch_test.go
+++ b/internal/jobs/ingest_batch_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/continua-ai/continua/db/gen/go/platform"
 	"github.com/continua-ai/continua/internal/config"
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/ingest"
 	"github.com/continua-ai/continua/internal/jobargs"
 	"github.com/continua-ai/continua/internal/store"
@@ -33,7 +34,7 @@ func newIngestBatchTestDepsWithConfig(
 	pool := testutil.TestDB(t)
 	s := store.New(pool)
 	processor := ingest.NewProcessor(s, cfg)
-	client, err := NewClient(pool, s, processor, cfg)
+	client, err := NewClient(pool, s, processor, enginecontrol.NewService(s), cfg)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/jobs/module.go
+++ b/internal/jobs/module.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/continua-ai/continua/internal/config"
+	"github.com/continua-ai/continua/internal/enginecontrol"
 	"github.com/continua-ai/continua/internal/ingest"
 	"github.com/continua-ai/continua/internal/jobargs"
 	"github.com/continua-ai/continua/internal/store"
@@ -43,6 +44,7 @@ func NewClient(
 	pool *pgxpool.Pool,
 	s *store.Store,
 	processor *ingest.Processor,
+	sharedControl *enginecontrol.Service,
 	cfg *config.Config,
 ) (*river.Client[pgx.Tx], error) {
 	workers := river.NewWorkers()
@@ -71,6 +73,28 @@ func NewClient(
 				RunOnStart: true,
 			},
 		),
+	}
+
+	if retentionEnabled(cfg) {
+		retentionWorker := NewRetentionWorker(
+			s,
+			sharedControl,
+			projectionRetention(cfg),
+			historyRetention(cfg),
+		)
+		river.AddWorker(workers, retentionWorker)
+		periodicJobs = append(periodicJobs, river.NewPeriodicJob(
+			river.PeriodicInterval(jobargs.RetentionInterval),
+			func() (river.JobArgs, *river.InsertOpts) {
+				args := jobargs.RetentionArgs{}
+				opts := args.InsertOpts()
+				return args, &opts
+			},
+			&river.PeriodicJobOpts{
+				ID:         "engine-retention-maintenance",
+				RunOnStart: false,
+			},
+		))
 	}
 
 	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
@@ -108,4 +132,22 @@ func failedPayloadRetention(cfg *config.Config) time.Duration {
 		return 7 * 24 * time.Hour
 	}
 	return cfg.Ingest.FailedPayloadRetention
+}
+
+func retentionEnabled(cfg *config.Config) bool {
+	return projectionRetention(cfg) > 0 || historyRetention(cfg) > 0
+}
+
+func projectionRetention(cfg *config.Config) time.Duration {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Engine.ProjectionRetentionAfter
+}
+
+func historyRetention(cfg *config.Config) time.Duration {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Engine.HistoryRetentionAfter
 }

--- a/internal/jobs/module_test.go
+++ b/internal/jobs/module_test.go
@@ -1,0 +1,130 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/internal/config"
+	"github.com/continua-ai/continua/internal/enginecontrol"
+	"github.com/continua-ai/continua/internal/ingest"
+	"github.com/continua-ai/continua/internal/jobargs"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestRetentionArgs_InsertOpts_UsesMaintenanceQueueAndActiveUniqueStates(t *testing.T) {
+	opts := jobargs.RetentionArgs{}.InsertOpts()
+
+	assert.Equal(t, jobargs.QueueMaintenance, opts.Queue)
+	require.True(t, opts.UniqueOpts.ByArgs)
+	assert.ElementsMatch(t, jobargs.ActiveUniqueStates(), opts.UniqueOpts.ByState)
+	assert.NotContains(t, opts.UniqueOpts.ByState, rivertype.JobStateCompleted)
+	assert.NotContains(t, opts.UniqueOpts.ByState, rivertype.JobStateCancelled)
+	assert.NotContains(t, opts.UniqueOpts.ByState, rivertype.JobStateDiscarded)
+}
+
+func TestRetentionInterval_IsDaily(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, jobargs.RetentionInterval)
+}
+
+func TestNewClient_WithoutRetentionConfig_DoesNotRegisterRetentionWorker(t *testing.T) {
+	client := newRetentionModuleTestClient(t, nil)
+
+	_, err := client.Insert(context.Background(), jobargs.RetentionArgs{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), jobargs.RetentionArgs{}.Kind())
+}
+
+func TestNewClient_WithRetentionConfig_RegistersRetentionWorker(t *testing.T) {
+	client := newRetentionModuleTestClient(t, &config.Config{
+		Engine: config.EngineConfig{
+			ProjectionRetentionAfter: 24 * time.Hour,
+		},
+		Jobs: config.JobsConfig{
+			IngestWorkers:      1,
+			RollupWorkers:      1,
+			MaintenanceWorkers: 1,
+			DefaultWorkers:     1,
+		},
+	})
+
+	inserted, err := client.Insert(context.Background(), jobargs.RetentionArgs{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, jobargs.RetentionArgs{}.Kind(), inserted.Job.Kind)
+	assert.Equal(t, jobargs.QueueMaintenance, inserted.Job.Queue)
+	assert.ElementsMatch(t, jobargs.ActiveUniqueStates(), inserted.Job.UniqueStates)
+}
+
+func TestNewClient_WithRetentionConfig_DoesNotRunRetentionOnStart(t *testing.T) {
+	client := newRetentionModuleTestClient(t, &config.Config{
+		Engine: config.EngineConfig{
+			ProjectionRetentionAfter: 24 * time.Hour,
+		},
+		Jobs: config.JobsConfig{
+			IngestWorkers:      1,
+			RollupWorkers:      1,
+			MaintenanceWorkers: 1,
+			DefaultWorkers:     1,
+		},
+	})
+
+	ctx := context.Background()
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() {
+		_ = client.Stop(context.Background())
+	})
+
+	waitForJobKindCount(t, client, jobargs.CleanupArgs{}.Kind(), 1)
+	assertJobKindCount(t, client, jobargs.RetentionArgs{}.Kind(), 0)
+}
+
+func newRetentionModuleTestClient(t *testing.T, cfg *config.Config) *river.Client[pgx.Tx] {
+	t.Helper()
+
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `
+		DELETE FROM river_job
+		WHERE kind IN ($1, $2)
+	`, jobargs.RetentionArgs{}.Kind(), jobargs.CleanupArgs{}.Kind())
+	require.NoError(t, err)
+
+	s := store.New(pool)
+	processor := ingest.NewProcessor(s, cfg)
+	client, err := NewClient(pool, s, processor, enginecontrol.NewService(s), cfg)
+	require.NoError(t, err)
+	return client
+}
+
+func waitForJobKindCount(t *testing.T, client *river.Client[pgx.Tx], kind string, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		result, err := client.JobList(context.Background(), river.NewJobListParams().Kinds(kind).First(10))
+		require.NoError(t, err)
+		if len(result.Jobs) >= want {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	result, err := client.JobList(context.Background(), river.NewJobListParams().Kinds(kind).First(10))
+	require.NoError(t, err)
+	t.Fatalf("timed out waiting for %d %s jobs, found %d", want, kind, len(result.Jobs))
+}
+
+func assertJobKindCount(t *testing.T, client *river.Client[pgx.Tx], kind string, want int) {
+	t.Helper()
+
+	result, err := client.JobList(context.Background(), river.NewJobListParams().Kinds(kind).First(10))
+	require.NoError(t, err)
+	assert.Len(t, result.Jobs, want)
+}

--- a/internal/jobs/retention.go
+++ b/internal/jobs/retention.go
@@ -1,0 +1,135 @@
+package jobs
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/continua-ai/continua/internal/enginecontrol"
+	"github.com/continua-ai/continua/internal/jobargs"
+	"github.com/continua-ai/continua/internal/store"
+)
+
+const (
+	defaultRetentionBatchSize = 100
+	retentionAdvisoryLockKey  = int64(62026040601)
+)
+
+type RetentionWorker struct {
+	river.WorkerDefaults[jobargs.RetentionArgs]
+	store               *store.Store
+	control             *enginecontrol.Service
+	projectionRetention time.Duration
+	historyRetention    time.Duration
+	batchSize           int
+}
+
+func NewRetentionWorker(
+	s *store.Store,
+	control *enginecontrol.Service,
+	projectionRetention time.Duration,
+	historyRetention time.Duration,
+) *RetentionWorker {
+	return &RetentionWorker{
+		store:               s,
+		control:             control,
+		projectionRetention: projectionRetention,
+		historyRetention:    historyRetention,
+		batchSize:           defaultRetentionBatchSize,
+	}
+}
+
+func (w *RetentionWorker) Timeout(*river.Job[jobargs.RetentionArgs]) time.Duration {
+	return 5 * time.Minute
+}
+
+func (w *RetentionWorker) Work(ctx context.Context, _ *river.Job[jobargs.RetentionArgs]) error {
+	if w == nil || w.store == nil || w.control == nil {
+		return nil
+	}
+
+	lockConn, err := w.store.Pool().Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer lockConn.Release()
+
+	locked, err := w.tryAdvisoryLock(ctx, lockConn)
+	if err != nil {
+		return err
+	}
+	if !locked {
+		return nil
+	}
+	defer w.unlockAdvisoryLock(context.Background(), lockConn)
+
+	startedAt := time.Now().UTC()
+	var projectionCount int
+	var historyCount int
+
+	if w.projectionRetention > 0 {
+		candidates, err := w.store.ListProjectionRetentionCandidates(
+			ctx,
+			startedAt.Add(-w.projectionRetention),
+			w.batchSize,
+		)
+		if err != nil {
+			return err
+		}
+		for _, candidate := range candidates {
+			if _, err := w.control.PurgeRun(ctx, candidate.ProjectID, candidate.RunID, enginecontrol.PurgeModeProjectionOnly); err != nil {
+				return err
+			}
+			projectionCount++
+		}
+	}
+
+	if w.historyRetention > 0 {
+		candidates, err := w.store.ListHistoryRetentionCandidates(
+			ctx,
+			startedAt.Add(-w.historyRetention),
+			w.batchSize,
+		)
+		if err != nil {
+			return err
+		}
+		for _, candidate := range candidates {
+			if _, err := w.control.PurgeRun(ctx, candidate.ProjectID, candidate.RunID, enginecontrol.PurgeModeFull); err != nil {
+				return err
+			}
+			historyCount++
+		}
+	}
+
+	log.Printf(
+		"event=engine_retention_completed projection_count=%d history_count=%d duration_ms=%d",
+		projectionCount,
+		historyCount,
+		time.Since(startedAt).Milliseconds(),
+	)
+	return nil
+}
+
+func (w *RetentionWorker) tryAdvisoryLock(ctx context.Context, conn *pgxpool.Conn) (bool, error) {
+	var locked bool
+	if conn == nil {
+		return false, nil
+	}
+	if err := conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", retentionAdvisoryLockKey).Scan(&locked); err != nil {
+		return false, err
+	}
+	return locked, nil
+}
+
+func (w *RetentionWorker) unlockAdvisoryLock(ctx context.Context, conn *pgxpool.Conn) {
+	if w == nil || conn == nil {
+		return
+	}
+	var unlocked bool
+	if err := conn.QueryRow(ctx, "SELECT pg_advisory_unlock($1)", retentionAdvisoryLockKey).Scan(&unlocked); err != nil {
+		log.Printf("event=engine_retention_unlock_failed err=%v", err)
+	}
+}

--- a/internal/jobs/retention_test.go
+++ b/internal/jobs/retention_test.go
@@ -1,0 +1,321 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	platformdb "github.com/continua-ai/continua/db/gen/go/platform"
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	publichistory "github.com/continua-ai/continua/engine/pkg/history"
+	"github.com/continua-ai/continua/internal/enginecontrol"
+	"github.com/continua-ai/continua/internal/jobargs"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestRetentionWorker_Stage1OnlyPurgesProjectionDetail(t *testing.T) {
+	fixture := newRetentionFixture(t)
+	completedAt := time.Now().UTC().Add(-96 * time.Hour).Round(time.Microsecond)
+
+	record := fixture.seedCompletedRun(t, completedAt, "up_to_date")
+	worker := NewRetentionWorker(fixture.store, enginecontrol.NewService(fixture.store), 24*time.Hour, 0)
+
+	err := worker.Work(fixture.ctx, &river.Job[jobargs.RetentionArgs]{Args: jobargs.RetentionArgs{}})
+	require.NoError(t, err)
+
+	assertTraceProjectionState(t, fixture, record.trace.ID, "summary_only")
+	assertSpanCounts(t, fixture, record.trace.ID, 1, 0)
+	assertHistoryCount(t, fixture, record.run.ID, 1)
+}
+
+func TestRetentionWorker_BothStagesPromoteToJournalExpiredAndSkipExistingJournalExpired(t *testing.T) {
+	fixture := newRetentionFixture(t)
+	completedAt := time.Now().UTC().Add(-96 * time.Hour).Round(time.Microsecond)
+
+	promoted := fixture.seedCompletedRun(t, completedAt, "up_to_date")
+	skipped := fixture.seedCompletedRun(t, completedAt.Add(-time.Minute), "journal_expired")
+	worker := NewRetentionWorker(fixture.store, enginecontrol.NewService(fixture.store), 24*time.Hour, 48*time.Hour)
+
+	err := worker.Work(fixture.ctx, &river.Job[jobargs.RetentionArgs]{Args: jobargs.RetentionArgs{}})
+	require.NoError(t, err)
+
+	assertTraceProjectionState(t, fixture, promoted.trace.ID, "journal_expired")
+	assertSpanCounts(t, fixture, promoted.trace.ID, 1, 0)
+	assertHistoryCount(t, fixture, promoted.run.ID, 0)
+
+	assertTraceProjectionState(t, fixture, skipped.trace.ID, "journal_expired")
+	assertSpanCounts(t, fixture, skipped.trace.ID, 2, 1)
+	assertHistoryCount(t, fixture, skipped.run.ID, 1)
+}
+
+func TestRetentionWorker_AdvisoryLockStaysBoundToHeldConnection(t *testing.T) {
+	fixture := newRetentionFixture(t)
+	worker := NewRetentionWorker(fixture.store, enginecontrol.NewService(fixture.store), 24*time.Hour, 0)
+
+	lockConn, err := fixture.store.Pool().Acquire(fixture.ctx)
+	require.NoError(t, err)
+	defer lockConn.Release()
+
+	locked, err := worker.tryAdvisoryLock(fixture.ctx, lockConn)
+	require.NoError(t, err)
+	require.True(t, locked)
+
+	var secondSessionLocked bool
+	err = fixture.store.Pool().QueryRow(fixture.ctx, "SELECT pg_try_advisory_lock($1)", retentionAdvisoryLockKey).Scan(&secondSessionLocked)
+	require.NoError(t, err)
+	assert.False(t, secondSessionLocked)
+
+	worker.unlockAdvisoryLock(fixture.ctx, lockConn)
+
+	err = fixture.store.Pool().QueryRow(fixture.ctx, "SELECT pg_try_advisory_lock($1)", retentionAdvisoryLockKey).Scan(&secondSessionLocked)
+	require.NoError(t, err)
+	assert.True(t, secondSessionLocked)
+
+	var unlocked bool
+	err = fixture.store.Pool().QueryRow(fixture.ctx, "SELECT pg_advisory_unlock($1)", retentionAdvisoryLockKey).Scan(&unlocked)
+	require.NoError(t, err)
+	assert.True(t, unlocked)
+}
+
+func TestRetentionWorker_RestartAfterProjectionPurgePromotesToJournalExpiredOnce(t *testing.T) {
+	fixture := newRetentionFixture(t)
+	completedAt := time.Now().UTC().Add(-96 * time.Hour).Round(time.Microsecond)
+	record := fixture.seedCompletedRun(t, completedAt, "up_to_date")
+
+	control := enginecontrol.NewService(fixture.store)
+	_, err := control.PurgeRun(
+		fixture.ctx,
+		record.run.ProjectID,
+		record.run.ID,
+		enginecontrol.PurgeModeProjectionOnly,
+	)
+	require.NoError(t, err)
+
+	assertTraceProjectionState(t, fixture, record.trace.ID, "summary_only")
+	assertSpanCounts(t, fixture, record.trace.ID, 1, 0)
+	assertHistoryCount(t, fixture, record.run.ID, 1)
+
+	worker := NewRetentionWorker(fixture.store, control, 24*time.Hour, 48*time.Hour)
+	job := &river.Job[jobargs.RetentionArgs]{Args: jobargs.RetentionArgs{}}
+
+	err = worker.Work(fixture.ctx, job)
+	require.NoError(t, err)
+
+	assertTraceProjectionState(t, fixture, record.trace.ID, "journal_expired")
+	assertSpanCounts(t, fixture, record.trace.ID, 1, 0)
+	assertHistoryCount(t, fixture, record.run.ID, 0)
+
+	err = worker.Work(fixture.ctx, job)
+	require.NoError(t, err)
+
+	assertTraceProjectionState(t, fixture, record.trace.ID, "journal_expired")
+	assertSpanCounts(t, fixture, record.trace.ID, 1, 0)
+	assertHistoryCount(t, fixture, record.run.ID, 0)
+}
+
+type retentionFixture struct {
+	ctx         context.Context
+	store       *store.Store
+	engine      *enginedb.Queries
+	projectID   uuid.UUID
+	projectName string
+}
+
+type retentionRecord struct {
+	trace platformdb.Trace
+	run   enginedb.EngineRun
+}
+
+func newRetentionFixture(t *testing.T) *retentionFixture {
+	t.Helper()
+
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+
+	return &retentionFixture{
+		ctx:       ctx,
+		store:     s,
+		engine:    enginedb.New(pool),
+		projectID: testutil.CreateTestProject(t, ctx, s.Queries()),
+	}
+}
+
+func (f *retentionFixture) seedCompletedRun(
+	t *testing.T,
+	completedAt time.Time,
+	projectionState string,
+) retentionRecord {
+	t.Helper()
+
+	instanceKey := "retention-instance-" + uuid.NewString()[:8]
+	traceExternalID := "engine:" + uuid.NewString()
+
+	instance, err := f.engine.CreateInstance(f.ctx, enginedb.CreateInstanceParams{
+		ProjectID:      f.projectID,
+		InstanceKey:    instanceKey,
+		DefinitionName: "checkout",
+	})
+	require.NoError(t, err)
+
+	run, err := f.engine.CreateRun(f.ctx, enginedb.CreateRunParams{
+		ProjectID:         f.projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           completedAt.Add(-time.Hour),
+	})
+	require.NoError(t, err)
+
+	startedPayload, err := publichistory.MarshalPayload(publichistory.WorkflowStartedPayload{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       instanceKey,
+		Input:             []byte(`{"cart_id":"retention"}`),
+	})
+	require.NoError(t, err)
+	history, err := f.engine.AppendHistory(f.ctx, enginedb.AppendHistoryParams{
+		ProjectID:  f.projectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 1,
+		EventType:  publichistory.EventWorkflowStarted,
+		Payload:    startedPayload,
+	})
+	require.NoError(t, err)
+
+	_, err = f.store.Pool().Exec(f.ctx, `
+		UPDATE engine.runs
+		SET status = 'completed',
+		    waiting_for = NULL,
+		    result = '{"ok":true}',
+		    completed_at = $2,
+		    updated_at = $2
+		WHERE id = $1
+	`, run.ID, completedAt)
+	require.NoError(t, err)
+	_, err = f.store.Pool().Exec(f.ctx, `
+		UPDATE engine.instances
+		SET status = 'completed',
+		    updated_at = $2
+		WHERE id = $1
+	`, instance.ID, completedAt)
+	require.NoError(t, err)
+
+	trace, err := f.store.Queries().UpsertTrace(f.ctx, platformdb.UpsertTraceParams{
+		ProjectID: f.projectID,
+		TraceID:   traceExternalID,
+		Name:      testutil.StrPtr("Retention Trace"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(completedAt.Add(-time.Hour)),
+		EndTime:   testutil.PgtypeTimestamptz(completedAt),
+		Output:    []byte(`{"ok":true}`),
+	})
+	require.NoError(t, err)
+
+	_, err = f.store.Pool().Exec(f.ctx, `
+		UPDATE traces
+		SET engine_run_id = $2,
+		    engine_instance_key = $3,
+		    engine_run_status = 'completed',
+		    engine_definition_name = 'checkout',
+		    engine_definition_version = 'v1',
+		    engine_projection_state = $4,
+		    engine_latest_history_id = $5,
+		    engine_last_projected_history_id = $5,
+		    engine_projection_updated_at = $6,
+		    updated_at = $6
+		WHERE id = $1
+	`, trace.ID, run.ID, instanceKey, projectionState, history.ID, completedAt)
+	require.NoError(t, err)
+
+	_, err = f.store.Queries().CreateSpan(f.ctx, platformdb.CreateSpanParams{
+		ProjectID: f.projectID,
+		TraceID:   trace.ID,
+		SpanID:    "engine:root:" + run.ID.String(),
+		Name:      "Retention Trace",
+		Type:      "chain",
+		Status:    "completed",
+		Level:     "default",
+		StartTime: completedAt.Add(-time.Hour),
+		EndTime:   testutil.PgtypeTimestamptz(completedAt),
+		Depth:     testutil.Int32Ptr(0),
+	})
+	require.NoError(t, err)
+	_, err = f.store.Queries().CreateSpan(f.ctx, platformdb.CreateSpanParams{
+		ProjectID:    f.projectID,
+		TraceID:      trace.ID,
+		SpanID:       "engine:activity:" + run.ID.String() + ":ship-order",
+		ParentSpanID: testutil.StrPtr("engine:root:" + run.ID.String()),
+		Name:         "ship-order",
+		Type:         "tool",
+		Status:       "completed",
+		Level:        "default",
+		StartTime:    completedAt.Add(-30 * time.Minute),
+		EndTime:      testutil.PgtypeTimestamptz(completedAt.Add(-20 * time.Minute)),
+		Depth:        testutil.Int32Ptr(1),
+	})
+	require.NoError(t, err)
+	_, err = f.store.Queries().InsertSpanEvent(f.ctx, platformdb.InsertSpanEventParams{
+		ProjectID: f.projectID,
+		TraceID:   trace.ID,
+		SpanID:    "engine:root:" + run.ID.String(),
+		EventType: "custom",
+		Level:     "info",
+		EventTs:   testutil.PgtypeTimestamptz(completedAt.Add(-10 * time.Minute)),
+		Message:   testutil.StrPtr("retained detail"),
+		Payload:   []byte(`{"detail":true}`),
+	})
+	require.NoError(t, err)
+
+	return retentionRecord{trace: trace, run: run}
+}
+
+func assertTraceProjectionState(t *testing.T, fixture *retentionFixture, traceID uuid.UUID, want string) {
+	t.Helper()
+
+	var state string
+	err := fixture.store.Pool().QueryRow(fixture.ctx, `
+		SELECT engine_projection_state
+		FROM traces
+		WHERE id = $1
+	`, traceID).Scan(&state)
+	require.NoError(t, err)
+	assert.Equal(t, want, state)
+}
+
+func assertSpanCounts(t *testing.T, fixture *retentionFixture, traceID uuid.UUID, wantSpans int, wantEvents int) {
+	t.Helper()
+
+	var spanCount int
+	err := fixture.store.Pool().QueryRow(fixture.ctx, `
+		SELECT COUNT(*)
+		FROM spans
+		WHERE trace_id = $1
+	`, traceID).Scan(&spanCount)
+	require.NoError(t, err)
+	assert.Equal(t, wantSpans, spanCount)
+
+	var eventCount int
+	err = fixture.store.Pool().QueryRow(fixture.ctx, `
+		SELECT COUNT(*)
+		FROM span_events
+		WHERE trace_id = $1
+	`, traceID).Scan(&eventCount)
+	require.NoError(t, err)
+	assert.Equal(t, wantEvents, eventCount)
+}
+
+func assertHistoryCount(t *testing.T, fixture *retentionFixture, runID uuid.UUID, want int) {
+	t.Helper()
+
+	rows, err := fixture.engine.GetHistoryByRun(fixture.ctx, runID)
+	require.NoError(t, err)
+	assert.Len(t, rows, want)
+}

--- a/internal/jobs/retention_test.go
+++ b/internal/jobs/retention_test.go
@@ -120,11 +120,10 @@ func TestRetentionWorker_RestartAfterProjectionPurgePromotesToJournalExpiredOnce
 }
 
 type retentionFixture struct {
-	ctx         context.Context
-	store       *store.Store
-	engine      *enginedb.Queries
-	projectID   uuid.UUID
-	projectName string
+	ctx       context.Context
+	store     *store.Store
+	engine    *enginedb.Queries
+	projectID uuid.UUID
 }
 
 type retentionRecord struct {

--- a/internal/store/doc.go
+++ b/internal/store/doc.go
@@ -1,0 +1,7 @@
+// Package store provides platform database access.
+//
+// The engine projector remains the primary writer for projected engine trace
+// detail and projection-state fields. Purge/retention/repair are the only
+// coordinated co-writers, and they must go through the projection CAS helpers
+// and detail-deletion wrappers in this package.
+package store

--- a/internal/store/engine_projection.go
+++ b/internal/store/engine_projection.go
@@ -1,0 +1,188 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+)
+
+type EngineRetentionCandidate struct {
+	ProjectID       uuid.UUID
+	RunID           uuid.UUID
+	TraceID         uuid.UUID
+	ProjectionState string
+	CompletedAt     time.Time
+}
+
+func (s *Store) ListProjectionRetentionCandidates(
+	ctx context.Context,
+	before time.Time,
+	limit int,
+) ([]EngineRetentionCandidate, error) {
+	return s.listEngineRetentionCandidates(ctx, before, limit, []string{"up_to_date", "catching_up"})
+}
+
+func (s *Store) ListHistoryRetentionCandidates(
+	ctx context.Context,
+	before time.Time,
+	limit int,
+) ([]EngineRetentionCandidate, error) {
+	return s.listEngineRetentionCandidates(ctx, before, limit, []string{"summary_only", "up_to_date", "catching_up"})
+}
+
+func (s *Store) listEngineRetentionCandidates(
+	ctx context.Context,
+	before time.Time,
+	limit int,
+	states []string,
+) ([]EngineRetentionCandidate, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT r.project_id,
+		       r.id,
+		       t.id,
+		       t.engine_projection_state,
+		       r.completed_at
+		FROM engine.runs AS r
+		INNER JOIN public.traces AS t
+		    ON t.project_id = r.project_id
+		   AND t.engine_run_id = r.id
+		WHERE r.status IN ('completed', 'failed', 'cancelled', 'terminated')
+		  AND r.completed_at IS NOT NULL
+		  AND r.completed_at < $1
+		  AND t.engine_projection_state = ANY($2::text[])
+		ORDER BY r.completed_at ASC, r.id ASC
+		LIMIT $3
+	`, before, states, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list engine retention candidates: %w", err)
+	}
+	defer rows.Close()
+
+	candidates := make([]EngineRetentionCandidate, 0, limit)
+	for rows.Next() {
+		var candidate EngineRetentionCandidate
+		if err := rows.Scan(
+			&candidate.ProjectID,
+			&candidate.RunID,
+			&candidate.TraceID,
+			&candidate.ProjectionState,
+			&candidate.CompletedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan engine retention candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate engine retention candidates: %w", err)
+	}
+
+	return candidates, nil
+}
+
+func (t *Tx) GetTraceByProjectAndEngineRunIDForUpdate(
+	ctx context.Context,
+	projectID uuid.UUID,
+	runID uuid.UUID,
+) (platform.Trace, error) {
+	trace, err := t.q.GetTraceByProjectAndEngineRunIDForUpdate(ctx, platform.GetTraceByProjectAndEngineRunIDForUpdateParams{
+		ProjectID:   projectID,
+		EngineRunID: pgUUID(runID),
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return platform.Trace{}, ErrNotFound
+	}
+	return trace, err
+}
+
+func (t *Tx) DeleteSpanEventsByTrace(ctx context.Context, traceID uuid.UUID) error {
+	return t.q.DeleteSpanEventsByTrace(ctx, traceID)
+}
+
+func (t *Tx) DeleteNonRootSpansByTrace(ctx context.Context, traceID uuid.UUID) error {
+	return t.q.DeleteNonRootSpansByTrace(ctx, traceID)
+}
+
+func (t *Tx) FlipProjectionStateToSummaryOnly(ctx context.Context, runID uuid.UUID) (int64, error) {
+	return t.q.FlipProjectionStateToSummaryOnly(ctx, pgUUID(runID))
+}
+
+func (t *Tx) FlipProjectionStateToJournalExpired(ctx context.Context, runID uuid.UUID) (int64, error) {
+	return t.q.FlipProjectionStateToJournalExpired(ctx, pgUUID(runID))
+}
+
+func (t *Tx) FlipProjectionStateToCatchingUp(ctx context.Context, runID uuid.UUID) (int64, error) {
+	return t.q.FlipProjectionStateToCatchingUp(ctx, pgUUID(runID))
+}
+
+func (t *Tx) EnsureTerminalTraceShell(
+	ctx context.Context,
+	traceID uuid.UUID,
+	status string,
+	completedAt time.Time,
+	output json.RawMessage,
+) error {
+	commandTag, err := t.tx.Exec(ctx, `
+		UPDATE public.traces
+		SET status = $2,
+		    end_time = $3::timestamptz,
+		    output = $4::jsonb,
+		    error_count = CASE
+		        WHEN $2 IN ('failed', 'cancelled') THEN GREATEST(COALESCE(error_count, 0), 1)
+		        ELSE error_count
+		    END,
+		    updated_at = NOW(),
+		    version = COALESCE(version, 1) + 1
+		WHERE id = $1
+	`, traceID, status, completedAt, output)
+	if err != nil {
+		return fmt.Errorf("ensure terminal trace shell: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return fmt.Errorf("ensure terminal trace shell matched zero rows for trace %s", traceID)
+	}
+	return nil
+}
+
+func (t *Tx) EnsureTerminalRootSpanShell(
+	ctx context.Context,
+	traceID uuid.UUID,
+	spanID string,
+	status string,
+	completedAt time.Time,
+	output json.RawMessage,
+	statusMessage *string,
+) error {
+	commandTag, err := t.tx.Exec(ctx, `
+		UPDATE public.spans
+		SET status = $3,
+		    end_time = $4::timestamptz,
+		    output = $5::jsonb,
+		    status_message = $6::text,
+		    duration_ms = CASE
+		        WHEN $4::timestamptz IS NOT NULL THEN EXTRACT(EPOCH FROM ($4::timestamptz - start_time)) * 1000
+		        ELSE duration_ms
+		    END,
+		    updated_at = NOW(),
+		    version = COALESCE(version, 1) + 1
+		WHERE trace_id = $1
+		  AND span_id = $2
+	`, traceID, spanID, status, completedAt, output, statusMessage)
+	if err != nil {
+		return fmt.Errorf("ensure terminal root span shell: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return fmt.Errorf("ensure terminal root span shell matched zero rows for trace %s span %s", traceID, spanID)
+	}
+	return nil
+}

--- a/internal/store/performance_test.go
+++ b/internal/store/performance_test.go
@@ -514,6 +514,7 @@ func TestIndex_GINSearchIndex(t *testing.T) {
 	require.NoError(t, searchRows.Err())
 }
 
+//nolint:revive // Keep testing.T first in test helper signatures.
 func explainPlan(
 	t *testing.T,
 	pool *pgxpool.Pool,

--- a/internal/store/performance_test.go
+++ b/internal/store/performance_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -348,6 +349,102 @@ func TestIndex_QueryPerformanceWithProjectFilter(t *testing.T) {
 	assert.NotContains(t, plan, "rows=55", "Should not scan all rows from both projects")
 }
 
+func TestIndex_TraceEngineFiltersUseTargetedIndexes(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	q := store.New(pool).Queries()
+	projectID := testutil.CreateTestProject(t, ctx, q)
+
+	engineTrace, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "engine-index-trace",
+		Name:      testutil.StrPtr("Engine Indexed Trace"),
+	})
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		UPDATE traces
+		SET engine_run_id = $2,
+		    engine_instance_key = 'instance-checkout',
+		    engine_definition_name = 'checkout',
+		    engine_run_status = 'waiting',
+		    engine_projection_state = 'catching_up',
+		    engine_projection_updated_at = NOW()
+		WHERE id = $1
+	`, engineTrace.ID, uuid.New())
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name  string
+		query string
+		arg   any
+	}{
+		{
+			name: "engine_instance_key",
+			query: `
+				EXPLAIN (ANALYZE, FORMAT TEXT)
+				SELECT id
+				FROM traces
+				WHERE project_id = $1
+				  AND engine_instance_key = $2
+				ORDER BY COALESCE(start_time, server_received_at) DESC
+				LIMIT 10
+			`,
+			arg: "instance-checkout",
+		},
+		{
+			name: "engine_definition_name",
+			query: `
+				EXPLAIN (ANALYZE, FORMAT TEXT)
+				SELECT id
+				FROM traces
+				WHERE project_id = $1
+				  AND engine_definition_name = $2
+				ORDER BY COALESCE(start_time, server_received_at) DESC
+				LIMIT 10
+			`,
+			arg: "checkout",
+		},
+		{
+			name: "engine_run_status",
+			query: `
+				EXPLAIN (ANALYZE, FORMAT TEXT)
+				SELECT id
+				FROM traces
+				WHERE project_id = $1
+				  AND engine_run_status = $2
+				ORDER BY COALESCE(start_time, server_received_at) DESC
+				LIMIT 10
+			`,
+			arg: "waiting",
+		},
+		{
+			name: "engine_projection_state",
+			query: `
+				EXPLAIN (ANALYZE, FORMAT TEXT)
+				SELECT id
+				FROM traces
+				WHERE project_id = $1
+				  AND engine_projection_state = $2
+				ORDER BY COALESCE(start_time, server_received_at) DESC
+				LIMIT 10
+			`,
+			arg: "catching_up",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := explainPlan(t, pool, ctx, tc.query, projectID, tc.arg)
+			assert.True(t,
+				strings.Contains(plan, "Index Scan") || strings.Contains(plan, "Bitmap"),
+				"expected index-backed plan for %s:\n%s", tc.name, plan,
+			)
+			assert.NotContains(t, plan, "Seq Scan", "expected indexed plan for %s:\n%s", tc.name, plan)
+		})
+	}
+}
+
 func TestIndex_GINSearchIndex(t *testing.T) {
 	// Verify GIN index is used for full-text search
 
@@ -415,4 +512,38 @@ func TestIndex_GINSearchIndex(t *testing.T) {
 		// Consume EXPLAIN output and immediately discard it.
 	}
 	require.NoError(t, searchRows.Err())
+}
+
+func explainPlan(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	ctx context.Context,
+	query string,
+	args ...any,
+) string {
+	t.Helper()
+
+	conn, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	_, err = conn.Exec(ctx, "SET enable_seqscan = off")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = conn.Exec(ctx, "SET enable_seqscan = on")
+	}()
+
+	rows, err := conn.Query(ctx, query, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var explainOutput strings.Builder
+	for rows.Next() {
+		var line string
+		err := rows.Scan(&line)
+		require.NoError(t, err)
+		explainOutput.WriteString(line + "\n")
+	}
+	require.NoError(t, rows.Err())
+	return explainOutput.String()
 }

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -11,22 +11,22 @@ import (
 
 // TraceFilter defines filter options for trace search.
 type TraceFilter struct {
-	ProjectID            uuid.UUID
-	Query                string     // Full-text search query
-	Status               string     // running, completed, failed
-	StartTimeFrom        *time.Time // Filter traces starting at or after this time
-	StartTimeTo          *time.Time // Filter traces starting at or before this time
-	UserID               string     // Filter by user_id
-	SessionID            *uuid.UUID // Filter by session_id
-	EngineInstanceKey    string     // Filter by engine_instance_key
-	EngineDefinitionName string     // Filter by engine_definition_name
-	EngineRunStatus      string     // Filter by engine_run_status
-	EngineProjectionState string    // Filter by engine_projection_state
-	HasErrors            *bool      // Filter by error_count > 0
-	MinDurationMs        *int64     // Filter by duration in milliseconds
-	SortDir              SortDirection
-	Limit                int32
-	Offset               int32
+	ProjectID             uuid.UUID
+	Query                 string     // Full-text search query
+	Status                string     // running, completed, failed
+	StartTimeFrom         *time.Time // Filter traces starting at or after this time
+	StartTimeTo           *time.Time // Filter traces starting at or before this time
+	UserID                string     // Filter by user_id
+	SessionID             *uuid.UUID // Filter by session_id
+	EngineInstanceKey     string     // Filter by engine_instance_key
+	EngineDefinitionName  string     // Filter by engine_definition_name
+	EngineRunStatus       string     // Filter by engine_run_status
+	EngineProjectionState string     // Filter by engine_projection_state
+	HasErrors             *bool      // Filter by error_count > 0
+	MinDurationMs         *int64     // Filter by duration in milliseconds
+	SortDir               SortDirection
+	Limit                 int32
+	Offset                int32
 }
 
 // TraceSearchResult contains the results of a trace search.
@@ -51,7 +51,7 @@ func (e *TraceFilterValidationError) Error() string {
 //nolint:gocritic // Pass-by-value keeps this immutable and avoids accidental caller mutation.
 func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (TraceSearchResult, error) {
 	result := TraceSearchResult{}
-	if err := validateTraceFilter(filter); err != nil {
+	if err := validateTraceFilter(&filter); err != nil {
 		return result, err
 	}
 
@@ -275,7 +275,10 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 	return result, nil
 }
 
-func validateTraceFilter(filter TraceFilter) error {
+func validateTraceFilter(filter *TraceFilter) error {
+	if filter == nil {
+		return nil
+	}
 	if filter.EngineRunStatus != "" {
 		value := strings.ToLower(strings.TrimSpace(filter.EngineRunStatus))
 		switch value {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -11,24 +11,37 @@ import (
 
 // TraceFilter defines filter options for trace search.
 type TraceFilter struct {
-	ProjectID     uuid.UUID
-	Query         string     // Full-text search query
-	Status        string     // running, completed, failed
-	StartTimeFrom *time.Time // Filter traces starting at or after this time
-	StartTimeTo   *time.Time // Filter traces starting at or before this time
-	UserID        string     // Filter by user_id
-	SessionID     *uuid.UUID // Filter by session_id
-	HasErrors     *bool      // Filter by error_count > 0
-	MinDurationMs *int64     // Filter by duration in milliseconds
-	SortDir       SortDirection
-	Limit         int32
-	Offset        int32
+	ProjectID            uuid.UUID
+	Query                string     // Full-text search query
+	Status               string     // running, completed, failed
+	StartTimeFrom        *time.Time // Filter traces starting at or after this time
+	StartTimeTo          *time.Time // Filter traces starting at or before this time
+	UserID               string     // Filter by user_id
+	SessionID            *uuid.UUID // Filter by session_id
+	EngineInstanceKey    string     // Filter by engine_instance_key
+	EngineDefinitionName string     // Filter by engine_definition_name
+	EngineRunStatus      string     // Filter by engine_run_status
+	EngineProjectionState string    // Filter by engine_projection_state
+	HasErrors            *bool      // Filter by error_count > 0
+	MinDurationMs        *int64     // Filter by duration in milliseconds
+	SortDir              SortDirection
+	Limit                int32
+	Offset               int32
 }
 
 // TraceSearchResult contains the results of a trace search.
 type TraceSearchResult struct {
 	Traces []TraceRead
 	Total  int64
+}
+
+type TraceFilterValidationError struct {
+	Field string
+	Value string
+}
+
+func (e *TraceFilterValidationError) Error() string {
+	return fmt.Sprintf("invalid %s %q", e.Field, e.Value)
 }
 
 // ListTracesFiltered returns traces matching the filter criteria.
@@ -38,6 +51,9 @@ type TraceSearchResult struct {
 //nolint:gocritic // Pass-by-value keeps this immutable and avoids accidental caller mutation.
 func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (TraceSearchResult, error) {
 	result := TraceSearchResult{}
+	if err := validateTraceFilter(filter); err != nil {
+		return result, err
+	}
 
 	// Build the base query
 	var whereClauses []string
@@ -110,6 +126,30 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 	if filter.UserID != "" {
 		whereClauses = append(whereClauses, fmt.Sprintf("t.user_id = $%d", argNum))
 		args = append(args, filter.UserID)
+		argNum++
+	}
+
+	if filter.EngineInstanceKey != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("t.engine_instance_key = $%d", argNum))
+		args = append(args, filter.EngineInstanceKey)
+		argNum++
+	}
+
+	if filter.EngineDefinitionName != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("t.engine_definition_name = $%d", argNum))
+		args = append(args, filter.EngineDefinitionName)
+		argNum++
+	}
+
+	if filter.EngineRunStatus != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("t.engine_run_status = $%d", argNum))
+		args = append(args, strings.ToLower(strings.TrimSpace(filter.EngineRunStatus)))
+		argNum++
+	}
+
+	if filter.EngineProjectionState != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("t.engine_projection_state = $%d", argNum))
+		args = append(args, strings.TrimSpace(filter.EngineProjectionState))
 		argNum++
 	}
 
@@ -233,4 +273,26 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 	}
 
 	return result, nil
+}
+
+func validateTraceFilter(filter TraceFilter) error {
+	if filter.EngineRunStatus != "" {
+		value := strings.ToLower(strings.TrimSpace(filter.EngineRunStatus))
+		switch value {
+		case "queued", "running", "waiting", "completed", "failed", "cancelled", "terminated":
+		default:
+			return &TraceFilterValidationError{Field: "engine_run_status", Value: filter.EngineRunStatus}
+		}
+	}
+
+	if filter.EngineProjectionState != "" {
+		value := strings.TrimSpace(filter.EngineProjectionState)
+		switch value {
+		case "up_to_date", "catching_up", "summary_only", "journal_expired":
+		default:
+			return &TraceFilterValidationError{Field: "engine_projection_state", Value: filter.EngineProjectionState}
+		}
+	}
+
+	return nil
 }

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -753,5 +753,136 @@ func TestSearch_Pagination(t *testing.T) {
 	}
 }
 
+func TestSearch_FilterByEngineMetadata(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+
+	engineTrace, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "engine-trace",
+		Name:      testutil.StrPtr("engine trace"),
+	})
+	require.NoError(t, err)
+	otherEngineTrace, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "engine-trace-other",
+		Name:      testutil.StrPtr("other engine trace"),
+	})
+	require.NoError(t, err)
+	nonEngineTrace, err := q.UpsertTrace(ctx, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "non-engine-trace",
+		Name:      testutil.StrPtr("non engine trace"),
+	})
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		UPDATE traces
+		SET engine_run_id = $2,
+		    engine_instance_key = 'instance-checkout',
+		    engine_definition_name = 'checkout',
+		    engine_run_status = 'waiting',
+		    engine_projection_state = 'catching_up',
+		    engine_projection_updated_at = NOW()
+		WHERE id = $1
+	`, engineTrace.ID, uuid.New())
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		UPDATE traces
+		SET engine_run_id = $2,
+		    engine_instance_key = 'instance-billing',
+		    engine_definition_name = 'billing',
+		    engine_run_status = 'completed',
+		    engine_projection_state = 'up_to_date',
+		    engine_projection_updated_at = NOW()
+		WHERE id = $1
+	`, otherEngineTrace.ID, uuid.New())
+	require.NoError(t, err)
+
+	byInstance, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:         projectID,
+		EngineInstanceKey: "instance-checkout",
+		Limit:             10,
+	})
+	require.NoError(t, err)
+	require.Len(t, byInstance.Traces, 1)
+	assert.Equal(t, engineTrace.ID, byInstance.Traces[0].ID)
+
+	byDefinition, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:            projectID,
+		EngineDefinitionName: "checkout",
+		Limit:                10,
+	})
+	require.NoError(t, err)
+	require.Len(t, byDefinition.Traces, 1)
+	assert.Equal(t, engineTrace.ID, byDefinition.Traces[0].ID)
+
+	byRunStatus, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:       projectID,
+		EngineRunStatus: "waiting",
+		Limit:           10,
+	})
+	require.NoError(t, err)
+	require.Len(t, byRunStatus.Traces, 1)
+	assert.Equal(t, engineTrace.ID, byRunStatus.Traces[0].ID)
+
+	byProjectionState, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:             projectID,
+		EngineProjectionState: "catching_up",
+		Limit:                 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, byProjectionState.Traces, 1)
+	assert.Equal(t, engineTrace.ID, byProjectionState.Traces[0].ID)
+
+	combined, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:             projectID,
+		EngineDefinitionName:  "checkout",
+		EngineRunStatus:       "waiting",
+		EngineProjectionState: "catching_up",
+		Limit:                 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, combined.Traces, 1)
+	assert.Equal(t, engineTrace.ID, combined.Traces[0].ID)
+
+	allTraces, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID: projectID,
+		Limit:     10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, allTraces.Traces, 3)
+
+	engineFilteredIDs := []uuid.UUID{byInstance.Traces[0].ID, combined.Traces[0].ID}
+	assert.NotContains(t, engineFilteredIDs, nonEngineTrace.ID)
+}
+
+func TestSearch_RejectsInvalidEngineFilters(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	projectID := testutil.CreateTestProject(t, ctx, s.Queries())
+
+	_, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:       projectID,
+		EngineRunStatus: "not-a-status",
+		Limit:           10,
+	})
+	require.Error(t, err)
+	assert.ErrorAs(t, err, new(*store.TraceFilterValidationError))
+
+	_, err = s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:             projectID,
+		EngineProjectionState: "not-a-state",
+		Limit:                 10,
+	})
+	require.Error(t, err)
+	assert.ErrorAs(t, err, new(*store.TraceFilterValidationError))
+}
+
 // Helper functions
 // (moved to internal/testutil/testutil.go to avoid redeclaration)

--- a/internal/store/traces.go
+++ b/internal/store/traces.go
@@ -212,3 +212,7 @@ func (t *Tx) UpdateTraceRollups(ctx context.Context, params platform.UpdateTrace
 func (t *Tx) UpsertTrace(ctx context.Context, params *platform.UpsertTraceParams) (platform.Trace, error) {
 	return t.q.UpsertTrace(ctx, *params)
 }
+
+func pgUUID(value uuid.UUID) pgtype.UUID {
+	return pgtype.UUID{Bytes: value, Valid: true}
+}

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/design.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/design.md
@@ -1,0 +1,172 @@
+# Design: Engine Retention, Repair, And Control SDK
+
+## Context
+
+This is the second operator-tooling layer built on top of `add-engine-operational-hardening-core` (Proposal 1). Proposal 1 introduces `TERMINATED`, `workflow.cancelled` / `workflow.terminated` history events, the operator terminate handler, the pending-work read endpoint, authoritative instance status, and projector-owned terminal debugger cleanup. Those contracts MUST be frozen before this change begins.
+
+This proposal adds:
+
+- manual purge (`projection_only` / `full`) for terminal runs
+- per-run async repair request
+- a platform-side env-driven retention maintenance job with two stages
+- additive trace-search filters on existing engine metadata columns
+- a separate Python control client that wraps the frozen control surface
+- documentation + regression test for `definition_version_mismatch` surfacing (already baseline from Proposal 1, not new work)
+
+It deliberately stays additive: no new trace-shell columns, no trace status enum migrations, no public bulk APIs, no projection schema changes.
+
+## Goals / Non-Goals
+
+### Goals
+- Give operators manual purge control with two explicit modes (projection_only, full)
+- Give operators manual repair to rebuild detail from retained engine history
+- Bound projection and history growth automatically via env-driven retention
+- Let operators filter traces by engine instance key, definition name, run status, and projection state from the existing trace list endpoint
+- Expose the full frozen control surface to Python as a first-class client module
+- Keep non-engine traces, sessions, ingest, and happy-path engine flows unchanged
+
+### Non-Goals
+- ContinueAsNew
+- suspend/resume
+- activity heartbeats
+- TypeScript control SDK
+- WebSocket runtime
+- public bulk backfill APIs
+- definition-catalog lookups for mismatch remediation
+- `engine_wait_kind` storage column
+- `engine_last_error_code` storage column
+- `projection_purged_at` storage column
+- any new trace status enum values
+
+## Decisions
+
+### Decision: Purge modes use existing projection states as barriers
+- Purge `projection_only` → deletes `public.span_events` for the trace + all non-root `public.spans`, keeps trace row + root span, flips `engine_projection_state` to `summary_only`.
+- Purge `full` → same projection purge, then deletes `engine.history` rows for the run, flips `engine_projection_state` to `journal_expired`.
+- No new state values are introduced; `summary_only` and `journal_expired` already exist in the Proposal 1 baseline.
+- **Alternatives considered:** a dedicated `purged` state; or storing `projection_purged_at` as a separate column. Rejected because the existing state machine already captures the two post-purge regimes, and `engine_projection_updated_at` already records when the state last changed. Adding new columns or states would require a migration that this phase explicitly avoids.
+
+### Decision: Projector treats `summary_only` and `journal_expired` as hard write barriers via a centralized write wrapper
+- The projector checks `engine_projection_state` before every detailed projection write. If the trace is in `summary_only` or `journal_expired`, the projector skips detail writes and does not advance the checkpoint for that run beyond what the barrier allows.
+- **Implementation requirement:** The barrier check MUST be centralized in a single write wrapper that reads/locks the trace row within the same transaction as the write. Today the projector fans out through multiple write helpers (`projectHistoryRows`, terminal projection, etc.) without a shared trace-lock wrapper. This change requires introducing one wrapper that every detail-write path calls, so no code path can accidentally skip the barrier check.
+- This matches Proposal 1's existing "projector is the single writer for projection tables" invariant and prevents a late catching_up loop from recreating detail rows that purge just deleted.
+- **Alternatives considered:** deleting the detail again on every projector loop (wasteful, racy); a CAS checkpoint that could be advanced past the barrier (breaks determinism); checking the barrier in each write helper individually (error-prone, easy to miss a code path). Rejected.
+
+### Decision: Purge/catching_up race is resolved by barrier CAS under row lock
+- Purge opens a transaction, locks the `public.traces` row (`SELECT ... FOR UPDATE`), reads the current `engine_projection_state`, flips it to `summary_only` or `journal_expired`, and deletes the detail rows inside the same transaction. The projector checks the barrier before every write; if the projector was mid-catchup, its next write hits the barrier and aborts that iteration.
+- **Alternatives considered:** advisory locks on `run_id`; a separate `purge_pending` flag. Rejected because the existing row lock on `public.traces` is enough to serialize the two writers, and a flag would introduce another column.
+
+### Decision: Purge is terminal-only; non-terminal runs return 409
+- Purge rejects runs whose `engine_run_status` is not `completed`, `failed`, `cancelled`, or `terminated`.
+- The service reuses the existing typed engine error code `run_not_terminal` rather than inventing a purge-specific variant.
+- This preserves the invariant that only terminal runs have a stable final shell; a non-terminal run would lose in-flight detail rows that the projector is still writing.
+- **Alternatives considered:** waiting for terminal inside the handler; allowing `waiting` runs. Rejected — operators can terminate first via Proposal 1, then purge.
+
+### Decision: Repair is an async projector-resume request, scoped to catching_up recovery
+- The current repo runs the projector loop only inside the separate `continua-engine` process. The platform server cannot synchronously call `engine/internal/projector` without either moving code out of `engine/internal/`, introducing RPC, or duplicating projector logic.
+- Repair therefore does NOT synchronously drive catch-up from the API process. Instead, repair on `summary_only` checks whether retained history exists beyond the checkpoint. If it does, the service flips `engine_projection_state` back to `catching_up` and returns an accepted response; the existing `continua-engine` projector loop later reads the resumed trace and rebuilds detail from `engine_last_projected_history_id + 1`.
+- If the checkpoint already equals `engine_latest_history_id` (trace was fully `up_to_date` before purge), repair returns `{accepted: false, reason: "no_events_to_project"}` and preserves `summary_only`. This means repair never "undoes" an operator's deliberate purge of a fully-projected trace.
+- If the trace is already `catching_up`, repair returns `{accepted: true, reason: "already_catching_up"}` and relies on the existing projector loop already in flight.
+- Full checkpoint-rewind (reproject from zero), a synchronous in-process repair entry point, and RPC into `continua-engine` are explicitly deferred to future changes.
+- **Alternatives considered:** extracting a callable shared projector package, introducing RPC/HTTP to `continua-engine`, or always rewinding the checkpoint to 0. Rejected for this phase because async resume is the only directly implementable choice against the current runtime split without materially expanding scope.
+
+### Decision: Purge and repair orchestration are extracted into a shared Fx-provided service
+- Today `engineControlService` is constructed privately inside `internal/api/newConfiguredServer`, which prevents `internal/jobs` from depending on the same orchestration logic.
+- This change therefore requires extracting purge/repair orchestration into a shared service that is provided separately through Fx (for example `internal/enginecontrol/`), and then injecting that service into both the API server and the retention worker.
+- The API layer remains responsible for auth, request parsing, and HTTP error mapping. The shared service owns the transaction, store coordination, and typed domain errors for purge/repair.
+- **Alternatives considered:** keep the service private to `internal/api` and have jobs call HTTP, or duplicate the logic in jobs. Rejected because both add coupling and duplicate failure modes for no benefit.
+
+### Decision: Retention is env-only with fail-fast validation, owned by the platform server
+- `ENGINE_PROJECTION_RETENTION_AFTER` and `ENGINE_HISTORY_RETENTION_AFTER` are env durations (Go `time.ParseDuration`-compatible strings like `168h`, `720h`).
+- Empty or `0` disables that stage. `ENGINE_HISTORY_RETENTION_AFTER` without `ENGINE_PROJECTION_RETENTION_AFTER`, or history ≤ projection, is a startup error.
+- Retention config lives in `internal/config/config.go`, not in `engine/internal/config/config.go`.
+- The current repo runs the platform server from `cmd/continua` and the engine maintenance/projector loops from the separate `continua-engine` binary. Because purge logic already lives root-side in `internal/api/engine_control.go` and touches both `public.traces` and `engine.history`, retention must run in the same root process instead of trying to inject a callback across a process boundary.
+- **Alternatives considered:** database-backed retention config, per-project overrides, engine-side maintenance via callback injection, engine-to-platform HTTP self-calls. Rejected for this phase — env config is sufficient, and root-side ownership is the only approach that is directly implementable against the current binary split without introducing RPC.
+
+### Decision: Retention runs as a single platform-side River maintenance job with two stages
+- One periodic maintenance job in the platform server scans terminal runs and performs stage 1 purge on runs past the projection window, then stage 2 purge on runs past the history window.
+- The job runs on the existing River maintenance surface already owned by `internal/jobs`, not inside `continua-engine`.
+- For each candidate, the worker calls the shared root-side purge service directly in-process. It does NOT self-call the public HTTP endpoint and does NOT duplicate purge SQL in a separate retention path.
+- In this phase, the periodic retention job runs once every 24 hours, with `RunOnStart` disabled.
+- The periodic job also uses active-state uniqueness on its job args so duplicate enqueues from multiple River clients collapse to one active job, while an advisory lock (or equivalent DB-backed serialization guard) still gates execution so multiple platform instances cannot run overlapping retention iterations even if a duplicate slips through.
+- **Alternatives considered:** two separate workers, per-run cron schedules, engine-side maintenance, HTTP self-call to the platform purge endpoint. Rejected — a single platform-side job is simpler, matches the current runtime split, and reuses the existing maintenance infrastructure.
+
+### Decision: Retention candidate selection lives in root-side handwritten store code
+- Candidate selection needs both `engine.runs.completed_at` and `public.traces.engine_projection_state`, so it spans the engine and platform schemas.
+- The current sqlc inputs are intentionally schema-local: `engine/db/sqlc.yaml` loads only engine migrations, and `db/platform/sqlc.yaml` loads only platform migrations. The retention join therefore SHOULD live in root-side handwritten store code (`internal/store/`) rather than adding cross-schema sqlc coupling in this phase.
+- The engine sqlc layer still owns the engine-only `DeleteHistoryByRun` query.
+- **Alternatives considered:** adding `public` schema inputs to engine sqlc, or adding engine schema inputs to platform sqlc. Rejected for this phase — both increase generation coupling for a single cross-schema retention query that is straightforward to express in handwritten root-side SQL.
+
+### Decision: Retention idempotency is driven by projection state
+- Stage 1 only touches runs whose current `engine_projection_state` is `up_to_date` or `catching_up`. After stage 1, a run is `summary_only`; re-entering the loop is a no-op for that run.
+- Stage 2 only touches runs whose current `engine_projection_state` is `summary_only` (or `up_to_date`/`catching_up` — stage 2 can apply `full` purge directly for runs older than the history window and skip stage 1). After stage 2, a run is `journal_expired`; re-entering the loop is a no-op.
+- This makes crash/restart safe without additional tracking tables.
+- **Alternatives considered:** a dedicated retention log table. Rejected — unnecessary complexity.
+
+### Decision: Trace search filters are additive in the handwritten builder
+- The existing `internal/store/search.go` handwritten dynamic SQL builder is the only changed surface. Four filters (`engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state`) are added as optional predicates.
+- Queries without engine filters produce identical SQL to today.
+- Queries with engine filters naturally exclude non-engine traces because those columns are `NULL` and the predicates are equality.
+- **Alternatives considered:** a dedicated engine-traces endpoint; a view. Rejected — additive filters on the existing endpoint preserve the current URL-driven UX and keep the SQL path coherent.
+
+### Decision: `engine_history_expired` is a typed marker distinguishing purged-empty from never-had-events
+- The existing `GET /v1/engine/runs/{run_id}/history` endpoint already returns HTTP 200 with whatever history rows exist (empty `events: []` when none match). Today there is no way to distinguish "this run had history that was purged" from "this run hasn't produced events yet or is fully paginated."
+- This change adds an explicit `expired: true` marker in the response body when the run's `engine_projection_state` is `journal_expired`. Non-expired runs omit the marker or return `expired: false`.
+- The 404 case is unchanged: it means the run does not exist or belongs to a different project.
+- **Alternatives considered:** HTTP 410 Gone; a separate `/v1/engine/runs/{id}/history-status` endpoint. Rejected — 410 is opaque to many clients, and a separate endpoint would double the round-trip cost for no gain.
+
+### Decision: Mismatch UX reuses existing fields
+- The engine run detail response already carries `definition_name`, `definition_version`, and a `failure` object (per Proposal 1). When the failure code is `definition_version_mismatch`, clients can surface the mismatch without a new endpoint.
+- No definition-catalog lookups, no "available versions" hint, no mismatch-specific route.
+- **Alternatives considered:** a dedicated `/v1/engine/runs/{id}/mismatch` endpoint; a catalog endpoint. Deferred to a later phase.
+
+### Decision: Python control client is a separate module
+- `sdks/python/src/continua/engine_control.py` (or `control/engine.py`) is a standalone client class that takes `endpoint` + `api_key` (consistent with the existing ingest `Client`) and exposes engine control methods.
+- It does NOT share state with `Client` (the ingest batching client) and does NOT inject itself into batching paths.
+- **Alternatives considered:** add control methods to `Client`. Rejected — ingest batching and engine control have different lifetimes, auth reuse is fine but batching semantics are irrelevant.
+
+### Decision: `wait_for_terminal()` is polling-only with a default 1s interval
+- No WebSocket/SSE dependency. Polls `GET /v1/engine/runs/{run_id}/result` (or the run detail endpoint) every 1s by default.
+- Accepts an optional timeout; raises a timeout error when the deadline is exceeded.
+- Returns the final run summary/detail object (the same shape as `get_result()` for a terminal run).
+- **Alternatives considered:** server-side long-poll. Deferred — polling is the baseline the platform already supports.
+
+## Risks / Trade-offs
+
+- **Lossy repair for terminal-then-up_to_date runs:** after projection_only purge on a trace that was fully projected, the checkpoint is at the terminal row. Repair returns `{accepted: false, reason: "no_events_to_project"}` and leaves the trace as `summary_only`. Full checkpoint rewind is explicitly deferred.
+  - **Mitigation:** document that fully-projected-then-purged traces retain the summary shell only; checkpoint rewind is a separate future proposal if operators request it.
+
+- **Async repair latency:** a successful repair request only flips the trace back to `catching_up`; detail rebuild completes later when the separate `continua-engine` projector loop reaches that run.
+  - **Mitigation:** make the async contract explicit in the API/SDK, return `projection_state: catching_up` on accepted repair requests, and direct callers to poll the existing read endpoints for completion.
+
+- **Retention scan load:** the platform-side retention worker scans terminal runs by completion time. On a large database this could be expensive if the index does not exist.
+  - **Mitigation:** this phase includes an index-only migration on `engine.runs(completed_at) WHERE status IN ('completed','failed','cancelled','terminated')`. The current engine indexes stop at instance/claim paths (see `000001_engine_foundation.up.sql`); the retention index is explicitly required. Schedule retention at low-traffic intervals.
+
+- **Projector barrier enforcement correctness:** the projector must check the barrier on every write. If a code path skips the check, purge can be silently undone.
+  - **Mitigation:** centralize the barrier check in a single projector-write wrapper. Add tests that run catching_up + purge concurrently and assert detail stays deleted.
+
+- **Search filter SQL drift:** adding filters to the handwritten builder risks SQL injection or planner regressions if done carelessly.
+  - **Mitigation:** follow the existing bind-variable pattern in `search.go`; validate enum inputs against known values before binding; add EXPLAIN-based tests for the new filter combinations.
+
+- **Python control client drift:** the control client wraps endpoints that Proposal 1 introduced. If those endpoints change shape during Proposal 1's implementation, the client must track.
+  - **Mitigation:** the client builds on the frozen OpenAPI surface; regenerate types from the same OpenAPI schema via `make generate` and reuse them in the client.
+
+- **Purge vs late activation race:** a terminate/cancel commit could in theory race with a purge on the same run.
+  - **Mitigation:** purge is terminal-only; by the time a run is terminal, no further activation can commit. Terminate + purge are sequenced by the operator (terminate first, wait for terminal, then purge). The barrier CAS + row lock handle any residual projector write race.
+
+- **History endpoint contract expansion:** clients that relied on 404 for missing history may need to handle the new `expired: true` marker.
+  - **Mitigation:** the existing 404 case (run does not exist) is preserved; only `journal_expired` runs get the new marker. Document the marker in OpenAPI; the marker is additive to an existing response body.
+
+## Migration Plan
+
+- No table schema migrations on `public.traces` or `engine.*` tables in this phase. One index-only migration on `engine.runs(completed_at)` filtered by terminal statuses is required for retention candidate queries.
+- Retention env config lives in `internal/config/config.go`: operators must set `ENGINE_PROJECTION_RETENTION_AFTER` / `ENGINE_HISTORY_RETENTION_AFTER` explicitly to opt in; default behavior is unchanged (retention disabled).
+- Purge / repair / filters / Python client are additive; no existing client contract is broken.
+- Rollback: remove retention env vars, redeploy; purge/repair handlers may remain in place but are unused. If the projector barrier check needs to be disabled for emergency rollback, flag it via a runtime config override (out of scope for this phase; document the code location).
+
+## Resolved Questions
+
+- **Repair on fully-projected-then-purged traces:** Decided: leave the checkpoint in place and return `{accepted: false, reason: "no_events_to_project"}`. Repair never "undoes" an operator's deliberate purge. Full checkpoint rewind is deferred to a separate proposal.
+- **Session-pinning for retention:** Decided: retention is purely time-based. Session-pinning is out of scope.
+- **Purge for non-engine traces:** Decided: no — the endpoint is under `/v1/engine/runs/{run_id}`, and non-engine traces do not have a run id. Non-engine trace cleanup is a separate concern.
+- **Retention on boot:** Decided: schedule only, to avoid thundering-herd on boot. Crash-safety is handled by idempotent state transitions, not boot scans.

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/proposal.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/proposal.md
@@ -1,0 +1,102 @@
+# Change: Add Engine Retention, Repair, And Control SDK
+
+## Why
+
+Once `add-engine-operational-hardening-core` (Proposal 1) freezes the engine statuses, history events, and control/read endpoints, operators still have no built-in way to:
+
+- purge detail projections or engine history for old runs without hand-deleting rows
+- re-run the projector against retained engine history to rebuild detail after an incident or a projection purge
+- bound projection/history growth automatically via retention rules
+- filter the trace list by engine-specific metadata (instance key, definition name, run status, projection state)
+- drive the engine's full control surface (start/signal/cancel/terminate/purge/repair/read) from Python without rebuilding boilerplate on top of the ingest batching client
+
+This change adds those operator tools as a second layer on top of Proposal 1: a manual purge endpoint, a per-run repair-request endpoint (scoped to catching_up recovery), an opt-in env-driven retention maintenance job, additive engine filters on the existing trace search, and a separate Python control client.
+
+The retention and purge paths are designed to preserve a minimal operator-useful shell (trace row, root span, terminal summary, engine run id, instance key, definition name/version, projection state) even when detail spans and/or engine history are deleted, so the debugger never loses the trace's identity or terminal outcome.
+
+## What Changes
+
+### API surface (extends `engine-public-api`)
+- Add `POST /v1/engine/runs/{run_id}/purge` with request body `{"mode": "projection_only" | "full"}`
+- Add `POST /v1/engine/runs/{run_id}/repair` (per-run only)
+- Purge is terminal-only; non-terminal runs return `409 Conflict` with the existing typed engine error `run_not_terminal`
+- `GET /v1/engine/runs/{run_id}/history` adds an explicit `expired: true` marker for `journal_expired` runs to distinguish purged-empty from never-had-events (the endpoint already returns HTTP 200 with empty events today; this change adds the typed marker, not a new status code)
+- `GET /v1/engine/runs/{run_id}/result` continues to return the retained terminal summary shell for `summary_only` and `journal_expired` runs; it does not become `404` after purge
+- No new engine trace-shell columns are added in this phase
+- `definition_version_mismatch` surfacing is already baseline from Proposal 1 (the run detail response already carries `definition_name`, `definition_version`, and the `failure` object); this change adds only a documentation note and a regression test — no new endpoint or field
+
+### Purge + repair semantics (extends `engine-trace-projection` and `engine-runtime-execution`)
+- `projection_only` purge deletes all `public.span_events` for the trace and all non-root `public.spans` for the trace, keeps the `public.traces` row and the root span that carries the terminal summary/result/failure payload, and sets `engine_projection_state = summary_only`
+- `full` purge performs the same projection purge, then purges `engine.history` / journal rows for the run, and sets `engine_projection_state = journal_expired`
+- Purge never deletes the last operator-useful shell (trace row, root span, run id, instance key, definition name/version, terminal status, projection state, terminal summary)
+- Purge is allowed even when the trace is still `catching_up`; in a race, purge wins by flipping `engine_projection_state` to `summary_only` or `journal_expired` under row lock or equivalent CAS guard
+- The projector treats `summary_only` and `journal_expired` as hard write barriers and does not recreate detailed projection rows after purge
+- Repair is an async request that reopens projection by flipping `summary_only -> catching_up` when retained engine history exists beyond `engine_last_projected_history_id`; the separate `continua-engine` projector loop performs the actual rebuild afterward
+- Repair on `summary_only` where the checkpoint already equals `engine_latest_history_id` (i.e. the trace was fully projected before purge) returns `{accepted: false, reason: "no_events_to_project"}` and preserves `summary_only` — it never "undoes" an operator's purge decision
+- Repair on `journal_expired` cannot restore detail and returns `{accepted: false, reason: "history_expired"}`
+- Repair on `up_to_date` is a no-op and returns `{accepted: false, reason: "already_up_to_date"}`
+- Repair on `catching_up` returns `{accepted: true, reason: "already_catching_up"}` and does not enqueue duplicate work
+- Single-run repair API is the only public repair surface in this phase; no bulk/internal repair driver, RPC bridge, or synchronous in-process projector entry point ships here
+
+### Automated retention (NEW capability `engine-retention-maintenance`)
+- Retention is env-only: `ENGINE_PROJECTION_RETENTION_AFTER`, `ENGINE_HISTORY_RETENTION_AFTER`
+- Empty or `0` disables that retention stage
+- `ENGINE_HISTORY_RETENTION_AFTER` requires `ENGINE_PROJECTION_RETENTION_AFTER` and must be greater than it
+- Invalid retention config is a startup error (fail-fast, not silent disable)
+- Maintenance adds one platform-side retention job only, running from the root server's existing River maintenance surface
+- Retention runs on a fixed daily cadence in this phase, without `RunOnStart`, using active-state uniqueness plus an advisory lock so duplicate enqueues across platform instances collapse into harmless no-ops
+- Stage 1 applies `projection_only` purge to terminal runs older than `ENGINE_PROJECTION_RETENTION_AFTER`
+- Stage 2 applies `full` purge to terminal runs older than `ENGINE_HISTORY_RETENTION_AFTER`
+- Retention transitions are idempotent across crash/restart
+
+### Trace search filter wiring (NEW capability `engine-trace-search`)
+- Add additive filters to the existing trace list endpoint (`GET /api/traces`) in the handwritten dynamic builder: `engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state`
+- Queries without engine filters behave exactly as they do today
+- Engine-filtered queries naturally exclude non-engine traces because those columns are NULL
+- `engine_definition_version`, `engine_wait_kind`, and error-code filters remain deferred
+
+### Schema + store (extends `engine-schema-runtime-delta`)
+- Reuse existing `public.traces` engine columns from Proposal 1's baseline (`engine_run_id`, `engine_instance_key`, `engine_definition_name`, `engine_definition_version`, `engine_projection_state`, `engine_projection_updated_at`, `engine_run_status`, `engine_wait_state`); no new trace-shell columns are added
+- Add an engine store query for deleting engine history rows for a run
+- Add root-side retention candidate selection in `internal/store/` as a handwritten cross-schema join between `engine.runs` and `public.traces`, plus platform store queries for span/span-event deletion by trace (projection purge), barrier flip on `public.traces.engine_projection_state` under CAS, and the four additive engine filters in `internal/store/search.go`
+
+### Python control client (NEW capability `engine-python-control-client`)
+- Ship a separate control module (`sdks/python/src/continua/engine_control.py` or equivalent), not additions to the ingest batching client
+- Wrap the full frozen control surface from Proposal 1 and this proposal: `start`, `signal`, `cancel`, `terminate`, `get_instance`, `get_run`, `get_result`, `get_history`, `get_pending_work`, `purge`, `repair`, `wait_for_terminal`
+- `wait_for_terminal()` is a polling helper with default poll interval `1s`, optional timeout, return value = final run summary/detail object, and timeout error on deadline exceeded
+
+## Impact
+
+- Affected specs (delta per capability):
+  - `engine-public-api` (ADDED: purge endpoint, repair endpoint, history-expired condition response, result-on-summary-only response; mismatch field surfacing is docs + regression test only — the fields already exist in Proposal 1 baseline)
+  - `engine-trace-projection` (ADDED: projection-only purge mapping, full purge mapping, barrier enforcement, retained operator shell, purge/catching_up race, repair projection behavior, projection state transitions on retention)
+  - `engine-runtime-execution` (ADDED: purge service semantics, repair service semantics, terminal-only gate, barrier CAS)
+  - `engine-schema-runtime-delta` (ADDED: retention env config validation in root config, engine history delete query, root-side retention candidate selection, platform span/span-event delete queries, projection state CAS writer)
+  - `engine-retention-maintenance` (NEW: env-driven platform-side retention job with two stages, idempotency, fail-fast config validation)
+  - `engine-trace-search` (NEW: additive engine filters on the existing trace list endpoint)
+  - `engine-python-control-client` (NEW: separate control module, frozen control surface wrapper, `wait_for_terminal` polling helper)
+- Affected code:
+  - `contracts/openapi/openapi.yaml` — purge, repair, history-expired condition, mismatch surfacing; `make generate`
+  - `engine/db/queries/` — history delete by run
+  - `engine/db/migrations/postgres/` — one index-only migration for retention candidate queries (index on `engine.runs.completed_at` filtered by terminal statuses); no table schema changes
+  - `engine/internal/projector/` — barrier enforcement inside the projector write path; async repair resumes via the existing projector loop after the projection state is flipped back to `catching_up`
+  - `db/platform/queries/` + `internal/store/` — root-side retention candidate selection across `engine.runs` + `public.traces`, span/span-event delete by trace, `engine_projection_state` CAS writer, additive engine filters in `search.go`
+  - `internal/enginecontrol/` (or equivalent shared Fx-provided service) — purge and repair orchestration used by API handlers and retention
+  - `internal/api/engine_control.go` — purge and repair handlers wired on `/v1/engine/runs/{run_id}/purge` and `/v1/engine/runs/{run_id}/repair`, mapped onto the shared control service
+  - `internal/config/config.go` — retention env parsing and validation in the platform server
+  - `internal/jobargs/` + `internal/jobs/` — periodic retention job registration and worker implementation
+  - `sdks/python/src/continua/` — new control module, tests
+  - No non-engine trace, session, or ingest behavior changes
+- No table schema migrations on `public.traces` or `engine.*` tables are required in this phase; one index-only migration is needed on `engine.runs` for retention candidate queries
+- API is strictly additive for existing engine clients; the `engine_history_expired` condition is a new case of the existing history endpoint and does not change today's 200/404 shapes for non-expired runs
+
+## Assumptions
+
+- `add-engine-operational-hardening-core` (Proposal 1) is fully implemented and archived; its `TERMINATED` status, `workflow.cancelled`/`workflow.terminated` history events, terminate handler, pending-work endpoint, cooperative cancel contract, instance-status authority, and projector terminal cleanup are frozen and referenced as baseline
+- All engine trace-shell columns needed for retention/filters (`engine_run_id`, `engine_instance_key`, `engine_definition_name`, `engine_definition_version`, `engine_projection_state`, `engine_projection_updated_at`, `engine_run_status`, `engine_wait_state`) already exist in `public.traces`
+- The projector is the single writer for `public.spans`, `public.span_events`, and projection-state fields on `public.traces`; the purge handler becomes the ONLY other allowed writer for projection-detail deletion and operates via a coordinated barrier CAS
+- The platform server (`cmd/continua`) and the engine runtime (`continua-engine`) remain separate binaries in this repo, so retention must run root-side with direct access to the purge service and platform tables rather than by injecting callbacks into the engine process
+- The same binary split means repair cannot synchronously drive projector catch-up from the API process in this phase; repair is therefore specified as an async state-transition request that the engine projector later consumes
+- `engine_wait_kind` and `engine_last_error_code` columns remain deferred and out of scope
+- `projection_purged_at` column is not added; purge timing is represented by `engine_projection_state` plus `engine_projection_updated_at`
+- ContinueAsNew, suspend/resume, activity heartbeats, TypeScript control SDK, WebSocket runtime, public bulk backfill APIs, and definition-catalog lookups all remain out of scope

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-public-api/spec.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-public-api/spec.md
@@ -1,0 +1,206 @@
+# Capability: engine-public-api
+
+Retention/repair/control-SDK layer on top of the Proposal 1 engine public API: introduces a manual purge endpoint with two modes, a per-run repair endpoint, an `engine_history_expired` condition on the existing history endpoint, terminal result responses for `summary_only` / `journal_expired` runs, and explicit surfacing of `definition_version_mismatch` failures via existing fields.
+
+Related capabilities: [engine-trace-projection](../engine-trace-projection/spec.md), [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-retention-maintenance](../engine-retention-maintenance/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Purge engine run endpoint
+
+`POST /v1/engine/runs/{run_id}/purge` MUST let operators delete projection detail and optionally engine history for a terminal run while preserving the operator shell.
+
+#### Scenario: Purge route registration and gating
+- **WHEN** `ENGINE_PUBLIC_API_ENABLED=true`
+- **THEN** `POST /v1/engine/runs/{run_id}/purge` is registered
+- **WHEN** `ENGINE_PUBLIC_API_ENABLED` is not set or is `false`
+- **THEN** the route returns 404
+
+#### Scenario: Purge authentication and project scoping
+- **WHEN** a purge request arrives with a valid API key
+- **THEN** `project_id` is taken from the API key and all engine operations are scoped to that project
+- **WHEN** no valid API key is provided
+- **THEN** the server returns 401
+
+#### Scenario: Purge request body shape
+- **WHEN** a purge request body is parsed
+- **THEN** the body is `{"mode": "projection_only" | "full"}`
+- **WHEN** the body is missing, malformed, or `mode` is any other value
+- **THEN** the server returns 400 with a typed validation error
+
+#### Scenario: Purge rejects non-terminal runs
+- **WHEN** a purge request targets a run whose `engine_run_status` is `queued`, `running`, or `waiting`
+- **THEN** the server returns 409 Conflict with the existing typed engine error `run_not_terminal`
+- **THEN** no projection rows, history rows, or state changes occur
+
+#### Scenario: Purge projection_only response
+- **WHEN** a purge request with `mode=projection_only` succeeds against a terminal run
+- **THEN** the server returns HTTP 200 with a body that includes at least `run_id`, `mode: "projection_only"`, and the new `projection_state: "summary_only"`
+- **THEN** the response indicates that `public.span_events` and non-root `public.spans` were deleted and the trace row + root span were preserved
+
+#### Scenario: Purge full response
+- **WHEN** a purge request with `mode=full` succeeds against a terminal run
+- **THEN** the server returns HTTP 200 with a body that includes at least `run_id`, `mode: "full"`, and the new `projection_state: "journal_expired"`
+- **THEN** the response indicates that projection detail was deleted and engine history rows for the run were deleted
+
+#### Scenario: Purge is allowed during catching_up
+- **WHEN** a purge request targets a terminal run whose trace is still `engine_projection_state=catching_up`
+- **THEN** the server proceeds, flipping the projection state to `summary_only` or `journal_expired` under row lock
+- **THEN** the projector's next write for that run hits the barrier and does not recreate detail rows
+
+#### Scenario: Purge on missing or cross-project run
+- **WHEN** the `run_id` does not exist or its trace belongs to a different project
+- **THEN** the server returns 404
+
+#### Scenario: Purge idempotency on already-purged runs
+- **WHEN** a purge request targets a run whose `engine_projection_state` already matches the requested or stronger barrier
+- **THEN** the server returns HTTP 200 with the current projection state
+- **THEN** no additional rows are deleted and the response indicates a no-op
+- **THEN** `full` on an already-`journal_expired` run is a no-op; `projection_only` on an already-`summary_only` or `journal_expired` run is a no-op
+
+#### Scenario: Purge never deletes the operator shell
+- **WHEN** any purge mode succeeds
+- **THEN** the `public.traces` row remains, including `engine_run_id`, `engine_instance_key`, `engine_definition_name`, `engine_definition_version`, `engine_run_status`, `engine_projection_state`, `engine_projection_updated_at`, and the terminal summary
+- **THEN** the root span carrying the terminal summary/result/failure payload remains
+
+---
+
+### Requirement: Repair engine run endpoint
+
+`POST /v1/engine/runs/{run_id}/repair` MUST request projector resume for a single run when retained engine history still exists, returning a structured result immediately.
+
+#### Scenario: Repair route registration and gating
+- **WHEN** `ENGINE_PUBLIC_API_ENABLED=true`
+- **THEN** `POST /v1/engine/runs/{run_id}/repair` is registered
+- **WHEN** `ENGINE_PUBLIC_API_ENABLED` is not set or is `false`
+- **THEN** the route returns 404
+
+#### Scenario: Repair authentication and project scoping
+- **WHEN** a repair request arrives with a valid API key
+- **THEN** `project_id` is taken from the API key and all engine operations are scoped to that project
+- **WHEN** no valid API key is provided
+- **THEN** the server returns 401
+
+#### Scenario: Repair is single-run only
+- **WHEN** a repair request is parsed
+- **THEN** the only targeted run is identified by `run_id` in the path
+- **THEN** no bulk or multi-run repair request shape is accepted at this public route
+
+#### Scenario: Repair response shape
+- **WHEN** repair returns HTTP 200
+- **THEN** the body includes at least `run_id`, a boolean `accepted`, a string `reason`, and the current `projection_state`
+- **THEN** allowed `reason` values include `already_up_to_date`, `history_expired`, `no_events_to_project`, `repair_requested`, and `already_catching_up`
+
+#### Scenario: Repair on up_to_date run
+- **WHEN** repair runs against a trace with `engine_projection_state=up_to_date`
+- **THEN** the response is `{accepted: false, reason: "already_up_to_date", projection_state: "up_to_date"}`
+- **THEN** no projector work is performed
+
+#### Scenario: Repair on summary_only run with retained history beyond checkpoint (catching_up recovery)
+- **WHEN** repair runs against a trace with `engine_projection_state=summary_only` and retained engine history beyond `engine_last_projected_history_id` (i.e. the trace was still `catching_up` before purge)
+- **THEN** the server flips the trace back to `projection_state: "catching_up"` and returns `{accepted: true, reason: "repair_requested", projection_state: "catching_up"}`
+- **THEN** the separate `continua-engine` projector later rebuilds detail from the checkpoint forward
+- **THEN** repair does not reproject from zero; it only resumes from the existing checkpoint
+
+#### Scenario: Repair on summary_only run where checkpoint equals latest (fully projected before purge)
+- **WHEN** repair runs against a trace with `engine_projection_state=summary_only` and `engine_last_projected_history_id == engine_latest_history_id`
+- **THEN** the response is `{accepted: false, reason: "no_events_to_project", projection_state: "summary_only"}`
+- **THEN** the `summary_only` barrier is preserved — repair never "undoes" an operator's deliberate purge of a fully-projected trace
+- **THEN** full checkpoint rewind is explicitly out of scope for this change
+
+#### Scenario: Repair on journal_expired run
+- **WHEN** repair runs against a trace with `engine_projection_state=journal_expired`
+- **THEN** the response is `{accepted: false, reason: "history_expired", projection_state: "journal_expired"}`
+- **THEN** no detail is rebuilt and the projection state is not advanced
+
+#### Scenario: Repair on catching_up run
+- **WHEN** repair runs against a trace with `engine_projection_state=catching_up`
+- **THEN** the response is `{accepted: true, reason: "already_catching_up", projection_state: "catching_up"}`
+- **THEN** the server does not enqueue duplicate work or synchronously wait for completion
+
+#### Scenario: Repair on missing or cross-project run
+- **WHEN** the `run_id` does not exist or its trace belongs to a different project
+- **THEN** the server returns 404
+
+#### Scenario: Repair requests converge without duplicate writes
+- **WHEN** repair runs multiple times against the same run
+- **THEN** repeated calls do not duplicate projection detail writes
+- **THEN** once the run is already `catching_up` or `up_to_date`, later responses reflect that current state instead of forcing another rebuild path
+
+---
+
+### Requirement: History endpoint distinguishes purged-empty from never-had-events
+
+`GET /v1/engine/runs/{run_id}/history` MUST add a typed `expired` marker for runs whose engine history has been purged, so clients can distinguish purged-empty from a run that simply has no events yet. The endpoint already returns HTTP 200 with empty events today; this change adds the marker, not a new status code.
+
+#### Scenario: Journal expired returns typed condition
+- **WHEN** a history request targets a run whose trace has `engine_projection_state=journal_expired`
+- **THEN** the server returns HTTP 200 with a body that includes an explicit expired marker (e.g. `expired: true`) and an empty `events` array
+- **THEN** the response is NOT 404
+
+#### Scenario: Non-expired history unchanged
+- **WHEN** a history request targets a run whose trace is `up_to_date`, `catching_up`, or `summary_only`
+- **THEN** the response shape is unchanged from the Proposal 1 baseline
+- **THEN** `expired` is not set or is `false`
+
+#### Scenario: Missing run still returns 404
+- **WHEN** the `run_id` does not exist or belongs to a different project
+- **THEN** the server returns 404
+- **THEN** the `engine_history_expired` marker is never used as a stand-in for a missing run
+
+---
+
+### Requirement: Result endpoint returns retained terminal shell after purge
+
+`GET /v1/engine/runs/{run_id}/result` MUST continue to return the retained terminal summary shell for `summary_only` and `journal_expired` runs.
+
+#### Scenario: summary_only terminal result
+- **WHEN** a result request targets a terminal run with `engine_projection_state=summary_only`
+- **THEN** the server returns HTTP 200 with the existing `EngineRunResultResponse` shape
+- **THEN** the response includes `run_id`, `status`, `result`, and `failure`
+
+#### Scenario: journal_expired terminal result
+- **WHEN** a result request targets a terminal run with `engine_projection_state=journal_expired`
+- **THEN** the server returns HTTP 200 with the existing `EngineRunResultResponse` shape
+- **THEN** the response includes `run_id`, `status`, `result`, and `failure`
+
+#### Scenario: Purged runs are not 404
+- **WHEN** a result request targets a `summary_only` or `journal_expired` terminal run
+- **THEN** the server does NOT return 404
+- **THEN** the retained summary shell is authoritative for the terminal outcome
+
+---
+
+### Requirement: Engine run detail surfaces definition_version_mismatch via existing fields
+
+The existing engine run detail response MUST expose the requested `definition_name`, `definition_version`, and the stored failure code so clients can identify `definition_version_mismatch` without a new endpoint.
+
+#### Scenario: Definition fields on run detail
+- **WHEN** the engine run detail endpoint returns a response for any engine run
+- **THEN** the response includes `definition_name` and `definition_version` fields mirroring the requested definition
+- **THEN** these fields are populated for every engine run, including failures
+
+#### Scenario: definition_version_mismatch failure code is surfaced
+- **WHEN** a run failed with `error_code=definition_version_mismatch`
+- **THEN** the response `failure` object includes the error code and message produced by the engine
+- **THEN** clients can identify the mismatch by comparing `definition_name`/`definition_version` against the failure code in the same response
+
+#### Scenario: No definition catalog endpoint
+- **WHEN** a client needs to display available definition versions for a failed run
+- **THEN** no dedicated mismatch or definition-catalog endpoint is provided by this change
+- **THEN** clients MUST rely on the fields already returned by engine run detail responses
+
+---
+
+### Requirement: Purge and repair endpoints require preview header
+
+`POST /v1/engine/runs/{run_id}/purge` and `POST /v1/engine/runs/{run_id}/repair` MUST require the `X-Continua-Engine-Preview: 1` header, consistent with all other mutating engine routes (`start`, `signal`, `cancel`, `terminate`).
+
+#### Scenario: Preview header is required
+- **WHEN** a purge or repair request lacks the `X-Continua-Engine-Preview: 1` header
+- **THEN** the server returns 400 with a message indicating the preview header is required
+- **THEN** these routes follow the same preview-gating pattern as `POST /v1/engine/runs/{run_id}/terminate` from Proposal 1
+
+#### Scenario: Disabled gate returns 404
+- **WHEN** `ENGINE_PUBLIC_API_ENABLED` is not set or is `false`
+- **THEN** both routes return 404

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-python-control-client/spec.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-python-control-client/spec.md
@@ -1,0 +1,124 @@
+# Capability: engine-python-control-client
+
+Separate Python control module that wraps the full frozen engine control surface (Proposal 1 + this proposal). Ships as its own class/module alongside the existing ingest batching client, with a polling `wait_for_terminal()` helper.
+
+Related capabilities: [engine-public-api](../engine-public-api/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Separate control module
+
+The Python SDK MUST expose engine control as a standalone module/class that does not modify the existing ingest batching client.
+
+#### Scenario: Module lives under the Python SDK package
+- **WHEN** a user imports the control client
+- **THEN** it is available from the existing `continua` package (e.g. `from continua import EngineControlClient` or equivalent)
+- **THEN** it lives in its own file under `sdks/python/src/continua/` (e.g. `engine_control.py`)
+- **THEN** it is NOT an extension of the existing ingest `Client` class
+
+#### Scenario: Constructor arguments
+- **WHEN** a user instantiates the control client
+- **THEN** required arguments are `endpoint` and `api_key` (consistent with the existing ingest `Client` which uses `endpoint`, not `base_url`)
+- **THEN** optional arguments include `timeout` and any HTTP session/transport injection consistent with the existing SDK's conventions
+- **THEN** the control client does NOT require a `Client` instance to be passed in
+
+#### Scenario: No shared batching state
+- **WHEN** the control client is instantiated or used
+- **THEN** it does not mutate or depend on the ingest batching client's in-flight batches, pollers, or background threads
+- **THEN** disabling the ingest client does not affect the control client
+
+#### Scenario: Auth via API key
+- **WHEN** the control client issues any request
+- **THEN** it sends the API key via the `X-API-Key` header (matching the existing OpenAPI `apiKeyAuth` security scheme and the existing ingest `Client` at `client.py:116`)
+- **THEN** `project_id` is derived server-side from the API key; the client does not pass a project id explicitly
+
+---
+
+### Requirement: Control surface methods
+
+The control client MUST expose the full frozen control surface from Proposal 1 and this proposal.
+
+#### Scenario: Method names and endpoints
+- **WHEN** the control client is used
+- **THEN** it exposes methods matching the following endpoint set (exact Python method names may follow SDK conventions, e.g. `snake_case`):
+  - `start` → `POST /v1/engine/runs` (start a new run)
+  - `signal` → `POST /v1/engine/runs/{run_id}/signal`
+  - `cancel` → `POST /v1/engine/runs/{run_id}/cancel`
+  - `terminate` → `POST /v1/engine/runs/{run_id}/terminate`
+  - `get_instance` → `GET /v1/engine/instances/{instance_key}` (matching the existing OpenAPI path parameter)
+  - `get_run` → `GET /v1/engine/runs/{run_id}`
+  - `get_result` → `GET /v1/engine/runs/{run_id}/result`
+  - `get_history` → `GET /v1/engine/runs/{run_id}/history`
+  - `get_pending_work` → `GET /v1/engine/runs/{run_id}/pending-work`
+  - `purge` → `POST /v1/engine/runs/{run_id}/purge`
+  - `repair` → `POST /v1/engine/runs/{run_id}/repair`
+  - `wait_for_terminal` → polling helper (see separate requirement)
+
+#### Scenario: Request / response typing
+- **WHEN** a control method is called
+- **THEN** request bodies and response objects use typed Python objects (dataclasses / pydantic / typed dicts) generated or derived from the OpenAPI schema
+- **THEN** response objects are returned to callers as typed values (not raw dicts)
+
+#### Scenario: Error mapping
+- **WHEN** a control method receives a non-2xx response
+- **THEN** the client raises a typed exception (e.g. `EngineRunNotTerminalError` for 409 on purge, `EngineRunNotFoundError` for 404)
+- **THEN** error types are documented and importable from the same module
+- **THEN** `EngineHistoryExpiredError` is NOT used — `get_history()` returns a typed response object with an `expired: bool` field (the server returns HTTP 200 for purged-empty history, not an error code). Callers check `response.expired` rather than catching an exception
+
+#### Scenario: Idempotent methods are safe to retry
+- **WHEN** `terminate`, `purge`, or `repair` is retried after the same operation already completed
+- **THEN** the second call returns the structured result from the server reflecting the current state without raising
+- **THEN** the client does not attempt its own write-side retry that could double-execute non-idempotent endpoints
+
+---
+
+### Requirement: wait_for_terminal polling helper
+
+The control client MUST provide a `wait_for_terminal()` polling helper.
+
+#### Scenario: Default poll interval
+- **WHEN** `wait_for_terminal(run_id)` is called without an explicit poll interval
+- **THEN** the client polls at a default interval of `1s`
+- **THEN** the poll interval is configurable via a keyword argument
+
+#### Scenario: Optional timeout
+- **WHEN** a timeout argument is provided
+- **THEN** the helper polls until terminal OR until the timeout is exceeded
+- **THEN** on timeout, the helper raises a typed timeout error (e.g. `EngineRunWaitTimeoutError`)
+- **THEN** omitting the timeout means no deadline is enforced
+
+#### Scenario: Terminal return value
+- **WHEN** the helper observes the run in a terminal state (`COMPLETED`, `FAILED`, `CANCELLED`, `TERMINATED`)
+- **THEN** it returns the final run summary / detail object (same shape as `get_result()` returns for terminal runs)
+- **THEN** the helper does not return for non-terminal observations
+
+#### Scenario: Uses existing control methods
+- **WHEN** the helper polls
+- **THEN** it calls `get_result()` (or `get_run()`) internally
+- **THEN** it does not introduce a dedicated waiting endpoint or separate HTTP path
+
+#### Scenario: Handles non-terminal 409 during polling
+- **WHEN** `get_result()` returns a 409 `run_not_terminal` response during polling
+- **THEN** the helper treats this as "not yet terminal" and continues polling
+- **THEN** the 409 is NOT raised as an exception during the polling loop — it is the expected non-terminal signal
+
+#### Scenario: Respects API key and scoping
+- **WHEN** the helper runs
+- **THEN** it uses the same `api_key` and `endpoint` as the control client instance
+- **THEN** cross-project runs appear as 404 (same as any other control method)
+
+---
+
+### Requirement: Contract-driven code generation alignment
+
+The control client SHOULD reuse types generated from the OpenAPI schema via the existing SDK generation flow where applicable, and MUST NOT duplicate request / response shapes by hand.
+
+#### Scenario: Types derived from OpenAPI
+- **WHEN** a request body or response type is defined in OpenAPI (e.g. `EngineRunResultResponse`, `EnginePendingWorkResponse`, purge/repair request+response bodies)
+- **THEN** the control client uses the same shape (possibly via generated code or a thin hand-maintained mirror that is kept in sync via `make generate`)
+- **THEN** hand-authored drift between the SDK shape and the OpenAPI schema is not introduced
+
+#### Scenario: Tests enforce contract shape
+- **WHEN** SDK tests run against a running platform (integration tests) or recorded fixtures (unit tests)
+- **THEN** they assert that responses decode into the typed shapes without discarding fields
+- **THEN** adding a new field server-side does NOT silently break the SDK

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-retention-maintenance/spec.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-retention-maintenance/spec.md
@@ -1,0 +1,161 @@
+# Capability: engine-retention-maintenance
+
+Env-driven platform-side retention maintenance that automates `projection_only` and `full` purges on terminal engine runs. It is implemented as one River-backed maintenance path with two stages, is idempotent across crash/restart, and keys off existing engine projection states.
+
+Related capabilities: [engine-trace-projection](../engine-trace-projection/spec.md), [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-schema-runtime-delta](../engine-schema-runtime-delta/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Retention env configuration
+
+The platform server MUST configure retention via two environment variables and MUST make the feature opt-in.
+
+#### Scenario: Default disabled
+- **WHEN** neither `ENGINE_PROJECTION_RETENTION_AFTER` nor `ENGINE_HISTORY_RETENTION_AFTER` is set
+- **THEN** no retention job is registered or scheduled
+- **THEN** the platform behaves identically to a deployment without retention
+
+#### Scenario: Projection-only retention enabled
+- **WHEN** `ENGINE_PROJECTION_RETENTION_AFTER` is set to a valid duration and `ENGINE_HISTORY_RETENTION_AFTER` is empty or zero
+- **THEN** the retention worker runs stage 1 (`projection_only` purge) only
+- **THEN** stage 2 (`full` purge) is skipped
+
+#### Scenario: Both stages enabled
+- **WHEN** both `ENGINE_PROJECTION_RETENTION_AFTER` and `ENGINE_HISTORY_RETENTION_AFTER` are set to valid durations and history > projection
+- **THEN** the retention worker runs stage 1 then stage 2 on each iteration
+- **THEN** stage 2 targets only runs whose completion age exceeds `ENGINE_HISTORY_RETENTION_AFTER`
+
+#### Scenario: History without projection is invalid
+- **WHEN** `ENGINE_HISTORY_RETENTION_AFTER` is set but `ENGINE_PROJECTION_RETENTION_AFTER` is unset or zero
+- **THEN** startup fails fast with a typed configuration error
+- **THEN** the process does not silently disable retention
+
+#### Scenario: Invalid ordering is invalid
+- **WHEN** both are set and `ENGINE_HISTORY_RETENTION_AFTER <= ENGINE_PROJECTION_RETENTION_AFTER`
+- **THEN** startup fails fast with a typed configuration error
+- **THEN** the process does not silently disable retention
+
+#### Scenario: Unparseable duration is invalid
+- **WHEN** either env var is present but cannot be parsed as a duration
+- **THEN** startup fails fast with a typed configuration error naming the offending variable
+- **THEN** the process does not silently disable retention
+
+---
+
+### Requirement: Single platform-side retention job with two stages
+
+The platform server MUST add exactly one retention maintenance path, implemented as one periodic River job and its worker, that processes stage 1 and stage 2 in order during each run.
+
+#### Scenario: One maintenance path only
+- **WHEN** retention is enabled
+- **THEN** exactly one platform-side periodic job / worker pair implements the retention loop
+- **THEN** two separate workers are NOT introduced for the two stages
+- **THEN** no engine-side maintenance subroutine is introduced in `continua-engine`
+
+#### Scenario: Shared service dependency
+- **WHEN** the retention worker is constructed
+- **THEN** it depends on the same shared Fx-provided purge service used by the public API
+- **THEN** it does not depend on a service that is privately constructed inside the API server
+
+#### Scenario: Stage 1 runs before stage 2
+- **WHEN** the retention worker executes an iteration
+- **THEN** stage 1 (`projection_only` purge on runs past `ENGINE_PROJECTION_RETENTION_AFTER`) runs first
+- **THEN** stage 2 (`full` purge on runs past `ENGINE_HISTORY_RETENTION_AFTER`) runs after stage 1 completes
+
+#### Scenario: Stage gating honors current projection state
+- **WHEN** stage 1 selects candidates
+- **THEN** only traces whose current `engine_projection_state` is `up_to_date` or `catching_up` are transitioned to `summary_only`
+- **WHEN** stage 2 selects candidates
+- **THEN** traces whose current `engine_projection_state` is `summary_only`, `up_to_date`, or `catching_up` are transitioned to `journal_expired`
+- **THEN** traces already at `journal_expired` are skipped by both stages
+
+#### Scenario: Stage 2 skips stage 1 when run is past history window
+- **WHEN** a terminal run's completion age already exceeds `ENGINE_HISTORY_RETENTION_AFTER`
+- **THEN** stage 2 applies the `full` purge directly
+- **THEN** stage 1 does NOT need to have run on that specific run first
+
+---
+
+### Requirement: Retention transitions are idempotent across crash/restart
+
+The retention worker MUST produce the same end state if it is interrupted mid-iteration and restarted.
+
+#### Scenario: Crash before purge service commit
+- **WHEN** retention is interrupted before a candidate purge commits
+- **THEN** the trace remains in its original projection state or the transaction rolls back cleanly
+- **THEN** the next iteration reselects the candidate and retries
+
+#### Scenario: Crash after commit
+- **WHEN** retention committed a barrier flip and its row deletions
+- **THEN** the next iteration sees the trace in the new state
+- **THEN** the next iteration does not re-delete or re-flip
+
+#### Scenario: Repeated iterations converge
+- **WHEN** retention runs N times with no new terminal runs
+- **THEN** the final state after each iteration is identical
+- **THEN** stable traces are skipped by candidate selection
+
+---
+
+### Requirement: Retention applies only to terminal runs
+
+The retention worker MUST NOT purge a run whose status is non-terminal.
+
+#### Scenario: Candidate filter
+- **WHEN** retention selects candidates at either stage
+- **THEN** only runs whose authoritative `engine.runs.status IN ('completed','failed','cancelled','terminated')` are considered
+- **THEN** runs in `queued`, `running`, or `waiting` are never purged by retention
+
+#### Scenario: Status check re-verified at purge time
+- **WHEN** retention hands a candidate to the shared purge service
+- **THEN** the purge service re-verifies the terminal-only gate inside its own transaction
+- **THEN** a race where a run becomes non-terminal after selection is safely rejected
+
+---
+
+### Requirement: Purge execution uses the shared root-side service
+
+The retention worker MUST NOT directly access `public.traces`, `public.spans`, or `public.span_events`. It MUST execute purges through the same shared root-side purge service used by the public API.
+
+#### Scenario: Shared service invocation
+- **WHEN** the retention worker needs to purge a candidate run
+- **THEN** it calls the shared in-process purge service directly
+- **THEN** it does NOT self-call the public HTTP endpoint
+- **THEN** it does NOT duplicate purge SQL in a separate retention-only code path
+
+#### Scenario: No cross-process callback bridge
+- **WHEN** retention is wired up
+- **THEN** no injected callback is passed from `cmd/continua` into the separate `continua-engine` binary
+- **THEN** retention remains fully root-side and directly implementable against the current runtime split
+
+#### Scenario: Shared service respects purge contract
+- **WHEN** the shared service is invoked by retention
+- **THEN** it executes the full purge contract (terminal-only gate, CAS barrier, row lock, detail deletion, optional history deletion)
+- **THEN** the structured purge result still includes the post-purge projection state and a `deleted` flag for idempotency
+
+---
+
+### Requirement: Retention scheduling
+
+The retention job MUST have a deterministic, non-interactive schedule.
+
+#### Scenario: Fixed daily cadence with no boot scan
+- **WHEN** the platform server starts
+- **THEN** retention does NOT run immediately on boot
+- **THEN** retention is triggered by a periodic River schedule once every 24 hours in this phase
+- **THEN** `RunOnStart` is disabled
+
+#### Scenario: Active-state uniqueness on periodic enqueue
+- **WHEN** multiple River clients register the same periodic retention job
+- **THEN** the job args use active-state uniqueness so only one active retention job is retained for a given cadence tick
+- **THEN** duplicate enqueues are treated as best-effort collapsible duplicates rather than separate intended work items
+
+#### Scenario: Single-instance execution
+- **WHEN** multiple platform instances run in parallel
+- **THEN** retention is serialized so only one instance performs a given iteration at a time (via an advisory lock or equivalent)
+- **THEN** iterations do not overlap to the point of double-purging
+
+#### Scenario: Bounded batch size per iteration
+- **WHEN** retention runs an iteration
+- **THEN** each stage processes a bounded batch of candidates
+- **THEN** over-large backlogs drain across multiple iterations without blocking the platform

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-runtime-execution/spec.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-runtime-execution/spec.md
@@ -1,0 +1,137 @@
+# Capability: engine-runtime-execution
+
+Purge / repair service additions to the platform-side engine control layer: defines the purge service contract (terminal-only, mode-gated, CAS-guarded, shared by public API and retention) and the repair-request contract (single-run, async, scoped to catching_up recovery, structured result).
+
+Related capabilities: [engine-trace-projection](../engine-trace-projection/spec.md), [engine-public-api](../engine-public-api/spec.md), [engine-schema-runtime-delta](../engine-schema-runtime-delta/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Purge service semantics
+
+The purge service MUST be terminal-only, mode-gated, barrier-serialized, and must never delete the operator shell.
+
+#### Scenario: Terminal-only gate
+- **WHEN** the purge service receives a request for a run
+- **THEN** it checks the run's `engine_run_status` via the engine runs table
+- **WHEN** the status is not one of `completed`, `failed`, `cancelled`, `terminated`
+- **THEN** the service returns the existing typed `run_not_terminal` error and performs no deletion
+- **THEN** the API handler maps this error to HTTP 409
+
+#### Scenario: Shared purge path for API and retention
+- **WHEN** purge is invoked from the public API or the retention worker
+- **THEN** the same purge service implementation performs the terminal gate, mode dispatch, CAS barrier handling, and row deletion
+- **THEN** no separate retention-only purge logic is introduced
+
+#### Scenario: Mode dispatch
+- **WHEN** the purge service is called with `mode=projection_only`
+- **THEN** it performs the projection-only delete + barrier flip to `summary_only`
+- **WHEN** the purge service is called with `mode=full`
+- **THEN** it performs the projection-only delete, then the engine history delete, then the barrier flip to `journal_expired`
+
+#### Scenario: Barrier CAS under row lock
+- **WHEN** the purge service executes
+- **THEN** it opens a transaction that takes `SELECT ... FOR UPDATE` on the target `public.traces` row
+- **THEN** it reads `engine_projection_state` inside the transaction and refuses to downgrade a stronger barrier
+- **THEN** `projection_only` on a trace already at `journal_expired` is a no-op
+- **THEN** `projection_only` on a trace already at `summary_only` is a no-op (no re-delete, no state change)
+- **THEN** `full` on a trace already at `journal_expired` is a no-op
+
+#### Scenario: Projection delete scope
+- **WHEN** the purge service deletes detail
+- **THEN** only rows tied to the target run's trace are deleted
+- **THEN** the trace row and the trace's root span are never deleted
+- **THEN** no spans belonging to other traces are affected
+
+#### Scenario: Engine history delete scope for full purge
+- **WHEN** the purge service deletes engine history (only in `full` mode)
+- **THEN** only `engine.history` rows with the target `run_id` are deleted
+- **THEN** the `engine.runs` row is preserved
+- **THEN** the `engine.instances` row is preserved
+
+#### Scenario: Purge is single-run
+- **WHEN** the purge service executes
+- **THEN** exactly one run's detail / history is touched per call
+- **THEN** no bulk purge path exists in this capability
+
+#### Scenario: Purge emits structured result
+- **WHEN** purge succeeds
+- **THEN** the service returns `{run_id, mode, projection_state, deleted: boolean}` (or equivalent structured result)
+- **THEN** `deleted=true` when rows were deleted, `deleted=false` for idempotent no-op calls
+
+---
+
+### Requirement: Shared control orchestration is provided outside the API server
+
+The platform MUST expose purge/repair orchestration as an Fx-provided shared service outside the private API server constructor so both API handlers and background jobs can depend on the same implementation.
+
+#### Scenario: API handlers use shared service
+- **WHEN** the API server is constructed
+- **THEN** it receives the shared control service through dependency injection
+- **THEN** it does NOT privately construct purge/repair orchestration inside `newConfiguredServer`
+
+#### Scenario: Retention worker uses the same shared service
+- **WHEN** the retention worker is constructed
+- **THEN** it receives the same shared control service through dependency injection
+- **THEN** it does NOT duplicate purge/repair orchestration or self-call the HTTP API
+
+---
+
+### Requirement: Repair request semantics
+
+The repair service MUST be single-run, MUST be async against the current runtime split, MUST reuse the existing projector catch-up path indirectly by resuming `catching_up`, MUST be scoped to catching_up recovery (no full checkpoint rewind), and MUST return a structured result.
+
+#### Scenario: Single-run entry
+- **WHEN** the repair service receives a `run_id`
+- **THEN** it resolves the trace for that run via the same project-scoped lookup used by other engine handlers
+- **THEN** it operates on exactly that one trace
+
+#### Scenario: Repair dispatches on current projection state
+- **WHEN** the trace is `up_to_date`
+- **THEN** the service returns `{accepted: false, reason: "already_up_to_date"}` without invoking the projector
+- **WHEN** the trace is `summary_only`
+- **THEN** the service checks whether retained history exists beyond the checkpoint
+- **THEN** if retained history exists, it clears the barrier (state transitions to `catching_up`) and returns `{accepted: true, reason: "repair_requested", projection_state: "catching_up"}`
+- **WHEN** the trace is `journal_expired`
+- **THEN** the service returns `{accepted: false, reason: "history_expired"}` without clearing the barrier
+- **WHEN** the trace is `catching_up`
+- **THEN** the service returns `{accepted: true, reason: "already_catching_up", projection_state: "catching_up"}`
+
+#### Scenario: Checkpoint-forward resume
+- **WHEN** repair is accepted for a `summary_only` trace
+- **THEN** the existing `continua-engine` projector later applies events from `engine_last_projected_history_id + 1` through `engine_latest_history_id`
+- **THEN** repair does NOT rewind the checkpoint to 0 by default
+- **THEN** if the checkpoint equals `engine_latest_history_id` (no events to rebuild), the service returns `{accepted: false, reason: "no_events_to_project"}` and the barrier is preserved
+
+#### Scenario: Repair returns current, not final, projection state
+- **WHEN** repair returns
+- **THEN** the response includes the current `projection_state`
+- **THEN** accepted repair requests report `projection_state = 'catching_up'`
+- **THEN** `up_to_date` is reported only by later read APIs after the separate projector loop finishes catch-up
+
+#### Scenario: Repair requests converge
+- **WHEN** repair runs multiple times against the same run
+- **THEN** the service does not create duplicate detail rows
+- **THEN** once a run is already `catching_up` or `up_to_date`, later responses reflect that current state instead of restarting rebuild
+
+#### Scenario: Repair never bypasses projector writes
+- **WHEN** repair executes
+- **THEN** the repair service itself does not write projection detail rows
+- **THEN** all later detail writes still flow through the separate projector's existing write path
+- **THEN** no handwritten SQL writes detail rows directly from the repair service
+
+---
+
+### Requirement: Purge and repair handlers honor project scoping
+
+API handlers for purge and repair MUST derive `project_id` from the authenticated API key and MUST reject cross-project runs with 404.
+
+#### Scenario: Project scoping from API key
+- **WHEN** a purge or repair handler runs
+- **THEN** `project_id` is taken from the API-key auth context
+- **THEN** the run lookup filters by `project_id`
+- **THEN** a run belonging to a different project is indistinguishable from a missing run (returns 404)
+
+#### Scenario: No bypass via run id
+- **WHEN** a caller supplies a valid `run_id` that exists in another project
+- **THEN** the handler returns 404
+- **THEN** no purge or repair action is taken

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-schema-runtime-delta/spec.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-schema-runtime-delta/spec.md
@@ -1,0 +1,200 @@
+# Capability: engine-schema-runtime-delta
+
+Schema / store additions for retention + purge + repair + trace-search: no new trace-shell columns; adds an engine-side history delete query, root-side cross-schema retention candidate selection, platform-side queries for span/span-event deletion and projection-state CAS writes, and root-side env validation for retention startup.
+
+Related capabilities: [engine-trace-projection](../engine-trace-projection/spec.md), [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-retention-maintenance](../engine-retention-maintenance/spec.md), [engine-trace-search](../engine-trace-search/spec.md)
+
+## ADDED Requirements
+
+### Requirement: No new trace-shell columns
+
+This change MUST NOT add new columns to `public.traces` or the engine trace-shell tables.
+
+#### Scenario: Reuse of existing engine columns
+- **WHEN** retention, purge, repair, filters, or the Python control client need a projection or identity value
+- **THEN** they read from the existing columns already populated by Proposal 1's baseline: `engine_run_id`, `engine_instance_key`, `engine_definition_name`, `engine_definition_version`, `engine_projection_state`, `engine_projection_updated_at`, `engine_run_status`, `engine_wait_state`
+- **THEN** no migration adds `projection_purged_at`, `engine_wait_kind`, `engine_last_error_code`, or any other trace-shell column in this phase
+
+#### Scenario: Existing engine columns remain sufficient
+- **WHEN** retention selects candidates by completion age
+- **THEN** the query uses engine run completion time (for example `engine.runs.completed_at`) in combination with the engine run status classification
+- **THEN** no derived or denormalized column on `public.traces` is introduced for this purpose
+
+---
+
+### Requirement: Retention candidate index
+
+This change MUST add one index-only migration on `engine.runs` to support efficient retention candidate queries.
+
+#### Scenario: Index on completed_at with terminal status filter
+- **WHEN** the retention worker queries for candidates by completion time
+- **THEN** the query is supported by a partial index on `engine.runs(completed_at) WHERE status IN ('completed','failed','cancelled','terminated')`
+- **THEN** this avoids a full table scan on `engine.runs` for large databases
+
+#### Scenario: Index-only migration
+- **WHEN** the migration runs
+- **THEN** only an index is created
+- **THEN** no table schema changes, new columns, or existing column modifications are introduced
+- **THEN** the migration is backwards-compatible and can be applied without downtime
+
+---
+
+### Requirement: Engine history delete query
+
+The engine MUST provide a query that deletes all `engine.history` rows for a given `run_id` in one statement.
+
+#### Scenario: Delete by run id
+- **WHEN** the engine history delete query runs with a `run_id`
+- **THEN** all `engine.history` rows with that `run_id` are deleted in a single `DELETE` statement
+- **THEN** no cursor or paginated delete path is used for single-run history purges
+
+#### Scenario: Query leaves runs and instances intact
+- **WHEN** the history delete query runs
+- **THEN** no rows are deleted from `engine.runs` or `engine.instances`
+- **THEN** the terminal shell remains readable via engine read endpoints
+
+#### Scenario: sqlc annotation
+- **WHEN** the query is declared in engine query files
+- **THEN** it is annotated as `:exec`
+- **THEN** the generated Go function takes `ctx, run_id` and returns an error
+
+---
+
+### Requirement: Root-side retention candidate selection
+
+The root/platform store MUST provide read helpers that list terminal runs eligible for each retention stage, ordered and bounded.
+
+#### Scenario: Stage 1 candidates
+- **WHEN** the stage 1 retention helper runs with a threshold timestamp and a limit
+- **THEN** it returns terminal runs (`status IN ('completed','failed','cancelled','terminated')`) whose `completed_at < threshold` AND whose projected trace has `engine_projection_state IN ('up_to_date','catching_up')`
+- **THEN** rows are ordered by `runs.completed_at ASC, runs.id ASC`
+- **THEN** the result set is capped by the provided limit
+
+#### Scenario: Stage 2 candidates
+- **WHEN** the stage 2 retention helper runs with a threshold timestamp and a limit
+- **THEN** it returns terminal runs whose `completed_at < threshold` AND whose projected trace has `engine_projection_state IN ('summary_only','up_to_date','catching_up')`
+- **THEN** rows are ordered by `runs.completed_at ASC, runs.id ASC`
+- **THEN** the result set is capped by the provided limit
+- **THEN** traces already at `journal_expired` are excluded
+
+#### Scenario: Cross-schema join lives root-side
+- **WHEN** candidate selection needs both run status and projection state
+- **THEN** the helper joins `engine.runs` with `public.traces` via `engine_run_id`
+- **THEN** cross-project scoping is NOT applied at this layer because retention runs across the whole engine
+- **THEN** the helper lives in root-side handwritten store code (`internal/store/` or equivalent), not in `engine/db/queries/`, because the current sqlc inputs are schema-local
+
+#### Scenario: Helper preserves ordering and bounds
+- **WHEN** the retention worker pages through candidates
+- **THEN** the helper preserves the underlying ordering and limit contract
+- **THEN** the worker does not reimplement ordering logic outside the helper
+
+---
+
+### Requirement: Projection state CAS writer
+
+The platform store MUST expose a CAS writer that updates `public.traces.engine_projection_state` only when the current state matches an expected set and advances `engine_projection_updated_at`.
+
+#### Scenario: Flip to summary_only under CAS
+- **WHEN** purge or retention flips a trace to `summary_only`
+- **THEN** the writer updates `engine_projection_state = 'summary_only'` WHERE `engine_run_id = $1 AND engine_projection_state IN ('up_to_date','catching_up')`
+- **THEN** `engine_projection_updated_at = NOW()` on the mutated row
+- **THEN** zero rows updated means the expected state was not matched (no-op or already stronger barrier)
+
+#### Scenario: Flip to journal_expired under CAS
+- **WHEN** purge or retention flips a trace to `journal_expired`
+- **THEN** the writer updates `engine_projection_state = 'journal_expired'` WHERE `engine_run_id = $1 AND engine_projection_state IN ('up_to_date','catching_up','summary_only')`
+- **THEN** `engine_projection_updated_at = NOW()` on the mutated row
+
+#### Scenario: Flip from summary_only to catching_up for repair
+- **WHEN** repair clears the barrier for a `summary_only` trace
+- **THEN** the writer updates `engine_projection_state = 'catching_up'` WHERE `engine_run_id = $1 AND engine_projection_state = 'summary_only'`
+- **THEN** zero rows updated means the trace was already beyond `summary_only` and repair reports the current state as-is
+
+#### Scenario: Writer never downgrades a stronger barrier
+- **WHEN** the writer attempts to flip `journal_expired` back to `summary_only`, `catching_up`, or `up_to_date`
+- **THEN** the CAS predicate does NOT match
+- **THEN** zero rows are updated and the state remains `journal_expired`
+
+---
+
+### Requirement: Platform detail deletion queries
+
+The platform store MUST provide queries to delete `public.span_events` and non-root `public.spans` for a trace as part of the projection purge path.
+
+#### Scenario: Delete all span events by trace
+- **WHEN** the span-event delete query runs with a trace identifier
+- **THEN** all rows in `public.span_events` tied to that trace are deleted in a single `DELETE`
+- **THEN** no span or trace rows are touched
+
+#### Scenario: Delete non-root spans by trace
+- **WHEN** the non-root span delete query runs with a trace identifier
+- **THEN** all rows in `public.spans` tied to that trace where the span is NOT the trace's root span are deleted
+- **THEN** the root span row remains
+- **THEN** the query uses a single `DELETE` with a subquery or NOT EXISTS guard to identify the root span
+
+#### Scenario: Trace row is never touched
+- **WHEN** the detail deletion queries run
+- **THEN** the `public.traces` row is not inserted, updated, or deleted by these queries
+- **THEN** the trace shell is modified only by the separate projection-state CAS writer
+
+#### Scenario: sqlc annotations
+- **WHEN** the queries are declared
+- **THEN** each is annotated `:exec`
+- **THEN** generated Go functions take `ctx, trace_id` and return an error
+
+---
+
+### Requirement: Retention env config validation at startup
+
+The platform server MUST read `ENGINE_PROJECTION_RETENTION_AFTER` and `ENGINE_HISTORY_RETENTION_AFTER` from env (via `internal/config/config.go`) and MUST fail startup when the pairing is invalid.
+
+#### Scenario: Both empty means retention disabled
+- **WHEN** both env vars are empty or missing
+- **THEN** the retention worker is not scheduled
+- **THEN** startup proceeds normally
+
+#### Scenario: Only projection set
+- **WHEN** `ENGINE_PROJECTION_RETENTION_AFTER` is set and `ENGINE_HISTORY_RETENTION_AFTER` is empty or zero
+- **THEN** stage 1 (projection_only purge) runs and stage 2 is disabled
+- **THEN** startup proceeds normally
+
+#### Scenario: History without projection
+- **WHEN** `ENGINE_HISTORY_RETENTION_AFTER` is set but `ENGINE_PROJECTION_RETENTION_AFTER` is empty or zero
+- **THEN** startup MUST fail fast with an explicit configuration error naming both env vars
+- **THEN** the retention worker is NOT scheduled
+
+#### Scenario: History less than or equal to projection
+- **WHEN** both env vars are set and `ENGINE_HISTORY_RETENTION_AFTER <= ENGINE_PROJECTION_RETENTION_AFTER`
+- **THEN** startup MUST fail fast with an explicit configuration error
+- **THEN** the retention worker is NOT scheduled
+
+#### Scenario: Unparseable duration
+- **WHEN** either env var is present but cannot be parsed as a Go `time.Duration` string
+- **THEN** startup MUST fail fast with an explicit configuration error identifying the offending variable
+- **THEN** the retention worker is NOT scheduled
+
+#### Scenario: Zero disables the stage
+- **WHEN** either env var is explicitly set to `"0"` or `"0s"`
+- **THEN** the corresponding stage is treated as disabled
+- **THEN** the `history > projection` rule is evaluated only against stages that are enabled
+
+---
+
+### Requirement: Store helpers respect runtime and schema boundaries
+
+The engine store MUST expose the history delete wrapper only. The root/platform store MUST expose retention candidate selection, projection-state CAS writers, and detail-deletion queries.
+
+#### Scenario: Root-side candidate selection
+- **WHEN** the retention worker needs candidates
+- **THEN** it calls root-side store helpers that execute the handwritten cross-schema candidate selection
+- **THEN** no candidate-selection SQL is added to `engine/db/queries/`
+
+#### Scenario: Engine-side history delete
+- **WHEN** the root-side purge service needs to delete engine history
+- **THEN** it calls the engine store's `DeleteHistoryByRun` wrapper through the existing engine query layer
+- **THEN** the engine-side history delete remains an engine-only concern
+
+#### Scenario: Platform-side CAS writers and detail deletion
+- **WHEN** the root-side purge service needs to flip projection state or delete spans/span_events
+- **THEN** it calls platform store wrappers in `internal/store/`
+- **THEN** the retention worker does not bypass the purge service to write those tables directly

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-trace-projection/spec.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-trace-projection/spec.md
@@ -1,0 +1,197 @@
+# Capability: engine-trace-projection
+
+Purge / repair / retention additions to the engine trace projection: defines `projection_only` and `full` purge mappings, the retained operator shell, hard write barriers when projection state is `summary_only` or `journal_expired`, race resolution with in-progress `catching_up`, repair behavior from the projector checkpoint, and retention-driven state transitions.
+
+Related capabilities: [engine-runtime-execution](../engine-runtime-execution/spec.md), [engine-public-api](../engine-public-api/spec.md), [engine-retention-maintenance](../engine-retention-maintenance/spec.md)
+
+## ADDED Requirements
+
+### Requirement: projection_only purge mapping
+
+A `projection_only` purge MUST delete all `public.span_events` for the trace and all non-root `public.spans` for the trace, preserve the `public.traces` row and the root span, and set `engine_projection_state = 'summary_only'`.
+
+#### Scenario: Span events deleted
+- **WHEN** `projection_only` purge runs for a terminal trace
+- **THEN** every row in `public.span_events` tied to that trace is deleted
+
+#### Scenario: Non-root spans deleted
+- **WHEN** `projection_only` purge runs for a terminal trace
+- **THEN** every row in `public.spans` tied to that trace where `parent_span_id IS NOT NULL` (or otherwise classified as non-root) is deleted
+
+#### Scenario: Trace row preserved
+- **WHEN** `projection_only` purge runs
+- **THEN** the `public.traces` row for the trace remains
+- **THEN** all engine shell columns (`engine_run_id`, `engine_instance_key`, `engine_definition_name`, `engine_definition_version`, `engine_run_status`, `engine_projection_state`, `engine_projection_updated_at`, `engine_latest_history_id`, `engine_last_projected_history_id`) remain populated
+
+#### Scenario: Root span preserved
+- **WHEN** `projection_only` purge runs
+- **THEN** the root span carrying the terminal summary/result/failure payload remains in `public.spans`
+- **THEN** the root span's terminal status, timestamps, and payload are unchanged
+
+#### Scenario: Projection state flips to summary_only
+- **WHEN** `projection_only` purge commits
+- **THEN** `public.traces.engine_projection_state = 'summary_only'`
+- **THEN** `public.traces.engine_projection_updated_at` is advanced to the purge timestamp
+
+---
+
+### Requirement: full purge mapping
+
+A `full` purge MUST perform the same projection deletions as `projection_only`, then delete engine history rows for the run, then set `engine_projection_state = 'journal_expired'`.
+
+#### Scenario: Projection deletions first
+- **WHEN** `full` purge runs for a terminal run
+- **THEN** the projection deletions (span events + non-root spans) from `projection_only` run before any engine history deletion
+- **THEN** the trace row and root span remain
+
+#### Scenario: Engine history rows deleted
+- **WHEN** `full` purge runs
+- **THEN** every row in `engine.history` with `run_id = <run>` is deleted
+- **THEN** any engine journal/inbox tail rows the implementation considers part of the history partition are deleted per the apply-stage plan
+
+#### Scenario: Projection state flips to journal_expired
+- **WHEN** `full` purge commits
+- **THEN** `public.traces.engine_projection_state = 'journal_expired'`
+- **THEN** `public.traces.engine_projection_updated_at` is advanced to the purge timestamp
+
+#### Scenario: Engine run row retention
+- **WHEN** `full` purge commits
+- **THEN** the `engine.runs` row remains (so read endpoints can still return the terminal shell)
+- **THEN** the `engine.instances` row remains
+
+---
+
+### Requirement: Projection state barriers block detail writes
+
+The projector MUST treat `engine_projection_state IN ('summary_only', 'journal_expired')` as a hard write barrier and MUST NOT recreate detailed projection rows for that trace.
+
+#### Scenario: Projector checks barrier via centralized write wrapper on every detail write
+- **WHEN** the projector is about to write to `public.spans` or `public.span_events` for a trace
+- **THEN** the write goes through a single centralized wrapper that reads/locks the `public.traces` row within the same transaction
+- **THEN** the wrapper aborts the write if `engine_projection_state` is `summary_only` or `journal_expired`
+- **THEN** ALL projector detail-write paths (`projectHistoryRows`, terminal projection, etc.) MUST call through this wrapper — no code path may bypass the barrier check
+
+#### Scenario: Checkpoint does not advance past barrier
+- **WHEN** the projector encounters the barrier during a catch-up loop for a run
+- **THEN** `engine_last_projected_history_id` for that run is NOT advanced past events whose detail writes were skipped
+- **THEN** the projector does not mark the run `up_to_date` on the basis of skipped events
+
+#### Scenario: Barrier persists across projector restarts
+- **WHEN** the projector process restarts
+- **THEN** the barrier is re-read from `public.traces.engine_projection_state`
+- **THEN** no in-memory flag is needed to enforce the barrier
+
+#### Scenario: Non-barrier runs are unaffected
+- **WHEN** the projector processes a trace whose `engine_projection_state` is `up_to_date` or `catching_up`
+- **THEN** normal detail writes proceed as before
+- **THEN** the barrier check is a no-op for non-purged traces
+
+---
+
+### Requirement: Purge wins races with catching_up projector
+
+Purge MUST serialize with the projector via row lock (or equivalent CAS guard) so the projector cannot recreate detail rows after purge has committed.
+
+#### Scenario: Purge acquires trace row lock
+- **WHEN** a purge transaction runs
+- **THEN** it takes `SELECT ... FOR UPDATE` on `public.traces` for the target run's trace before any deletion
+- **THEN** it flips `engine_projection_state` and deletes detail rows inside the same transaction
+
+#### Scenario: Projector write blocked until purge commits
+- **WHEN** the projector is mid-catchup on the same trace
+- **THEN** its write takes the same row lock (or detects state change via CAS)
+- **THEN** it either blocks until purge commits and then aborts on the barrier, or detects the state mismatch via CAS and aborts without writing
+
+#### Scenario: Post-purge projector iteration is a no-op
+- **WHEN** the projector's next iteration reads the barrier
+- **THEN** it skips detail writes for that run
+- **THEN** no re-inserted span or span-event row appears for the purged trace
+
+#### Scenario: Purge during catching_up completes cleanly
+- **WHEN** purge commits while `engine_projection_state` was `catching_up`
+- **THEN** the state flips from `catching_up` directly to `summary_only` (for projection_only) or `journal_expired` (for full)
+- **THEN** partial detail rows written before the purge transaction started are deleted by the purge itself
+
+---
+
+### Requirement: Repair resumes the normal projector path from checkpoint (catching_up recovery only)
+
+Repair MUST reuse the projector's existing catch-up mechanism indirectly by returning the trace to `catching_up`, MUST only rebuild when history exists beyond the checkpoint, and MUST NOT introduce a separate write path. Full checkpoint rewind is explicitly out of scope.
+
+#### Scenario: Repair clears the barrier for summary_only with history beyond checkpoint
+- **WHEN** repair runs against a `summary_only` trace AND `engine_last_projected_history_id < engine_latest_history_id` (i.e. the trace was still `catching_up` before purge)
+- **THEN** the repair request flips the trace back to `catching_up`
+- **THEN** the separate `continua-engine` projector later applies events from `engine_last_projected_history_id + 1` onwards
+- **THEN** the state becomes `up_to_date` when the checkpoint reaches `engine_latest_history_id`
+
+#### Scenario: Repair on summary_only with checkpoint at latest is a no-op
+- **WHEN** repair runs against a `summary_only` trace AND `engine_last_projected_history_id == engine_latest_history_id` (trace was fully `up_to_date` before purge)
+- **THEN** the barrier is NOT cleared
+- **THEN** repair returns `no_events_to_project` and the trace stays `summary_only`
+- **THEN** the operator's deliberate purge decision is preserved
+
+#### Scenario: Repair respects journal_expired barrier
+- **WHEN** repair runs against a `journal_expired` trace
+- **THEN** the barrier is NOT cleared
+- **THEN** repair returns a `history_expired` reason without attempting to rebuild detail
+- **THEN** the projection state remains `journal_expired`
+
+#### Scenario: Repair on catching_up is accepted but does not duplicate work
+- **WHEN** repair runs against a trace already in `catching_up`
+- **THEN** the trace remains `catching_up`
+- **THEN** the existing projector loop continues its current catch-up work
+- **THEN** no duplicate rebuild path is started
+
+#### Scenario: Repair never bypasses single-writer invariant
+- **WHEN** repair eventually results in rebuilt detail
+- **THEN** all writes to `public.spans`, `public.span_events`, and engine projection columns go through the projector's existing write path
+- **THEN** no handwritten detail-write SQL is introduced by repair
+
+#### Scenario: Checkpoint-forward rebuild is deterministic
+- **WHEN** accepted repair causes the projector to apply events from the retained checkpoint forward
+- **THEN** re-running repair on the same run produces the same rebuilt detail
+- **THEN** synthetic terminal-cleanup events (from Proposal 1) are re-emitted idempotently via the existing `VariantKey` mechanism
+
+---
+
+### Requirement: Retained operator shell after purge
+
+After any purge mode, the trace row MUST retain a complete operator-useful shell.
+
+#### Scenario: Required shell fields
+- **WHEN** a purge completes
+- **THEN** the `public.traces` row still carries `engine_run_id`, `engine_instance_key`, `engine_definition_name`, `engine_definition_version`, `engine_run_status`, `engine_projection_state`, `engine_projection_updated_at`, and the terminal summary
+- **THEN** the root span still carries terminal status, timestamps, and the terminal result/failure payload
+- **THEN** the debugger can display the trace's identity, terminal outcome, and engine linkage from retained fields alone
+
+#### Scenario: Non-engine traces are untouched
+- **WHEN** purge targets an engine run
+- **THEN** only the trace linked via `engine_run_id` is affected
+- **THEN** other traces, sessions, and non-engine projection rows are unchanged
+
+---
+
+### Requirement: Projection state transitions driven by retention
+
+Retention MUST drive engine projection state transitions in a specific order and MUST remain idempotent across restarts.
+
+#### Scenario: Stage 1 transition
+- **WHEN** retention stage 1 targets a terminal run whose current state is `up_to_date` or `catching_up` and whose completion age exceeds `ENGINE_PROJECTION_RETENTION_AFTER`
+- **THEN** the trace's `engine_projection_state` transitions to `summary_only`
+- **THEN** the detail rows are deleted per the `projection_only` purge mapping
+
+#### Scenario: Stage 2 transition
+- **WHEN** retention stage 2 targets a terminal run whose completion age exceeds `ENGINE_HISTORY_RETENTION_AFTER`
+- **THEN** the trace's `engine_projection_state` transitions to `journal_expired`
+- **THEN** engine history rows for the run are deleted per the `full` purge mapping
+- **THEN** stage 2 may apply to runs in `summary_only` (most common case) or directly to runs in `up_to_date`/`catching_up` if they are already past the history window
+
+#### Scenario: Retention is idempotent across restarts
+- **WHEN** the retention worker restarts mid-scan
+- **THEN** runs already transitioned to the target state are skipped
+- **THEN** rescanning the same window produces the same end state with no duplicate work
+
+#### Scenario: Retention does not transition non-terminal runs
+- **WHEN** retention scans the eligible run set
+- **THEN** only runs whose authoritative `engine.runs.status IN ('completed','failed','cancelled','terminated')` are transitioned
+- **THEN** non-terminal runs are never purged by retention

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-trace-search/spec.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/specs/engine-trace-search/spec.md
@@ -1,0 +1,100 @@
+# Capability: engine-trace-search
+
+Additive engine filters on the existing trace list endpoint: `engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state`. Wired into the existing handwritten dynamic SQL builder in `internal/store/search.go`.
+
+Related capabilities: [engine-public-api](../engine-public-api/spec.md), [engine-trace-projection](../engine-trace-projection/spec.md)
+
+## ADDED Requirements
+
+### Requirement: Additive engine filters on trace list endpoint
+
+The existing trace list endpoint (`GET /api/traces`) MUST accept four additive engine filters without changing any existing query-parameter behavior.
+
+#### Scenario: Filter names and columns
+- **WHEN** a trace list request includes engine filters
+- **THEN** the supported filter names are `engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state`
+- **THEN** each filter is an equality predicate against the corresponding `public.traces` column
+- **THEN** no new OR / IN / range semantics are introduced in this phase
+
+#### Scenario: Filters are optional
+- **WHEN** a trace list request does NOT include any engine filter
+- **THEN** the endpoint returns the same result set it would have returned before this change
+- **THEN** no engine predicate is appended to the query
+
+#### Scenario: engine_run_status filter values
+- **WHEN** `engine_run_status` is provided
+- **THEN** allowed values match the existing `engine_run_status` CHECK constraint (`queued`, `running`, `waiting`, `completed`, `failed`, `cancelled`, `terminated`)
+- **THEN** invalid values return 400 with a typed validation error
+
+#### Scenario: engine_projection_state filter values
+- **WHEN** `engine_projection_state` is provided
+- **THEN** allowed values are `up_to_date`, `catching_up`, `summary_only`, `journal_expired`
+- **THEN** invalid values return 400 with a typed validation error
+
+#### Scenario: Out-of-scope filters are silently ignored
+- **WHEN** a request includes `engine_definition_version`, `engine_wait_kind`, or an error-code filter
+- **THEN** the server silently ignores the unrecognized parameters (standard REST behavior)
+- **THEN** no 400 is returned for unknown query parameter names
+- **THEN** the result set is based only on the four supported engine filters
+
+---
+
+### Requirement: Engine-filtered queries exclude non-engine traces naturally
+
+Engine-filtered trace queries MUST rely on the fact that the filter columns are `NULL` for non-engine traces, so non-engine traces are naturally excluded by equality predicates.
+
+#### Scenario: Equality predicate excludes NULLs
+- **WHEN** a trace list request includes any engine filter
+- **THEN** the generated SQL uses `column = $N` (not `IS NOT DISTINCT FROM`)
+- **THEN** rows where the filter column is `NULL` are not matched
+- **THEN** non-engine traces (with NULL engine columns) are excluded from the result set
+
+#### Scenario: Mixed engine + non-engine result set when no filter
+- **WHEN** a trace list request includes no engine filter
+- **THEN** the result set contains both engine-linked and non-engine traces as it did before this change
+- **THEN** no engine predicate is appended
+
+#### Scenario: Combined filters AND together
+- **WHEN** a request includes multiple engine filters
+- **THEN** all provided filters are combined with AND
+- **THEN** the result set is further narrowed by each additional predicate
+
+---
+
+### Requirement: Filter wiring preserves existing pagination and ordering
+
+Engine filters MUST NOT alter the existing trace list pagination, ordering, or other query parameters.
+
+#### Scenario: Pagination unaffected
+- **WHEN** an engine filter is combined with `limit` / `cursor` / offset parameters
+- **THEN** pagination behaves identically to the no-engine-filter case
+- **THEN** cursor encoding / decoding is unchanged
+
+#### Scenario: Ordering unaffected
+- **WHEN** an engine filter is combined with existing sort parameters
+- **THEN** the ordering is the same as it would be without the engine filter
+- **THEN** the ORDER BY clause is unchanged by engine filters
+
+#### Scenario: No new index required in this phase, but EXPLAIN verification is required
+- **WHEN** the filters are applied
+- **THEN** existing indexes on `public.traces` (including those added by engine trace-linkage migrations) are expected to be sufficient for the equality filters
+- **THEN** if query plans regress, indexes MAY be added in a follow-up but are not required by this capability
+- **THEN** EXPLAIN-based tests MUST verify that the four engine filter queries use index scans (or at worst index-condition pushdown) rather than sequential scans against the current index set. If EXPLAIN reveals sequential scans for any filter combination, the implementation SHOULD add a targeted index in this phase rather than deferring
+
+---
+
+### Requirement: Handwritten dynamic builder owns the new filters
+
+The filter wiring MUST live in the existing handwritten SQL builder (`internal/store/search.go`) and MUST NOT introduce a new store method or endpoint.
+
+#### Scenario: Single wiring point
+- **WHEN** filter code is added
+- **THEN** it is added to the existing dynamic builder's optional-predicate section
+- **THEN** no new exported store method is added
+- **THEN** no new `/api/*` endpoint is added for engine-filtered trace search
+
+#### Scenario: Parameter binding
+- **WHEN** a filter value is applied
+- **THEN** it is passed as a bound parameter (positional placeholder)
+- **THEN** values are never concatenated into SQL strings
+- **THEN** enum values (`engine_run_status`, `engine_projection_state`) are validated against the allowed set before binding

--- a/openspec/changes/add-engine-retention-repair-and-control-sdk/tasks.md
+++ b/openspec/changes/add-engine-retention-repair-and-control-sdk/tasks.md
@@ -1,0 +1,177 @@
+## 1. OpenAPI Contract Updates
+
+- [x] 1.1 Add `POST /v1/engine/runs/{run_id}/purge` to `contracts/openapi/openapi.yaml` with request body `EnginePurgeRequest { mode: "projection_only" | "full" }` and response `EnginePurgeResponse { run_id, mode, projection_state, deleted }`
+- [x] 1.2 Add `POST /v1/engine/runs/{run_id}/repair` with no request body and response `EngineRepairResponse { run_id, accepted, reason, projection_state }`; document allowed `reason` values (`already_up_to_date`, `history_expired`, `no_events_to_project`, `repair_requested`, `already_catching_up`)
+- [x] 1.3 Update `GET /v1/engine/runs/{run_id}/history` response to include an optional `expired: boolean` marker for `journal_expired` runs; document that the endpoint never returns 404 for purged runs
+- [x] 1.4 Document in OpenAPI descriptions that `GET /v1/engine/runs/{run_id}/result` continues to return `EngineRunResultResponse` for `summary_only` and `journal_expired` runs (no 404)
+- [x] 1.5 Document the existing `run_not_terminal` typed 409 error for purge on non-terminal runs
+- [x] 1.6 Extend `GET /api/traces` query parameters with optional filters `engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state`
+- [x] 1.7 Run `make generate` and verify Go server bindings, TypeScript client, and Python types regenerate without drift
+
+**Validation:** `make generate` succeeds; generated bindings include purge/repair request/response schemas, `expired` history marker, and trace-list engine filter parameters
+
+## 2. Engine Queries + Store (History Delete)
+
+- [x] 2.1 Add `DeleteHistoryByRun :exec` in `engine/db/queries/history.sql`: `DELETE FROM engine.history WHERE run_id = $1`
+- [x] 2.2 Run `make generate` and verify the generated query; add the engine store wrapper `DeleteHistoryByRun`
+
+**Validation:** engine generate succeeds; the history-delete wrapper compiles
+
+## 3. Platform / Root Store (Retention Candidates + Projection Delete + Barrier CAS)
+
+- [x] 3.1 Add a root-side retention candidate helper in `internal/store/` using handwritten SQL that joins `engine.runs` with `public.traces` via `engine_run_id` for stage 1, filters `runs.status IN ('completed','failed','cancelled','terminated')`, `runs.completed_at < $1`, `traces.engine_projection_state IN ('up_to_date','catching_up')`, orders by `runs.completed_at ASC, runs.id ASC`, and applies a bounded `LIMIT`
+- [x] 3.2 Add the matching root-side handwritten helper for stage 2, filtering `traces.engine_projection_state IN ('summary_only','up_to_date','catching_up')`
+- [x] 3.3 Add `DeleteSpanEventsByTrace :exec` in `db/platform/queries/spans.sql` (or the closest existing file): `DELETE FROM span_events WHERE trace_id = $1`
+- [x] 3.4 Add `DeleteNonRootSpansByTrace :exec` that deletes `public.spans` rows for a trace excluding the root span (use a subquery or `WHERE trace_id = $1 AND parent_span_id IS NOT NULL` depending on how the existing schema identifies the root)
+- [x] 3.5 Add `FlipProjectionStateToSummaryOnly :exec` (CAS on current state ∈ `{'up_to_date','catching_up'}`) updating `engine_projection_state='summary_only'` and `engine_projection_updated_at=NOW()`, keyed by `engine_run_id`
+- [x] 3.6 Add `FlipProjectionStateToJournalExpired :exec` (CAS on current state ∈ `{'up_to_date','catching_up','summary_only'}`)
+- [x] 3.7 Add `FlipProjectionStateToCatchingUp :exec` (CAS on current state = `'summary_only'`) for repair entry
+- [x] 3.8 Run `make generate` for the platform queries and add/extend root-side store helpers so the retention candidate helpers preserve ordering and limits, and the CAS writers return the number of rows affected (or a boolean `mutated` flag) so callers can detect no-op CAS
+- [x] 3.9 Grep callers of `public.traces.engine_projection_state` writes and confirm the projector is the only other writer; document the purge-as-co-writer exception in `internal/store/` package doc
+
+**Validation:** platform generate succeeds; root-side candidate helpers return ordered terminal runs; wrappers compile; CAS writers return zero rows when the predicate does not match
+
+## 4. Purge Handler + Service
+
+- [x] 4.0 Extract purge/repair orchestration out of the API server's private `engineControlService` construction into a separately Fx-provided shared service package (for example `internal/enginecontrol/`), then inject that shared service into both the API layer and jobs
+- [x] 4.1 Add `PurgeRun` on that shared service so it: opens a transaction, locks `public.traces` by `engine_run_id` via `SELECT ... FOR UPDATE`, verifies run terminal status via the engine runs store, dispatches on mode, calls the platform delete wrappers + CAS writer, and (for `full` mode) calls `DeleteHistoryByRun` against the engine store
+- [x] 4.2 Map `run_not_terminal` into a typed HTTP 409 response
+- [x] 4.3 Handle idempotent no-op cases: `projection_only` on `summary_only`/`journal_expired`, `full` on `journal_expired` — return 200 with `deleted=false` and the current `projection_state`
+- [x] 4.4 Wire the HTTP route with `ENGINE_PUBLIC_API_ENABLED=true` gating, `X-Continua-Engine-Preview: 1` header requirement, API key authentication, and project scoping
+- [x] 4.5 Add handler unit tests covering: terminal+projection_only, terminal+full, already-purged idempotency, non-terminal 409, missing-run 404, cross-project 404
+
+**Validation:** handler tests pass; no-op cases return correct structured responses; cross-project scoping is enforced
+
+## 5. Repair Handler + Service
+
+- [x] 5.1 Add `RepairRun` on the shared control service that dispatches on current `engine_projection_state`: `up_to_date` → `{accepted:false, reason:"already_up_to_date"}`, `summary_only` → check if checkpoint equals `engine_latest_history_id`; if equal return `{accepted:false, reason:"no_events_to_project"}` (trace was fully projected before purge, never undo the operator's purge decision); otherwise flip to `catching_up` via CAS writer and return `{accepted:true, reason:"repair_requested", projection_state:"catching_up"}`, `journal_expired` → `{accepted:false, reason:"history_expired"}`, `catching_up` → `{accepted:true, reason:"already_catching_up", projection_state:"catching_up"}`
+- [x] 5.2 Ensure repair remains async against the current runtime split: the API/shared service MUST NOT try to call `engine/internal/projector` synchronously, and must rely on the separate `continua-engine` projector loop to catch up after the state flip
+- [x] 5.3 Ensure repair on a fully-projected-then-purged trace (checkpoint == latest) is a no-op that preserves `summary_only`; full checkpoint rewind is explicitly out of scope
+- [x] 5.4 Wire the HTTP route with `ENGINE_PUBLIC_API_ENABLED=true` gating, `X-Continua-Engine-Preview: 1` header requirement, API key authentication, and project scoping
+- [x] 5.5 Add handler unit tests covering: up_to_date no-op, summary_only accepted repair request (`catching_up`), summary_only `no_events_to_project`, journal_expired rejection, catching_up `already_catching_up`, missing-run 404, cross-project 404
+
+**Validation:** handler tests pass; `reason` strings are stable; repair responses reflect current state without attempting synchronous projector work
+
+## 6. Projector Barrier Enforcement
+
+- [x] 6.1 Introduce a single centralized write wrapper that ALL projector detail-write paths (`projectHistoryRows`, terminal projection writes, etc.) call before writing to `public.spans` / `public.span_events`. The wrapper MUST read/lock the `public.traces` row within the same transaction and abort if `engine_projection_state IN ('summary_only','journal_expired')`
+- [x] 6.2 Refactor existing projector fan-out paths to call through the centralized wrapper instead of writing directly; ensure no code path can bypass the barrier check
+- [x] 6.3 Prevent the projector from advancing `engine_last_projected_history_id` past events whose detail writes were skipped
+- [x] 6.4 Add projector tests: catching_up + concurrent purge flips to summary_only, and the next projector iteration does NOT recreate detail rows; re-projecting after `journal_expired` is also a no-op
+- [x] 6.5 Add a package-doc note in `engine/internal/projector/` (or the projector's platform-side equivalent) calling out that purge is the only other writer allowed to mutate projection state, via the CAS writer
+
+**Validation:** projector tests pass; no detail row reappears after purge; checkpoint does not advance past barrier
+
+## 7. Retention Worker
+
+- [x] 7.0 Add index-only migration on `engine.runs(completed_at) WHERE status IN ('completed','failed','cancelled','terminated')` to support retention candidate queries efficiently
+- [x] 7.1 Add retention env parsing in `internal/config/config.go`: `EngineProjectionRetentionAfter` and `EngineHistoryRetentionAfter` (as `time.Duration`), with fail-fast validation (history > projection, history without projection is an error, unparseable is an error, `0` disables the stage, empty disables the stage)
+- [x] 7.2 Add `RetentionArgs` (or equivalent) in `internal/jobargs/` with active-state uniqueness, plus a fixed `RetentionInterval = 24 * time.Hour` for this phase
+- [x] 7.3 Register a single platform-side periodic retention job in `internal/jobs/module.go` that runs only when at least one stage is enabled, routes onto the maintenance queue, uses the fixed daily cadence with `RunOnStart: false`, and does NOT add an engine-side maintenance subroutine
+- [x] 7.4 Add a retention worker in `internal/jobs/` that uses the root-side retention candidate helpers and calls the shared root-side purge service directly in-process; it must NOT self-call the public HTTP endpoint
+- [x] 7.5 Ensure the worker depends on the separately Fx-provided shared control service, not on a service constructed privately inside `internal/api`
+- [x] 7.6 Keep advisory-lock serialization around actual execution even though periodic enqueue also uses active-state uniqueness
+- [x] 7.7 Implement stage 1 (projection_only) inside the worker: compute `threshold = NOW() - ENGINE_PROJECTION_RETENTION_AFTER`, call the stage 1 candidate helper, iterate in order, and call the shared purge service with `projection_only`
+- [x] 7.8 Implement stage 2 (full): compute `threshold = NOW() - ENGINE_HISTORY_RETENTION_AFTER`, call the stage 2 candidate helper, iterate in order, and call the shared purge service with `full`
+- [x] 7.9 Enforce bounded batch size per iteration (`limit` argument to candidate helpers)
+- [x] 7.10 Add retention tests: no env → no periodic job/worker; invalid env → startup fails; daily cadence is registered with `RunOnStart: false`; active-state uniqueness is configured; stage1-only → only projection_only purges occur; both stages → stage1 then stage2; idempotency after simulated crash; stage2 skips `journal_expired` traces; the shared purge service is called with the correct mode for each candidate
+
+**Validation:** retention tests pass; startup fails fast on invalid config; idempotent transitions hold
+
+## 8. Trace Search Filter Wiring
+
+- [x] 8.1 Extend `internal/store/search.go` dynamic SQL builder with the four additive predicates (`engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state`), using positional placeholders and the existing optional-predicate pattern
+- [x] 8.2 Validate enum values before binding (`engine_run_status` against the seven allowed values, `engine_projection_state` against the four allowed values)
+- [x] 8.3 Map query parameters from the trace list handler into the builder's optional filter struct without altering existing parameters, pagination, or ordering
+- [x] 8.4 Add search tests: no engine filter → current behavior unchanged; each of the four filters individually; AND combinations; invalid enum value → 400; mixed engine + non-engine traces in the underlying table → engine-filtered result set excludes non-engine traces
+- [x] 8.5 Add EXPLAIN-based tests verifying that each of the four engine filter queries uses index scans (not sequential scans) against the current index set (`engine_run_id`, projection-pending indexes from `000013_engine_trace_linkage.up.sql`). If EXPLAIN reveals sequential scans for `engine_instance_key`, `engine_definition_name`, `engine_run_status`, or `engine_projection_state`, add a targeted index in this phase
+
+**Validation:** search tests pass; EXPLAIN tests confirm no sequential scans; non-engine traces are excluded when filters are present; existing traces list regression tests remain green
+
+## 9. Engine Run Detail Mismatch Surfacing (docs + regression test only)
+
+Note: `definition_version_mismatch` surfacing is already baseline from Proposal 1 — the run detail response already carries `definition_name`, `definition_version`, and the `failure` object. This is NOT new feature work.
+
+- [x] 9.1 Confirm `definition_name`, `definition_version`, and `failure` are already returned by the existing engine run detail response (Proposal 1 baseline)
+- [x] 9.2 Add a documentation-only OpenAPI note (in the endpoint description or schema description) describing how clients identify `definition_version_mismatch` from the existing fields
+- [x] 9.3 Add a single regression test asserting that a run failed with `error_code=definition_version_mismatch` has the requested definition fields and the failure code in the same response body
+
+**Validation:** existing fields are populated as documented; regression test confirms the mismatch code is surfaced alongside definition fields
+
+## 10. Python Control Client Module
+
+- [x] 10.1 Add `sdks/python/src/continua/engine_control.py` exporting a standalone `EngineControlClient` class with `endpoint`, `api_key`, and optional `timeout` / HTTP session arguments (using `endpoint` for consistency with the existing ingest `Client`)
+- [x] 10.2 Implement all control methods: `start`, `signal`, `cancel`, `terminate`, `get_instance` (keyed by `instance_key` matching the OpenAPI path `/v1/engine/instances/{instance_key}`), `get_run`, `get_result`, `get_history`, `get_pending_work`, `purge`, `repair`
+- [x] 10.3 Define typed exceptions (`EngineRunNotTerminalError`, `EngineRunNotFoundError`, `EngineRunWaitTimeoutError`) and map HTTP status codes / typed engine error codes to them. Note: `get_history()` returns a typed response with an `expired: bool` field for purged history (HTTP 200, not an error), so there is no `EngineHistoryExpiredError` — callers check `response.expired` instead
+- [x] 10.4 Use types derived from the OpenAPI schema for request/response bodies (regenerate via `make generate`, or hand-author mirrors kept in sync) and ensure responses decode into typed values
+- [x] 10.5 Export the control client and exceptions from `sdks/python/src/continua/__init__.py`
+- [x] 10.6 Confirm the control client is standalone and does NOT modify the ingest `Client` class or its batching state
+
+**Validation:** module imports cleanly; typed exceptions are raised for expected error conditions; control client works without an ingest client instance
+
+## 11. wait_for_terminal Helper
+
+- [x] 11.1 Implement `EngineControlClient.wait_for_terminal(run_id, *, timeout=None, poll_interval=1.0)`
+- [x] 11.2 Poll `get_result(run_id)` at `poll_interval` seconds until the run is terminal OR the timeout is exceeded; treat 409 `run_not_terminal` as "not yet terminal" and continue polling (do NOT raise it as an exception during the loop)
+- [x] 11.3 Return the terminal `EngineRunResultResponse` object when terminal is observed
+- [x] 11.4 Raise `EngineRunWaitTimeoutError` when the timeout elapses without observing terminal
+- [x] 11.5 Ensure the helper uses the same `api_key`, `endpoint`, and HTTP session as the control client instance
+- [x] 11.6 Add helper tests covering: fast terminal (no wait), completed/failed/cancelled/terminated runs, timeout path, zero-timeout edge case, custom poll_interval
+
+**Validation:** helper tests pass; timeout raises the typed error; terminal observation returns the typed result
+
+## 12. Python Control Client Tests
+
+- [x] 12.1 Add unit tests under `sdks/python/tests/` mocking the HTTP layer for each control method's request shape, response decoding, and error mapping
+- [x] 12.2 Add integration tests under `sdks/python/tests/test_engine_control_integration.py` (or equivalent) that exercise the live platform control surface (including purge + repair + wait_for_terminal round trips) against the test harness used by other Python SDK integration tests
+- [x] 12.3 Cover purge terminal-only rejection (non-terminal run → typed error), purge idempotency, and repair `already_up_to_date` / `history_expired` / `repair_requested` / `already_catching_up` / `no_events_to_project` reasons
+- [x] 12.4 Run `cd sdks/python && uv run pytest` locally and verify all tests pass
+
+**Validation:** `uv run pytest` is green; integration tests round-trip all control methods
+
+## 13. Integration Tests (Platform)
+
+- [x] 13.1 Integration test: `projection_only` purge deletes `public.span_events` and non-root `public.spans` for the trace, preserves trace row + root span, flips state to `summary_only`
+- [x] 13.2 Integration test: `full` purge performs the projection_only path then deletes `engine.history` rows for the run and flips state to `journal_expired`
+- [x] 13.3 Integration test: purge on a non-terminal run returns 409 with the typed error and performs no deletion
+- [x] 13.4 Integration test: purge during `catching_up` is correct — after commit, the projector's next iteration does not recreate detail rows
+- [x] 13.5 Integration test: automated retention with `ENGINE_PROJECTION_RETENTION_AFTER` only does exactly one round of projection_only purges on eligible terminal runs
+- [x] 13.6 Integration test: automated retention with both vars runs stage 1 then stage 2 and skips `journal_expired` traces
+- [x] 13.7 Integration test: invalid retention config fails startup (history without projection, history ≤ projection, unparseable duration)
+- [x] 13.8 Integration test: retention is idempotent across crash/restart (simulate crash, restart, verify same end state)
+- [x] 13.9 Integration test: repair on a `summary_only` trace with retained history returns `{accepted:true, reason:"repair_requested", projection_state:"catching_up"}` without trying to synchronously run the projector in the API process
+- [x] 13.10 Integration test: after accepted repair on a previously purged `catching_up` trace, the separate projector loop rebuilds detail from checkpoint forward (not from zero) and eventually restores `up_to_date`
+- [x] 13.11 Integration test: repair on `up_to_date` run is a no-op with `reason=already_up_to_date`
+- [x] 13.12 Integration test: repair on `journal_expired` returns `reason=history_expired` and does not rebuild detail
+- [x] 13.13 Integration test: repair on `catching_up` returns `reason=already_catching_up` and does not duplicate work
+- [x] 13.14 Integration test: `GET /v1/engine/runs/{run_id}/history` returns `expired: true` for `journal_expired` runs and is never 404
+- [x] 13.15 Integration test: `GET /v1/engine/runs/{run_id}/result` continues to return the terminal shell for `summary_only` and `journal_expired` runs
+- [x] 13.16 Integration test: mixed engine + non-engine trace list query returns both when no engine filter is provided
+- [x] 13.17 Integration test: each of the four engine filters individually returns the expected rows; AND combinations narrow correctly; non-engine traces are excluded when any engine filter is applied
+
+**Validation:** all integration tests pass against a real Postgres
+
+## 14. Regression Guard
+
+- [x] 14.1 Run `make generate` and verify no drift
+- [x] 14.2 Run `cd engine && go test ./...` — all engine tests pass (including history-delete and barrier-related coverage)
+- [x] 14.3 Run `go test ./internal/api/... ./internal/ingest/... ./internal/store/... ./internal/jobs/...`
+- [x] 14.4 Run `pnpm --filter web test` to confirm the web app compiles against the regenerated TypeScript client (trace filters are additive query params; no UI change required in this phase)
+- [x] 14.5 Run `cd sdks/python && uv run pytest`
+- [x] 14.6 Confirm Proposal 1 happy-path tests still pass without modification (terminate, pending-work, workflow.cancelled/terminated history, projector terminal cleanup)
+
+**Validation:** engine, root Go, Python SDK, and web Vitest suites pass
+
+---
+
+### Parallelization Notes
+
+- Tasks 1, 2, 3 can run partially in parallel: Task 1 (OpenAPI) must complete before Tasks 4, 5, 8, 9, 10; Tasks 2 and 3 are independent store/query additions and can run in parallel
+- Task 4 (purge handler) depends on Tasks 1, 2, 3 (OpenAPI + engine history delete + platform delete/CAS)
+- Task 5 (repair handler) depends on Tasks 1, 3, 4 (OpenAPI + platform CAS + shared control-service extraction)
+- Task 6 (projector barrier) depends on Task 3 (CAS writer semantics) but can be developed in parallel with Tasks 4 and 5
+- Task 7 (retention) depends on Tasks 2, 3, 4 (candidates, CAS writer, purge service)
+- Task 8 (search filters) is independent and can run in parallel with everything else
+- Task 9 (mismatch surfacing) is doc + test only and can run in parallel
+- Tasks 10, 11, 12 (Python client) depend on Task 1 (OpenAPI frozen)
+- Tasks 13, 14 (integration tests + regression guard) are final

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -135,5 +135,5 @@ sdks/                → TypeScript and Python SDKs
 - Engine module cannot import from internal/ (Go enforced boundary)
 - Web UI must be static (no SSR) for Go binary embedding
 - All contract changes require `make generate` before commit
-- Existing migrations are immutable
+- This repo is still pre-production: migrations may be rewritten or squashed until the first production release. After the first production release, existing migrations are immutable.
 - Placeholder-heavy areas such as `internal/ws`, `internal/replay`, `internal/proxy`, and `engine/` should not be treated as implemented

--- a/sdks/python/src/continua/__init__.py
+++ b/sdks/python/src/continua/__init__.py
@@ -22,9 +22,13 @@ Example:
 __version__ = "0.0.1"
 
 from .client import Continua
+from .engine_control import EngineControlClient
 from .exceptions import (
     AuthenticationError,
     ContinuaError,
+    EngineRunNotFoundError,
+    EngineRunNotTerminalError,
+    EngineRunWaitTimeoutError,
     NetworkError,
     RateLimitError,
     ValidationError,
@@ -36,6 +40,7 @@ from .trace import TraceContext, get_current_trace, trace
 __all__ = [
     # Core client
     "Continua",
+    "EngineControlClient",
     # Decorators and context managers
     "trace",
     "span",
@@ -51,6 +56,9 @@ __all__ = [
     # Exceptions
     "ContinuaError",
     "AuthenticationError",
+    "EngineRunNotFoundError",
+    "EngineRunNotTerminalError",
+    "EngineRunWaitTimeoutError",
     "RateLimitError",
     "ValidationError",
     "NetworkError",

--- a/sdks/python/src/continua/engine_control.py
+++ b/sdks/python/src/continua/engine_control.py
@@ -1,0 +1,250 @@
+"""Standalone engine control client for Continua."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from uuid import UUID
+
+import httpx
+from pydantic import BaseModel
+
+from .exceptions import (
+    AuthenticationError,
+    EngineRunNotFoundError,
+    EngineRunNotTerminalError,
+    EngineRunWaitTimeoutError,
+    NetworkError,
+    ValidationError,
+)
+from .types import (
+    EngineControlResponse,
+    EngineInstanceResponse,
+    EnginePendingWorkResponse,
+    EnginePurgeMode,
+    EnginePurgeRequest,
+    EnginePurgeResponse,
+    EngineRepairResponse,
+    EngineRunHistoryResponse,
+    EngineRunResponse,
+    EngineRunResultResponse,
+    EngineSignalRunRequest,
+    EngineStartRunRequest,
+    EngineStartRunResponse,
+)
+
+_PREVIEW_HEADERS = {"X-Continua-Engine-Preview": "1"}
+
+
+class EngineControlClient:
+    """Client for the engine control and read API surface."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str = "http://localhost:8080",
+        api_key: str,
+        timeout: float = 30.0,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self.endpoint = endpoint.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+        self._owns_client = client is None
+        self._client = client or httpx.Client(
+            base_url=self.endpoint,
+            headers={"X-API-Key": api_key},
+            timeout=timeout,
+        )
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def start(self, request: EngineStartRunRequest | dict[str, Any]) -> EngineStartRunResponse:
+        return self._request_model(
+            "POST",
+            "/v1/engine/runs",
+            EngineStartRunResponse,
+            json=self._json_body(request),
+            headers=_PREVIEW_HEADERS,
+        )
+
+    def signal(
+        self,
+        run_id: UUID | str,
+        request: EngineSignalRunRequest | dict[str, Any],
+    ) -> EngineControlResponse:
+        return self._request_model(
+            "POST",
+            f"/v1/engine/runs/{run_id}/signal",
+            EngineControlResponse,
+            json=self._json_body(request),
+            headers=_PREVIEW_HEADERS,
+        )
+
+    def cancel(self, run_id: UUID | str) -> EngineControlResponse:
+        return self._request_model(
+            "POST",
+            f"/v1/engine/runs/{run_id}/cancel",
+            EngineControlResponse,
+            headers=_PREVIEW_HEADERS,
+        )
+
+    def terminate(self, run_id: UUID | str) -> EngineRunResultResponse:
+        return self._request_model(
+            "POST",
+            f"/v1/engine/runs/{run_id}/terminate",
+            EngineRunResultResponse,
+            headers=_PREVIEW_HEADERS,
+        )
+
+    def get_instance(self, instance_key: str) -> EngineInstanceResponse:
+        return self._request_model(
+            "GET",
+            f"/v1/engine/instances/{instance_key}",
+            EngineInstanceResponse,
+        )
+
+    def get_run(self, run_id: UUID | str) -> EngineRunResponse:
+        return self._request_model("GET", f"/v1/engine/runs/{run_id}", EngineRunResponse)
+
+    def get_result(self, run_id: UUID | str) -> EngineRunResultResponse:
+        return self._request_model(
+            "GET",
+            f"/v1/engine/runs/{run_id}/result",
+            EngineRunResultResponse,
+        )
+
+    def get_history(
+        self,
+        run_id: UUID | str,
+        *,
+        after: int | None = None,
+        limit: int | None = None,
+    ) -> EngineRunHistoryResponse:
+        params: dict[str, Any] = {}
+        if after is not None:
+            params["after"] = after
+        if limit is not None:
+            params["limit"] = limit
+        return self._request_model(
+            "GET",
+            f"/v1/engine/runs/{run_id}/history",
+            EngineRunHistoryResponse,
+            params=params or None,
+        )
+
+    def get_pending_work(self, run_id: UUID | str) -> EnginePendingWorkResponse:
+        return self._request_model(
+            "GET",
+            f"/v1/engine/runs/{run_id}/pending-work",
+            EnginePendingWorkResponse,
+        )
+
+    def purge(
+        self,
+        run_id: UUID | str,
+        *,
+        mode: EnginePurgeMode | str,
+    ) -> EnginePurgeResponse:
+        request = EnginePurgeRequest(mode=mode)
+        return self._request_model(
+            "POST",
+            f"/v1/engine/runs/{run_id}/purge",
+            EnginePurgeResponse,
+            json=request.model_dump(mode="json"),
+            headers=_PREVIEW_HEADERS,
+        )
+
+    def repair(self, run_id: UUID | str) -> EngineRepairResponse:
+        return self._request_model(
+            "POST",
+            f"/v1/engine/runs/{run_id}/repair",
+            EngineRepairResponse,
+            headers=_PREVIEW_HEADERS,
+        )
+
+    def wait_for_terminal(
+        self,
+        run_id: UUID | str,
+        *,
+        timeout: float | None = None,
+        poll_interval: float = 1.0,
+    ) -> EngineRunResultResponse:
+        deadline = None if timeout is None else time.monotonic() + timeout
+
+        while True:
+            try:
+                return self.get_result(run_id)
+            except EngineRunNotTerminalError:
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise EngineRunWaitTimeoutError(str(run_id), timeout)
+                time.sleep(poll_interval)
+
+    def _request_model(
+        self,
+        method: str,
+        path: str,
+        model: type[BaseModel],
+        *,
+        json: Any | None = None,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> BaseModel:
+        response = self._request(method, path, json=json, params=params, headers=headers)
+        return model.model_validate(response.json())
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any | None = None,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        try:
+            response = self._client.request(
+                method,
+                path,
+                json=json,
+                params=params,
+                headers=headers,
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError("Network request failed", cause=exc) from exc
+
+        if 200 <= response.status_code < 300:
+            return response
+
+        self._raise_for_response(response)
+        raise AssertionError("unreachable")
+
+    def _raise_for_response(self, response: httpx.Response) -> None:
+        payload: dict[str, Any] = {}
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+
+        error_code = payload.get("code")
+        error_message = payload.get("message") or response.text or "Request failed"
+
+        if response.status_code == 401:
+            raise AuthenticationError(error_message)
+        if response.status_code == 404:
+            raise EngineRunNotFoundError(error_message)
+        if response.status_code == 409 and error_code == "run_not_terminal":
+            raise EngineRunNotTerminalError(error_message)
+        if response.status_code == 400:
+            raise ValidationError("Validation error", error_message)
+        raise NetworkError(
+            f"Engine control request failed with status {response.status_code}",
+        )
+
+    @staticmethod
+    def _json_body(value: BaseModel | dict[str, Any]) -> dict[str, Any]:
+        if isinstance(value, BaseModel):
+            return value.model_dump(mode="json", exclude_none=True)
+        return value

--- a/sdks/python/src/continua/exceptions.py
+++ b/sdks/python/src/continua/exceptions.py
@@ -74,3 +74,24 @@ class NetworkError(ContinuaError):
         self.message = message
         self.retry_count = retry_count
         self.__cause__ = cause
+
+
+class EngineRunNotTerminalError(ContinuaError):
+    """Raised when an engine run has not yet reached a terminal state."""
+
+
+class EngineRunNotFoundError(ContinuaError):
+    """Raised when an engine run or related engine resource cannot be found."""
+
+
+class EngineRunWaitTimeoutError(ContinuaError):
+    """Raised when wait_for_terminal exceeds its timeout."""
+
+    def __init__(self, run_id: str, timeout: float | None) -> None:
+        if timeout is None:
+            message = f"Timed out waiting for engine run {run_id}"
+        else:
+            message = f"Timed out waiting for engine run {run_id} after {timeout} seconds"
+        super().__init__(message)
+        self.run_id = run_id
+        self.timeout = timeout

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -32,6 +32,19 @@ class EngineProjectionState(Enum):
     journal_expired = "journal_expired"
 
 
+class EnginePurgeMode(Enum):
+    projection_only = "projection_only"
+    full = "full"
+
+
+class EngineRepairReason(Enum):
+    already_up_to_date = "already_up_to_date"
+    history_expired = "history_expired"
+    no_events_to_project = "no_events_to_project"
+    repair_requested = "repair_requested"
+    already_catching_up = "already_catching_up"
+
+
 class EngineRunStatus(Enum):
     QUEUED = "QUEUED"
     RUNNING = "RUNNING"
@@ -201,6 +214,13 @@ class EngineInstanceResponse(BaseModel):
 
 
 class EngineRunResponse(EngineRunSummary):
+    """
+    Engine run detail. Clients can identify `definition_version_mismatch`
+    from the existing `definition_name`, `definition_version`, and
+    `failure.error_code` fields without a dedicated mismatch endpoint.
+
+    """
+
     instance_id: UUID
 
 
@@ -208,7 +228,8 @@ class EngineRunResultResponse(BaseModel):
     run_id: UUID
     status: EngineRunStatus
     result: Any = Field(
-        ..., description="Terminal workflow result payload when available."
+        ...,
+        description="Terminal workflow result payload when available. `summary_only` and\n`journal_expired` runs continue to return the retained terminal shell.\n",
     )
     failure: EngineFailureSummary | None = None
 
@@ -225,6 +246,31 @@ class EngineRunHistoryResponse(BaseModel):
     events: list[EngineHistoryEvent]
     has_more: bool
     next_after: int | None = None
+    expired: bool | None = Field(
+        None,
+        description="True when retained engine history for the run has been purged.",
+    )
+
+
+class EnginePurgeRequest(BaseModel):
+    mode: EnginePurgeMode
+
+
+class EnginePurgeResponse(BaseModel):
+    run_id: UUID
+    mode: EnginePurgeMode
+    projection_state: EngineProjectionState
+    deleted: bool = Field(
+        ...,
+        description="True when purge deleted projection detail and/or history rows.",
+    )
+
+
+class EngineRepairResponse(BaseModel):
+    run_id: UUID
+    accepted: bool
+    reason: EngineRepairReason
+    projection_state: EngineProjectionState
 
 
 class EngineSignalRunRequest(BaseModel):

--- a/sdks/python/tests/conftest.py
+++ b/sdks/python/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest test-path bootstrap for the local SDK package."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/sdks/python/tests/test_engine_control.py
+++ b/sdks/python/tests/test_engine_control.py
@@ -1,0 +1,546 @@
+"""Tests for the engine control client."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_response(status: str = "QUEUED", projection_state: str = "up_to_date") -> dict[str, object]:
+    return {
+        "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+        "instance_id": "f8a5bcbf-fc93-42fa-a2fb-e99bf76ed910",
+        "instance_key": "instance-1",
+        "definition_name": "checkout",
+        "definition_version": "v1",
+        "projection_state": projection_state,
+        "status": status,
+        "pending_work": {"pending_activity_tasks": 0, "pending_inbox_items": 0},
+        "created_at": "2026-04-06T10:00:00Z",
+        "updated_at": "2026-04-06T10:00:00Z",
+        "result": None,
+    }
+
+
+def _result_response(status: str = "COMPLETED") -> dict[str, object]:
+    return {
+        "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+        "status": status,
+        "result": {"ok": True} if status == "COMPLETED" else None,
+        "failure": None if status == "COMPLETED" else {
+            "error_code": "failed",
+            "error_message": "boom",
+            "status": status.lower(),
+        },
+    }
+
+
+def _control_response(wake_applied: bool = True) -> dict[str, object]:
+    return {
+        "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+        "instance_key": "instance-1",
+        "accepted": True,
+        "wake_applied": wake_applied,
+    }
+
+
+def test_get_run_decodes_typed_response():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value=_run_response()),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.types import EngineRunStatus
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.get_run("8fb17dc9-6565-4f3e-b671-8fd437416534")
+
+        assert response.instance_key == "instance-1"
+        assert response.status == EngineRunStatus.QUEUED
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534",
+            json=None,
+            params=None,
+            headers=None,
+        )
+
+
+def test_start_sends_preview_header_and_decodes_response():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                    "instance_id": "f8a5bcbf-fc93-42fa-a2fb-e99bf76ed910",
+                    "instance_key": "instance-1",
+                    "definition_name": "checkout",
+                    "definition_version": "v1",
+                    "projection_state": "up_to_date",
+                    "trace_id": "engine:8fb17dc9-6565-4f3e-b671-8fd437416534",
+                    "status": "QUEUED",
+                    "pending_work": {"pending_activity_tasks": 0, "pending_inbox_items": 0},
+                    "created_at": "2026-04-06T10:00:00Z",
+                    "updated_at": "2026-04-06T10:00:00Z",
+                }
+            ),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.start(
+            {
+                "definition_name": "checkout",
+                "definition_version": "v1",
+                "instance_key": "instance-1",
+                "request_key": "request-1",
+            }
+        )
+
+        assert response.instance_key == "instance-1"
+        mock_client.request.assert_called_once_with(
+            "POST",
+            "/v1/engine/runs",
+            json={
+                "definition_name": "checkout",
+                "definition_version": "v1",
+                "instance_key": "instance-1",
+                "request_key": "request-1",
+            },
+            params=None,
+            headers={"X-Continua-Engine-Preview": "1"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args", "path", "response_body", "expected_headers", "expected_json", "expected_params"),
+    [
+        (
+            "signal",
+            ("8fb17dc9-6565-4f3e-b671-8fd437416534", {"signal_name": "approval", "payload": {"ok": True}}),
+            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/signal",
+            _control_response(True),
+            {"X-Continua-Engine-Preview": "1"},
+            {"signal_name": "approval", "payload": {"ok": True}},
+            None,
+        ),
+        (
+            "cancel",
+            ("8fb17dc9-6565-4f3e-b671-8fd437416534",),
+            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/cancel",
+            _control_response(False),
+            {"X-Continua-Engine-Preview": "1"},
+            None,
+            None,
+        ),
+        (
+            "terminate",
+            ("8fb17dc9-6565-4f3e-b671-8fd437416534",),
+            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/terminate",
+            _result_response("TERMINATED"),
+            {"X-Continua-Engine-Preview": "1"},
+            None,
+            None,
+        ),
+        (
+            "get_instance",
+            ("instance-1",),
+            "/v1/engine/instances/instance-1",
+            {
+                "instance_id": "f8a5bcbf-fc93-42fa-a2fb-e99bf76ed910",
+                "instance_key": "instance-1",
+                "definition_name": "checkout",
+                "status": "ACTIVE",
+                "current_run": _run_response(),
+                "created_at": "2026-04-06T10:00:00Z",
+                "updated_at": "2026-04-06T10:00:00Z",
+            },
+            None,
+            None,
+            None,
+        ),
+        (
+            "get_pending_work",
+            ("8fb17dc9-6565-4f3e-b671-8fd437416534",),
+            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/pending-work",
+            {
+                "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                "current_wait": None,
+                "activities": [],
+                "timers": [],
+                "signals": [],
+                "pending_activity_tasks": 0,
+                "pending_inbox_items": 0,
+            },
+            None,
+            None,
+            None,
+        ),
+    ],
+)
+def test_control_methods_use_expected_paths_and_headers(
+    method_name: str,
+    args: tuple[object, ...],
+    path: str,
+    response_body: dict[str, object],
+    expected_headers: dict[str, str] | None,
+    expected_json: dict[str, object] | None,
+    expected_params: dict[str, object] | None,
+):
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value=response_body),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        method = getattr(client, method_name)
+        method(*args)
+
+        mock_client.request.assert_called_once_with(
+            "GET" if method_name.startswith("get_") else "POST",
+            path,
+            json=expected_json,
+            params=expected_params,
+            headers=expected_headers,
+        )
+
+
+def test_purge_sends_preview_header_and_body():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                    "mode": "projection_only",
+                    "projection_state": "summary_only",
+                    "deleted": True,
+                }
+            ),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.purge(
+            "8fb17dc9-6565-4f3e-b671-8fd437416534",
+            mode="projection_only",
+        )
+
+        assert response.deleted is True
+        mock_client.request.assert_called_once_with(
+            "POST",
+            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/purge",
+            json={"mode": "projection_only"},
+            params=None,
+            headers={"X-Continua-Engine-Preview": "1"},
+        )
+
+
+def test_purge_decodes_idempotent_response():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                    "mode": "projection_only",
+                    "projection_state": "summary_only",
+                    "deleted": False,
+                }
+            ),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.types import EngineProjectionState
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.purge(
+            "8fb17dc9-6565-4f3e-b671-8fd437416534",
+            mode="projection_only",
+        )
+
+        assert response.deleted is False
+        assert response.projection_state == EngineProjectionState.summary_only
+
+
+def test_get_history_decodes_expired_marker_and_params():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "expired": True,
+                    "events": [],
+                    "has_more": False,
+                }
+            ),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.get_history(
+            "8fb17dc9-6565-4f3e-b671-8fd437416534",
+            after=10,
+            limit=50,
+        )
+
+        assert response.expired is True
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/history",
+            json=None,
+            params={"after": 10, "limit": 50},
+            headers=None,
+        )
+
+
+def test_repair_decodes_reason_and_projection_state():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                    "accepted": True,
+                    "reason": "repair_requested",
+                    "projection_state": "catching_up",
+                }
+            ),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.types import EngineProjectionState, EngineRepairReason
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.repair("8fb17dc9-6565-4f3e-b671-8fd437416534")
+
+        assert response.reason == EngineRepairReason.repair_requested
+        assert response.projection_state == EngineProjectionState.catching_up
+
+
+@pytest.mark.parametrize(
+    ("reason", "accepted", "projection_state"),
+    [
+        ("already_up_to_date", False, "up_to_date"),
+        ("history_expired", False, "journal_expired"),
+        ("repair_requested", True, "catching_up"),
+        ("already_catching_up", True, "catching_up"),
+        ("no_events_to_project", False, "summary_only"),
+    ],
+)
+def test_repair_decodes_all_supported_reasons(
+    reason: str,
+    accepted: bool,
+    projection_state: str,
+):
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                    "accepted": accepted,
+                    "reason": reason,
+                    "projection_state": projection_state,
+                }
+            ),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.types import EngineProjectionState, EngineRepairReason
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.repair("8fb17dc9-6565-4f3e-b671-8fd437416534")
+
+        assert response.reason == EngineRepairReason(reason)
+        assert response.accepted is accepted
+        assert response.projection_state == EngineProjectionState(projection_state)
+
+
+def test_purge_maps_run_not_terminal_to_typed_error():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=409,
+            json=MagicMock(return_value={"code": "run_not_terminal", "message": "not terminal"}),
+            text="not terminal",
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.exceptions import EngineRunNotTerminalError
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+
+        with pytest.raises(EngineRunNotTerminalError, match="not terminal"):
+            client.purge("8fb17dc9-6565-4f3e-b671-8fd437416534", mode="full")
+
+
+def test_get_result_maps_run_not_terminal_to_typed_error():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=409,
+            json=MagicMock(return_value={"code": "run_not_terminal", "message": "not yet"}),
+            text="not yet",
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.exceptions import EngineRunNotTerminalError
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+
+        with pytest.raises(EngineRunNotTerminalError, match="not yet"):
+            client.get_result("8fb17dc9-6565-4f3e-b671-8fd437416534")
+
+
+def test_get_run_maps_not_found_to_typed_error():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=404,
+            json=MagicMock(return_value={"code": "not_found", "message": "missing"}),
+            text="missing",
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.exceptions import EngineRunNotFoundError
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+
+        with pytest.raises(EngineRunNotFoundError, match="missing"):
+            client.get_run("8fb17dc9-6565-4f3e-b671-8fd437416534")
+
+
+def test_wait_for_terminal_returns_terminal_result():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        with patch("continua.engine_control.time.sleep") as mock_sleep:
+            mock_client = MagicMock()
+            mock_client.request.side_effect = [
+                MagicMock(
+                    status_code=409,
+                    json=MagicMock(return_value={"code": "run_not_terminal", "message": "pending"}),
+                    text="pending",
+                ),
+                MagicMock(
+                    status_code=200,
+                    json=MagicMock(return_value=_result_response()),
+                ),
+            ]
+            mock_client_class.return_value = mock_client
+
+            from continua import EngineControlClient
+            from continua.types import EngineRunStatus
+
+            client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+            response = client.wait_for_terminal(
+                "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                timeout=5.0,
+                poll_interval=0.01,
+            )
+
+            assert response.status == EngineRunStatus.COMPLETED
+            assert mock_client.request.call_count == 2
+            mock_sleep.assert_called_once_with(0.01)
+
+
+def test_wait_for_terminal_times_out():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        with patch("continua.engine_control.time.sleep"):
+            with patch(
+                "continua.engine_control.time.monotonic",
+                side_effect=[0.0, 0.0, 0.2],
+            ):
+                mock_client = MagicMock()
+                mock_client.request.return_value = MagicMock(
+                    status_code=409,
+                    json=MagicMock(return_value={"code": "run_not_terminal", "message": "pending"}),
+                    text="pending",
+                )
+                mock_client_class.return_value = mock_client
+
+                from continua import EngineControlClient
+                from continua.exceptions import EngineRunWaitTimeoutError
+
+                client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+
+                with pytest.raises(EngineRunWaitTimeoutError, match="Timed out waiting"):
+                    client.wait_for_terminal(
+                        "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                        timeout=0.1,
+                        poll_interval=0.01,
+                    )
+
+
+def test_wait_for_terminal_zero_timeout_raises_immediately():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        with patch("continua.engine_control.time.sleep") as mock_sleep:
+            with patch("continua.engine_control.time.monotonic", return_value=0.0):
+                mock_client = MagicMock()
+                mock_client.request.return_value = MagicMock(
+                    status_code=409,
+                    json=MagicMock(return_value={"code": "run_not_terminal", "message": "pending"}),
+                    text="pending",
+                )
+                mock_client_class.return_value = mock_client
+
+                from continua import EngineControlClient
+                from continua.exceptions import EngineRunWaitTimeoutError
+
+                client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+
+                with pytest.raises(EngineRunWaitTimeoutError):
+                    client.wait_for_terminal(
+                        "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                        timeout=0.0,
+                        poll_interval=0.01,
+                    )
+
+                mock_sleep.assert_not_called()
+
+
+@pytest.mark.parametrize("status", ["COMPLETED", "FAILED", "CANCELLED", "TERMINATED"])
+def test_wait_for_terminal_returns_each_terminal_status(status: str):
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value=_result_response(status)),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.types import EngineRunStatus
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.wait_for_terminal("8fb17dc9-6565-4f3e-b671-8fd437416534")
+
+        assert response.status == EngineRunStatus(status)

--- a/sdks/python/tests/test_engine_control_integration.py
+++ b/sdks/python/tests/test_engine_control_integration.py
@@ -1,0 +1,107 @@
+"""Live integration tests for the Python engine control client.
+
+These tests require a running Continua server with:
+- ENGINE_PUBLIC_API_ENABLED=true
+- a project using CONTINUA_API_KEY
+- a published engine definition checkout/v1
+
+They reuse the same opt-in local-server style as the other Python integration tests.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import httpx
+import pytest
+
+from continua import EngineControlClient, EngineRunNotFoundError
+from continua.types import (
+    EngineProjectionState,
+    EnginePurgeMode,
+    EngineRepairReason,
+    EngineRunStatus,
+)
+
+CONTINUA_ENDPOINT = os.environ.get("CONTINUA_ENDPOINT", "http://localhost:8081")
+CONTINUA_API_KEY = os.environ.get("CONTINUA_API_KEY", "test-api-key-12345")
+
+
+def server_available() -> bool:
+    try:
+        response = httpx.get(f"{CONTINUA_ENDPOINT}/api/health", timeout=2.0)
+        return response.status_code == 200
+    except httpx.RequestError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not server_available(),
+    reason=f"Continua server not available at {CONTINUA_ENDPOINT}",
+)
+
+
+def _client() -> EngineControlClient:
+    return EngineControlClient(
+        api_key=CONTINUA_API_KEY,
+        endpoint=CONTINUA_ENDPOINT,
+        timeout=10.0,
+    )
+
+
+def _start_checkout_run(client: EngineControlClient):
+    try:
+        return client.start(
+            {
+                "definition_name": "checkout",
+                "definition_version": "v1",
+                "instance_key": f"py-engine-instance-{uuid.uuid4()}",
+                "request_key": f"py-engine-request-{uuid.uuid4()}",
+            }
+        )
+    except EngineRunNotFoundError as exc:
+        pytest.skip(
+            "engine control integration requires ENGINE_PUBLIC_API_ENABLED=true "
+            f"and checkout/v1 to be published: {exc}"
+        )
+
+
+def test_engine_control_round_trip_terminate_purge_and_repair():
+    client = _client()
+    try:
+        started = _start_checkout_run(client)
+
+        run = client.get_run(started.run_id)
+        assert run.run_id == started.run_id
+        assert run.instance_key == started.instance_key
+
+        instance = client.get_instance(started.instance_key)
+        assert instance.instance_key == started.instance_key
+        assert instance.run.run_id == started.run_id
+
+        terminated = client.terminate(started.run_id)
+        assert terminated.status == EngineRunStatus.TERMINATED
+
+        waited = client.wait_for_terminal(started.run_id, timeout=5.0, poll_interval=0.1)
+        assert waited.status == EngineRunStatus.TERMINATED
+
+        projection_only = client.purge(started.run_id, mode=EnginePurgeMode.projection_only)
+        assert projection_only.projection_state == EngineProjectionState.summary_only
+
+        summary_only_repair = client.repair(started.run_id)
+        assert summary_only_repair.reason == EngineRepairReason.no_events_to_project
+        assert summary_only_repair.projection_state == EngineProjectionState.summary_only
+
+        full = client.purge(started.run_id, mode=EnginePurgeMode.full)
+        assert full.projection_state == EngineProjectionState.journal_expired
+
+        history = client.get_history(started.run_id)
+        assert history.expired is True
+        assert history.events == []
+
+        expired_repair = client.repair(started.run_id)
+        assert expired_repair.reason == EngineRepairReason.history_expired
+        assert expired_repair.projection_state == EngineProjectionState.journal_expired
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary
- add engine purge and repair control support, retention maintenance wiring, and projector barrier hardening
- add engine-specific trace search filters plus supporting indexes and coverage
- add Python engine control client coverage and check in the OpenSpec change artifacts
- document the repo's pre-production migration rewrite policy

## Why
This change implements the approved OpenSpec work for engine retention, repair, and control support. It also closes the follow-up QA issues around terminal-shell preservation, authoritative retained-history repair checks, retention locking, and the remaining spec/task documentation.

## Validation
- `openspec validate add-engine-retention-repair-and-control-sdk --strict`
- `go test ./internal/api/... ./internal/store/... ./internal/jobs/...`
- `cd engine && go test ./...`
- `pnpm --filter web test`
- `cd sdks/python && uv run pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New engine control APIs: run purge (projection_only/full) and run repair
  * Automated, configurable daily retention maintenance (projection/history stages)
  * Trace listing gains engine filters: instance key, definition name, run status, projection state
  * Python EngineControl SDK with wait_for_terminal()

* **Behavior Changes**
  * Purged or journal-expired runs still return the retained terminal result; run history includes an expired marker
  * Trace filters validate values and return 400 for invalid engine filter inputs

* **Documentation**
  * Migration immutability clarified: rewrites allowed pre-production; immutable after first production release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->