### PR TITLE
Add engine ContinueAsNew support

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -97,14 +97,15 @@ const (
 
 // Defines values for EngineRunStatus.
 const (
-	EngineRunStatusCANCELLED  EngineRunStatus = "CANCELLED"
-	EngineRunStatusCOMPLETED  EngineRunStatus = "COMPLETED"
-	EngineRunStatusFAILED     EngineRunStatus = "FAILED"
-	EngineRunStatusQUEUED     EngineRunStatus = "QUEUED"
-	EngineRunStatusRUNNING    EngineRunStatus = "RUNNING"
-	EngineRunStatusSUSPENDED  EngineRunStatus = "SUSPENDED"
-	EngineRunStatusTERMINATED EngineRunStatus = "TERMINATED"
-	EngineRunStatusWAITING    EngineRunStatus = "WAITING"
+	EngineRunStatusCANCELLED      EngineRunStatus = "CANCELLED"
+	EngineRunStatusCOMPLETED      EngineRunStatus = "COMPLETED"
+	EngineRunStatusCONTINUEDASNEW EngineRunStatus = "CONTINUED_AS_NEW"
+	EngineRunStatusFAILED         EngineRunStatus = "FAILED"
+	EngineRunStatusQUEUED         EngineRunStatus = "QUEUED"
+	EngineRunStatusRUNNING        EngineRunStatus = "RUNNING"
+	EngineRunStatusSUSPENDED      EngineRunStatus = "SUSPENDED"
+	EngineRunStatusTERMINATED     EngineRunStatus = "TERMINATED"
+	EngineRunStatusWAITING        EngineRunStatus = "WAITING"
 )
 
 // Defines values for IngestEventLevel.
@@ -288,14 +289,15 @@ const (
 
 // Defines values for ListTracesParamsEngineRunStatus.
 const (
-	ListTracesParamsEngineRunStatusCancelled  ListTracesParamsEngineRunStatus = "cancelled"
-	ListTracesParamsEngineRunStatusCompleted  ListTracesParamsEngineRunStatus = "completed"
-	ListTracesParamsEngineRunStatusFailed     ListTracesParamsEngineRunStatus = "failed"
-	ListTracesParamsEngineRunStatusQueued     ListTracesParamsEngineRunStatus = "queued"
-	ListTracesParamsEngineRunStatusRunning    ListTracesParamsEngineRunStatus = "running"
-	ListTracesParamsEngineRunStatusSuspended  ListTracesParamsEngineRunStatus = "suspended"
-	ListTracesParamsEngineRunStatusTerminated ListTracesParamsEngineRunStatus = "terminated"
-	ListTracesParamsEngineRunStatusWaiting    ListTracesParamsEngineRunStatus = "waiting"
+	ListTracesParamsEngineRunStatusCancelled      ListTracesParamsEngineRunStatus = "cancelled"
+	ListTracesParamsEngineRunStatusCompleted      ListTracesParamsEngineRunStatus = "completed"
+	ListTracesParamsEngineRunStatusContinuedAsNew ListTracesParamsEngineRunStatus = "continued_as_new"
+	ListTracesParamsEngineRunStatusFailed         ListTracesParamsEngineRunStatus = "failed"
+	ListTracesParamsEngineRunStatusQueued         ListTracesParamsEngineRunStatus = "queued"
+	ListTracesParamsEngineRunStatusRunning        ListTracesParamsEngineRunStatus = "running"
+	ListTracesParamsEngineRunStatusSuspended      ListTracesParamsEngineRunStatus = "suspended"
+	ListTracesParamsEngineRunStatusTerminated     ListTracesParamsEngineRunStatus = "terminated"
+	ListTracesParamsEngineRunStatusWaiting        ListTracesParamsEngineRunStatus = "waiting"
 )
 
 // BatchStatusResponse defines model for BatchStatusResponse.
@@ -544,16 +546,20 @@ type EngineRunHistoryResponse struct {
 
 // EngineRunResponse defines model for EngineRunResponse.
 type EngineRunResponse struct {
-	CompletedAt       *time.Time              `json:"completed_at,omitempty"`
-	CreatedAt         time.Time               `json:"created_at"`
-	CustomStatus      *map[string]interface{} `json:"custom_status,omitempty"`
-	DefinitionName    string                  `json:"definition_name"`
-	DefinitionVersion string                  `json:"definition_version"`
-	Failure           *EngineFailureSummary   `json:"failure,omitempty"`
-	InstanceId        openapi_types.UUID      `json:"instance_id"`
-	InstanceKey       string                  `json:"instance_key"`
-	PendingWork       EnginePendingWork       `json:"pending_work"`
-	ProjectionState   EngineProjectionState   `json:"projection_state"`
+	CompletedAt          *time.Time              `json:"completed_at,omitempty"`
+	ContinuedFromRunId   *openapi_types.UUID     `json:"continued_from_run_id,omitempty"`
+	ContinuedFromTraceId *string                 `json:"continued_from_trace_id,omitempty"`
+	ContinuedToRunId     *openapi_types.UUID     `json:"continued_to_run_id,omitempty"`
+	ContinuedToTraceId   *string                 `json:"continued_to_trace_id,omitempty"`
+	CreatedAt            time.Time               `json:"created_at"`
+	CustomStatus         *map[string]interface{} `json:"custom_status,omitempty"`
+	DefinitionName       string                  `json:"definition_name"`
+	DefinitionVersion    string                  `json:"definition_version"`
+	Failure              *EngineFailureSummary   `json:"failure,omitempty"`
+	InstanceId           openapi_types.UUID      `json:"instance_id"`
+	InstanceKey          string                  `json:"instance_key"`
+	PendingWork          EnginePendingWork       `json:"pending_work"`
+	ProjectionState      EngineProjectionState   `json:"projection_state"`
 
 	// Result Terminal workflow result payload when available.
 	Result    interface{}        `json:"result,omitempty"`
@@ -565,7 +571,11 @@ type EngineRunResponse struct {
 
 // EngineRunResultResponse defines model for EngineRunResultResponse.
 type EngineRunResultResponse struct {
-	Failure *EngineFailureSummary `json:"failure,omitempty"`
+	ContinuedFromRunId   *openapi_types.UUID   `json:"continued_from_run_id,omitempty"`
+	ContinuedFromTraceId *string               `json:"continued_from_trace_id,omitempty"`
+	ContinuedToRunId     *openapi_types.UUID   `json:"continued_to_run_id,omitempty"`
+	ContinuedToTraceId   *string               `json:"continued_to_trace_id,omitempty"`
+	Failure              *EngineFailureSummary `json:"failure,omitempty"`
 
 	// Result Terminal workflow result payload when available. `summary_only` and
 	// `journal_expired` runs continue to return the retained terminal shell.
@@ -579,15 +589,19 @@ type EngineRunStatus string
 
 // EngineRunSummary defines model for EngineRunSummary.
 type EngineRunSummary struct {
-	CompletedAt       *time.Time              `json:"completed_at,omitempty"`
-	CreatedAt         time.Time               `json:"created_at"`
-	CustomStatus      *map[string]interface{} `json:"custom_status,omitempty"`
-	DefinitionName    string                  `json:"definition_name"`
-	DefinitionVersion string                  `json:"definition_version"`
-	Failure           *EngineFailureSummary   `json:"failure,omitempty"`
-	InstanceKey       string                  `json:"instance_key"`
-	PendingWork       EnginePendingWork       `json:"pending_work"`
-	ProjectionState   EngineProjectionState   `json:"projection_state"`
+	CompletedAt          *time.Time              `json:"completed_at,omitempty"`
+	ContinuedFromRunId   *openapi_types.UUID     `json:"continued_from_run_id,omitempty"`
+	ContinuedFromTraceId *string                 `json:"continued_from_trace_id,omitempty"`
+	ContinuedToRunId     *openapi_types.UUID     `json:"continued_to_run_id,omitempty"`
+	ContinuedToTraceId   *string                 `json:"continued_to_trace_id,omitempty"`
+	CreatedAt            time.Time               `json:"created_at"`
+	CustomStatus         *map[string]interface{} `json:"custom_status,omitempty"`
+	DefinitionName       string                  `json:"definition_name"`
+	DefinitionVersion    string                  `json:"definition_version"`
+	Failure              *EngineFailureSummary   `json:"failure,omitempty"`
+	InstanceKey          string                  `json:"instance_key"`
+	PendingWork          EnginePendingWork       `json:"pending_work"`
+	ProjectionState      EngineProjectionState   `json:"projection_state"`
 
 	// Result Terminal workflow result payload when available.
 	Result    interface{}        `json:"result,omitempty"`

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -450,7 +450,7 @@ export interface components {
         /** @enum {string} */
         EngineRepairReason: "already_up_to_date" | "history_expired" | "no_events_to_project" | "repair_requested" | "already_catching_up";
         /** @enum {string} */
-        EngineRunStatus: "QUEUED" | "RUNNING" | "WAITING" | "SUSPENDED" | "COMPLETED" | "FAILED" | "CANCELLED" | "TERMINATED";
+        EngineRunStatus: "QUEUED" | "RUNNING" | "WAITING" | "SUSPENDED" | "COMPLETED" | "FAILED" | "CANCELLED" | "TERMINATED" | "CONTINUED_AS_NEW";
         EngineTraceInfo: {
             /** Format: uuid */
             run_id: string;
@@ -523,6 +523,12 @@ export interface components {
         EngineRunSummary: components["schemas"]["EngineTraceInfo"] & {
             status: components["schemas"]["EngineRunStatus"];
             instance_key: string;
+            /** Format: uuid */
+            continued_from_run_id?: string;
+            /** Format: uuid */
+            continued_to_run_id?: string;
+            continued_from_trace_id?: string;
+            continued_to_trace_id?: string;
             custom_status?: Record<string, never>;
             wait_state?: components["schemas"]["EngineWaitState"];
             pending_work: components["schemas"]["EnginePendingWork"];
@@ -617,6 +623,12 @@ export interface components {
         EngineRunResultResponse: {
             /** Format: uuid */
             run_id: string;
+            /** Format: uuid */
+            continued_from_run_id?: string;
+            /** Format: uuid */
+            continued_to_run_id?: string;
+            continued_from_trace_id?: string;
+            continued_to_trace_id?: string;
             status: components["schemas"]["EngineRunStatus"];
             /** @description Terminal workflow result payload when available. `summary_only` and
              *     `journal_expired` runs continue to return the retained terminal shell.
@@ -1971,7 +1983,7 @@ export interface operations {
                 /** @description Filter by engine definition name */
                 engine_definition_name?: string;
                 /** @description Filter by engine run lifecycle status */
-                engine_run_status?: "queued" | "running" | "waiting" | "suspended" | "completed" | "failed" | "cancelled" | "terminated";
+                engine_run_status?: "queued" | "running" | "waiting" | "suspended" | "completed" | "failed" | "cancelled" | "terminated" | "continued_as_new";
                 /** @description Filter by engine projection state */
                 engine_projection_state?: components["schemas"]["EngineProjectionState"];
                 /** @description Filter traces with errors (error_count > 0) */

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -793,6 +793,7 @@ paths:
               - failed
               - cancelled
               - terminated
+              - continued_as_new
         - name: engine_projection_state
           in: query
           description: Filter by engine projection state
@@ -1171,6 +1172,7 @@ components:
         - FAILED
         - CANCELLED
         - TERMINATED
+        - CONTINUED_AS_NEW
     EngineTraceInfo:
       type: object
       required:
@@ -1342,6 +1344,16 @@ components:
             status:
               $ref: '#/components/schemas/EngineRunStatus'
             instance_key:
+              type: string
+            continued_from_run_id:
+              type: string
+              format: uuid
+            continued_to_run_id:
+              type: string
+              format: uuid
+            continued_from_trace_id:
+              type: string
+            continued_to_trace_id:
               type: string
             custom_status:
               type: object
@@ -1534,6 +1546,16 @@ components:
         run_id:
           type: string
           format: uuid
+        continued_from_run_id:
+          type: string
+          format: uuid
+        continued_to_run_id:
+          type: string
+          format: uuid
+        continued_from_trace_id:
+          type: string
+        continued_to_trace_id:
+          type: string
         status:
           $ref: '#/components/schemas/EngineRunStatus'
         result:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -783,7 +783,7 @@ paths:
           description: Filter by engine run lifecycle status
           schema:
             type: string
-            enum: [queued, running, waiting, suspended, completed, failed, cancelled, terminated]
+            enum: [queued, running, waiting, suspended, completed, failed, cancelled, terminated, continued_as_new]
         - name: engine_projection_state
           in: query
           description: Filter by engine projection state
@@ -1147,7 +1147,7 @@ components:
 
     EngineRunStatus:
       type: string
-      enum: [QUEUED, RUNNING, WAITING, SUSPENDED, COMPLETED, FAILED, CANCELLED, TERMINATED]
+      enum: [QUEUED, RUNNING, WAITING, SUSPENDED, COMPLETED, FAILED, CANCELLED, TERMINATED, CONTINUED_AS_NEW]
 
     EngineTraceInfo:
       type: object
@@ -1293,6 +1293,16 @@ components:
             status:
               $ref: '#/components/schemas/EngineRunStatus'
             instance_key:
+              type: string
+            continued_from_run_id:
+              type: string
+              format: uuid
+            continued_to_run_id:
+              type: string
+              format: uuid
+            continued_from_trace_id:
+              type: string
+            continued_to_trace_id:
               type: string
             custom_status:
               type: object
@@ -1471,6 +1481,16 @@ components:
         run_id:
           type: string
           format: uuid
+        continued_from_run_id:
+          type: string
+          format: uuid
+        continued_to_run_id:
+          type: string
+          format: uuid
+        continued_from_trace_id:
+          type: string
+        continued_to_trace_id:
+          type: string
         status:
           $ref: '#/components/schemas/EngineRunStatus'
         result:

--- a/db/platform/migrations/postgres/000020_engine_run_status_continue_as_new.down.sql
+++ b/db/platform/migrations/postgres/000020_engine_run_status_continue_as_new.down.sql
@@ -1,0 +1,43 @@
+DO $$
+DECLARE
+    continued_count INTEGER;
+    offending_rows TEXT;
+    overflow_suffix TEXT := '';
+BEGIN
+    SELECT COUNT(*)
+    INTO continued_count
+    FROM traces
+    WHERE engine_run_status = 'continued_as_new';
+
+    IF continued_count > 0 THEN
+        SELECT string_agg(format('id=%s trace_id=%s', id, trace_id), ', ' ORDER BY id)
+        INTO offending_rows
+        FROM (
+            SELECT id, trace_id
+            FROM traces
+            WHERE engine_run_status = 'continued_as_new'
+            ORDER BY id
+            LIMIT 10
+        ) blocked;
+
+        IF continued_count > 10 THEN
+            overflow_suffix := format(' (and %s more)', continued_count - 10);
+        END IF;
+
+        RAISE EXCEPTION '%', format(
+            'cannot roll back traces_engine_run_status_check while traces.engine_run_status still contains continued_as_new rows: %s%s',
+            offending_rows,
+            overflow_suffix
+        );
+    END IF;
+END $$;
+
+ALTER TABLE traces
+    DROP CONSTRAINT IF EXISTS traces_engine_run_status_check;
+
+ALTER TABLE traces
+    ADD CONSTRAINT traces_engine_run_status_check
+    CHECK (
+        engine_run_status IS NULL
+        OR engine_run_status IN ('queued', 'running', 'waiting', 'suspended', 'completed', 'failed', 'cancelled', 'terminated')
+    );

--- a/db/platform/migrations/postgres/000020_engine_run_status_continue_as_new.up.sql
+++ b/db/platform/migrations/postgres/000020_engine_run_status_continue_as_new.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE traces
+    DROP CONSTRAINT IF EXISTS traces_engine_run_status_check;
+
+ALTER TABLE traces
+    ADD CONSTRAINT traces_engine_run_status_check
+    CHECK (
+        engine_run_status IS NULL
+        OR engine_run_status IN ('queued', 'running', 'waiting', 'suspended', 'completed', 'failed', 'cancelled', 'terminated', 'continued_as_new')
+    );
+

--- a/engine/cmd/continua-engine/main_test.go
+++ b/engine/cmd/continua-engine/main_test.go
@@ -162,12 +162,16 @@ func TestMigrateDownRejectsWaitingRuns(t *testing.T) {
 		t.Fatal("expected waiting enum label to remain after failed rollback")
 	}
 
-	updatedRun, err := store.GetRun(ctx, run.ID)
-	if err != nil {
-		t.Fatalf("GetRun() error = %v", err)
+	var status string
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT status::text
+		FROM engine.runs
+		WHERE id = $1
+	`, run.ID).Scan(&status); err != nil {
+		t.Fatalf("load run status after failed rollback: %v", err)
 	}
-	if updatedRun.Status != enginedb.EngineRunLifecycleStatusWaiting {
-		t.Fatalf("expected waiting run to remain unchanged after failed rollback, got %+v", updatedRun)
+	if status != string(enginedb.EngineRunLifecycleStatusWaiting) {
+		t.Fatalf("expected waiting run to remain unchanged after failed rollback, got %q", status)
 	}
 }
 

--- a/engine/cmd/continua-engine/main_test.go
+++ b/engine/cmd/continua-engine/main_test.go
@@ -44,14 +44,14 @@ func TestMigrateCommandsRoundTrip(t *testing.T) {
 	t.Setenv("ENGINE_DATABASE_URL", db.DatabaseURL)
 	t.Setenv("DATABASE_URL", "")
 
-	stdout, stderr, err := executeCommand(t, "migrate", "down", "7")
+	stdout, stderr, err := executeCommand(t, "migrate", "down", "8")
 	if err != nil {
-		t.Fatalf("execute migrate down 7: %v", err)
+		t.Fatalf("execute migrate down 8: %v", err)
 	}
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout, "Rolled back 7 engine migration step(s)") {
+	if !strings.Contains(stdout, "Rolled back 8 engine migration step(s)") {
 		t.Fatalf("unexpected migrate down output: %q", stdout)
 	}
 
@@ -60,11 +60,11 @@ func TestMigrateCommandsRoundTrip(t *testing.T) {
 	}
 	for _, column := range []string{"result", "custom_status", "waiting_for", "completed_at"} {
 		if columnExists(t, db.DatabaseURL, "engine", "runs", column) {
-			t.Fatalf("expected engine.runs.%s to be removed after migrate down 5", column)
+			t.Fatalf("expected engine.runs.%s to be removed after migrate down 8", column)
 		}
 	}
 	if enumLabelExists(t, db.DatabaseURL, "engine", "run_lifecycle_status", "waiting") {
-		t.Fatal("expected waiting enum label to be removed after migrate down 5")
+		t.Fatal("expected waiting enum label to be removed after migrate down 8")
 	}
 
 	stdout, stderr, err = executeCommand(t, "migrate", "up")
@@ -143,9 +143,9 @@ func TestMigrateDownRejectsWaitingRuns(t *testing.T) {
 		t.Fatalf("TransitionRunToWaiting() error = %v", err)
 	}
 
-	stdout, stderr, err := executeCommand(t, "migrate", "down", "7")
+	stdout, stderr, err := executeCommand(t, "migrate", "down", "8")
 	if err == nil {
-		t.Fatal("expected migrate down 7 to fail when waiting rows exist")
+		t.Fatal("expected migrate down 8 to fail when waiting rows exist")
 	}
 	if stdout != "" {
 		t.Fatalf("expected empty stdout on failed rollback, got %q", stdout)
@@ -261,8 +261,8 @@ func TestBackfillMigrationRecomputesInstanceStatusesFromLatestRun(t *testing.T) 
 		t.Fatalf("corrupt instance statuses: %v", err)
 	}
 
-	if stdout, stderr, err := executeCommand(t, "migrate", "down", "4"); err != nil {
-		t.Fatalf("execute migrate down 4: %v (stdout=%q stderr=%q)", err, stdout, stderr)
+	if stdout, stderr, err := executeCommand(t, "migrate", "down", "5"); err != nil {
+		t.Fatalf("execute migrate down 5: %v (stdout=%q stderr=%q)", err, stdout, stderr)
 	}
 	if stdout, stderr, err := executeCommand(t, "migrate", "up"); err != nil {
 		t.Fatalf("execute migrate up after backfill rollback: %v (stdout=%q stderr=%q)", err, stdout, stderr)

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -554,6 +554,9 @@ func withRuntime(
 		return err
 	}
 	store := enginestore.New(pool)
+	if cfg.Runtime.ProjectIDFilter != nil {
+		store = store.WithProjectFilter(*cfg.Runtime.ProjectIDFilter)
+	}
 	defer store.Close()
 
 	definitions, activities, err := buildRegistries()

--- a/engine/db/gen/go/activity_tasks.sql.go
+++ b/engine/db/gen/go/activity_tasks.sql.go
@@ -127,6 +127,65 @@ func (q *Queries) ClaimNextActivityTask(ctx context.Context, arg ClaimNextActivi
 	return i, err
 }
 
+const claimNextActivityTaskByProject = `-- name: ClaimNextActivityTaskByProject :one
+UPDATE engine.activity_tasks
+SET status = 'claimed',
+    claimed_by = $1,
+    claimed_at = NOW(),
+    lease_expires_at = NOW() + ($2::bigint * INTERVAL '1 microsecond'),
+    attempt_count = attempt_count + 1,
+    updated_at = NOW()
+WHERE id = (
+    SELECT candidate.id
+    FROM engine.activity_tasks AS candidate
+    WHERE candidate.project_id = $3
+      AND ((candidate.status = 'queued' AND candidate.available_at <= NOW())
+        OR (candidate.status = 'claimed' AND candidate.lease_expires_at IS NOT NULL AND candidate.lease_expires_at < NOW()))
+    ORDER BY candidate.available_at ASC, candidate.id ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+`
+
+type ClaimNextActivityTaskByProjectParams struct {
+	ClaimedBy           *string   `json:"claimed_by"`
+	LeaseDurationMicros int64     `json:"lease_duration_micros"`
+	ProjectFilterID     uuid.UUID `json:"project_filter_id"`
+}
+
+func (q *Queries) ClaimNextActivityTaskByProject(ctx context.Context, arg ClaimNextActivityTaskByProjectParams) (EngineActivityTask, error) {
+	row := q.db.QueryRow(ctx, claimNextActivityTaskByProject, arg.ClaimedBy, arg.LeaseDurationMicros, arg.ProjectFilterID)
+	var i EngineActivityTask
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunID,
+		&i.HistoryID,
+		&i.ActivityKey,
+		&i.ActivityType,
+		&i.Input,
+		&i.Output,
+		&i.Status,
+		&i.AvailableAt,
+		&i.AttemptCount,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.CompletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.MaxAttempts,
+		&i.InitialBackoffMs,
+		&i.MaxBackoffMs,
+		&i.BackoffMultiplier,
+	)
+	return i, err
+}
+
 const clearActivityTaskHistoryByRun = `-- name: ClearActivityTaskHistoryByRun :execrows
 UPDATE engine.activity_tasks
 SET history_id = NULL,

--- a/engine/db/gen/go/inbox.sql.go
+++ b/engine/db/gen/go/inbox.sql.go
@@ -277,6 +277,37 @@ func (q *Queries) ListDueTimerRunIDs(ctx context.Context) ([]pgtype.UUID, error)
 	return items, nil
 }
 
+const listDueTimerRunIDsByProject = `-- name: ListDueTimerRunIDsByProject :many
+SELECT DISTINCT run_id
+FROM engine.inbox
+WHERE project_id = $1
+  AND kind = 'timer'
+  AND run_id IS NOT NULL
+  AND status = 'pending'
+  AND available_at <= NOW()
+ORDER BY run_id ASC
+`
+
+func (q *Queries) ListDueTimerRunIDsByProject(ctx context.Context, projectID uuid.UUID) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, listDueTimerRunIDsByProject, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var run_id pgtype.UUID
+		if err := rows.Scan(&run_id); err != nil {
+			return nil, err
+		}
+		items = append(items, run_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listOpenInboxItemsByRunAndKind = `-- name: ListOpenInboxItemsByRunAndKind :many
 SELECT id, project_id, instance_id, run_id, history_id, kind, payload, status, available_at, claimed_by, claimed_at, lease_expires_at, dedupe_key, resolved_at, created_at, updated_at
 FROM engine.inbox

--- a/engine/db/gen/go/models.go
+++ b/engine/db/gen/go/models.go
@@ -194,14 +194,15 @@ func (ns NullEngineRequestDedupeStatus) Value() (driver.Value, error) {
 type EngineRunLifecycleStatus string
 
 const (
-	EngineRunLifecycleStatusQueued     EngineRunLifecycleStatus = "queued"
-	EngineRunLifecycleStatusRunning    EngineRunLifecycleStatus = "running"
-	EngineRunLifecycleStatusCompleted  EngineRunLifecycleStatus = "completed"
-	EngineRunLifecycleStatusFailed     EngineRunLifecycleStatus = "failed"
-	EngineRunLifecycleStatusCancelled  EngineRunLifecycleStatus = "cancelled"
-	EngineRunLifecycleStatusWaiting    EngineRunLifecycleStatus = "waiting"
-	EngineRunLifecycleStatusTerminated EngineRunLifecycleStatus = "terminated"
-	EngineRunLifecycleStatusSuspended  EngineRunLifecycleStatus = "suspended"
+	EngineRunLifecycleStatusQueued         EngineRunLifecycleStatus = "queued"
+	EngineRunLifecycleStatusRunning        EngineRunLifecycleStatus = "running"
+	EngineRunLifecycleStatusCompleted      EngineRunLifecycleStatus = "completed"
+	EngineRunLifecycleStatusFailed         EngineRunLifecycleStatus = "failed"
+	EngineRunLifecycleStatusCancelled      EngineRunLifecycleStatus = "cancelled"
+	EngineRunLifecycleStatusWaiting        EngineRunLifecycleStatus = "waiting"
+	EngineRunLifecycleStatusTerminated     EngineRunLifecycleStatus = "terminated"
+	EngineRunLifecycleStatusSuspended      EngineRunLifecycleStatus = "suspended"
+	EngineRunLifecycleStatusContinuedAsNew EngineRunLifecycleStatus = "continued_as_new"
 )
 
 func (e *EngineRunLifecycleStatus) Scan(src interface{}) error {
@@ -339,23 +340,25 @@ type EngineRequestDedupe struct {
 }
 
 type EngineRun struct {
-	ID                uuid.UUID                `json:"id"`
-	ProjectID         uuid.UUID                `json:"project_id"`
-	InstanceID        uuid.UUID                `json:"instance_id"`
-	RunNumber         int32                    `json:"run_number"`
-	DefinitionVersion string                   `json:"definition_version"`
-	Status            EngineRunLifecycleStatus `json:"status"`
-	ReadyAt           time.Time                `json:"ready_at"`
-	AttemptCount      int32                    `json:"attempt_count"`
-	LastErrorCode     *string                  `json:"last_error_code"`
-	LastErrorMessage  *string                  `json:"last_error_message"`
-	ClaimedBy         *string                  `json:"claimed_by"`
-	ClaimedAt         pgtype.Timestamptz       `json:"claimed_at"`
-	LeaseExpiresAt    pgtype.Timestamptz       `json:"lease_expires_at"`
-	CreatedAt         time.Time                `json:"created_at"`
-	UpdatedAt         time.Time                `json:"updated_at"`
-	Result            []byte                   `json:"result"`
-	CustomStatus      []byte                   `json:"custom_status"`
-	WaitingFor        []byte                   `json:"waiting_for"`
-	CompletedAt       pgtype.Timestamptz       `json:"completed_at"`
+	ID                 uuid.UUID                `json:"id"`
+	ProjectID          uuid.UUID                `json:"project_id"`
+	InstanceID         uuid.UUID                `json:"instance_id"`
+	RunNumber          int32                    `json:"run_number"`
+	DefinitionVersion  string                   `json:"definition_version"`
+	Status             EngineRunLifecycleStatus `json:"status"`
+	ReadyAt            time.Time                `json:"ready_at"`
+	AttemptCount       int32                    `json:"attempt_count"`
+	LastErrorCode      *string                  `json:"last_error_code"`
+	LastErrorMessage   *string                  `json:"last_error_message"`
+	ClaimedBy          *string                  `json:"claimed_by"`
+	ClaimedAt          pgtype.Timestamptz       `json:"claimed_at"`
+	LeaseExpiresAt     pgtype.Timestamptz       `json:"lease_expires_at"`
+	CreatedAt          time.Time                `json:"created_at"`
+	UpdatedAt          time.Time                `json:"updated_at"`
+	Result             []byte                   `json:"result"`
+	CustomStatus       []byte                   `json:"custom_status"`
+	WaitingFor         []byte                   `json:"waiting_for"`
+	CompletedAt        pgtype.Timestamptz       `json:"completed_at"`
+	ContinuedFromRunID pgtype.UUID              `json:"continued_from_run_id"`
+	ContinuedToRunID   pgtype.UUID              `json:"continued_to_run_id"`
 }

--- a/engine/db/gen/go/runs.sql.go
+++ b/engine/db/gen/go/runs.sql.go
@@ -67,6 +67,62 @@ func (q *Queries) ClaimNextRun(ctx context.Context, arg ClaimNextRunParams) (Eng
 	return i, err
 }
 
+const claimNextRunByProject = `-- name: ClaimNextRunByProject :one
+UPDATE engine.runs
+SET status = 'running',
+    claimed_by = $1,
+    claimed_at = NOW(),
+    lease_expires_at = NOW() + ($2::bigint * INTERVAL '1 microsecond'),
+    attempt_count = attempt_count + 1,
+    updated_at = NOW()
+WHERE id = (
+    SELECT candidate.id
+    FROM engine.runs AS candidate
+    WHERE candidate.project_id = $3
+      AND ((candidate.status = 'queued' AND candidate.ready_at <= NOW())
+        OR (candidate.status = 'running' AND candidate.lease_expires_at IS NOT NULL AND candidate.lease_expires_at < NOW()))
+    ORDER BY candidate.ready_at ASC, candidate.id ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
+`
+
+type ClaimNextRunByProjectParams struct {
+	ClaimedBy           *string   `json:"claimed_by"`
+	LeaseDurationMicros int64     `json:"lease_duration_micros"`
+	ProjectFilterID     uuid.UUID `json:"project_filter_id"`
+}
+
+func (q *Queries) ClaimNextRunByProject(ctx context.Context, arg ClaimNextRunByProjectParams) (EngineRun, error) {
+	row := q.db.QueryRow(ctx, claimNextRunByProject, arg.ClaimedBy, arg.LeaseDurationMicros, arg.ProjectFilterID)
+	var i EngineRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunNumber,
+		&i.DefinitionVersion,
+		&i.Status,
+		&i.ReadyAt,
+		&i.AttemptCount,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
+	)
+	return i, err
+}
+
 const createRun = `-- name: CreateRun :one
 INSERT INTO engine.runs (
     project_id,

--- a/engine/db/gen/go/runs.sql.go
+++ b/engine/db/gen/go/runs.sql.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const claimNextRun = `-- name: ClaimNextRun :one
@@ -29,7 +30,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 type ClaimNextRunParams struct {
@@ -60,6 +61,8 @@ func (q *Queries) ClaimNextRun(ctx context.Context, arg ClaimNextRunParams) (Eng
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
@@ -70,18 +73,20 @@ INSERT INTO engine.runs (
     instance_id,
     run_number,
     definition_version,
-    ready_at
+    ready_at,
+    continued_from_run_id
 )
-VALUES ($1, $2, $3, $4, $5)
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 type CreateRunParams struct {
-	ProjectID         uuid.UUID `json:"project_id"`
-	InstanceID        uuid.UUID `json:"instance_id"`
-	RunNumber         int32     `json:"run_number"`
-	DefinitionVersion string    `json:"definition_version"`
-	ReadyAt           time.Time `json:"ready_at"`
+	ProjectID          uuid.UUID   `json:"project_id"`
+	InstanceID         uuid.UUID   `json:"instance_id"`
+	RunNumber          int32       `json:"run_number"`
+	DefinitionVersion  string      `json:"definition_version"`
+	ReadyAt            time.Time   `json:"ready_at"`
+	ContinuedFromRunID pgtype.UUID `json:"continued_from_run_id"`
 }
 
 func (q *Queries) CreateRun(ctx context.Context, arg CreateRunParams) (EngineRun, error) {
@@ -91,6 +96,7 @@ func (q *Queries) CreateRun(ctx context.Context, arg CreateRunParams) (EngineRun
 		arg.RunNumber,
 		arg.DefinitionVersion,
 		arg.ReadyAt,
+		arg.ContinuedFromRunID,
 	)
 	var i EngineRun
 	err := row.Scan(
@@ -113,15 +119,17 @@ func (q *Queries) CreateRun(ctx context.Context, arg CreateRunParams) (EngineRun
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
 
 const getLatestRunByInstance = `-- name: GetLatestRunByInstance :one
-SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 FROM engine.runs
 WHERE instance_id = $1
-ORDER BY created_at DESC, id DESC
+ORDER BY run_number DESC, id DESC
 LIMIT 1
 `
 
@@ -148,12 +156,14 @@ func (q *Queries) GetLatestRunByInstance(ctx context.Context, instanceID uuid.UU
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
 
 const getRun = `-- name: GetRun :one
-SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 FROM engine.runs
 WHERE id = $1
 `
@@ -181,12 +191,14 @@ func (q *Queries) GetRun(ctx context.Context, id uuid.UUID) (EngineRun, error) {
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
 
 const getRunByProjectAndID = `-- name: GetRunByProjectAndID :one
-SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 FROM engine.runs
 WHERE project_id = $1
   AND id = $2
@@ -220,12 +232,14 @@ func (q *Queries) GetRunByProjectAndID(ctx context.Context, arg GetRunByProjectA
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
 
 const getRunByProjectAndIDForUpdate = `-- name: GetRunByProjectAndIDForUpdate :one
-SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 FROM engine.runs
 WHERE project_id = $1
   AND id = $2
@@ -260,12 +274,14 @@ func (q *Queries) GetRunByProjectAndIDForUpdate(ctx context.Context, arg GetRunB
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
 
 const getRunForUpdate = `-- name: GetRunForUpdate :one
-SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 FROM engine.runs
 WHERE id = $1
 FOR UPDATE
@@ -294,15 +310,17 @@ func (q *Queries) GetRunForUpdate(ctx context.Context, id uuid.UUID) (EngineRun,
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
 
 const listRunsByInstance = `-- name: ListRunsByInstance :many
-SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 FROM engine.runs
 WHERE instance_id = $1
-ORDER BY created_at DESC, id DESC
+ORDER BY run_number DESC, id DESC
 LIMIT $2 OFFSET $3
 `
 
@@ -341,6 +359,8 @@ func (q *Queries) ListRunsByInstance(ctx context.Context, arg ListRunsByInstance
 			&i.CustomStatus,
 			&i.WaitingFor,
 			&i.CompletedAt,
+			&i.ContinuedFromRunID,
+			&i.ContinuedToRunID,
 		); err != nil {
 			return nil, err
 		}
@@ -367,7 +387,7 @@ SET status = 'cancelled',
     updated_at = NOW()
 WHERE id = $1
   AND status = 'running'
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 type TransitionRunToCancelledParams struct {
@@ -398,6 +418,8 @@ func (q *Queries) TransitionRunToCancelled(ctx context.Context, arg TransitionRu
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
@@ -418,7 +440,7 @@ SET status = 'completed',
 WHERE id = $1
   AND status = 'running'
   AND claimed_by = $2
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 type TransitionRunToCompletedParams struct {
@@ -456,6 +478,69 @@ func (q *Queries) TransitionRunToCompleted(ctx context.Context, arg TransitionRu
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
+	)
+	return i, err
+}
+
+const transitionRunToContinuedAsNew = `-- name: TransitionRunToContinuedAsNew :one
+UPDATE engine.runs
+SET status = 'continued_as_new',
+    result = NULL,
+    custom_status = $4,
+    waiting_for = NULL,
+    completed_at = NOW(),
+    last_error_code = NULL,
+    last_error_message = NULL,
+    continued_to_run_id = $3,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'running'
+  AND claimed_by = $2
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
+`
+
+type TransitionRunToContinuedAsNewParams struct {
+	ID               uuid.UUID   `json:"id"`
+	ClaimedBy        *string     `json:"claimed_by"`
+	ContinuedToRunID pgtype.UUID `json:"continued_to_run_id"`
+	CustomStatus     []byte      `json:"custom_status"`
+}
+
+func (q *Queries) TransitionRunToContinuedAsNew(ctx context.Context, arg TransitionRunToContinuedAsNewParams) (EngineRun, error) {
+	row := q.db.QueryRow(ctx, transitionRunToContinuedAsNew,
+		arg.ID,
+		arg.ClaimedBy,
+		arg.ContinuedToRunID,
+		arg.CustomStatus,
+	)
+	var i EngineRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunNumber,
+		&i.DefinitionVersion,
+		&i.Status,
+		&i.ReadyAt,
+		&i.AttemptCount,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Result,
+		&i.CustomStatus,
+		&i.WaitingFor,
+		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
@@ -476,7 +561,7 @@ SET status = 'failed',
 WHERE id = $1
   AND status = 'running'
   AND claimed_by = $2
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 type TransitionRunToFailedParams struct {
@@ -516,6 +601,8 @@ func (q *Queries) TransitionRunToFailed(ctx context.Context, arg TransitionRunTo
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
@@ -531,7 +618,7 @@ SET status = 'queued',
     updated_at = NOW()
 WHERE id = $1
   AND status = 'suspended'
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 func (q *Queries) TransitionRunToQueuedFromSuspended(ctx context.Context, id uuid.UUID) (EngineRun, error) {
@@ -557,6 +644,8 @@ func (q *Queries) TransitionRunToQueuedFromSuspended(ctx context.Context, id uui
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
@@ -570,7 +659,7 @@ SET status = 'suspended',
     updated_at = NOW()
 WHERE id = $1
   AND status IN ('queued', 'waiting')
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 func (q *Queries) TransitionRunToSuspended(ctx context.Context, id uuid.UUID) (EngineRun, error) {
@@ -596,6 +685,8 @@ func (q *Queries) TransitionRunToSuspended(ctx context.Context, id uuid.UUID) (E
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
@@ -614,7 +705,7 @@ SET status = 'terminated',
     updated_at = NOW()
 WHERE id = $1
   AND status IN ('queued', 'running', 'waiting', 'suspended')
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 func (q *Queries) TransitionRunToTerminated(ctx context.Context, id uuid.UUID) (EngineRun, error) {
@@ -640,6 +731,8 @@ func (q *Queries) TransitionRunToTerminated(ctx context.Context, id uuid.UUID) (
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
@@ -660,7 +753,7 @@ SET status = 'waiting',
 WHERE id = $1
   AND status = 'running'
   AND claimed_by = $2
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 type TransitionRunToWaitingParams struct {
@@ -698,6 +791,8 @@ func (q *Queries) TransitionRunToWaiting(ctx context.Context, arg TransitionRunT
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
@@ -709,7 +804,7 @@ SET status = $2,
     last_error_message = $4,
     updated_at = NOW()
 WHERE id = $1
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 type UpdateRunStatusParams struct {
@@ -747,6 +842,8 @@ func (q *Queries) UpdateRunStatus(ctx context.Context, arg UpdateRunStatusParams
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }
@@ -762,7 +859,7 @@ SET status = 'queued',
     updated_at = NOW()
 WHERE id = $1
   AND status = 'waiting'
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id
 `
 
 func (q *Queries) WakeWaitingRun(ctx context.Context, id uuid.UUID) (EngineRun, error) {
@@ -788,6 +885,8 @@ func (q *Queries) WakeWaitingRun(ctx context.Context, id uuid.UUID) (EngineRun, 
 		&i.CustomStatus,
 		&i.WaitingFor,
 		&i.CompletedAt,
+		&i.ContinuedFromRunID,
+		&i.ContinuedToRunID,
 	)
 	return i, err
 }

--- a/engine/db/migrations/postgres/000009_continue_as_new.down.sql
+++ b/engine/db/migrations/postgres/000009_continue_as_new.down.sql
@@ -1,0 +1,69 @@
+DO $$
+DECLARE
+    continued_as_new_count INTEGER;
+    offending_rows TEXT;
+    overflow_suffix TEXT := '';
+BEGIN
+    SELECT COUNT(*)
+    INTO continued_as_new_count
+    FROM engine.runs
+    WHERE status::text = 'continued_as_new';
+
+    IF continued_as_new_count > 0 THEN
+        SELECT string_agg(format('id=%s instance_id=%s', id, instance_id), ', ' ORDER BY id)
+        INTO offending_rows
+        FROM (
+            SELECT id, instance_id
+            FROM engine.runs
+            WHERE status::text = 'continued_as_new'
+            ORDER BY id
+            LIMIT 10
+        ) blocked;
+
+        IF continued_as_new_count > 10 THEN
+            overflow_suffix := format(' (and %s more)', continued_as_new_count - 10);
+        END IF;
+
+        RAISE EXCEPTION '%', format(
+            'cannot roll back continue-as-new lifecycle enum while engine.runs still contains continued_as_new rows: %s%s',
+            offending_rows,
+            overflow_suffix
+        );
+    END IF;
+END $$;
+
+ALTER TABLE engine.runs
+    DROP COLUMN IF EXISTS continued_to_run_id,
+    DROP COLUMN IF EXISTS continued_from_run_id;
+
+CREATE TYPE engine.run_lifecycle_status_revert AS ENUM (
+    'queued',
+    'running',
+    'waiting',
+    'completed',
+    'failed',
+    'cancelled',
+    'terminated',
+    'suspended'
+);
+
+ALTER TABLE engine.runs
+    ADD COLUMN status_revert engine.run_lifecycle_status_revert;
+
+UPDATE engine.runs
+SET status_revert = status::text::engine.run_lifecycle_status_revert;
+
+ALTER TABLE engine.runs
+    ALTER COLUMN status_revert SET NOT NULL,
+    ALTER COLUMN status_revert SET DEFAULT 'queued';
+
+ALTER TABLE engine.runs
+    DROP COLUMN status;
+
+DROP TYPE engine.run_lifecycle_status;
+
+ALTER TABLE engine.runs
+    RENAME COLUMN status_revert TO status;
+
+ALTER TYPE engine.run_lifecycle_status_revert RENAME TO run_lifecycle_status;
+

--- a/engine/db/migrations/postgres/000009_continue_as_new.up.sql
+++ b/engine/db/migrations/postgres/000009_continue_as_new.up.sql
@@ -1,0 +1,6 @@
+ALTER TYPE engine.run_lifecycle_status ADD VALUE IF NOT EXISTS 'continued_as_new';
+
+ALTER TABLE engine.runs
+    ADD COLUMN continued_from_run_id UUID REFERENCES engine.runs(id),
+    ADD COLUMN continued_to_run_id UUID REFERENCES engine.runs(id);
+

--- a/engine/db/queries/activity_tasks.sql
+++ b/engine/db/queries/activity_tasks.sql
@@ -72,6 +72,26 @@ WHERE id = (
 )
 RETURNING *;
 
+-- name: ClaimNextActivityTaskByProject :one
+UPDATE engine.activity_tasks
+SET status = 'claimed',
+    claimed_by = sqlc.arg(claimed_by),
+    claimed_at = NOW(),
+    lease_expires_at = NOW() + (sqlc.arg(lease_duration_micros)::bigint * INTERVAL '1 microsecond'),
+    attempt_count = attempt_count + 1,
+    updated_at = NOW()
+WHERE id = (
+    SELECT candidate.id
+    FROM engine.activity_tasks AS candidate
+    WHERE candidate.project_id = sqlc.arg(project_filter_id)
+      AND ((candidate.status = 'queued' AND candidate.available_at <= NOW())
+        OR (candidate.status = 'claimed' AND candidate.lease_expires_at IS NOT NULL AND candidate.lease_expires_at < NOW()))
+    ORDER BY candidate.available_at ASC, candidate.id ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING *;
+
 -- name: CompleteActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'completed',

--- a/engine/db/queries/inbox.sql
+++ b/engine/db/queries/inbox.sql
@@ -70,6 +70,16 @@ WHERE kind = 'timer'
   AND available_at <= NOW()
 ORDER BY run_id ASC;
 
+-- name: ListDueTimerRunIDsByProject :many
+SELECT DISTINCT run_id
+FROM engine.inbox
+WHERE project_id = $1
+  AND kind = 'timer'
+  AND run_id IS NOT NULL
+  AND status = 'pending'
+  AND available_at <= NOW()
+ORDER BY run_id ASC;
+
 -- name: MarkInboxProcessed :one
 UPDATE engine.inbox
 SET status = 'processed',

--- a/engine/db/queries/runs.sql
+++ b/engine/db/queries/runs.sql
@@ -218,3 +218,23 @@ WHERE id = (
     FOR UPDATE SKIP LOCKED
 )
 RETURNING *;
+
+-- name: ClaimNextRunByProject :one
+UPDATE engine.runs
+SET status = 'running',
+    claimed_by = sqlc.arg(claimed_by),
+    claimed_at = NOW(),
+    lease_expires_at = NOW() + (sqlc.arg(lease_duration_micros)::bigint * INTERVAL '1 microsecond'),
+    attempt_count = attempt_count + 1,
+    updated_at = NOW()
+WHERE id = (
+    SELECT candidate.id
+    FROM engine.runs AS candidate
+    WHERE candidate.project_id = sqlc.arg(project_filter_id)
+      AND ((candidate.status = 'queued' AND candidate.ready_at <= NOW())
+        OR (candidate.status = 'running' AND candidate.lease_expires_at IS NOT NULL AND candidate.lease_expires_at < NOW()))
+    ORDER BY candidate.ready_at ASC, candidate.id ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING *;

--- a/engine/db/queries/runs.sql
+++ b/engine/db/queries/runs.sql
@@ -4,9 +4,10 @@ INSERT INTO engine.runs (
     instance_id,
     run_number,
     definition_version,
-    ready_at
+    ready_at,
+    continued_from_run_id
 )
-VALUES ($1, $2, $3, $4, $5)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING *;
 
 -- name: GetRun :one
@@ -37,14 +38,14 @@ FOR UPDATE;
 SELECT *
 FROM engine.runs
 WHERE instance_id = $1
-ORDER BY created_at DESC, id DESC
+ORDER BY run_number DESC, id DESC
 LIMIT $2 OFFSET $3;
 
 -- name: GetLatestRunByInstance :one
 SELECT *
 FROM engine.runs
 WHERE instance_id = $1
-ORDER BY created_at DESC, id DESC
+ORDER BY run_number DESC, id DESC
 LIMIT 1;
 
 -- name: UpdateRunStatus :one
@@ -125,6 +126,25 @@ SET status = 'cancelled',
     updated_at = NOW()
 WHERE id = $1
   AND status = 'running'
+RETURNING *;
+
+-- name: TransitionRunToContinuedAsNew :one
+UPDATE engine.runs
+SET status = 'continued_as_new',
+    result = NULL,
+    custom_status = $4,
+    waiting_for = NULL,
+    completed_at = NOW(),
+    last_error_code = NULL,
+    last_error_message = NULL,
+    continued_to_run_id = $3,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'running'
+  AND claimed_by = $2
 RETURNING *;
 
 -- name: TransitionRunToTerminated :one

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"os"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -44,6 +46,7 @@ type RuntimeConfig struct {
 	RunLeaseTTL             time.Duration
 	ActivityLeaseTTL        time.Duration
 	RequestDedupeTTL        time.Duration
+	ProjectIDFilter         *uuid.UUID
 }
 
 // Load resolves the engine database configuration from environment variables.
@@ -80,6 +83,10 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	projectIDFilter, err := uuidFromEnv("CONTINUA_ENGINE_TEST_PROJECT_FILTER")
+	if err != nil {
+		return nil, err
+	}
 
 	return &Config{
 		Database: DatabaseConfig{
@@ -97,6 +104,7 @@ func Load() (*Config, error) {
 			RunLeaseTTL:             runLeaseTTL,
 			ActivityLeaseTTL:        activityLeaseTTL,
 			RequestDedupeTTL:        requestDedupeTTL,
+			ProjectIDFilter:         projectIDFilter,
 		},
 	}, nil
 }
@@ -112,4 +120,17 @@ func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) 
 		return 0, errors.New(key + " must be a valid duration: " + err.Error())
 	}
 	return parsed, nil
+}
+
+func uuidFromEnv(key string) (*uuid.UUID, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return nil, nil
+	}
+
+	parsed, err := uuid.Parse(value)
+	if err != nil {
+		return nil, errors.New(key + " must be a valid UUID: " + err.Error())
+	}
+	return &parsed, nil
 }

--- a/engine/internal/history/events.go
+++ b/engine/internal/history/events.go
@@ -11,6 +11,7 @@ const (
 	EventWorkflowCompleted      = publichistory.EventWorkflowCompleted
 	EventWorkflowFailed         = publichistory.EventWorkflowFailed
 	EventWorkflowCancelled      = publichistory.EventWorkflowCancelled
+	EventWorkflowContinuedAsNew = publichistory.EventWorkflowContinuedAsNew
 	EventWorkflowSuspended      = publichistory.EventWorkflowSuspended
 	EventWorkflowResumed        = publichistory.EventWorkflowResumed
 	EventWorkflowTerminated     = publichistory.EventWorkflowTerminated
@@ -36,6 +37,7 @@ type WorkflowStartedPayload = publichistory.WorkflowStartedPayload
 type WorkflowCompletedPayload = publichistory.WorkflowCompletedPayload
 type WorkflowFailedPayload = publichistory.WorkflowFailedPayload
 type WorkflowCancelledPayload = publichistory.WorkflowCancelledPayload
+type WorkflowContinuedAsNewPayload = publichistory.WorkflowContinuedAsNewPayload
 type WorkflowSuspendedPayload = publichistory.WorkflowSuspendedPayload
 type WorkflowResumedPayload = publichistory.WorkflowResumedPayload
 type WorkflowTerminatedPayload = publichistory.WorkflowTerminatedPayload

--- a/engine/internal/projector/projector.go
+++ b/engine/internal/projector/projector.go
@@ -45,7 +45,8 @@ const (
 var darkLaunchProjectID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
 
 type Projector struct {
-	store *enginestore.Store
+	store         *enginestore.Store
+	projectFilter *uuid.UUID
 }
 
 type projectionTarget struct {
@@ -68,7 +69,11 @@ type terminalProjection struct {
 }
 
 func New(store *enginestore.Store) *Projector {
-	return &Projector{store: store}
+	var projectFilter *uuid.UUID
+	if store != nil {
+		projectFilter = store.ProjectFilter()
+	}
+	return &Projector{store: store, projectFilter: projectFilter}
 }
 
 func (p *Projector) PollOnce(ctx context.Context, _ string) error {
@@ -925,7 +930,7 @@ func emitProjectedEvent(ctx context.Context, tx pgx.Tx, event *projectedEvent) e
 	return nil
 }
 
-func selectProjectionTarget(ctx context.Context, tx pgx.Tx) (projectionTarget, error) {
+func selectProjectionTarget(ctx context.Context, tx pgx.Tx, projectFilter *uuid.UUID) (projectionTarget, error) {
 	var target projectionTarget
 	var projectionUpdatedAt pgtypeTimestamptz
 	err := tx.QueryRow(ctx, `
@@ -945,6 +950,7 @@ func selectProjectionTarget(ctx context.Context, tx pgx.Tx) (projectionTarget, e
 		           t.updated_at
 		    FROM public.traces AS t
 		WHERE t.engine_run_id IS NOT NULL
+		  AND ($1::uuid IS NULL OR t.project_id = $1)
 		  AND COALESCE(t.engine_projection_state, '') NOT IN ('summary_only', 'journal_expired')
 		)
 		SELECT id,
@@ -959,7 +965,7 @@ func selectProjectionTarget(ctx context.Context, tx pgx.Tx) (projectionTarget, e
 		WHERE last_projected_history_id < latest_history_id
 		ORDER BY engine_projection_updated_at ASC NULLS FIRST, updated_at ASC, id ASC
 		LIMIT 1
-	`).Scan(
+	`, nullableProjectFilter(projectFilter)).Scan(
 		&target.TraceID,
 		&target.ProjectID,
 		&target.TraceName,
@@ -976,6 +982,13 @@ func selectProjectionTarget(ctx context.Context, tx pgx.Tx) (projectionTarget, e
 		target.ProjectionUpdatedAt = &projectionUpdatedAt.Time
 	}
 	return target, nil
+}
+
+func nullableProjectFilter(projectFilter *uuid.UUID) pgtype.UUID {
+	if projectFilter == nil {
+		return pgtype.UUID{}
+	}
+	return pgtype.UUID{Bytes: *projectFilter, Valid: true}
 }
 
 func advanceProjectionCheckpoint(
@@ -1039,7 +1052,7 @@ func (p *Projector) pollSingleHistoryRow(ctx context.Context) (bool, error) {
 		_ = tx.Rollback(ctx)
 	}()
 
-	target, err := selectProjectionTarget(ctx, tx.Tx())
+	target, err := selectProjectionTarget(ctx, tx.Tx(), p.projectFilter)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return false, nil

--- a/engine/internal/projector/projector.go
+++ b/engine/internal/projector/projector.go
@@ -286,6 +286,13 @@ func projectHistoryRow(
 			ErrorMessage:  "workflow cancelled",
 			CleanupReason: "cancelled",
 		})
+	case *publichistory.WorkflowContinuedAsNewPayload:
+		return projectTerminalHistoryRow(ctx, tx, target, row, &terminalProjection{
+			RunStatus:     enginedb.EngineRunLifecycleStatusContinuedAsNew,
+			ErrorCode:     "continued_as_new",
+			ErrorMessage:  "workflow continued as new",
+			CleanupReason: "continued_as_new",
+		})
 	case *publichistory.WorkflowTerminatedPayload:
 		return projectTerminalHistoryRow(ctx, tx, target, row, &terminalProjection{
 			RunStatus:     enginedb.EngineRunLifecycleStatusTerminated,

--- a/engine/internal/projector/projector.go
+++ b/engine/internal/projector/projector.go
@@ -405,28 +405,80 @@ func writeTerminalProjection(
 		return fmt.Errorf("projected trace not found for run %s", target.RunID)
 	}
 
-	commandTag, err = tx.Exec(ctx, `
-		UPDATE public.spans
-		SET status = $3,
-		    end_time = $4::timestamptz,
-		    output = $5::jsonb,
-		    status_message = $6::text,
-		    duration_ms = CASE
-		        WHEN $4::timestamptz IS NOT NULL THEN EXTRACT(EPOCH FROM ($4::timestamptz - start_time)) * 1000
-		        ELSE duration_ms
-		    END,
+	if err := upsertTerminalRootSpan(
+		ctx,
+		tx,
+		target,
+		spanStatus,
+		completedAt,
+		outputPayload,
+		stringPtr(projection.ErrorMessage),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func upsertTerminalRootSpan(
+	ctx context.Context,
+	tx pgx.Tx,
+	target *projectionTarget,
+	spanStatus string,
+	completedAt time.Time,
+	outputPayload json.RawMessage,
+	statusMessage *string,
+) error {
+	if target == nil {
+		return errors.New("projection target is required")
+	}
+
+	commandTag, err := tx.Exec(ctx, `
+		INSERT INTO public.spans (
+		    project_id,
+		    trace_id,
+		    span_id,
+		    name,
+		    type,
+		    status,
+		    level,
+		    start_time,
+		    end_time,
+		    output,
+		    status_message,
+		    duration_ms,
+		    depth
+		)
+		SELECT $1,
+		       t.id,
+		       $3,
+		       COALESCE(NULLIF($4, ''), NULLIF(t.name, ''), 'workflow'),
+		       $5,
+		       $6,
+		       $7,
+		       COALESCE(t.start_time, $8::timestamptz),
+		       $8::timestamptz,
+		       $9::jsonb,
+		       $10::text,
+		       EXTRACT(EPOCH FROM ($8::timestamptz - COALESCE(t.start_time, $8::timestamptz))) * 1000,
+		       0
+		FROM public.traces AS t
+		WHERE t.id = $2
+		ON CONFLICT (trace_id, span_id) DO UPDATE
+		SET status = EXCLUDED.status,
+		    end_time = EXCLUDED.end_time,
+		    output = EXCLUDED.output,
+		    status_message = EXCLUDED.status_message,
+		    duration_ms = EXCLUDED.duration_ms,
 		    updated_at = NOW(),
-		    version = COALESCE(version, 1) + 1
-		WHERE trace_id = $1
-		  AND span_id = $2
-	`, target.TraceID, rootSpanExternalID(target.RunID), spanStatus, completedAt, outputPayload, nullableText(stringPtr(projection.ErrorMessage)))
+		    version = COALESCE(spans.version, 1) + 1
+	`, target.ProjectID, target.TraceID, rootSpanExternalID(target.RunID), target.TraceName, defaultProjectedSpanTypeRoot, spanStatus, defaultProjectedSpanLevel, completedAt, outputPayload, statusMessage)
 	if err != nil {
 		return err
 	}
 	if commandTag.RowsAffected() == 0 && target.ProjectID != darkLaunchProjectID {
-		return fmt.Errorf("projected root span not found for run %s", target.RunID)
+		return fmt.Errorf("projected trace not found for run %s", target.RunID)
 	}
-
 	return nil
 }
 

--- a/engine/internal/projector/projector_test.go
+++ b/engine/internal/projector/projector_test.go
@@ -250,6 +250,46 @@ func TestProjectorPollOnce_DoesNotOverwriteTerminalTraceSummary(t *testing.T) {
 	}
 }
 
+func TestProjectorPollOnce_RecreatesMissingTerminalRootSpan(t *testing.T) {
+	fixture := newProjectorFixture(t)
+
+	result := mustJSON(t, map[string]bool{"ok": true})
+	completedHistory := fixture.appendHistoryEvent(2, publichistory.EventWorkflowCompleted, publichistory.WorkflowCompletedPayload{
+		Result: result,
+	})
+	fixture.setTraceProjection(completedHistory.ID, fixture.startedHistory.ID, publicprojection.StateCatchingUp.String())
+
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		DELETE FROM public.spans
+		WHERE trace_id = $1
+		  AND span_id = $2
+	`, fixture.traceID, rootSpanExternalID(fixture.run.ID)); err != nil {
+		t.Fatalf("delete root span: %v", err)
+	}
+
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-recreate-terminal-root"); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+
+	var rootSpanStatus string
+	var rootSpanOutput []byte
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT status,
+		       output
+		FROM public.spans
+		WHERE trace_id = $1
+		  AND span_id = $2
+	`, fixture.traceID, rootSpanExternalID(fixture.run.ID)).Scan(&rootSpanStatus, &rootSpanOutput); err != nil {
+		t.Fatalf("query recreated root span: %v", err)
+	}
+	if rootSpanStatus != "completed" {
+		t.Fatalf("expected completed root span status, got %q", rootSpanStatus)
+	}
+	if !jsonEqual(rootSpanOutput, result) {
+		t.Fatalf("expected recreated root span output %s, got %s", result, rootSpanOutput)
+	}
+}
+
 func TestProjectorPollOnce_SuspendResumeControlEventsPreserveRunningStatuses(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/engine/internal/projector/projector_test.go
+++ b/engine/internal/projector/projector_test.go
@@ -835,62 +835,101 @@ func TestProjectorPollOnce_TerminatedHistoryProjectsFailureAndCleanup(t *testing
 }
 
 func TestProjectorPollOnce_CancelledHistoryClearsPureSignalWaitWithoutSyntheticSignalEvent(t *testing.T) {
-	fixture := newProjectorFixture(t)
-	cancelledAt := time.Now().UTC().Round(time.Microsecond)
-
-	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
-		UPDATE engine.runs
-		SET status = 'cancelled',
-		    waiting_for = NULL,
-		    result = NULL,
-		    completed_at = $2,
-		    last_error_code = 'cancelled',
-		    last_error_message = 'workflow cancelled',
-		    updated_at = $2
-		WHERE id = $1
-	`, fixture.run.ID, cancelledAt); err != nil {
-		t.Fatalf("mark run cancelled: %v", err)
-	}
-	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
-		UPDATE engine.instances
-		SET status = 'cancelled',
-		    updated_at = $2
-		WHERE id = $1
-	`, fixture.instance.ID, cancelledAt); err != nil {
-		t.Fatalf("mark instance cancelled: %v", err)
-	}
-	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
-		UPDATE public.traces
-		SET engine_wait_state = $2::jsonb,
-		    updated_at = NOW()
-		WHERE id = $1
-	`, fixture.traceID, mustJSON(t, map[string]any{"kind": "signal", "signal_name": "approval"})); err != nil {
-		t.Fatalf("seed signal wait state: %v", err)
-	}
-
-	fixture.appendHistoryEvent(2, publichistory.EventWorkflowCancelled, publichistory.WorkflowCancelledPayload{})
-
-	if err := fixture.projector.PollOnce(fixture.ctx, "projector-cancelled-signal"); err != nil {
-		t.Fatalf("PollOnce() error = %v", err)
+	testCases := []struct {
+		name           string
+		runStatus      enginedb.EngineRunLifecycleStatus
+		instanceStatus enginedb.EngineInstanceLifecycleStatus
+		eventType      string
+		payload        any
+		traceStatus    string
+		resolution     string
+		errorCode      *string
+		errorMessage   *string
+	}{
+		{
+			name:           "cancelled",
+			runStatus:      enginedb.EngineRunLifecycleStatusCancelled,
+			instanceStatus: enginedb.EngineInstanceLifecycleStatusCancelled,
+			eventType:      publichistory.EventWorkflowCancelled,
+			payload:        publichistory.WorkflowCancelledPayload{},
+			traceStatus:    "cancelled",
+			resolution:     "cancelled",
+			errorCode:      enginetest.Ptr("cancelled"),
+			errorMessage:   enginetest.Ptr("workflow cancelled"),
+		},
+		{
+			name:           "continued_as_new",
+			runStatus:      enginedb.EngineRunLifecycleStatusContinuedAsNew,
+			instanceStatus: enginedb.EngineInstanceLifecycleStatusActive,
+			eventType:      publichistory.EventWorkflowContinuedAsNew,
+			payload: publichistory.WorkflowContinuedAsNewPayload{
+				Input: mustJSON(t, map[string]any{"cursor": 2}),
+			},
+			traceStatus: "completed",
+			resolution:  "continued_as_new",
+		},
 	}
 
-	var traceStatus string
-	var waitState []byte
-	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
-		SELECT status, engine_wait_state
-		FROM public.traces
-		WHERE id = $1
-	`, fixture.traceID).Scan(&traceStatus, &waitState); err != nil {
-		t.Fatalf("query cancelled trace summary: %v", err)
-	}
-	if traceStatus != "cancelled" {
-		t.Fatalf("expected cancelled trace status, got %q", traceStatus)
-	}
-	if len(waitState) != 0 {
-		t.Fatalf("expected cancelled projection to clear pure signal wait state, got %s", waitState)
-	}
-	if resolvedWaits := queryResolvedWaitEvents(t, fixture, "cancelled"); len(resolvedWaits) != 0 {
-		t.Fatalf("expected no synthetic signal wait resolution events, got %+v", resolvedWaits)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newProjectorFixture(t)
+			completedAt := time.Now().UTC().Round(time.Microsecond)
+
+			if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+				UPDATE engine.runs
+				SET status = $2,
+				    waiting_for = NULL,
+				    result = NULL,
+				    completed_at = $3,
+				    last_error_code = $4,
+				    last_error_message = $5,
+				    updated_at = $3
+				WHERE id = $1
+			`, fixture.run.ID, tc.runStatus, completedAt, tc.errorCode, tc.errorMessage); err != nil {
+				t.Fatalf("mark run terminal: %v", err)
+			}
+			if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+				UPDATE engine.instances
+				SET status = $2,
+				    updated_at = $3
+				WHERE id = $1
+			`, fixture.instance.ID, tc.instanceStatus, completedAt); err != nil {
+				t.Fatalf("mark instance terminal: %v", err)
+			}
+			if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+				UPDATE public.traces
+				SET engine_wait_state = $2::jsonb,
+				    updated_at = NOW()
+				WHERE id = $1
+			`, fixture.traceID, mustJSON(t, map[string]any{"kind": "signal", "signal_name": "approval"})); err != nil {
+				t.Fatalf("seed signal wait state: %v", err)
+			}
+
+			fixture.appendHistoryEvent(2, tc.eventType, tc.payload)
+
+			if err := fixture.projector.PollOnce(fixture.ctx, "projector-signal-"+tc.name); err != nil {
+				t.Fatalf("PollOnce() error = %v", err)
+			}
+
+			var traceStatus string
+			var waitState []byte
+			if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+				SELECT status, engine_wait_state
+				FROM public.traces
+				WHERE id = $1
+			`, fixture.traceID).Scan(&traceStatus, &waitState); err != nil {
+				t.Fatalf("query terminal trace summary: %v", err)
+			}
+			if traceStatus != tc.traceStatus {
+				t.Fatalf("expected %s trace status, got %q", tc.traceStatus, traceStatus)
+			}
+			if len(waitState) != 0 {
+				t.Fatalf("expected terminal projection to clear pure signal wait state, got %s", waitState)
+			}
+			if resolvedWaits := queryResolvedWaitEvents(t, fixture, tc.resolution); len(resolvedWaits) != 0 {
+				t.Fatalf("expected no synthetic signal wait resolution events, got %+v", resolvedWaits)
+			}
+		})
 	}
 }
 
@@ -948,6 +987,15 @@ func TestProjectorPollOnce_ClearsWaitStateOnEveryTerminalTransition(t *testing.T
 			errorCode:    enginetest.Ptr("terminated"),
 			errorMessage: enginetest.Ptr("run terminated by operator"),
 		},
+		{
+			name:           "continued_as_new",
+			runStatus:      enginedb.EngineRunLifecycleStatusContinuedAsNew,
+			instanceStatus: enginedb.EngineInstanceLifecycleStatusActive,
+			eventType:      publichistory.EventWorkflowContinuedAsNew,
+			payload: publichistory.WorkflowContinuedAsNewPayload{
+				Input: mustJSON(t, map[string]any{"cursor": 2}),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1004,6 +1052,145 @@ func TestProjectorPollOnce_ClearsWaitStateOnEveryTerminalTransition(t *testing.T
 				t.Fatalf("expected terminal projection to clear wait state, got %s", waitState)
 			}
 		})
+	}
+}
+
+func TestProjectorPollOnce_ContinuedAsNewProjectsCompletedTerminalShell(t *testing.T) {
+	fixture := newProjectorFixture(t)
+	completedAt := time.Now().UTC().Round(time.Microsecond)
+
+	if _, err := fixture.store.CreateActivityTask(fixture.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:    fixture.projectID,
+		InstanceID:   fixture.instance.ID,
+		RunID:        fixture.run.ID,
+		ActivityKey:  "ship-order",
+		ActivityType: "demo.ship",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+		AvailableAt:  completedAt.Add(-time.Minute),
+		MaxAttempts:  1,
+	}); err != nil {
+		t.Fatalf("CreateActivityTask() error = %v", err)
+	}
+	timerPayload, err := publichistory.MarshalPayload(publichistory.TimerScheduledPayload{
+		TimerKey: "deadline",
+		DueAt:    completedAt.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(timer) error = %v", err)
+	}
+	if _, err := fixture.store.CreateInboxItem(fixture.ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   fixture.projectID,
+		InstanceID:  fixture.instance.ID,
+		RunID:       pgtype.UUID{Bytes: fixture.run.ID, Valid: true},
+		Kind:        "timer",
+		Payload:     timerPayload,
+		AvailableAt: completedAt.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateInboxItem(timer) error = %v", err)
+	}
+	if _, err := fixture.store.CancelOpenActivityTasksByRun(fixture.ctx, fixture.run.ID); err != nil {
+		t.Fatalf("CancelOpenActivityTasksByRun() error = %v", err)
+	}
+	if _, err := fixture.store.DiscardOpenInboxItemsByRun(fixture.ctx, fixture.run.ID); err != nil {
+		t.Fatalf("DiscardOpenInboxItemsByRun() error = %v", err)
+	}
+
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE engine.runs
+		SET status = 'continued_as_new',
+		    waiting_for = NULL,
+		    result = NULL,
+		    completed_at = $2,
+		    updated_at = $2
+		WHERE id = $1
+	`, fixture.run.ID, completedAt); err != nil {
+		t.Fatalf("mark run continued_as_new: %v", err)
+	}
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE engine.instances
+		SET status = 'active',
+		    updated_at = $2
+		WHERE id = $1
+	`, fixture.instance.ID, completedAt); err != nil {
+		t.Fatalf("mark instance active: %v", err)
+	}
+	if _, err := fixture.db.Pool.Exec(fixture.ctx, `
+		UPDATE public.traces
+		SET engine_wait_state = $2::jsonb,
+		    updated_at = NOW()
+		WHERE id = $1
+	`, fixture.traceID, mustJSON(t, map[string]any{"kind": "signal", "signal_name": "approval"})); err != nil {
+		t.Fatalf("seed projected wait state: %v", err)
+	}
+
+	terminalHistory := fixture.appendHistoryEvent(2, publichistory.EventWorkflowContinuedAsNew, publichistory.WorkflowContinuedAsNewPayload{
+		Input: mustJSON(t, map[string]any{"cursor": 2, "phase": "next"}),
+	})
+
+	if err := fixture.projector.PollOnce(fixture.ctx, "projector-continued-as-new"); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+
+	var traceStatus string
+	var runStatus string
+	var waitState []byte
+	var pendingActivityTasks int64
+	var pendingInboxItems int64
+	var traceOutput []byte
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT status,
+		       engine_run_status,
+		       engine_wait_state,
+		       engine_pending_activity_tasks,
+		       engine_pending_inbox_items,
+		       output
+		FROM public.traces
+		WHERE id = $1
+	`, fixture.traceID).Scan(&traceStatus, &runStatus, &waitState, &pendingActivityTasks, &pendingInboxItems, &traceOutput); err != nil {
+		t.Fatalf("query continued trace summary: %v", err)
+	}
+	if traceStatus != "completed" {
+		t.Fatalf("expected completed trace status, got %q", traceStatus)
+	}
+	if runStatus != string(enginedb.EngineRunLifecycleStatusContinuedAsNew) {
+		t.Fatalf("expected projected continued_as_new run status, got %q", runStatus)
+	}
+	if len(waitState) != 0 {
+		t.Fatalf("expected continued_as_new projection to clear wait state, got %s", waitState)
+	}
+	if pendingActivityTasks != 0 || pendingInboxItems != 0 {
+		t.Fatalf("expected terminal projection to clear pending counts, got activity=%d inbox=%d", pendingActivityTasks, pendingInboxItems)
+	}
+	if len(traceOutput) != 0 {
+		t.Fatalf("expected continued_as_new trace output to stay null, got %s", traceOutput)
+	}
+
+	var rootSpanStatus string
+	var rootSpanOutput []byte
+	if err := fixture.db.Pool.QueryRow(fixture.ctx, `
+		SELECT status, output
+		FROM public.spans
+		WHERE trace_id = $1
+		  AND span_id = $2
+	`, fixture.traceID, rootSpanExternalID(fixture.run.ID)).Scan(&rootSpanStatus, &rootSpanOutput); err != nil {
+		t.Fatalf("query continued root span: %v", err)
+	}
+	if rootSpanStatus != "completed" {
+		t.Fatalf("expected completed root span, got %q", rootSpanStatus)
+	}
+	if len(rootSpanOutput) != 0 {
+		t.Fatalf("expected continued_as_new root span output to stay null, got %s", rootSpanOutput)
+	}
+
+	resolvedWaits := queryResolvedWaitEvents(t, fixture, "continued_as_new")
+	if len(resolvedWaits) != 2 {
+		t.Fatalf("expected continuation cleanup to resolve 2 waits, got %+v", resolvedWaits)
+	}
+	if resolvedWaits[0].Sequence != terminalHistory.SequenceNo*10+1 || resolvedWaits[0].WaitID != "activity:ship-order" {
+		t.Fatalf("unexpected first continuation wait event: %+v", resolvedWaits[0])
+	}
+	if resolvedWaits[1].Sequence != terminalHistory.SequenceNo*10+2 || resolvedWaits[1].WaitID != "timer:deadline" {
+		t.Fatalf("unexpected second continuation wait event: %+v", resolvedWaits[1])
 	}
 }
 

--- a/engine/internal/projector/projector_test.go
+++ b/engine/internal/projector/projector_test.go
@@ -32,7 +32,7 @@ func TestProjectorPollOnce_RestartSafeForProjectedActivityRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BeginTx() error = %v", err)
 	}
-	target, err := selectProjectionTarget(fixture.ctx, tx.Tx())
+	target, err := selectProjectionTarget(fixture.ctx, tx.Tx(), nil)
 	if err != nil {
 		_ = tx.Rollback(fixture.ctx)
 		t.Fatalf("selectProjectionTarget() error = %v", err)
@@ -447,7 +447,7 @@ func TestProjectorBarrier_ConcurrentPurgeToSummaryOnlySkipsDetailWrites(t *testi
 	}
 	defer func() { _ = tx.Rollback(fixture.ctx) }()
 
-	target, err := selectProjectionTarget(fixture.ctx, tx.Tx())
+	target, err := selectProjectionTarget(fixture.ctx, tx.Tx(), nil)
 	if err != nil {
 		t.Fatalf("selectProjectionTarget() error = %v", err)
 	}
@@ -519,7 +519,7 @@ func TestProjectorBarrier_ConcurrentFullPurgeBlocksCheckpointWithoutHistoryRows(
 	}
 	defer func() { _ = tx.Rollback(fixture.ctx) }()
 
-	target, err := selectProjectionTarget(fixture.ctx, tx.Tx())
+	target, err := selectProjectionTarget(fixture.ctx, tx.Tx(), nil)
 	if err != nil {
 		t.Fatalf("selectProjectionTarget() error = %v", err)
 	}

--- a/engine/internal/store/activity_tasks.go
+++ b/engine/internal/store/activity_tasks.go
@@ -56,6 +56,13 @@ func (o *storeOps) ClaimNextActivityTask(
 	workerID string,
 	leaseDuration time.Duration,
 ) (enginedb.EngineActivityTask, error) {
+	if o.projectFilter != nil {
+		return mapResult(o.q.ClaimNextActivityTaskByProject(ctx, enginedb.ClaimNextActivityTaskByProjectParams{
+			ProjectFilterID:     *o.projectFilter,
+			ClaimedBy:           nullableWorkerID(workerID),
+			LeaseDurationMicros: leaseDurationMicros(leaseDuration),
+		}))
+	}
 	return mapResult(o.q.ClaimNextActivityTask(ctx, enginedb.ClaimNextActivityTaskParams{
 		ClaimedBy:           nullableWorkerID(workerID),
 		LeaseDurationMicros: leaseDurationMicros(leaseDuration),

--- a/engine/internal/store/inbox.go
+++ b/engine/internal/store/inbox.go
@@ -52,7 +52,15 @@ func (o *storeOps) ListDiscardedTimerInboxItemsByRun(
 }
 
 func (o *storeOps) ListDueTimerRunIDs(ctx context.Context) ([]uuid.UUID, error) {
-	rawIDs, err := o.q.ListDueTimerRunIDs(ctx)
+	var (
+		rawIDs []pgtype.UUID
+		err    error
+	)
+	if o.projectFilter != nil {
+		rawIDs, err = o.q.ListDueTimerRunIDsByProject(ctx, *o.projectFilter)
+	} else {
+		rawIDs, err = o.q.ListDueTimerRunIDs(ctx)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/engine/internal/store/runs.go
+++ b/engine/internal/store/runs.go
@@ -131,6 +131,13 @@ func (o *storeOps) ClaimNextRun(
 	workerID string,
 	leaseDuration time.Duration,
 ) (enginedb.EngineRun, error) {
+	if o.projectFilter != nil {
+		return mapResult(o.q.ClaimNextRunByProject(ctx, enginedb.ClaimNextRunByProjectParams{
+			ProjectFilterID:     *o.projectFilter,
+			ClaimedBy:           nullableWorkerID(workerID),
+			LeaseDurationMicros: leaseDurationMicros(leaseDuration),
+		}))
+	}
 	return mapResult(o.q.ClaimNextRun(ctx, enginedb.ClaimNextRunParams{
 		ClaimedBy:           nullableWorkerID(workerID),
 		LeaseDurationMicros: leaseDurationMicros(leaseDuration),

--- a/engine/internal/store/runs.go
+++ b/engine/internal/store/runs.go
@@ -88,6 +88,17 @@ func (o *storeOps) TransitionRunToCancelled(
 	return enginedb.EngineRun{}, o.classifyRunInvariantMiss(ctx, arg.ID, "cancel", err)
 }
 
+func (o *storeOps) TransitionRunToContinuedAsNew(
+	ctx context.Context,
+	arg enginedb.TransitionRunToContinuedAsNewParams,
+) (enginedb.EngineRun, error) {
+	run, err := o.q.TransitionRunToContinuedAsNew(ctx, arg)
+	if err == nil {
+		return run, nil
+	}
+	return enginedb.EngineRun{}, o.classifyRunCASMiss(ctx, arg.ID, err)
+}
+
 func (o *storeOps) TransitionRunToTerminated(
 	ctx context.Context,
 	id uuid.UUID,

--- a/engine/internal/store/store.go
+++ b/engine/internal/store/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -25,7 +26,8 @@ var (
 )
 
 type storeOps struct {
-	q *enginedb.Queries
+	q             *enginedb.Queries
+	projectFilter *uuid.UUID
 }
 
 // Store provides engine database access backed by a dedicated pgx pool.
@@ -47,6 +49,28 @@ func New(pool *pgxpool.Pool) *Store {
 		pool:     pool,
 		storeOps: &storeOps{q: enginedb.New(pool)},
 	}
+}
+
+func (s *Store) WithProjectFilter(projectID uuid.UUID) *Store {
+	if s == nil {
+		return nil
+	}
+	filter := projectID
+	return &Store{
+		pool: s.pool,
+		storeOps: &storeOps{
+			q:             s.q,
+			projectFilter: &filter,
+		},
+	}
+}
+
+func (o *storeOps) ProjectFilter() *uuid.UUID {
+	if o == nil || o.projectFilter == nil {
+		return nil
+	}
+	filter := *o.projectFilter
+	return &filter
 }
 
 // NewPool constructs a pgx pool using the engine defaults from config.
@@ -103,8 +127,11 @@ func (s *Store) BeginTx(ctx context.Context, opts pgx.TxOptions) (*Tx, error) {
 	}
 
 	return &Tx{
-		tx:       tx,
-		storeOps: &storeOps{q: s.q.WithTx(tx)},
+		tx: tx,
+		storeOps: &storeOps{
+			q:             s.q.WithTx(tx),
+			projectFilter: s.projectFilter,
+		},
 	}, nil
 }
 

--- a/engine/internal/workflow/activation.go
+++ b/engine/internal/workflow/activation.go
@@ -2,7 +2,11 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -12,7 +16,23 @@ import (
 	enginehistory "github.com/continua-ai/continua/engine/internal/history"
 	engineprojector "github.com/continua-ai/continua/engine/internal/projector"
 	"github.com/continua-ai/continua/engine/internal/store"
+	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
 )
+
+const (
+	engineTracePrefix    = "engine:"
+	engineRootSpanPrefix = "engine:root:"
+)
+
+type continuationTraceSeed struct {
+	SessionID   pgtype.UUID
+	Name        *string
+	UserID      *string
+	Tags        []string
+	Environment *string
+	Release     *string
+	Metadata    []byte
+}
 
 type Activator struct {
 	store       *store.Store
@@ -77,7 +97,7 @@ func (a *Activator) Activate(ctx context.Context, claimedRun *enginedb.EngineRun
 			FailureCode:    "definition_version_mismatch",
 			FailureMessage: fmt.Sprintf("definition %s@%s is not registered", instance.DefinitionName, run.DefinitionVersion),
 		}
-		if err := a.commitDecision(ctx, tx, &run, workerClaimedBy, &decision); err != nil {
+		if err := a.commitDecision(ctx, tx, &instance, &run, workerClaimedBy, &decision); err != nil {
 			return err
 		}
 		return tx.Commit(ctx)
@@ -88,7 +108,7 @@ func (a *Activator) Activate(ctx context.Context, claimedRun *enginedb.EngineRun
 		return err
 	}
 
-	if err := a.commitDecision(ctx, tx, &run, workerClaimedBy, &decision); err != nil {
+	if err := a.commitDecision(ctx, tx, &instance, &run, workerClaimedBy, &decision); err != nil {
 		return err
 	}
 	if decision.Kind == decisionCompleted {
@@ -103,6 +123,7 @@ func (a *Activator) Activate(ctx context.Context, claimedRun *enginedb.EngineRun
 func (a *Activator) commitDecision(
 	ctx context.Context,
 	tx *store.Tx,
+	instance *enginedb.EngineInstance,
 	run *enginedb.EngineRun,
 	workerClaimedBy *string,
 	decision *activationDecision,
@@ -242,9 +263,85 @@ func (a *Activator) commitDecision(
 			return err
 		}
 		return updateRunInstanceStatus(ctx, tx, run.InstanceID, enginedb.EngineInstanceLifecycleStatusCancelled)
+	case decisionContinuedAsNew:
+		return a.commitContinuationDecision(ctx, tx, instance, run, workerClaimedBy, decision)
 	default:
 		return fmt.Errorf("unsupported activation decision kind %q", decision.Kind)
 	}
+}
+
+func (a *Activator) commitContinuationDecision(
+	ctx context.Context,
+	tx *store.Tx,
+	instance *enginedb.EngineInstance,
+	run *enginedb.EngineRun,
+	workerClaimedBy *string,
+	decision *activationDecision,
+) error {
+	if instance == nil || run == nil || decision == nil {
+		return errors.New("continuation commit requires instance, run, and decision")
+	}
+
+	traceSeed, err := loadContinuationTraceSeed(ctx, tx, run.ProjectID, run.ID)
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.CancelOpenActivityTasksByRun(ctx, run.ID); err != nil {
+		return err
+	}
+	if _, err := tx.DiscardOpenInboxItemsByRun(ctx, run.ID); err != nil {
+		return err
+	}
+
+	startedAt := timeNowUTC()
+	nextRun, err := tx.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:          run.ProjectID,
+		InstanceID:         run.InstanceID,
+		RunNumber:          run.RunNumber + 1,
+		DefinitionVersion:  run.DefinitionVersion,
+		ReadyAt:            startedAt,
+		ContinuedFromRunID: pgtype.UUID{Bytes: run.ID, Valid: true},
+	})
+	if err != nil {
+		return err
+	}
+
+	startedPayload, err := enginehistory.MarshalPayload(enginehistory.WorkflowStartedPayload{
+		DefinitionName:    instance.DefinitionName,
+		DefinitionVersion: run.DefinitionVersion,
+		InstanceKey:       instance.InstanceKey,
+		Input:             cloneRaw(decision.ContinuationInput),
+	})
+	if err != nil {
+		return err
+	}
+	startedEvent, err := tx.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  nextRun.ProjectID,
+		InstanceID: nextRun.InstanceID,
+		RunID:      nextRun.ID,
+		SequenceNo: 1,
+		EventType:  enginehistory.EventWorkflowStarted,
+		Payload:    startedPayload,
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.TransitionRunToContinuedAsNew(ctx, enginedb.TransitionRunToContinuedAsNewParams{
+		ID:               run.ID,
+		ClaimedBy:        workerClaimedBy,
+		ContinuedToRunID: pgtype.UUID{Bytes: nextRun.ID, Valid: true},
+		CustomStatus:     decision.CustomStatus,
+	}); err != nil {
+		return err
+	}
+
+	if err := createContinuationTraceShell(ctx, tx, instance, &nextRun, traceSeed, &startedEvent, decision.ContinuationInput); err != nil {
+		return err
+	}
+
+	return updateRunInstanceStatus(ctx, tx, run.InstanceID, enginedb.EngineInstanceLifecycleStatusActive)
 }
 
 func updateRunInstanceStatus(
@@ -265,4 +362,198 @@ func sameClaimedBy(left, right *string) bool {
 		return left == nil && right == nil
 	}
 	return *left == *right
+}
+
+func loadContinuationTraceSeed(
+	ctx context.Context,
+	tx *store.Tx,
+	projectID uuid.UUID,
+	runID uuid.UUID,
+) (*continuationTraceSeed, error) {
+	if tx == nil {
+		return nil, errors.New("transaction is required")
+	}
+
+	row := tx.Tx().QueryRow(ctx, `
+		SELECT session_id,
+		       name,
+		       user_id,
+		       tags,
+		       environment,
+		       release,
+		       metadata
+		FROM public.traces
+		WHERE project_id = $1
+		  AND engine_run_id = $2
+		FOR UPDATE
+	`, projectID, runID)
+
+	var (
+		seed        continuationTraceSeed
+		name        pgtype.Text
+		userID      pgtype.Text
+		tags        []string
+		environment pgtype.Text
+		release     pgtype.Text
+		metadata    []byte
+	)
+	if err := row.Scan(&seed.SessionID, &name, &userID, &tags, &environment, &release, &metadata); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: projected trace shell missing for run %s", store.ErrInvariant, runID)
+		}
+		return nil, err
+	}
+
+	seed.Name = pgTextPtr(name)
+	seed.UserID = pgTextPtr(userID)
+	seed.Tags = append([]string(nil), tags...)
+	seed.Environment = pgTextPtr(environment)
+	seed.Release = pgTextPtr(release)
+	seed.Metadata = cloneBytes(metadata)
+	return &seed, nil
+}
+
+func createContinuationTraceShell(
+	ctx context.Context,
+	tx *store.Tx,
+	instance *enginedb.EngineInstance,
+	run *enginedb.EngineRun,
+	seed *continuationTraceSeed,
+	startedEvent *enginedb.EngineHistory,
+	input json.RawMessage,
+) error {
+	if tx == nil || instance == nil || run == nil || seed == nil || startedEvent == nil {
+		return errors.New("continuation trace shell requires tx, instance, run, seed, and started event")
+	}
+
+	runStatus := string(enginedb.EngineRunLifecycleStatusQueued)
+	projectionState := publicprojection.StateUpToDate.String()
+	traceName := seed.Name
+	traceRowID := uuid.UUID{}
+
+	if err := tx.Tx().QueryRow(ctx, `
+		INSERT INTO public.traces (
+		    project_id,
+		    session_id,
+		    trace_id,
+		    name,
+		    user_id,
+		    tags,
+		    environment,
+		    release,
+		    metadata,
+		    input,
+		    output,
+		    status,
+		    start_time,
+		    end_time,
+		    engine_run_id,
+		    engine_instance_key,
+		    engine_run_status,
+		    engine_custom_status,
+		    engine_wait_state,
+		    engine_pending_activity_tasks,
+		    engine_pending_inbox_items,
+		    engine_definition_name,
+		    engine_definition_version,
+		    engine_projection_state,
+		    engine_latest_history_id,
+		    engine_last_projected_history_id,
+		    engine_projection_updated_at
+		)
+		VALUES (
+		    $1, $2, $3, $4, $5, $6,
+		    $7, $8, $9, $10, $11,
+		    'running', $12, NULL,
+		    $13, $14, $15,
+		    NULL, NULL, 0, 0,
+		    $16, $17, $18, $19, $19, $20
+		)
+		RETURNING id
+	`,
+		run.ProjectID,
+		seed.SessionID,
+		engineTraceID(run.ID),
+		traceName,
+		seed.UserID,
+		seed.Tags,
+		seed.Environment,
+		seed.Release,
+		cloneBytes(seed.Metadata),
+		cloneRaw(input),
+		nil,
+		startedEvent.CreatedAt,
+		run.ID,
+		instance.InstanceKey,
+		runStatus,
+		instance.DefinitionName,
+		run.DefinitionVersion,
+		projectionState,
+		startedEvent.ID,
+		startedEvent.CreatedAt,
+	).Scan(&traceRowID); err != nil {
+		return err
+	}
+
+	rootSpanName := strings.TrimSpace(instance.DefinitionName)
+	if traceName != nil && strings.TrimSpace(*traceName) != "" {
+		rootSpanName = strings.TrimSpace(*traceName)
+	}
+	if rootSpanName == "" {
+		rootSpanName = "workflow"
+	}
+
+	if _, err := tx.Tx().Exec(ctx, `
+		INSERT INTO public.spans (
+		    project_id,
+		    trace_id,
+		    span_id,
+		    name,
+		    type,
+		    status,
+		    level,
+		    start_time,
+		    input,
+		    depth
+		)
+		VALUES ($1, $2, $3, $4, 'chain', 'running', 'default', $5, $6, 0)
+	`,
+		run.ProjectID,
+		traceRowID,
+		rootSpanExternalID(run.ID),
+		rootSpanName,
+		startedEvent.CreatedAt,
+		cloneRaw(input),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func engineTraceID(runID uuid.UUID) string {
+	return engineTracePrefix + runID.String()
+}
+
+func rootSpanExternalID(runID uuid.UUID) string {
+	return engineRootSpanPrefix + runID.String()
+}
+
+func pgTextPtr(value pgtype.Text) *string {
+	if !value.Valid {
+		return nil
+	}
+	text := value.String
+	return &text
+}
+
+func cloneBytes(raw []byte) []byte {
+	if len(raw) == 0 {
+		return nil
+	}
+	return append([]byte(nil), raw...)
+}
+
+func timeNowUTC() time.Time {
+	return time.Now().UTC()
 }

--- a/engine/internal/workflow/activation.go
+++ b/engine/internal/workflow/activation.go
@@ -85,7 +85,7 @@ func (a *Activator) Activate(ctx context.Context, claimedRun *enginedb.EngineRun
 	if !ok {
 		decision := activationDecision{
 			Kind:         decisionFailed,
-			NextSequence: historyRows[len(historyRows)-1].SequenceNo + 1,
+			NextSequence: nextHistorySequence(historyRows),
 			Events: []queuedHistoryEvent{{
 				EventType: enginehistory.EventWorkflowFailed,
 				Payload: mustMarshalPayload(enginehistory.WorkflowFailedPayload{
@@ -118,6 +118,13 @@ func (a *Activator) Activate(ctx context.Context, claimedRun *enginedb.EngineRun
 	}
 
 	return tx.Commit(ctx)
+}
+
+func nextHistorySequence(historyRows []enginedb.EngineHistory) int32 {
+	if len(historyRows) == 0 {
+		return 1
+	}
+	return historyRows[len(historyRows)-1].SequenceNo + 1
 }
 
 func (a *Activator) commitDecision(

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -227,6 +227,462 @@ func TestActivatorRejectsStaleClaimBeforeAppendingHistory(t *testing.T) {
 	}
 }
 
+func TestActivatorContinueAsNewCreatesNewRunAndInheritedTraceShell(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	testCase := workflowTestCase{
+		projectID:         enginetest.DefaultPlatformProjectID,
+		instanceKey:       "instance-continue-as-new",
+		definitionName:    "continue-demo",
+		definitionVersion: "v1",
+		input:             mustJSON(t, map[string]any{"cursor": 1}),
+	}
+	instance, run := createStartedRun(t, store, testCase)
+	startedHistory := mustStartedHistory(t, store, run.ID)
+	sessionID := insertSession(t, ctx, db.Pool, testCase.projectID, "session-continue-demo")
+	insertProjectedTraceShell(t, ctx, db.Pool, instance, run, "Original Trace", startedHistory.ID)
+	updateProjectedTraceShellFields(t, ctx, db.Pool, run.ID, sessionID)
+
+	if _, err := store.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:    run.ProjectID,
+		InstanceID:   run.InstanceID,
+		RunID:        run.ID,
+		ActivityKey:  "stale-activity",
+		ActivityType: "demo.activity",
+		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
+		AvailableAt:  time.Now().Add(-time.Minute),
+		MaxAttempts:  1,
+	}); err != nil {
+		t.Fatalf("CreateActivityTask() error = %v", err)
+	}
+	timerPayload, err := enginehistory.MarshalPayload(enginehistory.TimerScheduledPayload{
+		TimerKey: "stale-timer",
+		DueAt:    time.Now().Add(time.Hour).UTC(),
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(timer) error = %v", err)
+	}
+	if _, err := store.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   run.ProjectID,
+		InstanceID:  run.InstanceID,
+		RunID:       pgtype.UUID{Bytes: run.ID, Valid: true},
+		Kind:        "timer",
+		Payload:     timerPayload,
+		AvailableAt: time.Now().Add(time.Hour).UTC(),
+	}); err != nil {
+		t.Fatalf("CreateInboxItem() error = %v", err)
+	}
+
+	registry, err := NewRegistry(publicworkflow.Definition{
+		Name:    "continue-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			return publicworkflow.ContinueAsNew(json.RawMessage(`{"cursor":2,"phase":"next"}`))
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+
+	activator := NewActivator(store, registry)
+	if err := activator.Activate(ctx, &claimed); err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+
+	updatedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun(old) error = %v", err)
+	}
+	if updatedRun.Status != enginedb.EngineRunLifecycleStatusContinuedAsNew {
+		t.Fatalf("expected old run status continued_as_new, got %+v", updatedRun)
+	}
+	if !updatedRun.CompletedAt.Valid {
+		t.Fatalf("expected old run completed_at to be set, got %+v", updatedRun)
+	}
+	if !updatedRun.ContinuedToRunID.Valid {
+		t.Fatalf("expected old run continued_to_run_id, got %+v", updatedRun)
+	}
+
+	nextRun, err := store.GetRun(ctx, uuid.UUID(updatedRun.ContinuedToRunID.Bytes))
+	if err != nil {
+		t.Fatalf("GetRun(new) error = %v", err)
+	}
+	if nextRun.RunNumber != 2 {
+		t.Fatalf("expected next run_number=2, got %+v", nextRun)
+	}
+	if nextRun.Status != enginedb.EngineRunLifecycleStatusQueued {
+		t.Fatalf("expected next run queued, got %+v", nextRun)
+	}
+	if !nextRun.ContinuedFromRunID.Valid || uuid.UUID(nextRun.ContinuedFromRunID.Bytes) != run.ID {
+		t.Fatalf("expected bidirectional run linkage, got %+v", nextRun)
+	}
+
+	instanceAfter, err := store.GetInstance(ctx, run.InstanceID)
+	if err != nil {
+		t.Fatalf("GetInstance() error = %v", err)
+	}
+	if instanceAfter.Status != enginedb.EngineInstanceLifecycleStatusActive {
+		t.Fatalf("expected instance to remain active, got %+v", instanceAfter)
+	}
+
+	orderedRuns, err := store.ListRunsByInstance(ctx, enginedb.ListRunsByInstanceParams{
+		InstanceID: run.InstanceID,
+		Limit:      10,
+		Offset:     0,
+	})
+	if err != nil {
+		t.Fatalf("ListRunsByInstance() error = %v", err)
+	}
+	if len(orderedRuns) < 2 || orderedRuns[0].ID != nextRun.ID || orderedRuns[1].ID != run.ID {
+		t.Fatalf("expected latest run ordering by run_number, got %+v", orderedRuns)
+	}
+
+	oldHistory, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun(old) error = %v", err)
+	}
+	lastOldEvent := oldHistory[len(oldHistory)-1]
+	if lastOldEvent.EventType != enginehistory.EventWorkflowContinuedAsNew {
+		t.Fatalf("expected old run terminal continuation event, got %+v", lastOldEvent)
+	}
+	var continuedPayload enginehistory.WorkflowContinuedAsNewPayload
+	if err := enginehistory.UnmarshalPayload(lastOldEvent.Payload, &continuedPayload); err != nil {
+		t.Fatalf("UnmarshalPayload(continued_as_new) error = %v", err)
+	}
+	if string(continuedPayload.Input) != `{"cursor":2,"phase":"next"}` {
+		t.Fatalf("unexpected continuation payload: %s", continuedPayload.Input)
+	}
+
+	newHistory, err := store.GetHistoryByRun(ctx, nextRun.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun(new) error = %v", err)
+	}
+	if len(newHistory) != 1 || newHistory[0].EventType != enginehistory.EventWorkflowStarted {
+		t.Fatalf("expected fresh history on continuation run, got %+v", newHistory)
+	}
+	var newStarted enginehistory.WorkflowStartedPayload
+	if err := enginehistory.UnmarshalPayload(newHistory[0].Payload, &newStarted); err != nil {
+		t.Fatalf("UnmarshalPayload(workflow.started) error = %v", err)
+	}
+	if string(newStarted.Input) != `{"cursor":2,"phase":"next"}` {
+		t.Fatalf("unexpected continuation start input: %s", newStarted.Input)
+	}
+
+	var (
+		newTraceID                string
+		newSessionID              pgtype.UUID
+		newTraceName              *string
+		newUserID                 *string
+		newTags                   []string
+		newEnvironment            *string
+		newRelease                *string
+		newMetadata               []byte
+		newTraceInput             []byte
+		newTraceOutput            []byte
+		newTraceStatus            string
+		newTraceRunStatus         *string
+		newTraceCustomStatus      []byte
+		newTraceWaitState         []byte
+		newPendingActivityTasks   *int64
+		newPendingInboxItems      *int64
+		newDefinitionName         *string
+		newDefinitionVersion      *string
+		newProjectionState        *string
+		newLatestHistoryID        *int64
+		newLastProjectedHistoryID *int64
+	)
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT trace_id,
+		       session_id,
+		       name,
+		       user_id,
+		       tags,
+		       environment,
+		       release,
+		       metadata,
+		       input,
+		       output,
+		       status,
+		       engine_run_status,
+		       engine_custom_status,
+		       engine_wait_state,
+		       engine_pending_activity_tasks,
+		       engine_pending_inbox_items,
+		       engine_definition_name,
+		       engine_definition_version,
+		       engine_projection_state,
+		       engine_latest_history_id,
+		       engine_last_projected_history_id
+		FROM public.traces
+		WHERE engine_run_id = $1
+	`, nextRun.ID).Scan(
+		&newTraceID,
+		&newSessionID,
+		&newTraceName,
+		&newUserID,
+		&newTags,
+		&newEnvironment,
+		&newRelease,
+		&newMetadata,
+		&newTraceInput,
+		&newTraceOutput,
+		&newTraceStatus,
+		&newTraceRunStatus,
+		&newTraceCustomStatus,
+		&newTraceWaitState,
+		&newPendingActivityTasks,
+		&newPendingInboxItems,
+		&newDefinitionName,
+		&newDefinitionVersion,
+		&newProjectionState,
+		&newLatestHistoryID,
+		&newLastProjectedHistoryID,
+	); err != nil {
+		t.Fatalf("query continuation trace shell: %v", err)
+	}
+	if newTraceID != engineTraceID(nextRun.ID) {
+		t.Fatalf("expected derived continuation trace_id, got %q", newTraceID)
+	}
+	if !newSessionID.Valid || uuid.UUID(newSessionID.Bytes) != sessionID {
+		t.Fatalf("expected inherited session link, got %+v", newSessionID)
+	}
+	if newTraceName == nil || *newTraceName != "Original Trace" {
+		t.Fatalf("expected inherited trace name, got %+v", newTraceName)
+	}
+	if newUserID == nil || *newUserID != "user-123" {
+		t.Fatalf("expected inherited user_id, got %+v", newUserID)
+	}
+	if len(newTags) != 2 || newTags[0] != "prod" || newTags[1] != "loop" {
+		t.Fatalf("expected inherited tags, got %+v", newTags)
+	}
+	if newEnvironment == nil || *newEnvironment != "staging" {
+		t.Fatalf("expected inherited environment, got %+v", newEnvironment)
+	}
+	if newRelease == nil || *newRelease != "release-2026.04" {
+		t.Fatalf("expected inherited release, got %+v", newRelease)
+	}
+	if string(newMetadata) != `{"source":"projected-trace"}` {
+		t.Fatalf("expected inherited metadata, got %s", newMetadata)
+	}
+	if string(newTraceInput) != `{"cursor":2,"phase":"next"}` {
+		t.Fatalf("expected continuation trace input, got %s", newTraceInput)
+	}
+	if len(newTraceOutput) != 0 {
+		t.Fatalf("expected continuation trace output to stay null, got %s", newTraceOutput)
+	}
+	if newTraceStatus != "running" {
+		t.Fatalf("expected continuation trace running, got %q", newTraceStatus)
+	}
+	if newTraceRunStatus == nil || *newTraceRunStatus != string(enginedb.EngineRunLifecycleStatusQueued) {
+		t.Fatalf("expected continuation trace run status queued, got %+v", newTraceRunStatus)
+	}
+	if len(newTraceCustomStatus) != 0 || len(newTraceWaitState) != 0 {
+		t.Fatalf("expected nil custom/wait state, got custom=%s wait=%s", newTraceCustomStatus, newTraceWaitState)
+	}
+	if newPendingActivityTasks == nil || *newPendingActivityTasks != 0 || newPendingInboxItems == nil || *newPendingInboxItems != 0 {
+		t.Fatalf("expected zero pending work, got activities=%v inbox=%v", newPendingActivityTasks, newPendingInboxItems)
+	}
+	if newDefinitionName == nil || *newDefinitionName != instance.DefinitionName ||
+		newDefinitionVersion == nil || *newDefinitionVersion != nextRun.DefinitionVersion {
+		t.Fatalf("expected definition linkage on continuation trace, got name=%v version=%v", newDefinitionName, newDefinitionVersion)
+	}
+	if newProjectionState == nil || *newProjectionState != publicprojection.StateUpToDate.String() {
+		t.Fatalf("expected up_to_date projection state, got %+v", newProjectionState)
+	}
+	if newLatestHistoryID == nil || *newLatestHistoryID != newHistory[0].ID || newLastProjectedHistoryID == nil || *newLastProjectedHistoryID != newHistory[0].ID {
+		t.Fatalf("expected continuation trace checkpoints to match started history, got latest=%v last=%v", newLatestHistoryID, newLastProjectedHistoryID)
+	}
+
+	var (
+		rootSpanName   string
+		rootSpanStatus string
+		rootSpanInput  []byte
+	)
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT name, status, input
+		FROM public.spans
+		WHERE trace_id = (
+		        SELECT id
+		        FROM public.traces
+		        WHERE engine_run_id = $1
+		    )
+		  AND span_id = $2
+	`, nextRun.ID, rootSpanExternalID(nextRun.ID)).Scan(&rootSpanName, &rootSpanStatus, &rootSpanInput); err != nil {
+		t.Fatalf("query continuation root span: %v", err)
+	}
+	if rootSpanName != "Original Trace" || rootSpanStatus != "running" {
+		t.Fatalf("unexpected continuation root span summary: name=%q status=%q", rootSpanName, rootSpanStatus)
+	}
+	if string(rootSpanInput) != `{"cursor":2,"phase":"next"}` {
+		t.Fatalf("unexpected continuation root span input: %s", rootSpanInput)
+	}
+
+	cancelledTasks, err := store.ListCancelledActivityTasksByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("ListCancelledActivityTasksByRun() error = %v", err)
+	}
+	if len(cancelledTasks) != 1 || cancelledTasks[0].ActivityKey != "stale-activity" {
+		t.Fatalf("expected cancelled open activity task, got %+v", cancelledTasks)
+	}
+	discardedTimers, err := store.ListDiscardedTimerInboxItemsByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("ListDiscardedTimerInboxItemsByRun() error = %v", err)
+	}
+	if len(discardedTimers) != 1 {
+		t.Fatalf("expected discarded timer inbox item, got %+v", discardedTimers)
+	}
+}
+
+func TestActivatorContinueAsNewFailsWhenProjectedTraceShellIsMissing(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	testCase := workflowTestCase{
+		projectID:         enginetest.DefaultPlatformProjectID,
+		instanceKey:       "instance-continue-missing-shell",
+		definitionName:    "continue-demo",
+		definitionVersion: "v1",
+		input:             mustJSON(t, map[string]any{"cursor": 1}),
+	}
+	_, run := createStartedRun(t, store, testCase)
+
+	registry, err := NewRegistry(publicworkflow.Definition{
+		Name:    "continue-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			return publicworkflow.ContinueAsNew(map[string]any{"cursor": 2})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+
+	activator := NewActivator(store, registry)
+	err = activator.Activate(ctx, &claimed)
+	if !errors.Is(err, enginestore.ErrInvariant) {
+		t.Fatalf("expected ErrInvariant for missing projected trace shell, got %v", err)
+	}
+
+	updatedRun, getErr := store.GetRun(ctx, run.ID)
+	if getErr != nil {
+		t.Fatalf("GetRun() error = %v", getErr)
+	}
+	if updatedRun.Status != enginedb.EngineRunLifecycleStatusRunning {
+		t.Fatalf("expected run state rollback on invariant failure, got %+v", updatedRun)
+	}
+	runs, listErr := store.ListRunsByInstance(ctx, enginedb.ListRunsByInstanceParams{
+		InstanceID: run.InstanceID,
+		Limit:      10,
+		Offset:     0,
+	})
+	if listErr != nil {
+		t.Fatalf("ListRunsByInstance() error = %v", listErr)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected no continuation run to be created, got %+v", runs)
+	}
+}
+
+func TestActivatorContinueAsNewPreservesChainAcrossMultipleHops(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	testCase := workflowTestCase{
+		projectID:         enginetest.DefaultPlatformProjectID,
+		instanceKey:       "instance-continue-chain",
+		definitionName:    "continue-chain",
+		definitionVersion: "v1",
+		input:             mustJSON(t, map[string]any{"cursor": 1}),
+	}
+	instance, run := createStartedRun(t, store, testCase)
+	startedHistory := mustStartedHistory(t, store, run.ID)
+	insertProjectedTraceShell(t, ctx, db.Pool, instance, run, "Continuation Chain", startedHistory.ID)
+
+	registry, err := NewRegistry(publicworkflow.Definition{
+		Name:    "continue-chain",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			var input struct {
+				Cursor int `json:"cursor"`
+			}
+			if err := ctx.Input(&input); err != nil {
+				return err
+			}
+			if input.Cursor < 3 {
+				return publicworkflow.ContinueAsNew(map[string]any{"cursor": input.Cursor + 1})
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	activator := NewActivator(store, registry)
+	for {
+		claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+		if errors.Is(err, enginestore.ErrNotFound) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("ClaimNextRun() error = %v", err)
+		}
+		if err := activator.Activate(ctx, &claimed); err != nil {
+			t.Fatalf("Activate() error = %v", err)
+		}
+	}
+
+	runs, err := store.ListRunsByInstance(ctx, enginedb.ListRunsByInstanceParams{
+		InstanceID: instance.ID,
+		Limit:      10,
+		Offset:     0,
+	})
+	if err != nil {
+		t.Fatalf("ListRunsByInstance() error = %v", err)
+	}
+	if len(runs) != 3 {
+		t.Fatalf("expected three chained runs, got %+v", runs)
+	}
+	if runs[0].RunNumber != 3 || runs[1].RunNumber != 2 || runs[2].RunNumber != 1 {
+		t.Fatalf("expected ordering by descending run_number, got %+v", runs)
+	}
+	if runs[0].Status != enginedb.EngineRunLifecycleStatusCompleted {
+		t.Fatalf("expected final run to complete, got %+v", runs[0])
+	}
+	if runs[1].Status != enginedb.EngineRunLifecycleStatusContinuedAsNew {
+		t.Fatalf("expected middle run to be continued_as_new, got %+v", runs[1])
+	}
+	if runs[2].Status != enginedb.EngineRunLifecycleStatusContinuedAsNew {
+		t.Fatalf("expected first run to be continued_as_new, got %+v", runs[2])
+	}
+	if !runs[0].ContinuedFromRunID.Valid || uuid.UUID(runs[0].ContinuedFromRunID.Bytes) != runs[1].ID {
+		t.Fatalf("expected run 3 to continue from run 2, got %+v", runs[0])
+	}
+	if !runs[1].ContinuedFromRunID.Valid || uuid.UUID(runs[1].ContinuedFromRunID.Bytes) != runs[2].ID {
+		t.Fatalf("expected run 2 to continue from run 1, got %+v", runs[1])
+	}
+	if !runs[1].ContinuedToRunID.Valid || uuid.UUID(runs[1].ContinuedToRunID.Bytes) != runs[0].ID {
+		t.Fatalf("expected run 2 to continue to run 3, got %+v", runs[1])
+	}
+	if !runs[2].ContinuedToRunID.Valid || uuid.UUID(runs[2].ContinuedToRunID.Bytes) != runs[1].ID {
+		t.Fatalf("expected run 1 to continue to run 2, got %+v", runs[2])
+	}
+}
+
 func TestActivatorPersistsActivityRetryOptions(t *testing.T) {
 	db := enginetest.NewTestDatabase(t)
 	store := enginestore.New(db.Pool)
@@ -1108,6 +1564,67 @@ func appendHistoryEvent(
 		Payload:    raw,
 	}); err != nil {
 		t.Fatalf("AppendHistory() error = %v", err)
+	}
+}
+
+func mustStartedHistory(t *testing.T, store *enginestore.Store, runID uuid.UUID) enginedb.EngineHistory {
+	t.Helper()
+
+	historyRows, err := store.GetHistoryByRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	if len(historyRows) == 0 {
+		t.Fatalf("expected started history row for run %s", runID)
+	}
+	return historyRows[0]
+}
+
+func insertSession(
+	t *testing.T,
+	ctx context.Context,
+	pool interface {
+		QueryRow(context.Context, string, ...any) pgx.Row
+	},
+	projectID uuid.UUID,
+	externalID string,
+) uuid.UUID {
+	t.Helper()
+
+	var sessionID uuid.UUID
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO public.sessions (project_id, external_id, name, user_id, metadata)
+		VALUES ($1, $2, 'Session Name', 'session-user', '{"team":"runtime"}')
+		RETURNING id
+	`, projectID, externalID).Scan(&sessionID); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	return sessionID
+}
+
+func updateProjectedTraceShellFields(
+	t *testing.T,
+	ctx context.Context,
+	pool interface {
+		Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	},
+	runID uuid.UUID,
+	sessionID uuid.UUID,
+) {
+	t.Helper()
+
+	if _, err := pool.Exec(ctx, `
+		UPDATE public.traces
+		SET session_id = $2,
+		    name = 'Original Trace',
+		    user_id = 'user-123',
+		    tags = ARRAY['prod', 'loop'],
+		    environment = 'staging',
+		    release = 'release-2026.04',
+		    metadata = '{"source":"projected-trace"}'
+		WHERE engine_run_id = $1
+	`, runID, sessionID); err != nil {
+		t.Fatalf("update projected trace shell fields: %v", err)
 	}
 }
 

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -75,6 +75,61 @@ func TestActivatorFailsRunWhenDefinitionVersionIsMissing(t *testing.T) {
 	}
 }
 
+func TestActivatorFailsRunWhenDefinitionVersionIsMissingWithoutStartedHistory(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      enginetest.DefaultPlatformProjectID,
+		InstanceKey:    "instance-version-mismatch-no-history",
+		DefinitionName: "demo",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         enginetest.DefaultPlatformProjectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v-missing",
+		ReadyAt:           time.Now().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+
+	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	activator := NewActivator(store, registry)
+	if err := activator.Activate(ctx, &claimed); err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+
+	updatedRun, err := store.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if updatedRun.Status != enginedb.EngineRunLifecycleStatusFailed {
+		t.Fatalf("expected failed run status, got %+v", updatedRun)
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	if len(historyRows) != 1 || historyRows[0].SequenceNo != 1 || historyRows[0].EventType != enginehistory.EventWorkflowFailed {
+		t.Fatalf("expected single workflow.failed event at sequence 1, got %+v", historyRows)
+	}
+}
+
 func TestActivatorPersistsReplayMismatchFailure(t *testing.T) {
 	db := enginetest.NewTestDatabase(t)
 	store := enginestore.New(db.Pool)
@@ -1580,6 +1635,7 @@ func mustStartedHistory(t *testing.T, store *enginestore.Store, runID uuid.UUID)
 	return historyRows[0]
 }
 
+//nolint:revive // Keep testing.T first in test helper signatures.
 func insertSession(
 	t *testing.T,
 	ctx context.Context,
@@ -1602,6 +1658,7 @@ func insertSession(
 	return sessionID
 }
 
+//nolint:revive // Keep testing.T first in test helper signatures.
 func updateProjectedTraceShellFields(
 	t *testing.T,
 	ctx context.Context,

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -567,9 +567,7 @@ func TestActivatorContinueAsNewCreatesNewRunAndInheritedTraceShell(t *testing.T)
 	if rootSpanName != "Original Trace" || rootSpanStatus != "running" {
 		t.Fatalf("unexpected continuation root span summary: name=%q status=%q", rootSpanName, rootSpanStatus)
 	}
-	if string(rootSpanInput) != `{"cursor":2,"phase":"next"}` {
-		t.Fatalf("unexpected continuation root span input: %s", rootSpanInput)
-	}
+	assertRawJSONEqual(t, `{"cursor":2,"phase":"next"}`, rootSpanInput)
 
 	cancelledTasks, err := store.ListCancelledActivityTasksByRun(ctx, run.ID)
 	if err != nil {

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -411,9 +411,7 @@ func TestActivatorContinueAsNewCreatesNewRunAndInheritedTraceShell(t *testing.T)
 	if err := enginehistory.UnmarshalPayload(lastOldEvent.Payload, &continuedPayload); err != nil {
 		t.Fatalf("UnmarshalPayload(continued_as_new) error = %v", err)
 	}
-	if string(continuedPayload.Input) != `{"cursor":2,"phase":"next"}` {
-		t.Fatalf("unexpected continuation payload: %s", continuedPayload.Input)
-	}
+	assertRawJSONEqual(t, `{"cursor":2,"phase":"next"}`, continuedPayload.Input)
 
 	newHistory, err := store.GetHistoryByRun(ctx, nextRun.ID)
 	if err != nil {
@@ -426,9 +424,7 @@ func TestActivatorContinueAsNewCreatesNewRunAndInheritedTraceShell(t *testing.T)
 	if err := enginehistory.UnmarshalPayload(newHistory[0].Payload, &newStarted); err != nil {
 		t.Fatalf("UnmarshalPayload(workflow.started) error = %v", err)
 	}
-	if string(newStarted.Input) != `{"cursor":2,"phase":"next"}` {
-		t.Fatalf("unexpected continuation start input: %s", newStarted.Input)
-	}
+	assertRawJSONEqual(t, `{"cursor":2,"phase":"next"}`, newStarted.Input)
 
 	var (
 		newTraceID                string
@@ -1693,6 +1689,30 @@ func mustJSON(t *testing.T, value any) json.RawMessage {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 	return raw
+}
+
+func assertRawJSONEqual(t *testing.T, expected string, actual json.RawMessage) {
+	t.Helper()
+
+	expectedCanonical := canonicalRawJSON(t, json.RawMessage(expected))
+	actualCanonical := canonicalRawJSON(t, actual)
+	if actualCanonical != expectedCanonical {
+		t.Fatalf("unexpected JSON payload: got %s, want %s", actual, expected)
+	}
+}
+
+func canonicalRawJSON(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("json.Unmarshal(%s) error = %v", raw, err)
+	}
+	normalized, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal(%s) error = %v", raw, err)
+	}
+	return string(normalized)
 }
 
 func uuidOrFatal(t *testing.T) uuid.UUID {

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -519,12 +519,8 @@ func TestActivatorContinueAsNewCreatesNewRunAndInheritedTraceShell(t *testing.T)
 	if newRelease == nil || *newRelease != "release-2026.04" {
 		t.Fatalf("expected inherited release, got %+v", newRelease)
 	}
-	if string(newMetadata) != `{"source":"projected-trace"}` {
-		t.Fatalf("expected inherited metadata, got %s", newMetadata)
-	}
-	if string(newTraceInput) != `{"cursor":2,"phase":"next"}` {
-		t.Fatalf("expected continuation trace input, got %s", newTraceInput)
-	}
+	assertRawJSONEqual(t, `{"source":"projected-trace"}`, newMetadata)
+	assertRawJSONEqual(t, `{"cursor":2,"phase":"next"}`, newTraceInput)
 	if len(newTraceOutput) != 0 {
 		t.Fatalf("expected continuation trace output to stay null, got %s", newTraceOutput)
 	}

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -18,10 +18,11 @@ import (
 type decisionKind string
 
 const (
-	decisionWaiting   decisionKind = "waiting"
-	decisionCompleted decisionKind = "completed"
-	decisionFailed    decisionKind = "failed"
-	decisionCancelled decisionKind = "cancelled"
+	decisionWaiting        decisionKind = "waiting"
+	decisionCompleted      decisionKind = "completed"
+	decisionFailed         decisionKind = "failed"
+	decisionCancelled      decisionKind = "cancelled"
+	decisionContinuedAsNew decisionKind = "continued_as_new"
 )
 
 type queuedHistoryEvent struct {
@@ -30,17 +31,18 @@ type queuedHistoryEvent struct {
 }
 
 type activationDecision struct {
-	Kind             decisionKind
-	Events           []queuedHistoryEvent
-	NextSequence     int32
-	WaitingFor       json.RawMessage
-	CustomStatus     json.RawMessage
-	Result           json.RawMessage
-	NewActivity      *newActivityTask
-	NewTimer         *enginehistory.TimerScheduledPayload
-	ConsumedInboxIDs []uuid.UUID
-	FailureCode      string
-	FailureMessage   string
+	Kind              decisionKind
+	Events            []queuedHistoryEvent
+	NextSequence      int32
+	WaitingFor        json.RawMessage
+	CustomStatus      json.RawMessage
+	Result            json.RawMessage
+	NewActivity       *newActivityTask
+	NewTimer          *enginehistory.TimerScheduledPayload
+	ContinuationInput json.RawMessage
+	ConsumedInboxIDs  []uuid.UUID
+	FailureCode       string
+	FailureMessage    string
 }
 
 type newActivityTask struct {
@@ -276,6 +278,23 @@ func (r *workflowRunner) execute(definition publicworkflow.Definition) (decision
 				r.replayMismatch("", "", next, "recorded history contains events after workflow cancellation")
 			}
 			return r.cancelledDecision(), nil
+		}
+		if errors.Is(runErr, publicworkflow.ErrContinueAsNew) {
+			continuationInput, _ := publicworkflow.ContinueAsNewInput(runErr)
+			continuedAsNew := enginehistory.WorkflowContinuedAsNewPayload{Input: cloneRaw(continuationInput)}
+			if next, ok := r.peek(); ok {
+				recorded, ok := next.Payload.(*enginehistory.WorkflowContinuedAsNewPayload)
+				if !ok || !equalJSON(recorded.Input, continuedAsNew.Input) {
+					r.replayMismatch(enginehistory.EventWorkflowContinuedAsNew, "", next, "workflow continuation did not match recorded history")
+				}
+				r.cursor++
+			} else {
+				r.queueEvent(enginehistory.EventWorkflowContinuedAsNew, continuedAsNew)
+			}
+			if next, ok := r.peek(); ok {
+				r.replayMismatch("", "", next, "recorded history contains events after workflow continuation")
+			}
+			return r.continuedAsNewDecision(continuedAsNew.Input), nil
 		}
 
 		code := "workflow_failed"
@@ -696,6 +715,17 @@ func (r *workflowRunner) cancelledDecision() activationDecision {
 		ConsumedInboxIDs: append([]uuid.UUID(nil), r.consumedInboxIDs...),
 		FailureCode:      "cancelled",
 		FailureMessage:   "workflow cancelled",
+	}
+}
+
+func (r *workflowRunner) continuedAsNewDecision(input json.RawMessage) activationDecision {
+	return activationDecision{
+		Kind:              decisionContinuedAsNew,
+		Events:            append([]queuedHistoryEvent(nil), r.queuedEvents...),
+		NextSequence:      r.nextSequence,
+		CustomStatus:      cloneRaw(r.customStatus),
+		ContinuationInput: cloneRaw(input),
+		ConsumedInboxIDs:  append([]uuid.UUID(nil), r.consumedInboxIDs...),
 	}
 }
 

--- a/engine/internal/workflow/replay_test.go
+++ b/engine/internal/workflow/replay_test.go
@@ -102,6 +102,132 @@ func TestReplayDefinitionMismatchProducesFailureDecision(t *testing.T) {
 	}
 }
 
+func TestReplayDefinitionContinueAsNewFirstExecution(t *testing.T) {
+	input := mustRawJSON(t, map[string]any{"cursor": 1})
+	continuationInput := mustRawJSON(t, map[string]any{"cursor": 2, "phase": "next"})
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "continue-demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-continue-demo",
+			Input:             input,
+		}),
+	}
+
+	decision, err := replayDefinition(continueAsNewDefinition(json.RawMessage(continuationInput)), historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionContinuedAsNew {
+		t.Fatalf("expected continued-as-new decision, got %+v", decision)
+	}
+	if len(decision.Events) != 1 {
+		t.Fatalf("expected workflow.continued_as_new event, got %+v", decision.Events)
+	}
+	if decision.Events[0].EventType != enginehistory.EventWorkflowContinuedAsNew {
+		t.Fatalf("expected workflow.continued_as_new event, got %+v", decision.Events[0])
+	}
+	if !equalJSON(decision.ContinuationInput, continuationInput) {
+		t.Fatalf("expected continuation input %s, got %s", continuationInput, decision.ContinuationInput)
+	}
+}
+
+func TestReplayDefinitionContinueAsNewMatchesRecordedHistory(t *testing.T) {
+	input := mustRawJSON(t, map[string]any{"cursor": 1})
+	continuationInput := mustRawJSON(t, map[string]any{"cursor": 2, "phase": "next"})
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "continue-demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-continue-demo",
+			Input:             input,
+		}),
+		historyRow(t, 2, enginehistory.EventWorkflowContinuedAsNew, enginehistory.WorkflowContinuedAsNewPayload{
+			Input: continuationInput,
+		}),
+	}
+
+	decision, err := replayDefinition(continueAsNewDefinition(json.RawMessage(continuationInput)), historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionContinuedAsNew {
+		t.Fatalf("expected continued-as-new decision, got %+v", decision)
+	}
+	if len(decision.Events) != 0 {
+		t.Fatalf("expected replay to avoid new continuation events, got %+v", decision.Events)
+	}
+}
+
+func TestReplayDefinitionContinueAsNewMatchesSemanticallyEquivalentJSON(t *testing.T) {
+	input := mustRawJSON(t, map[string]any{"cursor": 1})
+	recordedInput := json.RawMessage(`{"a":1,"b":2}`)
+	replayedInput := json.RawMessage(`{"b":2,"a":1}`)
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "continue-demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-continue-demo",
+			Input:             input,
+		}),
+		historyRow(t, 2, enginehistory.EventWorkflowContinuedAsNew, enginehistory.WorkflowContinuedAsNewPayload{
+			Input: recordedInput,
+		}),
+	}
+
+	decision, err := replayDefinition(continueAsNewDefinition(replayedInput), historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionContinuedAsNew {
+		t.Fatalf("expected continued-as-new decision, got %+v", decision)
+	}
+	if len(decision.Events) != 0 {
+		t.Fatalf("expected semantic JSON replay equality to avoid new events, got %+v", decision.Events)
+	}
+	if !equalJSON(decision.ContinuationInput, recordedInput) {
+		t.Fatalf("expected continuation input to match recorded JSON, got %s", decision.ContinuationInput)
+	}
+}
+
+func TestReplayDefinitionContinueAsNewMismatchProducesFailureDecision(t *testing.T) {
+	input := mustRawJSON(t, map[string]any{"cursor": 1})
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "continue-demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-continue-demo",
+			Input:             input,
+		}),
+		historyRow(t, 2, enginehistory.EventWorkflowContinuedAsNew, enginehistory.WorkflowContinuedAsNewPayload{
+			Input: mustRawJSON(t, map[string]any{"cursor": 2}),
+		}),
+	}
+
+	decision, err := replayDefinition(publicworkflow.Definition{
+		Name:    "continue-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			return ctx.SetResult(map[string]bool{"done": true})
+		},
+	}, historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionFailed {
+		t.Fatalf("expected failed decision, got %+v", decision)
+	}
+	if len(decision.Events) != 2 {
+		t.Fatalf("expected replay mismatch + workflow failed events, got %+v", decision.Events)
+	}
+	if decision.Events[0].EventType != enginehistory.EventWorkflowReplayMismatch {
+		t.Fatalf("expected first event to be workflow.replay_mismatch, got %+v", decision.Events[0])
+	}
+	if decision.Events[1].EventType != enginehistory.EventWorkflowFailed {
+		t.Fatalf("expected second event to be workflow.failed, got %+v", decision.Events[1])
+	}
+}
+
 func TestReplayDefinitionSkipsRecordedActivityRetryEvents(t *testing.T) {
 	input := mustRawJSON(t, map[string]string{"name": "Ada"})
 	output := mustRawJSON(t, map[string]string{"greeting": "hello, Ada"})
@@ -725,6 +851,20 @@ func testDefinition(timerAt time.Time) publicworkflow.Definition {
 				"greeting": output["greeting"],
 				"approval": signal["approval"],
 			})
+		},
+	}
+}
+
+func continueAsNewDefinition(nextInput any) publicworkflow.Definition {
+	return publicworkflow.Definition{
+		Name:    "continue-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			var input map[string]any
+			if err := ctx.Input(&input); err != nil {
+				return err
+			}
+			return publicworkflow.ContinueAsNew(nextInput)
 		},
 	}
 }

--- a/engine/internal/workflow/replay_test.go
+++ b/engine/internal/workflow/replay_test.go
@@ -114,7 +114,7 @@ func TestReplayDefinitionContinueAsNewFirstExecution(t *testing.T) {
 		}),
 	}
 
-	decision, err := replayDefinition(continueAsNewDefinition(json.RawMessage(continuationInput)), historyRows, nil, nil)
+	decision, err := replayDefinition(continueAsNewDefinition(continuationInput), historyRows, nil, nil)
 	if err != nil {
 		t.Fatalf("replayDefinition() error = %v", err)
 	}
@@ -147,7 +147,7 @@ func TestReplayDefinitionContinueAsNewMatchesRecordedHistory(t *testing.T) {
 		}),
 	}
 
-	decision, err := replayDefinition(continueAsNewDefinition(json.RawMessage(continuationInput)), historyRows, nil, nil)
+	decision, err := replayDefinition(continueAsNewDefinition(continuationInput), historyRows, nil, nil)
 	if err != nil {
 		t.Fatalf("replayDefinition() error = %v", err)
 	}

--- a/engine/pkg/history/history.go
+++ b/engine/pkg/history/history.go
@@ -11,6 +11,7 @@ const (
 	EventWorkflowCompleted      = "workflow.completed"
 	EventWorkflowFailed         = "workflow.failed"
 	EventWorkflowCancelled      = "workflow.cancelled"
+	EventWorkflowContinuedAsNew = "workflow.continued_as_new"
 	EventWorkflowSuspended      = "workflow.suspended"
 	EventWorkflowResumed        = "workflow.resumed"
 	EventWorkflowTerminated     = "workflow.terminated"
@@ -49,6 +50,10 @@ type WorkflowFailedPayload struct {
 }
 
 type WorkflowCancelledPayload struct{}
+
+type WorkflowContinuedAsNewPayload struct {
+	Input json.RawMessage `json:"input,omitempty"`
+}
 
 type WorkflowSuspendedPayload struct{}
 
@@ -159,6 +164,9 @@ func DecodePayload(eventType string, raw []byte) (any, error) {
 		if eventType == EventWorkflowCancelled {
 			return WorkflowCancelledPayload{}, nil
 		}
+		if eventType == EventWorkflowContinuedAsNew {
+			return WorkflowContinuedAsNewPayload{}, nil
+		}
 		if eventType == EventWorkflowSuspended {
 			return WorkflowSuspendedPayload{}, nil
 		}
@@ -223,6 +231,8 @@ func payloadTarget(eventType string) (any, error) {
 		return &WorkflowFailedPayload{}, nil
 	case EventWorkflowCancelled:
 		return &WorkflowCancelledPayload{}, nil
+	case EventWorkflowContinuedAsNew:
+		return &WorkflowContinuedAsNewPayload{}, nil
 	case EventWorkflowSuspended:
 		return &WorkflowSuspendedPayload{}, nil
 	case EventWorkflowResumed:

--- a/engine/pkg/history/history_test.go
+++ b/engine/pkg/history/history_test.go
@@ -22,6 +22,29 @@ func TestDecodePayloadRoundTripsCancelledAndTerminated(t *testing.T) {
 		}
 	})
 
+	t.Run("workflow.continued_as_new", func(t *testing.T) {
+		expected := WorkflowContinuedAsNewPayload{
+			Input: []byte(`{"cursor":2,"batch":"next"}`),
+		}
+		raw, err := MarshalPayload(expected)
+		if err != nil {
+			t.Fatalf("MarshalPayload() error = %v", err)
+		}
+
+		payload, err := DecodePayload(EventWorkflowContinuedAsNew, raw)
+		if err != nil {
+			t.Fatalf("DecodePayload() error = %v", err)
+		}
+
+		typed, ok := payload.(*WorkflowContinuedAsNewPayload)
+		if !ok {
+			t.Fatalf("expected *WorkflowContinuedAsNewPayload, got %T", payload)
+		}
+		if string(typed.Input) != string(expected.Input) {
+			t.Fatalf("unexpected continued-as-new payload: %s", typed.Input)
+		}
+	})
+
 	t.Run("workflow.suspended", func(t *testing.T) {
 		raw, err := MarshalPayload(WorkflowSuspendedPayload{})
 		if err != nil {

--- a/engine/pkg/projection/terminal.go
+++ b/engine/pkg/projection/terminal.go
@@ -6,6 +6,8 @@ func TerminalStatuses(runStatus string) (traceStatus, spanStatus string) {
 	switch runStatus {
 	case "completed":
 		return "completed", "completed"
+	case "continued_as_new":
+		return "completed", "completed"
 	case "cancelled":
 		return "cancelled", "failed"
 	case "terminated":
@@ -23,6 +25,9 @@ func TerminalOutputPayload(
 ) (json.RawMessage, error) {
 	if runStatus == "completed" {
 		return cloneRaw(result), nil
+	}
+	if runStatus == "continued_as_new" {
+		return nil, nil
 	}
 	return json.Marshal(map[string]any{
 		"error_code":    derefString(errorCode),

--- a/engine/pkg/projection/terminal_test.go
+++ b/engine/pkg/projection/terminal_test.go
@@ -13,6 +13,7 @@ func TestTerminalStatuses(t *testing.T) {
 		wantSpan  string
 	}{
 		{name: "completed", runStatus: "completed", wantTrace: "completed", wantSpan: "completed"},
+		{name: "continued_as_new", runStatus: "continued_as_new", wantTrace: "completed", wantSpan: "completed"},
 		{name: "cancelled", runStatus: "cancelled", wantTrace: "cancelled", wantSpan: "failed"},
 		{name: "terminated", runStatus: "terminated", wantTrace: "failed", wantSpan: "failed"},
 		{name: "failed", runStatus: "failed", wantTrace: "failed", wantSpan: "failed"},
@@ -54,6 +55,16 @@ func TestTerminalOutputPayload(t *testing.T) {
 		}
 		if payload["error_code"] != errorCode || payload["error_message"] != errorMessage || payload["status"] != "terminated" {
 			t.Fatalf("unexpected payload: %+v", payload)
+		}
+	})
+
+	t.Run("continued_as_new keeps terminal output empty", func(t *testing.T) {
+		got, err := TerminalOutputPayload("continued_as_new", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("TerminalOutputPayload() error = %v", err)
+		}
+		if got != nil {
+			t.Fatalf("TerminalOutputPayload() = %s, want nil", got)
 		}
 	})
 }

--- a/engine/pkg/workflow/context.go
+++ b/engine/pkg/workflow/context.go
@@ -1,8 +1,11 @@
 package workflow
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
+
+	publichistory "github.com/continua-ai/continua/engine/pkg/history"
 )
 
 var ErrEmptyKey = errors.New("workflow: stable key is required")
@@ -12,6 +15,52 @@ var ErrEmptyKey = errors.New("workflow: stable key is required")
 // run to CANCELLED; returning nil after observing cancellation still produces
 // COMPLETED. Replay consults this sentinel through errors.Is.
 var ErrCancelled = errors.New("workflow: cancelled")
+
+// ErrContinueAsNew is the explicit replay-aware continuation sentinel.
+// Returning it records a terminal workflow.continued_as_new event and causes
+// the engine to atomically create the next run for the same instance. Replay
+// consults this sentinel through errors.Is.
+var ErrContinueAsNew = errors.New("workflow: continue as new")
+
+type continueAsNewError struct {
+	input json.RawMessage
+}
+
+func (e *continueAsNewError) Error() string {
+	return ErrContinueAsNew.Error()
+}
+
+func (e *continueAsNewError) Unwrap() error {
+	return ErrContinueAsNew
+}
+
+func (e *continueAsNewError) Input() json.RawMessage {
+	if len(e.input) == 0 {
+		return nil
+	}
+	return append(json.RawMessage(nil), e.input...)
+}
+
+// ContinueAsNew requests that the current run terminate and immediately start a
+// fresh run of the same instance with the provided input.
+func ContinueAsNew(input any) error {
+	raw, err := publichistory.MarshalPayload(input)
+	if err != nil {
+		return err
+	}
+
+	return &continueAsNewError{input: raw}
+}
+
+// ContinueAsNewInput extracts the marshaled continuation input from an error
+// wrapping ErrContinueAsNew.
+func ContinueAsNewInput(err error) (json.RawMessage, bool) {
+	var continuation *continueAsNewError
+	if errors.As(err, &continuation) {
+		return continuation.Input(), true
+	}
+	return nil, errors.Is(err, ErrContinueAsNew)
+}
 
 type Context interface {
 	Input(out any) error

--- a/engine/pkg/workflow/context_test.go
+++ b/engine/pkg/workflow/context_test.go
@@ -1,0 +1,60 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestContinueAsNewCreatesWrappedSentinel(t *testing.T) {
+	err := ContinueAsNew(map[string]any{"cursor": 7, "phase": "next"})
+	if err == nil {
+		t.Fatal("ContinueAsNew() returned nil")
+	}
+	if !errors.Is(err, ErrContinueAsNew) {
+		t.Fatalf("errors.Is(err, ErrContinueAsNew) = false for %v", err)
+	}
+
+	input, ok := ContinueAsNewInput(err)
+	if !ok {
+		t.Fatal("ContinueAsNewInput() = not found")
+	}
+	if got := string(input); got != `{"cursor":7,"phase":"next"}` {
+		t.Fatalf("ContinueAsNewInput() = %s", got)
+	}
+}
+
+func TestContinueAsNewInputFindsWrappedError(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", mustContinueAsNewError(t, map[string]any{"cursor": 9}))
+	if !errors.Is(err, ErrContinueAsNew) {
+		t.Fatalf("wrapped continuation error does not satisfy errors.Is: %v", err)
+	}
+
+	input, ok := ContinueAsNewInput(err)
+	if !ok {
+		t.Fatal("ContinueAsNewInput() did not find wrapped continuation error")
+	}
+	if got := string(input); got != `{"cursor":9}` {
+		t.Fatalf("ContinueAsNewInput() = %s", got)
+	}
+}
+
+func TestContinueAsNewRejectsUnmarshalableInput(t *testing.T) {
+	err := ContinueAsNew(make(chan int))
+	if err == nil {
+		t.Fatal("ContinueAsNew() unexpectedly succeeded")
+	}
+	if errors.Is(err, ErrContinueAsNew) {
+		t.Fatalf("marshal failure should not satisfy ErrContinueAsNew: %v", err)
+	}
+}
+
+func mustContinueAsNewError(t *testing.T, input any) error {
+	t.Helper()
+
+	err := ContinueAsNew(input)
+	if err == nil {
+		t.Fatal("ContinueAsNew() returned nil")
+	}
+	return err
+}

--- a/internal/api/engine_control.go
+++ b/internal/api/engine_control.go
@@ -72,6 +72,10 @@ type engineRunSummary struct {
 	RunID                uuid.UUID
 	InstanceID           uuid.UUID
 	InstanceKey          string
+	ContinuedFromRunID   *uuid.UUID
+	ContinuedToRunID     *uuid.UUID
+	ContinuedFromTraceID *string
+	ContinuedToTraceID   *string
 	DefinitionName       string
 	DefinitionVersion    string
 	ProjectionState      string
@@ -473,7 +477,8 @@ func (s *engineControlService) GetRunResult(
 	}
 
 	if summary.Status == enginedb.EngineRunLifecycleStatusCancelled ||
-		summary.Status == enginedb.EngineRunLifecycleStatusTerminated {
+		summary.Status == enginedb.EngineRunLifecycleStatusTerminated ||
+		summary.Status == enginedb.EngineRunLifecycleStatusContinuedAsNew {
 		summary.Result = nil
 	}
 
@@ -1085,6 +1090,10 @@ func (s *engineControlService) buildRunSummary(
 		RunID:                run.ID,
 		InstanceID:           instance.ID,
 		InstanceKey:          instance.InstanceKey,
+		ContinuedFromRunID:   pgUUIDPtr(run.ContinuedFromRunID),
+		ContinuedToRunID:     pgUUIDPtr(run.ContinuedToRunID),
+		ContinuedFromTraceID: engineTraceIDPtr(pgUUIDPtr(run.ContinuedFromRunID)),
+		ContinuedToTraceID:   engineTraceIDPtr(pgUUIDPtr(run.ContinuedToRunID)),
 		DefinitionName:       instance.DefinitionName,
 		DefinitionVersion:    run.DefinitionVersion,
 		ProjectionState:      projectionState,
@@ -1339,7 +1348,8 @@ func isTerminalEngineRun(status enginedb.EngineRunLifecycleStatus) bool {
 	case enginedb.EngineRunLifecycleStatusCompleted,
 		enginedb.EngineRunLifecycleStatusFailed,
 		enginedb.EngineRunLifecycleStatusCancelled,
-		enginedb.EngineRunLifecycleStatusTerminated:
+		enginedb.EngineRunLifecycleStatusTerminated,
+		enginedb.EngineRunLifecycleStatusContinuedAsNew:
 		return true
 	default:
 		return false
@@ -1351,8 +1361,15 @@ func terminalRunSummaryFromRun(run *enginedb.EngineRun) engineRunSummary {
 		return engineRunSummary{}
 	}
 
+	continuedFromRunID := pgUUIDPtr(run.ContinuedFromRunID)
+	continuedToRunID := pgUUIDPtr(run.ContinuedToRunID)
+
 	return engineRunSummary{
 		RunID:                run.ID,
+		ContinuedFromRunID:   continuedFromRunID,
+		ContinuedToRunID:     continuedToRunID,
+		ContinuedFromTraceID: engineTraceIDPtr(continuedFromRunID),
+		ContinuedToTraceID:   engineTraceIDPtr(continuedToRunID),
 		Status:               run.Status,
 		Result:               cloneRaw(run.Result),
 		LastErrorCode:        run.LastErrorCode,

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -994,7 +994,7 @@ func TestTerminateEngineRun_ProjectorEventuallyProjectsTerminalCleanup(t *testin
 	assert.Equal(t, string(enginedb.EngineRunLifecycleStatusWaiting), beforeRunStatus)
 	require.NotEmpty(t, beforeWaitState)
 
-	engineServe := startExternalEngineServeProcess(t)
+	engineServe := startExternalEngineServeProcess(t, projectID)
 	defer engineServe.stop(t)
 
 	traceStatus, runStatus, waitState := waitForProjectedTraceTerminalSummary(t, platformStore.Pool(), trace.ID)
@@ -1312,6 +1312,7 @@ func TestSuspendResumeEngineRun_SignalAccumulatedDuringSuspension(t *testing.T) 
 
 	engineServe := startExternalEngineServeProcessWithEnv(
 		t,
+		projectID,
 		"ENGINE_ACTIVITY_POLL_INTERVAL=50ms",
 		"ENGINE_MAINTENANCE_POLL_INTERVAL=50ms",
 	)
@@ -1361,6 +1362,7 @@ func TestSuspendResumeEngineRun_TimerFiresDuringSuspensionAndProcessesOnResume(t
 
 	engineServe := startExternalEngineServeProcessWithEnv(
 		t,
+		projectID,
 		"ENGINE_ACTIVITY_POLL_INTERVAL=50ms",
 		"ENGINE_MAINTENANCE_POLL_INTERVAL=50ms",
 	)
@@ -1408,6 +1410,7 @@ func TestSuspendResumeEngineRun_CancelDuringSuspensionCancelsOnResume(t *testing
 
 	engineServe := startExternalEngineServeProcessWithEnv(
 		t,
+		projectID,
 		"ENGINE_ACTIVITY_POLL_INTERVAL=50ms",
 		"ENGINE_MAINTENANCE_POLL_INTERVAL=50ms",
 	)
@@ -1448,6 +1451,7 @@ func TestSuspendResumeEngineRun_ActivityCompletesDuringSuspensionAndIsObservedAf
 	releaseFile := filepath.Join(t.TempDir(), "activity.release")
 	engineServe := startExternalEngineServeProcessWithEnv(
 		t,
+		projectID,
 		"ENGINE_ACTIVITY_POLL_INTERVAL=50ms",
 		"ENGINE_MAINTENANCE_POLL_INTERVAL=50ms",
 		"CONTINUA_ENGINE_TEST_ACTIVITY_RELEASE_FILE="+releaseFile,
@@ -1501,6 +1505,7 @@ func TestSuspendResumeEngineRun_RetryExhaustedDuringSuspensionFailsAfterResume(t
 
 	engineServe := startExternalEngineServeProcessWithEnv(
 		t,
+		projectID,
 		"ENGINE_ACTIVITY_POLL_INTERVAL=50ms",
 		"ENGINE_MAINTENANCE_POLL_INTERVAL=50ms",
 		"CONTINUA_ENGINE_TEST_ACTIVITY_FAIL_COUNT=2",
@@ -1560,6 +1565,7 @@ func TestSuspendResumeEngineRun_RetryScheduledDuringSuspensionCompletesAfterResu
 
 	engineServe := startExternalEngineServeProcessWithEnv(
 		t,
+		projectID,
 		"ENGINE_ACTIVITY_POLL_INTERVAL=50ms",
 		"ENGINE_MAINTENANCE_POLL_INTERVAL=50ms",
 		"CONTINUA_ENGINE_TEST_ACTIVITY_FAIL_COUNT=1",
@@ -2141,7 +2147,7 @@ func TestRepairEngineRun_ProjectorEventuallyRebuildsPurgedDetail(t *testing.T) {
 	assert.Equal(t, RepairRequested, repair.Reason)
 	assert.Equal(t, CatchingUp, repair.ProjectionState)
 
-	engineServe := startExternalEngineServeProcess(t)
+	engineServe := startExternalEngineServeProcess(t, projectID)
 	defer engineServe.stop(t)
 
 	waitForProjectedTraceCaughtUp(t, ctx, platformStore.Pool(), trace.ID, activityHistory.ID)
@@ -2421,7 +2427,7 @@ func TestEngineRunPendingWorkCountsStayConsistentAcrossRunReadAndProjectedSummar
 	})
 	require.NoError(t, err)
 
-	engineServe := startExternalEngineServeProcess(t)
+	engineServe := startExternalEngineServeProcess(t, projectID)
 	defer engineServe.stop(t)
 	waitForProjectedTracePendingInboxItems(t, ctx, platformStore.Pool(), trace.ID, timerHistory.ID, 2)
 
@@ -3273,11 +3279,11 @@ func (b *lockedBuffer) String() string {
 	return b.buf.String()
 }
 
-func startExternalEngineServeProcess(t *testing.T) *externalEngineServeProcess {
-	return startExternalEngineServeProcessWithEnv(t)
+func startExternalEngineServeProcess(t *testing.T, projectID uuid.UUID) *externalEngineServeProcess {
+	return startExternalEngineServeProcessWithEnv(t, projectID)
 }
 
-func startExternalEngineServeProcessWithEnv(t *testing.T, extraEnv ...string) *externalEngineServeProcess {
+func startExternalEngineServeProcessWithEnv(t *testing.T, projectID uuid.UUID, extraEnv ...string) *externalEngineServeProcess {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3293,6 +3299,7 @@ func startExternalEngineServeProcessWithEnv(t *testing.T, extraEnv ...string) *e
 		"ENGINE_RUN_LEASE_TTL=500ms",
 		"ENGINE_ACTIVITY_LEASE_TTL=500ms",
 		"ENGINE_REQUEST_DEDUPE_TTL=2s",
+		"CONTINUA_ENGINE_TEST_PROJECT_FILTER="+projectID.String(),
 	)
 	cmd.Env = applyEnvOverrides(cmd.Env, extraEnv...)
 

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -564,6 +564,141 @@ func TestEngineHandlers_ReadSignalCancelAndTraceSurfaces(t *testing.T) {
 	assert.Equal(t, "run_terminal", decodeJSONBody[Error](t, terminalSignalRec).Code)
 }
 
+func TestEngineHandlers_ExposeContinuationChainAcrossReadSurfaces(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-continue-read",
+		RequestKey:        "req-continue-read",
+	}))
+
+	oldRun, err := engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        start.RunId,
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Round(time.Microsecond)
+	nextRun, err := engineQueries.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:          projectID,
+		InstanceID:         oldRun.InstanceID,
+		RunNumber:          oldRun.RunNumber + 1,
+		DefinitionVersion:  oldRun.DefinitionVersion,
+		ReadyAt:            now,
+		ContinuedFromRunID: pgtype.UUID{Bytes: oldRun.ID, Valid: true},
+	})
+	require.NoError(t, err)
+
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'continued_as_new',
+		    completed_at = $2,
+		    updated_at = $2,
+		    continued_to_run_id = $3,
+		    waiting_for = NULL,
+		    claimed_by = NULL,
+		    claimed_at = NULL,
+		    lease_expires_at = NULL
+		WHERE id = $1
+	`, oldRun.ID, now, nextRun.ID)
+	require.NoError(t, err)
+
+	oldTrace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE traces
+		SET status = 'completed',
+		    end_time = $2,
+		    output = NULL,
+		    engine_run_status = 'continued_as_new',
+		    engine_projection_state = 'up_to_date',
+		    engine_projection_updated_at = $2,
+		    updated_at = $2
+		WHERE id = $1
+	`, oldTrace.ID, now)
+	require.NoError(t, err)
+
+	nextTrace := upsertTraceRecord(ctx, t, platformStore.Queries(), platformdb.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "engine:" + nextRun.ID.String(),
+		Name:      testutil.StrPtr("Checkout Workflow"),
+		Status:    "running",
+		StartTime: testutil.PgtypeTimestamptz(now),
+	})
+
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE traces
+		SET engine_run_id = $2,
+		    engine_instance_key = $3,
+		    engine_definition_name = 'checkout',
+		    engine_definition_version = 'v1',
+		    engine_run_status = 'queued',
+		    engine_projection_state = 'up_to_date',
+		    engine_projection_updated_at = $4,
+		    updated_at = $4
+		WHERE id = $1
+	`, nextTrace.ID, nextRun.ID, "instance-continue-read", now)
+	require.NoError(t, err)
+
+	instanceRec := invokeGetEngineInstance(t, server, projectID, "instance-continue-read")
+	require.Equal(t, http.StatusOK, instanceRec.Code)
+	instanceResp := decodeJSONBody[EngineInstanceResponse](t, instanceRec)
+	assert.Equal(t, nextRun.ID, instanceResp.CurrentRun.RunId)
+	assert.Equal(t, EngineRunStatusQUEUED, instanceResp.CurrentRun.Status)
+	require.NotNil(t, instanceResp.CurrentRun.ContinuedFromRunId)
+	assert.Equal(t, oldRun.ID, *instanceResp.CurrentRun.ContinuedFromRunId)
+	require.NotNil(t, instanceResp.CurrentRun.ContinuedFromTraceId)
+	assert.Equal(t, "engine:"+oldRun.ID.String(), *instanceResp.CurrentRun.ContinuedFromTraceId)
+
+	runRec := invokeGetEngineRun(t, server, projectID, oldRun.ID)
+	require.Equal(t, http.StatusOK, runRec.Code)
+	runResp := decodeJSONBody[EngineRunResponse](t, runRec)
+	assert.Equal(t, EngineRunStatusCONTINUEDASNEW, runResp.Status)
+	require.NotNil(t, runResp.ContinuedToRunId)
+	assert.Equal(t, nextRun.ID, *runResp.ContinuedToRunId)
+	require.NotNil(t, runResp.ContinuedToTraceId)
+	assert.Equal(t, "engine:"+nextRun.ID.String(), *runResp.ContinuedToTraceId)
+
+	resultRec := invokeGetEngineRunResult(t, server, projectID, oldRun.ID)
+	require.Equal(t, http.StatusOK, resultRec.Code)
+	assertJSONFieldNull(t, resultRec.Body.Bytes(), "result")
+	resultResp := decodeJSONBody[EngineRunResultResponse](t, resultRec)
+	assert.Equal(t, EngineRunStatusCONTINUEDASNEW, resultResp.Status)
+	assert.Nil(t, resultResp.Result)
+	require.NotNil(t, resultResp.ContinuedToRunId)
+	assert.Equal(t, nextRun.ID, *resultResp.ContinuedToRunId)
+	require.NotNil(t, resultResp.ContinuedToTraceId)
+	assert.Equal(t, "engine:"+nextRun.ID.String(), *resultResp.ContinuedToTraceId)
+
+	terminateRec := invokeTerminateEngineRun(t, server, projectID, oldRun.ID)
+	require.Equal(t, http.StatusOK, terminateRec.Code)
+	assertJSONFieldNull(t, terminateRec.Body.Bytes(), "result")
+	terminateResp := decodeJSONBody[EngineRunResultResponse](t, terminateRec)
+	assert.Equal(t, EngineRunStatusCONTINUEDASNEW, terminateResp.Status)
+	assert.Nil(t, terminateResp.Result)
+	require.NotNil(t, terminateResp.ContinuedToRunId)
+	assert.Equal(t, nextRun.ID, *terminateResp.ContinuedToRunId)
+	require.NotNil(t, terminateResp.ContinuedToTraceId)
+	assert.Equal(t, "engine:"+nextRun.ID.String(), *terminateResp.ContinuedToTraceId)
+
+	traceRec := invokeGetTrace(t, server, projectID, oldTrace.ID)
+	require.Equal(t, http.StatusOK, traceRec.Code)
+	traceResp := decodeJSONBody[TraceDetail](t, traceRec)
+	require.NotNil(t, traceResp.Engine)
+	assert.Equal(t, EngineRunStatusCONTINUEDASNEW, traceResp.Engine.Status)
+	require.NotNil(t, traceResp.Engine.ContinuedToRunId)
+	assert.Equal(t, nextRun.ID, *traceResp.Engine.ContinuedToRunId)
+	require.NotNil(t, traceResp.Engine.ContinuedToTraceId)
+	assert.Equal(t, "engine:"+nextRun.ID.String(), *traceResp.Engine.ContinuedToTraceId)
+}
+
 func TestGetEngineRunResult_ReturnsCancelledFailureSummary(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
@@ -1744,6 +1879,56 @@ func TestPurgeEngineRun_RejectsNonTerminalRun(t *testing.T) {
 	rec := invokePurgeEngineRun(t, server, projectID, start.RunId, ProjectionOnly)
 	require.Equal(t, http.StatusConflict, rec.Code)
 	assert.Equal(t, "run_not_terminal", decodeJSONBody[Error](t, rec).Code)
+}
+
+func TestPurgeEngineRun_AcceptsContinuedAsNewRun(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-purge-continued",
+		RequestKey:        "req-purge-continued",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	completedAt := time.Now().UTC().Round(time.Microsecond)
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'continued_as_new',
+		    waiting_for = NULL,
+		    result = NULL,
+		    completed_at = $2,
+		    updated_at = $2
+		WHERE id = $1
+	`, start.RunId, completedAt)
+	require.NoError(t, err)
+
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE traces
+		SET status = 'completed',
+		    end_time = $2,
+		    output = NULL,
+		    engine_run_status = 'continued_as_new',
+		    engine_projection_state = 'up_to_date',
+		    engine_projection_updated_at = $2,
+		    updated_at = $2
+		WHERE id = $1
+	`, trace.ID, completedAt)
+	require.NoError(t, err)
+
+	rec := invokePurgeEngineRun(t, server, projectID, start.RunId, ProjectionOnly)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[EnginePurgeResponse](t, rec)
+	assert.True(t, resp.Deleted)
+	assert.Equal(t, SummaryOnly, resp.ProjectionState)
 }
 
 func TestPurgeEngineRun_ReturnsNotFoundForMissingRunAndCrossProject(t *testing.T) {

--- a/internal/api/engine_mapper.go
+++ b/internal/api/engine_mapper.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
-	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
@@ -500,7 +500,7 @@ func openapiUUIDPtr(value *uuid.UUID) *openapi_types.UUID {
 	if value == nil {
 		return nil
 	}
-	id := openapi_types.UUID(*value)
+	id := *value
 	return &id
 }
 

--- a/internal/api/engine_mapper.go
+++ b/internal/api/engine_mapper.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -26,55 +27,68 @@ func engineInstanceResponseToAPI(result *engineInstanceResult) EngineInstanceRes
 
 func engineRunResponseToAPI(summary *engineRunSummary) EngineRunResponse {
 	return EngineRunResponse{
-		CompletedAt:       summary.CompletedAt,
-		CreatedAt:         summary.CreatedAt,
-		CustomStatus:      parseOptionalJSONObjectRaw(summary.CustomStatus),
-		DefinitionName:    summary.DefinitionName,
-		DefinitionVersion: summary.DefinitionVersion,
-		Failure:           engineFailureSummaryToAPI(summary.Status, summary.LastErrorCode, summary.LastErrorMessage),
-		InstanceId:        summary.InstanceID,
-		InstanceKey:       summary.InstanceKey,
-		PendingWork:       enginePendingWorkToAPI(summary),
-		ProjectionState:   engineProjectionStateFromString(summary.ProjectionState),
-		Result:            parseOptionalJSONValueRaw(summary.Result),
-		RunId:             summary.RunID,
-		Status:            engineRunStatusToAPI(summary.Status),
-		UpdatedAt:         summary.UpdatedAt,
-		WaitState:         parseOptionalWaitState(summary.WaitState),
+		CompletedAt:          summary.CompletedAt,
+		ContinuedFromRunId:   openapiUUIDPtr(summary.ContinuedFromRunID),
+		ContinuedFromTraceId: cloneStringPtr(summary.ContinuedFromTraceID),
+		ContinuedToRunId:     openapiUUIDPtr(summary.ContinuedToRunID),
+		ContinuedToTraceId:   cloneStringPtr(summary.ContinuedToTraceID),
+		CreatedAt:            summary.CreatedAt,
+		CustomStatus:         parseOptionalJSONObjectRaw(summary.CustomStatus),
+		DefinitionName:       summary.DefinitionName,
+		DefinitionVersion:    summary.DefinitionVersion,
+		Failure:              engineFailureSummaryToAPI(summary.Status, summary.LastErrorCode, summary.LastErrorMessage),
+		InstanceId:           summary.InstanceID,
+		InstanceKey:          summary.InstanceKey,
+		PendingWork:          enginePendingWorkToAPI(summary),
+		ProjectionState:      engineProjectionStateFromString(summary.ProjectionState),
+		Result:               parseOptionalJSONValueRaw(summary.Result),
+		RunId:                summary.RunID,
+		Status:               engineRunStatusToAPI(summary.Status),
+		UpdatedAt:            summary.UpdatedAt,
+		WaitState:            parseOptionalWaitState(summary.WaitState),
 	}
 }
 
 func engineRunResultResponseToAPI(summary *engineRunSummary) EngineRunResultResponse {
 	result := parseOptionalJSONValueRaw(summary.Result)
 	if summary.Status == enginedb.EngineRunLifecycleStatusCancelled ||
-		summary.Status == enginedb.EngineRunLifecycleStatusTerminated {
+		summary.Status == enginedb.EngineRunLifecycleStatusTerminated ||
+		summary.Status == enginedb.EngineRunLifecycleStatusContinuedAsNew {
 		result = nil
 	}
 
 	return EngineRunResultResponse{
-		Failure: engineFailureSummaryToAPI(summary.Status, summary.LastErrorCode, summary.LastErrorMessage),
-		Result:  result,
-		RunId:   summary.RunID,
-		Status:  engineRunStatusToAPI(summary.Status),
+		ContinuedFromRunId:   openapiUUIDPtr(summary.ContinuedFromRunID),
+		ContinuedFromTraceId: cloneStringPtr(summary.ContinuedFromTraceID),
+		ContinuedToRunId:     openapiUUIDPtr(summary.ContinuedToRunID),
+		ContinuedToTraceId:   cloneStringPtr(summary.ContinuedToTraceID),
+		Failure:              engineFailureSummaryToAPI(summary.Status, summary.LastErrorCode, summary.LastErrorMessage),
+		Result:               result,
+		RunId:                summary.RunID,
+		Status:               engineRunStatusToAPI(summary.Status),
 	}
 }
 
 func engineRunSummaryToAPI(summary *engineRunSummary) EngineRunSummary {
 	return EngineRunSummary{
-		CompletedAt:       summary.CompletedAt,
-		CreatedAt:         summary.CreatedAt,
-		CustomStatus:      parseOptionalJSONObjectRaw(summary.CustomStatus),
-		DefinitionName:    summary.DefinitionName,
-		DefinitionVersion: summary.DefinitionVersion,
-		Failure:           engineFailureSummaryToAPI(summary.Status, summary.LastErrorCode, summary.LastErrorMessage),
-		InstanceKey:       summary.InstanceKey,
-		PendingWork:       enginePendingWorkToAPI(summary),
-		ProjectionState:   engineProjectionStateFromString(summary.ProjectionState),
-		Result:            parseOptionalJSONValueRaw(summary.Result),
-		RunId:             summary.RunID,
-		Status:            engineRunStatusToAPI(summary.Status),
-		UpdatedAt:         summary.UpdatedAt,
-		WaitState:         parseOptionalWaitState(summary.WaitState),
+		CompletedAt:          summary.CompletedAt,
+		ContinuedFromRunId:   openapiUUIDPtr(summary.ContinuedFromRunID),
+		ContinuedFromTraceId: cloneStringPtr(summary.ContinuedFromTraceID),
+		ContinuedToRunId:     openapiUUIDPtr(summary.ContinuedToRunID),
+		ContinuedToTraceId:   cloneStringPtr(summary.ContinuedToTraceID),
+		CreatedAt:            summary.CreatedAt,
+		CustomStatus:         parseOptionalJSONObjectRaw(summary.CustomStatus),
+		DefinitionName:       summary.DefinitionName,
+		DefinitionVersion:    summary.DefinitionVersion,
+		Failure:              engineFailureSummaryToAPI(summary.Status, summary.LastErrorCode, summary.LastErrorMessage),
+		InstanceKey:          summary.InstanceKey,
+		PendingWork:          enginePendingWorkToAPI(summary),
+		ProjectionState:      engineProjectionStateFromString(summary.ProjectionState),
+		Result:               parseOptionalJSONValueRaw(summary.Result),
+		RunId:                summary.RunID,
+		Status:               engineRunStatusToAPI(summary.Status),
+		UpdatedAt:            summary.UpdatedAt,
+		WaitState:            parseOptionalWaitState(summary.WaitState),
 	}
 }
 
@@ -262,6 +276,8 @@ func projectedEngineRunStatusFromTrace(trace *store.TraceRead) EngineRunStatus {
 		return EngineRunStatusSUSPENDED
 	case string(enginedb.EngineRunLifecycleStatusWaiting):
 		return EngineRunStatusWAITING
+	case string(enginedb.EngineRunLifecycleStatusContinuedAsNew):
+		return EngineRunStatusCONTINUEDASNEW
 	case string(enginedb.EngineRunLifecycleStatusCompleted):
 		return EngineRunStatusCOMPLETED
 	case string(enginedb.EngineRunLifecycleStatusFailed):
@@ -421,6 +437,8 @@ func engineRunStatusToAPI(status enginedb.EngineRunLifecycleStatus) EngineRunSta
 		return EngineRunStatusQUEUED
 	case enginedb.EngineRunLifecycleStatusSuspended:
 		return EngineRunStatusSUSPENDED
+	case enginedb.EngineRunLifecycleStatusContinuedAsNew:
+		return EngineRunStatusCONTINUEDASNEW
 	case enginedb.EngineRunLifecycleStatusCompleted:
 		return EngineRunStatusCOMPLETED
 	case enginedb.EngineRunLifecycleStatusFailed:
@@ -476,6 +494,30 @@ func pgUUIDPtr(value pgtype.UUID) *uuid.UUID {
 
 	id := uuid.UUID(value.Bytes)
 	return &id
+}
+
+func openapiUUIDPtr(value *uuid.UUID) *openapi_types.UUID {
+	if value == nil {
+		return nil
+	}
+	id := openapi_types.UUID(*value)
+	return &id
+}
+
+func engineTraceIDPtr(runID *uuid.UUID) *string {
+	if runID == nil {
+		return nil
+	}
+	traceID := engineTracePrefix + runID.String()
+	return &traceID
+}
+
+func cloneStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/api/engine_mapper.go
+++ b/internal/api/engine_mapper.go
@@ -252,6 +252,10 @@ func shouldReadLiveEngineSummary(trace *store.TraceRead) bool {
 		return false
 	}
 
+	if strings.EqualFold(strings.TrimSpace(derefString(trace.EngineRunStatus)), string(enginedb.EngineRunLifecycleStatusContinuedAsNew)) {
+		return true
+	}
+
 	switch normalizedProjectionState(trace.EngineProjectionState) {
 	case publicprojection.StateCatchingUp.String(), publicprojection.StateSummaryOnly.String():
 		return true

--- a/internal/api/mapper_trace_test.go
+++ b/internal/api/mapper_trace_test.go
@@ -142,6 +142,10 @@ func TestTraceDetailToAPIWithProjectedEngineSummary_UsesProjectedInstanceKey(t *
 
 func TestTraceDetailToAPIWithEngine_PrefersLiveEngineSummary(t *testing.T) {
 	runID := uuid.New()
+	previousRunID := uuid.New()
+	nextRunID := uuid.New()
+	previousTraceID := "engine:" + previousRunID.String()
+	nextTraceID := "engine:" + nextRunID.String()
 	trace := platform.Trace{
 		ID:                      uuid.New(),
 		TraceID:                 "engine:" + runID.String(),
@@ -156,15 +160,19 @@ func TestTraceDetailToAPIWithEngine_PrefersLiveEngineSummary(t *testing.T) {
 	}
 
 	live := engineRunSummaryToAPI(&engineRunSummary{
-		RunID:             runID,
-		InstanceKey:       "instance-1",
-		DefinitionName:    "checkout",
-		DefinitionVersion: "v1",
-		ProjectionState:   publicprojection.StateCatchingUp.String(),
-		Status:            enginedb.EngineRunLifecycleStatusWaiting,
-		CreatedAt:         time.Now().Add(-time.Minute).UTC(),
-		UpdatedAt:         time.Now().UTC(),
-		WaitState:         json.RawMessage(`{"kind":"signal","signal_name":"approval"}`),
+		RunID:                runID,
+		InstanceKey:          "instance-1",
+		ContinuedFromRunID:   &previousRunID,
+		ContinuedToRunID:     &nextRunID,
+		ContinuedFromTraceID: &previousTraceID,
+		ContinuedToTraceID:   &nextTraceID,
+		DefinitionName:       "checkout",
+		DefinitionVersion:    "v1",
+		ProjectionState:      publicprojection.StateCatchingUp.String(),
+		Status:               enginedb.EngineRunLifecycleStatusWaiting,
+		CreatedAt:            time.Now().Add(-time.Minute).UTC(),
+		UpdatedAt:            time.Now().UTC(),
+		WaitState:            json.RawMessage(`{"kind":"signal","signal_name":"approval"}`),
 	})
 
 	detail := traceDetailToAPIWithEngine(&store.TraceRead{Trace: trace}, &live)
@@ -172,6 +180,14 @@ func TestTraceDetailToAPIWithEngine_PrefersLiveEngineSummary(t *testing.T) {
 	require.NotNil(t, detail.Engine)
 	assert.Equal(t, "instance-1", detail.Engine.InstanceKey)
 	assert.Equal(t, EngineRunStatusWAITING, detail.Engine.Status)
+	require.NotNil(t, detail.Engine.ContinuedFromRunId)
+	assert.Equal(t, previousRunID, *detail.Engine.ContinuedFromRunId)
+	require.NotNil(t, detail.Engine.ContinuedToRunId)
+	assert.Equal(t, nextRunID, *detail.Engine.ContinuedToRunId)
+	require.NotNil(t, detail.Engine.ContinuedFromTraceId)
+	assert.Equal(t, previousTraceID, *detail.Engine.ContinuedFromTraceId)
+	require.NotNil(t, detail.Engine.ContinuedToTraceId)
+	assert.Equal(t, nextTraceID, *detail.Engine.ContinuedToTraceId)
 	require.NotNil(t, detail.Engine.WaitState)
 	require.NotNil(t, detail.Engine.WaitState.SignalName)
 	assert.Equal(t, "approval", *detail.Engine.WaitState.SignalName)

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -97,14 +97,15 @@ const (
 
 // Defines values for EngineRunStatus.
 const (
-	EngineRunStatusCANCELLED  EngineRunStatus = "CANCELLED"
-	EngineRunStatusCOMPLETED  EngineRunStatus = "COMPLETED"
-	EngineRunStatusFAILED     EngineRunStatus = "FAILED"
-	EngineRunStatusQUEUED     EngineRunStatus = "QUEUED"
-	EngineRunStatusRUNNING    EngineRunStatus = "RUNNING"
-	EngineRunStatusSUSPENDED  EngineRunStatus = "SUSPENDED"
-	EngineRunStatusTERMINATED EngineRunStatus = "TERMINATED"
-	EngineRunStatusWAITING    EngineRunStatus = "WAITING"
+	EngineRunStatusCANCELLED      EngineRunStatus = "CANCELLED"
+	EngineRunStatusCOMPLETED      EngineRunStatus = "COMPLETED"
+	EngineRunStatusCONTINUEDASNEW EngineRunStatus = "CONTINUED_AS_NEW"
+	EngineRunStatusFAILED         EngineRunStatus = "FAILED"
+	EngineRunStatusQUEUED         EngineRunStatus = "QUEUED"
+	EngineRunStatusRUNNING        EngineRunStatus = "RUNNING"
+	EngineRunStatusSUSPENDED      EngineRunStatus = "SUSPENDED"
+	EngineRunStatusTERMINATED     EngineRunStatus = "TERMINATED"
+	EngineRunStatusWAITING        EngineRunStatus = "WAITING"
 )
 
 // Defines values for IngestEventLevel.
@@ -288,14 +289,15 @@ const (
 
 // Defines values for ListTracesParamsEngineRunStatus.
 const (
-	ListTracesParamsEngineRunStatusCancelled  ListTracesParamsEngineRunStatus = "cancelled"
-	ListTracesParamsEngineRunStatusCompleted  ListTracesParamsEngineRunStatus = "completed"
-	ListTracesParamsEngineRunStatusFailed     ListTracesParamsEngineRunStatus = "failed"
-	ListTracesParamsEngineRunStatusQueued     ListTracesParamsEngineRunStatus = "queued"
-	ListTracesParamsEngineRunStatusRunning    ListTracesParamsEngineRunStatus = "running"
-	ListTracesParamsEngineRunStatusSuspended  ListTracesParamsEngineRunStatus = "suspended"
-	ListTracesParamsEngineRunStatusTerminated ListTracesParamsEngineRunStatus = "terminated"
-	ListTracesParamsEngineRunStatusWaiting    ListTracesParamsEngineRunStatus = "waiting"
+	ListTracesParamsEngineRunStatusCancelled      ListTracesParamsEngineRunStatus = "cancelled"
+	ListTracesParamsEngineRunStatusCompleted      ListTracesParamsEngineRunStatus = "completed"
+	ListTracesParamsEngineRunStatusContinuedAsNew ListTracesParamsEngineRunStatus = "continued_as_new"
+	ListTracesParamsEngineRunStatusFailed         ListTracesParamsEngineRunStatus = "failed"
+	ListTracesParamsEngineRunStatusQueued         ListTracesParamsEngineRunStatus = "queued"
+	ListTracesParamsEngineRunStatusRunning        ListTracesParamsEngineRunStatus = "running"
+	ListTracesParamsEngineRunStatusSuspended      ListTracesParamsEngineRunStatus = "suspended"
+	ListTracesParamsEngineRunStatusTerminated     ListTracesParamsEngineRunStatus = "terminated"
+	ListTracesParamsEngineRunStatusWaiting        ListTracesParamsEngineRunStatus = "waiting"
 )
 
 // BatchStatusResponse defines model for BatchStatusResponse.
@@ -544,16 +546,20 @@ type EngineRunHistoryResponse struct {
 
 // EngineRunResponse defines model for EngineRunResponse.
 type EngineRunResponse struct {
-	CompletedAt       *time.Time              `json:"completed_at,omitempty"`
-	CreatedAt         time.Time               `json:"created_at"`
-	CustomStatus      *map[string]interface{} `json:"custom_status,omitempty"`
-	DefinitionName    string                  `json:"definition_name"`
-	DefinitionVersion string                  `json:"definition_version"`
-	Failure           *EngineFailureSummary   `json:"failure,omitempty"`
-	InstanceId        openapi_types.UUID      `json:"instance_id"`
-	InstanceKey       string                  `json:"instance_key"`
-	PendingWork       EnginePendingWork       `json:"pending_work"`
-	ProjectionState   EngineProjectionState   `json:"projection_state"`
+	CompletedAt          *time.Time              `json:"completed_at,omitempty"`
+	ContinuedFromRunId   *openapi_types.UUID     `json:"continued_from_run_id,omitempty"`
+	ContinuedFromTraceId *string                 `json:"continued_from_trace_id,omitempty"`
+	ContinuedToRunId     *openapi_types.UUID     `json:"continued_to_run_id,omitempty"`
+	ContinuedToTraceId   *string                 `json:"continued_to_trace_id,omitempty"`
+	CreatedAt            time.Time               `json:"created_at"`
+	CustomStatus         *map[string]interface{} `json:"custom_status,omitempty"`
+	DefinitionName       string                  `json:"definition_name"`
+	DefinitionVersion    string                  `json:"definition_version"`
+	Failure              *EngineFailureSummary   `json:"failure,omitempty"`
+	InstanceId           openapi_types.UUID      `json:"instance_id"`
+	InstanceKey          string                  `json:"instance_key"`
+	PendingWork          EnginePendingWork       `json:"pending_work"`
+	ProjectionState      EngineProjectionState   `json:"projection_state"`
 
 	// Result Terminal workflow result payload when available.
 	Result    interface{}        `json:"result,omitempty"`
@@ -565,7 +571,11 @@ type EngineRunResponse struct {
 
 // EngineRunResultResponse defines model for EngineRunResultResponse.
 type EngineRunResultResponse struct {
-	Failure *EngineFailureSummary `json:"failure,omitempty"`
+	ContinuedFromRunId   *openapi_types.UUID   `json:"continued_from_run_id,omitempty"`
+	ContinuedFromTraceId *string               `json:"continued_from_trace_id,omitempty"`
+	ContinuedToRunId     *openapi_types.UUID   `json:"continued_to_run_id,omitempty"`
+	ContinuedToTraceId   *string               `json:"continued_to_trace_id,omitempty"`
+	Failure              *EngineFailureSummary `json:"failure,omitempty"`
 
 	// Result Terminal workflow result payload when available. `summary_only` and
 	// `journal_expired` runs continue to return the retained terminal shell.
@@ -579,15 +589,19 @@ type EngineRunStatus string
 
 // EngineRunSummary defines model for EngineRunSummary.
 type EngineRunSummary struct {
-	CompletedAt       *time.Time              `json:"completed_at,omitempty"`
-	CreatedAt         time.Time               `json:"created_at"`
-	CustomStatus      *map[string]interface{} `json:"custom_status,omitempty"`
-	DefinitionName    string                  `json:"definition_name"`
-	DefinitionVersion string                  `json:"definition_version"`
-	Failure           *EngineFailureSummary   `json:"failure,omitempty"`
-	InstanceKey       string                  `json:"instance_key"`
-	PendingWork       EnginePendingWork       `json:"pending_work"`
-	ProjectionState   EngineProjectionState   `json:"projection_state"`
+	CompletedAt          *time.Time              `json:"completed_at,omitempty"`
+	ContinuedFromRunId   *openapi_types.UUID     `json:"continued_from_run_id,omitempty"`
+	ContinuedFromTraceId *string                 `json:"continued_from_trace_id,omitempty"`
+	ContinuedToRunId     *openapi_types.UUID     `json:"continued_to_run_id,omitempty"`
+	ContinuedToTraceId   *string                 `json:"continued_to_trace_id,omitempty"`
+	CreatedAt            time.Time               `json:"created_at"`
+	CustomStatus         *map[string]interface{} `json:"custom_status,omitempty"`
+	DefinitionName       string                  `json:"definition_name"`
+	DefinitionVersion    string                  `json:"definition_version"`
+	Failure              *EngineFailureSummary   `json:"failure,omitempty"`
+	InstanceKey          string                  `json:"instance_key"`
+	PendingWork          EnginePendingWork       `json:"pending_work"`
+	ProjectionState      EngineProjectionState   `json:"projection_state"`
 
 	// Result Terminal workflow result payload when available.
 	Result    interface{}        `json:"result,omitempty"`

--- a/internal/api/traces_handlers.go
+++ b/internal/api/traces_handlers.go
@@ -95,22 +95,23 @@ func (s *Server) GetTrace(w http.ResponseWriter, r *http.Request, id openapi_typ
 	}
 
 	var engineSummary *EngineRunSummary
-	readLiveEngineSummary := trace.EngineRunID.Valid
-
-	if readLiveEngineSummary {
-		if s.engineControl == nil {
-			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to read engine summary")
-			return
-		}
-
-		summary, err := s.engineControl.ReadRunSummary(r.Context(), projectID, uuid.UUID(trace.EngineRunID.Bytes))
+	if s.engineControl != nil {
+		readLiveEngineSummary, err := s.engineControl.shouldReadLiveTraceSummary(r.Context(), &trace)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to read engine summary")
 			return
 		}
 
-		mapped := engineRunSummaryToAPI(&summary)
-		engineSummary = &mapped
+		if readLiveEngineSummary {
+			summary, err := s.engineControl.ReadRunSummary(r.Context(), projectID, uuid.UUID(trace.EngineRunID.Bytes))
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to read engine summary")
+				return
+			}
+
+			mapped := engineRunSummaryToAPI(&summary)
+			engineSummary = &mapped
+		}
 	}
 
 	resp := traceDetailToAPIWithEngine(&trace, engineSummary)

--- a/internal/api/traces_handlers.go
+++ b/internal/api/traces_handlers.go
@@ -95,15 +95,7 @@ func (s *Server) GetTrace(w http.ResponseWriter, r *http.Request, id openapi_typ
 	}
 
 	var engineSummary *EngineRunSummary
-	readLiveEngineSummary := shouldReadLiveEngineSummary(&trace)
-	if !readLiveEngineSummary && s.engineControl != nil {
-		needsLiveSummary, err := s.engineControl.shouldReadLiveTraceSummary(r.Context(), &trace)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to read engine summary")
-			return
-		}
-		readLiveEngineSummary = needsLiveSummary
-	}
+	readLiveEngineSummary := trace.EngineRunID.Valid
 
 	if readLiveEngineSummary {
 		if s.engineControl == nil {

--- a/internal/api/traces_handlers_test.go
+++ b/internal/api/traces_handlers_test.go
@@ -818,6 +818,77 @@ func TestListTraces_InvalidEngineFiltersReturn400(t *testing.T) {
 	assert.Equal(t, "invalid_request", decodeJSONBody[Error](t, projectionStateRec).Code)
 }
 
+func TestListTraces_FilterByContinuedAsNewRunStatus(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+
+	continuedTrace := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "engine-trace-continued",
+		Name:      testutil.StrPtr("continued trace"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 7, 18, 0, 0, 0, time.UTC)),
+	})
+	waitingTrace := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "engine-trace-waiting",
+		Name:      testutil.StrPtr("waiting trace"),
+		Status:    "running",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 7, 19, 0, 0, 0, time.UTC)),
+	})
+	nonEngineTrace := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "non-engine-trace",
+		Name:      testutil.StrPtr("plain trace"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 3, 7, 20, 0, 0, 0, time.UTC)),
+	})
+
+	_, err := pool.Exec(ctx, `
+		UPDATE traces
+		SET engine_run_id = $2,
+		    engine_instance_key = 'instance-continued',
+		    engine_definition_name = 'checkout',
+		    engine_definition_version = 'v1',
+		    engine_run_status = 'continued_as_new',
+		    engine_projection_state = 'up_to_date',
+		    engine_projection_updated_at = NOW()
+		WHERE id = $1
+	`, continuedTrace.ID, uuid.New())
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		UPDATE traces
+		SET engine_run_id = $2,
+		    engine_instance_key = 'instance-waiting',
+		    engine_definition_name = 'checkout',
+		    engine_definition_version = 'v1',
+		    engine_run_status = 'waiting',
+		    engine_projection_state = 'up_to_date',
+		    engine_projection_updated_at = NOW()
+		WHERE id = $1
+	`, waitingTrace.ID, uuid.New())
+	require.NoError(t, err)
+
+	filter := ListTracesParamsEngineRunStatus("continued_as_new")
+	rec := invokeListTraces(t, server, projectID, ListTracesParams{
+		EngineRunStatus: &filter,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[TraceList](t, rec)
+	require.Len(t, resp.Traces, 1)
+	assert.Equal(t, continuedTrace.ID, resp.Traces[0].Id)
+	require.NotNil(t, resp.Traces[0].Engine)
+	assert.NotEqual(t, uuid.Nil, resp.Traces[0].Engine.RunId)
+	assert.NotEqual(t, nonEngineTrace.ID, resp.Traces[0].Id)
+}
+
 func TestGetTrace_ProjectScopingReturns404(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ctx := context.Background()

--- a/internal/enginecontrol/service.go
+++ b/internal/enginecontrol/service.go
@@ -278,7 +278,8 @@ func isTerminalRun(status enginedb.EngineRunLifecycleStatus) bool {
 	case enginedb.EngineRunLifecycleStatusCompleted,
 		enginedb.EngineRunLifecycleStatusFailed,
 		enginedb.EngineRunLifecycleStatusCancelled,
-		enginedb.EngineRunLifecycleStatusTerminated:
+		enginedb.EngineRunLifecycleStatusTerminated,
+		enginedb.EngineRunLifecycleStatusContinuedAsNew:
 		return true
 	default:
 		return false

--- a/internal/store/engine_projection.go
+++ b/internal/store/engine_projection.go
@@ -57,7 +57,7 @@ func (s *Store) listEngineRetentionCandidates(
 		INNER JOIN public.traces AS t
 		    ON t.project_id = r.project_id
 		   AND t.engine_run_id = r.id
-		WHERE r.status IN ('completed', 'failed', 'cancelled', 'terminated')
+		WHERE r.status IN ('completed', 'failed', 'cancelled', 'terminated', 'continued_as_new')
 		  AND r.completed_at IS NOT NULL
 		  AND r.completed_at < $1
 		  AND t.engine_projection_state = ANY($2::text[])

--- a/internal/store/engine_projection_test.go
+++ b/internal/store/engine_projection_test.go
@@ -1,0 +1,88 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	platformdb "github.com/continua-ai/continua/db/gen/go/platform"
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestListProjectionRetentionCandidates_IncludesContinuedAsNewRuns(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	engineQueries := enginedb.New(pool)
+
+	projectID := testutil.CreateTestProject(t, ctx, s.Queries())
+	instance, err := engineQueries.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "instance-retention-continued",
+		DefinitionName: "checkout",
+	})
+	require.NoError(t, err)
+
+	completedAt := time.Now().UTC().Add(-2 * time.Hour).Round(time.Microsecond)
+	run, err := engineQueries.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:          projectID,
+		InstanceID:         instance.ID,
+		RunNumber:          1,
+		DefinitionVersion:  "v1",
+		ReadyAt:            completedAt.Add(-time.Minute),
+		ContinuedFromRunID: pgtype.UUID{},
+	})
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		UPDATE engine.runs
+		SET status = 'continued_as_new',
+		    completed_at = $2,
+		    updated_at = $2
+		WHERE id = $1
+	`, run.ID, completedAt)
+	require.NoError(t, err)
+
+	trace, err := s.Queries().UpsertTrace(ctx, platformdb.UpsertTraceParams{
+		ProjectID: projectID,
+		TraceID:   "engine:" + run.ID.String(),
+		Name:      testutil.StrPtr("retention trace"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(completedAt.Add(-time.Minute)),
+		EndTime:   testutil.PgtypeTimestamptz(completedAt),
+	})
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		UPDATE traces
+		SET engine_run_id = $2,
+		    engine_instance_key = 'instance-retention-continued',
+		    engine_definition_name = 'checkout',
+		    engine_definition_version = 'v1',
+		    engine_run_status = 'continued_as_new',
+		    engine_projection_state = 'up_to_date',
+		    engine_projection_updated_at = $3,
+		    updated_at = $3
+		WHERE id = $1
+	`, trace.ID, run.ID, completedAt)
+	require.NoError(t, err)
+
+	projectionCandidates, err := s.ListProjectionRetentionCandidates(ctx, time.Now().UTC(), 10)
+	require.NoError(t, err)
+	require.Len(t, projectionCandidates, 1)
+	assert.Equal(t, projectID, projectionCandidates[0].ProjectID)
+	assert.Equal(t, run.ID, projectionCandidates[0].RunID)
+	assert.Equal(t, trace.ID, projectionCandidates[0].TraceID)
+
+	historyCandidates, err := s.ListHistoryRetentionCandidates(ctx, time.Now().UTC(), 10)
+	require.NoError(t, err)
+	require.Len(t, historyCandidates, 1)
+	assert.Equal(t, run.ID, historyCandidates[0].RunID)
+	assert.Equal(t, trace.ID, historyCandidates[0].TraceID)
+}

--- a/internal/store/engine_projection_test.go
+++ b/internal/store/engine_projection_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	platformdb "github.com/continua-ai/continua/db/gen/go/platform"
@@ -75,14 +75,24 @@ func TestListProjectionRetentionCandidates_IncludesContinuedAsNewRuns(t *testing
 
 	projectionCandidates, err := s.ListProjectionRetentionCandidates(ctx, time.Now().UTC(), 10)
 	require.NoError(t, err)
-	require.Len(t, projectionCandidates, 1)
-	assert.Equal(t, projectID, projectionCandidates[0].ProjectID)
-	assert.Equal(t, run.ID, projectionCandidates[0].RunID)
-	assert.Equal(t, trace.ID, projectionCandidates[0].TraceID)
+	require.True(t, containsEngineRetentionCandidate(projectionCandidates, projectID, run.ID, trace.ID))
 
 	historyCandidates, err := s.ListHistoryRetentionCandidates(ctx, time.Now().UTC(), 10)
 	require.NoError(t, err)
-	require.Len(t, historyCandidates, 1)
-	assert.Equal(t, run.ID, historyCandidates[0].RunID)
-	assert.Equal(t, trace.ID, historyCandidates[0].TraceID)
+	require.True(t, containsEngineRetentionCandidate(historyCandidates, projectID, run.ID, trace.ID))
+}
+
+func containsEngineRetentionCandidate(
+	candidates []store.EngineRetentionCandidate,
+	projectID uuid.UUID,
+	runID uuid.UUID,
+	traceID uuid.UUID,
+) bool {
+	for i := range candidates {
+		candidate := candidates[i]
+		if candidate.ProjectID == projectID && candidate.RunID == runID && candidate.TraceID == traceID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -282,7 +282,7 @@ func validateTraceFilter(filter *TraceFilter) error {
 	if filter.EngineRunStatus != "" {
 		value := strings.ToLower(strings.TrimSpace(filter.EngineRunStatus))
 		switch value {
-		case "queued", "running", "waiting", "suspended", "completed", "failed", "cancelled", "terminated":
+		case "queued", "running", "waiting", "suspended", "completed", "failed", "cancelled", "terminated", "continued_as_new":
 		default:
 			return &TraceFilterValidationError{Field: "engine_run_status", Value: filter.EngineRunStatus}
 		}

--- a/openspec/changes/add-engine-continue-as-new/design.md
+++ b/openspec/changes/add-engine-continue-as-new/design.md
@@ -1,0 +1,155 @@
+# Design: Engine ContinueAsNew
+
+## Context
+
+This is the third and final change in the Phase 4 runtime lifecycle plan. It adds `ContinueAsNew`, the workflow-authored mechanism for atomically terminating the current run and starting a new run of the same instance with fresh history.
+
+The engine currently supports single-run instances: `StartRun` creates an instance and run 1, and the run proceeds to a terminal status. There is no mechanism to continue an instance with a new run, and no run-chain linkage exists. History grows monotonically with every activation, and long-running workflows suffer increasing replay latency.
+
+The `ContinueAsNew` mechanism is standard in durable workflow engines (Temporal, Azure Durable Functions) and is the canonical solution for unbounded workflows. This change implements it within the existing activation transaction model while preserving the existing trace-shell shape for the continuation run's projected trace.
+
+## Goals / Non-Goals
+
+### Goals
+- Allow workflow authors to continue execution with fresh history via `ContinueAsNew(input)`
+- Create run N+1 atomically within the activation transaction that terminates run N
+- Preserve instance identity (instance key, session, definition name) across continuations
+- Inherit trace presentation fields (name, user_id, tags, environment, release, metadata) from the previous trace shell
+- Expose navigable run-chain and trace-chain linkage in API responses
+- Support continuation-following in the Python SDK's `wait_for_terminal`
+
+### Non-Goals
+- Definition version override on continuation (always uses the current run's version)
+- Carrying over open activity tasks or inbox items to the new run
+- Automatic ContinueAsNew (engine-triggered based on history size)
+- Cross-instance continuation (continuing as a different instance)
+- External ContinueAsNew endpoint (this is workflow-authored only)
+- Session reassignment during continuation
+
+## Decisions
+
+### Decision: ContinueAsNew is a sentinel error, following the ErrCancelled pattern
+- `workflow.ContinueAsNew(input any) error` returns an `ErrContinueAsNew` sentinel wrapping the continuation input.
+- The replay engine detects the sentinel via `errors.Is` (same pattern as `ErrCancelled`).
+- Returning the sentinel from the workflow `Run` function, or returning an error that wraps it, triggers continuation.
+- Swallowing the sentinel, or otherwise failing to return it after producing it, is a programming error and will produce a replay mismatch on subsequent activations (the history records `workflow.continued_as_new` but the replayed workflow does not return the sentinel).
+- **Alternatives considered:** a `Context.ContinueAsNew(input)` method that panics (like `blockOnWait`). Rejected — the error-return pattern is idiomatic Go and consistent with `ErrCancelled`.
+
+### Decision: CONTINUED_AS_NEW is a terminal run status
+- The current run is terminal: it will not be claimed, activated, or further modified.
+- Lowercase `continued_as_new` is added to `engine.run_lifecycle_status`, and the public API / SDK continue to expose uppercase `CONTINUED_AS_NEW`; the instance stays `active`.
+- For purge and retention purposes, `CONTINUED_AS_NEW` is terminal (eligible after the retention window).
+- All helpers that currently enumerate terminal run states must include `continued_as_new`, including read-path terminal checks, purge eligibility, retention candidate selection, and projector terminal mapping.
+- **Alternatives considered:** reusing `completed` with a special result payload. Rejected — `CONTINUED_AS_NEW` is semantically distinct (the workflow did not "complete" its work; it chose to continue) and needs its own status for filtering and debugger display.
+
+### Decision: Latest/current run semantics use run_number, not created_at
+- Once an instance can have multiple runs, "latest run" is defined as the highest `run_number` for that instance.
+- `GetLatestRunByInstance` and `ListRunsByInstance` must therefore order by `run_number DESC, id DESC`.
+- This ensures `GET /v1/engine/instances/{instance_key}` and other per-instance read paths reliably return the continuation target.
+- **Alternatives considered:** continuing to order by `created_at DESC, id DESC`. Rejected — timestamp ordering is no longer a safe proxy once an instance intentionally creates multiple runs.
+
+### Decision: Continuation creates run N+1 within the same activation transaction
+- The activation transaction that terminates run N also creates run N+1, its `workflow.started` history event, and the projected trace shell.
+- This ensures atomicity: either the continuation fully succeeds (old run terminal, new run created) or nothing changes.
+- The new run is created with `run_number = previous + 1` on the same instance.
+- `continued_to_run_id` is set on run N, `continued_from_run_id` on run N+1.
+- **Alternatives considered:** a two-phase approach (terminate run N, then externally start run N+1). Rejected — this creates a window where the instance has no active run, and requires the operator or a background job to create the continuation.
+
+### Decision: Old run cleanup mirrors cancellation
+- Open activity tasks on run N are cancelled (same `CancelOpenActivityTasksByRun` query used by cancellation).
+- Open inbox items on run N are discarded (same `DiscardOpenInboxItemsByRun` query).
+- This is correct because run N is terminal; its pending work is no longer relevant.
+- The new run starts fresh — no state is carried over except the continuation input and the instance identity.
+- On the projection side, `continued_as_new` gets its own cleanup reason so the old trace emits resolved wait events for cancelled activity waits and discarded timer waits, consistent with the existing terminal cleanup model.
+- Continuation also follows the existing terminal signal-wait behavior: terminal projection clears `engine_wait_state` for a signal wait so the debugger does not retain a stale pending signal state, and a pure signal wait does not require a synthetic resolved-signal timeline event.
+
+### Decision: Continuation trace bootstrap stays in the engine module
+- `StartRun` currently creates the initial trace shell/root span in the root module at `internal/api/engine_control.go`.
+- The continuation commit path lives in `engine/internal/workflow/activation.go`, in a separate Go module (`./engine`).
+- This change keeps continuation-side trace-shell/root-span creation in the engine module, where the activation transaction already runs and where engine code already writes `public.traces` / `public.spans` directly for projection work.
+- `StartRun` does not need a structural refactor for this change; the continuation path creates the same shell shape with inherited fields inside the engine module.
+- That shell shape is explicit: trace raw status `running`, root-span status `running`, `output = null`, trace/root input set to the continuation input, `engine_run_status = queued`, nil `engine_custom_status`, nil `engine_wait_state`, zero pending counts, `engine_instance_key = instance.instance_key`, and `engine_definition_name` / `engine_definition_version` populated for the new run.
+- **Alternatives considered:** extracting a helper in `internal/api` or `internal/enginecontrol`. Rejected — those packages are not importable from the separate engine module. Extracting a neutral shared package is possible later, but is unnecessary scope for this change.
+
+### Decision: ContinueAsNew inherits trace presentation fields from the previous trace shell
+- `StartRun` uses request-supplied session, trace name, user_id, tags, environment, release, metadata.
+- `ContinueAsNew` reads these fields from the previous run's `public.traces` row and uses them for the new trace shell.
+- The continuation does NOT re-read the request or accept overrides — it inherits what was set.
+- Session is preserved: the new trace is linked to the same session as the previous trace.
+- The previous projected trace shell is required to exist. If the trace row is unexpectedly missing, continuation fails the activation as an invariant violation instead of silently creating a degraded shell with guessed observability fields.
+- Nullable presentation fields on an existing trace row may still be absent and propagate as null; only the missing-row case is fatal.
+- **Alternatives considered:** allowing field overrides on continuation. Deferred — adds complexity for a rare use case. The workflow can set custom status if it needs to communicate state to the next run.
+
+### Decision: Continuation trace IDs are derived, not stored
+- The external engine trace ID is already deterministic: `engine:<run_id>`.
+- Run detail and result responses can therefore synthesize `continued_from_trace_id` / `continued_to_trace_id` directly from `continued_from_run_id` / `continued_to_run_id`.
+- No `public.traces` columns are required for continuation trace linkage.
+- **Alternatives considered:** storing `continued_from_trace_id` / `continued_to_trace_id` on `public.traces`. Rejected — those values are redundant derived data and add unnecessary platform-schema scope.
+
+### Decision: Run chain linkage uses UUID foreign keys
+- `continued_from_run_id UUID REFERENCES engine.runs(id)` and `continued_to_run_id UUID REFERENCES engine.runs(id)` on `engine.runs`.
+- UUID FKs are appropriate here because both the old and new runs are in the same `engine.runs` table and the linkage is a hard constraint.
+- These are set within the continuation transaction and are immutable after creation.
+
+### Decision: `workflow.continued_as_new` history event carries only the continuation input
+- Payload: `{ input: <raw JSON> }`
+- No other fields (definition version, instance key) are needed because the continuation uses the same values from the instance.
+- The event is the last event in run N's history and serves as both an audit trail and a projector input.
+
+### Decision: `get_result` does not overload the result payload
+- `GET /v1/engine/runs/{run_id}/result` for a `CONTINUED_AS_NEW` run returns status `CONTINUED_AS_NEW` plus the continuation chain fields.
+- The `result` field keeps its existing meaning: the stored workflow result payload from `run.Result`.
+- A continued run does not produce a terminal workflow result, so `result` remains `null` for this status.
+- The continuation input remains available in the terminal `workflow.continued_as_new` history event and in the new run's `workflow.started` input.
+- **Alternatives considered:** stuffing the continuation input into `result`. Rejected — it changes the meaning of the result endpoint and is not supported by the current read-path storage model.
+
+### Decision: Continuation chain fields belong on EngineRunSummary
+- `EngineRunSummary` is the shared engine shape used by `EngineInstanceResponse.current_run` and `TraceDetail.engine`, not just by run-detail handlers.
+- Continuation chain fields therefore belong on `EngineRunSummary` itself, with run detail and run result reusing the same fields rather than introducing a detail-only navigation surface.
+- This keeps debugger and instance surfaces continuation-aware without requiring an extra `GET /v1/engine/runs/{id}` fetch.
+
+### Decision: continued_as_new projects as outputless completion
+- `continued_as_new` projects as a completed terminal trace/root span for status purposes, but it does not represent successful workflow output for the finished run.
+- The projected trace/root span therefore keep `output = null` for this status and do not reuse the failure-shaped payload emitted for failed terminal states.
+- **Alternatives considered:** reusing the non-completed failure payload shape. Rejected — it produces a visually completed trace with synthetic failure output, which is semantically inconsistent.
+
+### Decision: Replay input matching uses equalJSON semantics
+- Replay matching for `workflow.continued_as_new` input uses the same rule already used for completion result replay: compare trimmed raw bytes first; if those differ, decode both payloads as JSON and require semantic equality of the decoded values.
+- This allows equivalent JSON objects with different key ordering or insignificant whitespace to replay successfully.
+- **Alternatives considered:** byte-identical matching only. Rejected — it is stricter than the engine's existing replay payload comparison semantics.
+
+### Decision: Internal and public status casing remain split
+- The engine runtime, DB enum value, projector state, and trace search filter use lowercase `continued_as_new`, matching the existing internal status style.
+- The OpenAPI `EngineRunStatus` enum and generated SDK enums use uppercase `CONTINUED_AS_NEW`, matching the existing public API contract.
+- **Alternatives considered:** flattening everything to one casing convention. Rejected — the current product already distinguishes lowercase internal/search values from uppercase public enums, and this change should extend that contract rather than silently rewrite it.
+
+### Decision: Python SDK follow_continuations defaults to False
+- `wait_for_terminal(run_id, ..., follow_continuations=False, max_continuations=32)`
+- Default `False` preserves backward compatibility: callers get the result of the specific run they asked about.
+- When `True`: if the result status is `CONTINUED_AS_NEW`, the SDK extracts `continued_to_run_id` and polls the next run, repeating up to `max_continuations` hops.
+- `EngineRunContinuationDepthError` is raised if the chain exceeds `max_continuations`.
+- **Alternatives considered:** always following continuations. Rejected — this changes the semantics of `wait_for_terminal` for existing callers and can create unexpected long waits.
+
+## Risks / Trade-offs
+
+- **Continuation within activation transaction:** the transaction does more work (create run, create history, create trace shell, create root span, update chain links, cleanup old run). This increases the transaction duration. Mitigation: all operations are single-row inserts/updates with indexed lookups; the overhead is comparable to a normal activation commit.
+
+- **Engine-module trace bootstrap drift:** the continuation path now needs to reproduce the same trace-shell/root-span shape that `StartRun` creates. Mitigation: keep the continuation bootstrap narrowly scoped, assert the inherited fields and shell checkpoint state in activation/integration tests, and defer any shared-package refactor until it is clearly worth the extra module work.
+
+- **Unbounded continuation chains:** a workflow that always calls `ContinueAsNew` creates an unbounded number of runs. Mitigation: each old run is terminal and eligible for retention/purge; the Python SDK has a `max_continuations` guard; operators can use retention to bound chain length.
+
+- **Presentation field inheritance drift:** if the previous trace's presentation fields were set by a StartRun request that no longer reflects the desired state, the continuation inherits stale values. Mitigation: the workflow can set custom status to communicate state; field overrides on continuation can be added in a future change.
+
+- **Terminal-status sweep misses:** multiple packages currently hard-code the terminal run set. Mitigation: call this out as a dedicated task bucket covering read APIs, purge, retention, and projector helpers, rather than relying on incidental edits.
+
+- **Projector complexity:** the projector must handle `continued_as_new` as a terminal status and map it to `completed` on the trace/root-span. Mitigation: this follows the existing pattern for `cancelled` and `terminated` mapping.
+
+## Migration Plan
+
+- One engine migration adding `continued_as_new` to `engine.run_lifecycle_status` and adding `continued_from_run_id`, `continued_to_run_id` columns to `engine.runs`.
+- One platform migration updating the `public.traces.engine_run_status` check constraint to allow `continued_as_new`.
+- API response field additions are strictly additive (nullable fields).
+- Trace chain IDs are derived in read APIs; no platform trace-link columns are added.
+- OpenAPI changes extend both contracts that already exist today: uppercase engine run statuses on engine endpoints, lowercase `engine_run_status` values on trace-search filters.
+- No existing client contract is broken.
+- Rollback: continuation fields are nullable and unused if the feature is disabled.

--- a/openspec/changes/add-engine-continue-as-new/proposal.md
+++ b/openspec/changes/add-engine-continue-as-new/proposal.md
@@ -1,0 +1,97 @@
+# Change: Add Engine ContinueAsNew
+
+## Why
+
+Long-running workflows that process unbounded work (event loops, polling loops, batch processors) accumulate history indefinitely: every timer, signal, and activity appends events that must be replayed on every activation. Without a mechanism to start fresh, replay latency grows linearly with workflow lifetime, and history retention becomes a scaling bottleneck.
+
+`ContinueAsNew` allows a workflow to atomically terminate the current run and start a new run of the same instance with fresh history, preserving the logical workflow identity (instance key, session, trace presentation) while resetting the replay burden. The old run is terminal (`CONTINUED_AS_NEW` in the public API, stored internally as `continued_as_new`) and linked to the new run via chain fields, giving operators and the debugger a navigable continuation trail.
+
+## What Changes
+
+### Workflow authoring API
+- Add `workflow.ContinueAsNew(input any) error` — returns a sentinel error recognized by the replay engine
+- Returning the sentinel from the workflow `Run` function, or returning an error that wraps it, triggers continuation
+- Swallowing the sentinel, or otherwise failing to return it after producing it, is a programming error that produces a replay mismatch on subsequent activations
+- Replay matches continuation input using the existing JSON-equivalence rule: trimmed byte equality first, otherwise decoded semantic JSON equality
+- The sentinel is replay-aware: on replay, `workflow.continued_as_new` is consumed as a terminal event
+
+### Engine runtime
+- Add lowercase `continued_as_new` to `engine.run_lifecycle_status` (the public API continues to expose uppercase `CONTINUED_AS_NEW`; the instance stays `active`)
+- Add `decisionContinuedAsNew` to the activation decision kinds
+- When the replay engine observes the `ContinueAsNew` sentinel:
+  1. Append `workflow.continued_as_new` history event (payload: `input`)
+  2. Transition the current run to stored status `continued_as_new` with `completed_at = NOW()`
+  3. Create run N+1 on the same instance with `run_number = previous + 1`, same `definition_version` (or allow override — deferred), fresh history starting with `workflow.started`
+  4. Cancel open activity tasks and discard open inbox items on the old run (same cleanup as cancellation)
+  5. Set `continued_to_run_id` on the old run, `continued_from_run_id` on the new run
+  6. Update terminal-status helpers, retention candidate selection, purge eligibility, and terminal projection logic to treat `continued_as_new` as terminal
+  7. All within the same activation transaction
+- Instance status remains `active` during continuation (there is still an active run)
+- Per-instance "latest run" lookups switch to `run_number DESC, id DESC` so the continuation target is unambiguously current once an instance has multiple runs
+
+### Trace projection
+- `StartRun` keeps its existing root-module trace bootstrap path
+- `ContinueAsNew` creates the new trace shell/root span inside the engine module activation path, using inherited session and trace presentation fields (name, user_id, tags, environment, release, metadata) from the previous run's projected trace shell
+- The new trace shell is created immediately within the continuation transaction, with the same live-shell shape as `StartRun`: trace/root raw status `running`, `output = null`, input set to the continuation input, `engine_run_status = queued`, nil wait/custom status, zero pending counts, `engine_instance_key = instance.instance_key`, and `engine_definition_name` / `engine_definition_version` set for the new run, plus `engine_projection_state = up_to_date` with the new `workflow.started` event as the initial checkpoint
+- `continued_as_new` maps to projected raw trace status `completed` and root-span status `completed` (the old run is terminal)
+- The terminal projection for `continued_as_new` keeps trace/root `output = null`; it MUST NOT synthesize the failure-shaped payload used for failed terminal states
+- `continued_as_new` uses its own terminal cleanup reason so discarded activity/timer waits on the old trace emit resolved wait events with continuation-specific resolution, consistent with the existing cancellation/termination cleanup model
+- When the old run was waiting on a signal, terminal projection clears the projected signal wait state so the debugger does not retain a stale pending wait; a pure signal wait does not require a synthetic resolved signal event
+- If the previous projected trace shell is unexpectedly missing, continuation fails the activation as an invariant violation rather than silently creating a degraded shell; nullable presentation fields may still remain null when the source trace row exists
+
+### API surface
+- `EngineRunSummary`, run detail, and run result responses include `continued_from_run_id`, `continued_to_run_id`, `continued_from_trace_id`, and `continued_to_trace_id` as nullable fields
+- `continued_from_trace_id` / `continued_to_trace_id` are derived from the corresponding run chain fields using the existing `engine:<run_id>` trace ID format; no extra trace-link columns are added
+- `GET /v1/engine/runs/{run_id}/result` returns status `CONTINUED_AS_NEW` for a continued run, while keeping `result` reserved for the stored workflow result payload, so continued runs return `null` there
+- Instance responses return the highest `run_number` as the current run, which is the continuation target after a continue-as-new hop
+- Trace detail surfaces that expose `TraceDetail.engine` inherit the same continuation fields through `EngineRunSummary`; they do not require a second run-detail fetch just to discover continuation links
+- Public OpenAPI and SDK enums use uppercase `CONTINUED_AS_NEW`; stored `engine_run_status` values and trace-search filters use lowercase `continued_as_new`
+
+### Schema
+- Add `continued_from_run_id UUID REFERENCES engine.runs(id)` and `continued_to_run_id UUID REFERENCES engine.runs(id)` to `engine.runs`
+- Add `workflow.continued_as_new` history event type
+- Update the `public.traces.engine_run_status` constraint to allow `continued_as_new`
+
+### Python SDK
+- Extend `wait_for_terminal(run_id, ..., follow_continuations=False, max_continuations=32)`:
+  - When `follow_continuations=True` and the result status is `CONTINUED_AS_NEW`, follow `continued_to_run_id` and poll the next run
+  - Repeat up to `max_continuations` hops
+  - Raise `EngineRunContinuationDepthError` if the chain exceeds the limit
+  - Default `follow_continuations=False` preserves backward compatibility
+- Add `CONTINUED_AS_NEW` to the `EngineRunStatus` enum
+
+## Impact
+
+- Affected specs (delta per capability):
+  - `engine-runtime-execution` (ADDED: CONTINUED_AS_NEW status, continuation decision, run chain linkage, latest-run ordering, old-run cleanup, terminal-status plumbing)
+  - `engine-public-api` (ADDED: continuation chain fields on summary/run/result responses, uppercase status contract, current-run semantics, trace-search filter enum)
+  - `engine-workflow-api` (ADDED: ContinueAsNew API)
+  - `engine-trace-projection` (ADDED: continued_as_new→completed mapping, immediate continuation trace shell creation, explicit live-shell/output semantics, signal-wait cleanup, presentation inheritance)
+  - `engine-python-control-client` (ADDED: follow_continuations on wait_for_terminal, CONTINUED_AS_NEW status, continuation depth error)
+- Affected code:
+  - `engine/pkg/workflow/context.go` — `ContinueAsNew(input any) error`, `ErrContinueAsNew` sentinel
+  - `engine/pkg/history/history.go` — `workflow.continued_as_new` event type and payload
+  - `engine/db/migrations/postgres/` — `continued_as_new` enum value, chain linkage columns on `engine.runs`
+  - `engine/db/queries/runs.sql` — `TransitionRunToContinuedAsNew`, chain linkage updates, and `run_number`-based latest-run ordering
+  - `engine/internal/workflow/replay.go` — `decisionContinuedAsNew`, replay handling of continuation sentinel
+  - `engine/internal/workflow/activation.go` — continuation decision commit: create run N+1, update chain links, read inherited trace presentation fields, and create the new trace shell/root span
+  - `internal/api/engine_control.go` — terminal-status handling and current-run semantics continue through the updated latest-run query
+  - `internal/api/engine_mapper.go` — add continuation fields to run/result response mapping and synthesize trace IDs from run links
+  - `contracts/openapi/openapi.yaml` — continuation chain fields on engine response schemas, uppercase `EngineRunStatus`, and lowercase `engine_run_status` trace-filter enum; `make generate`
+  - `db/platform/migrations/postgres/` — extend the `traces_engine_run_status_check` constraint for `continued_as_new`
+  - `internal/store/search.go` — accept `continued_as_new` in trace filtering
+  - `internal/store/engine_projection.go`, `internal/api/engine_control.go`, `internal/enginecontrol/service.go`, `engine/pkg/projection/terminal.go`, `engine/internal/projector/` — continued-as-new terminal handling for retention, purge, terminal shells, projected status mapping, and continuation-specific cleanup semantics
+  - `sdks/python/src/continua/engine_control.py` — `follow_continuations` parameter on `wait_for_terminal`
+  - `sdks/python/src/continua/types.py` — `CONTINUED_AS_NEW` enum value
+  - `sdks/python/src/continua/exceptions.py` — `EngineRunContinuationDepthError`
+
+## Assumptions
+
+- `add-engine-activity-retries` is implemented; the `RetryPolicy` and `ActivityOptions` contracts are frozen
+- The continuation creates a new run of the SAME `definition_version` — version override on continuation is deferred
+- ContinueAsNew is a workflow-authored decision, not an operator control; there is no external `POST /v1/engine/runs/{run_id}/continue` endpoint
+- The old run's open activity tasks and inbox items are cancelled/discarded (same cleanup as cancellation), not carried over to the new run
+- The new run starts fresh with `run_number = N+1` and a single `workflow.started` event; no history is carried over
+- Instance key is preserved; the continuation is logically the same workflow instance continuing with fresh state
+- The continuation input remains available in the old run's terminal history event and in the new run's `workflow.started` input; it is not overloaded into the old run's `result` field
+- `CONTINUED_AS_NEW` is terminal for purge and retention purposes (eligible for projection_only and full purge after retention window)

--- a/openspec/changes/add-engine-continue-as-new/specs/engine-public-api/spec.md
+++ b/openspec/changes/add-engine-continue-as-new/specs/engine-public-api/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Continuation Chain Fields in Engine Run Surfaces
+The `EngineRunSummary`, `EngineRunResponse`, and `EngineRunResultResponse` schemas SHALL include nullable fields: `continued_from_run_id`, `continued_to_run_id`, `continued_from_trace_id`, `continued_to_trace_id`.
+
+These fields SHALL be populated for runs that are part of a continuation chain and null for non-continued runs.
+
+`continued_from_trace_id` and `continued_to_trace_id` SHALL be derived from the corresponding run IDs using the deterministic `engine:<run_id>` trace ID format.
+
+#### Scenario: Run detail with continuation
+- **WHEN** a client calls `GET /v1/engine/runs/{run_id}` on a run that has `continued_to_run_id`
+- **THEN** the response includes `continued_to_run_id` and `continued_to_trace_id`
+
+#### Scenario: Trace detail engine summary with continuation
+- **WHEN** a client reads a trace detail whose `engine` summary refers to a continued run
+- **THEN** the `TraceDetail.engine` object includes the continuation chain fields without requiring a second run-detail fetch
+
+#### Scenario: Run detail without continuation
+- **WHEN** a client calls `GET /v1/engine/runs/{run_id}` on a run with no continuation chain
+- **THEN** the continuation fields are null
+
+### Requirement: ContinuedAsNew Status in Run Result
+`GET /v1/engine/runs/{run_id}/result` SHALL return a response with status `CONTINUED_AS_NEW` for continued runs.
+
+The continuation chain fields SHALL be populated.
+
+The `result` field SHALL continue to represent the stored workflow result payload and SHALL therefore be `null` for continued runs.
+
+#### Scenario: Get result on continued run
+- **WHEN** a client calls `GET /v1/engine/runs/{run_id}/result` on a `CONTINUED_AS_NEW` run
+- **THEN** the response includes `status: "CONTINUED_AS_NEW"`, `result: null`, and `continued_to_run_id`
+
+### Requirement: Instance Response Shows Highest Run Number
+`GET /v1/engine/instances/{instance_key}` SHALL return the run with the highest `run_number`, which for continued instances is the continuation target.
+
+#### Scenario: Instance shows continuation target
+- **WHEN** run 1 continued as run 2
+- **AND** a client calls `GET /v1/engine/instances/{instance_key}`
+- **THEN** the response includes run 2 as the current run
+
+### Requirement: ContinuedAsNew Status in OpenAPI Enum
+The `EngineRunStatus` enum in the OpenAPI schema SHALL include `CONTINUED_AS_NEW`.
+
+#### Scenario: Status enum includes continued_as_new
+- **WHEN** a client receives a run response with status `CONTINUED_AS_NEW`
+- **THEN** the status is valid per the OpenAPI schema
+
+### Requirement: Trace Search Filter Accepts continued_as_new
+The `engine_run_status` query parameter on `GET /api/traces` SHALL accept lowercase `continued_as_new`.
+
+#### Scenario: Trace search filters continued runs
+- **WHEN** a client calls `GET /api/traces?engine_run_status=continued_as_new`
+- **THEN** the request is valid per the OpenAPI schema
+- **AND** only continued runs are eligible to match the filter

--- a/openspec/changes/add-engine-continue-as-new/specs/engine-python-control-client/spec.md
+++ b/openspec/changes/add-engine-continue-as-new/specs/engine-python-control-client/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Continuation Following in wait_for_terminal
+The `EngineControlClient.wait_for_terminal` method SHALL accept `follow_continuations` (default `False`) and `max_continuations` (default `32`) parameters.
+
+When `follow_continuations=True` and the result status is `CONTINUED_AS_NEW`, the SDK SHALL extract `continued_to_run_id` from the result and poll the next run, repeating until a non-continuation terminal status is observed or the depth limit is reached.
+
+When `follow_continuations=False` (default), the method SHALL return the result of the specific run regardless of status, preserving backward compatibility.
+
+#### Scenario: Follow single continuation
+- **WHEN** a client calls `wait_for_terminal(run_id, follow_continuations=True)`
+- **AND** the run terminates with `CONTINUED_AS_NEW` pointing to run2
+- **AND** run2 terminates with `completed`
+- **THEN** the method returns run2's result
+
+#### Scenario: No follow by default
+- **WHEN** a client calls `wait_for_terminal(run_id)` (default follow_continuations=False)
+- **AND** the run terminates with `CONTINUED_AS_NEW`
+- **THEN** the method returns the CONTINUED_AS_NEW result directly
+
+#### Scenario: Multi-hop continuation
+- **WHEN** a client calls `wait_for_terminal(run_id, follow_continuations=True)`
+- **AND** the chain is run1 → run2 → run3 (completed)
+- **THEN** the method follows the chain and returns run3's result
+
+### Requirement: Continuation Depth Guard
+When `follow_continuations=True` and the continuation chain exceeds `max_continuations`, the SDK SHALL raise `EngineRunContinuationDepthError`.
+
+#### Scenario: Depth limit exceeded
+- **WHEN** a client calls `wait_for_terminal(run_id, follow_continuations=True, max_continuations=1)`
+- **AND** the chain has 2 or more continuations
+- **THEN** `EngineRunContinuationDepthError` is raised
+
+### Requirement: CONTINUED_AS_NEW Status Enum
+The `EngineRunStatus` enum in the Python SDK types SHALL include `CONTINUED_AS_NEW`.
+
+#### Scenario: Status enum includes continued_as_new
+- **WHEN** a client receives a run response with status `CONTINUED_AS_NEW`
+- **THEN** the SDK decodes it as `EngineRunStatus.CONTINUED_AS_NEW`
+
+### Requirement: Continuation Chain Fields in Response Types
+The `EngineRunResultResponse` type SHALL include `continued_from_run_id`, `continued_to_run_id`, `continued_from_trace_id`, `continued_to_trace_id` as optional string fields.
+
+#### Scenario: Response includes continuation fields
+- **WHEN** a client calls `get_result(run_id)` on a continued run
+- **THEN** the response object has `continued_to_run_id` and `continued_to_trace_id` populated
+
+### Requirement: EngineRunContinuationDepthError Exception
+The Python SDK SHALL expose `EngineRunContinuationDepthError` for cases where the continuation chain exceeds the depth limit during `wait_for_terminal`.
+
+#### Scenario: Depth error raised
+- **WHEN** continuation following exceeds `max_continuations`
+- **THEN** `EngineRunContinuationDepthError` is raised with the run_id and depth limit

--- a/openspec/changes/add-engine-continue-as-new/specs/engine-runtime-execution/spec.md
+++ b/openspec/changes/add-engine-continue-as-new/specs/engine-runtime-execution/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: ContinueAsNew Run Status
+The engine SHALL support a `CONTINUED_AS_NEW` terminal run lifecycle status that indicates the current run has been atomically replaced by a new continuation run.
+
+`CONTINUED_AS_NEW` is terminal for the current run: it SHALL NOT be claimed, activated, or further modified.
+
+`CONTINUED_AS_NEW` is terminal for purge and retention purposes.
+
+`continued_as_new` SHALL be included anywhere the runtime currently treats run statuses as terminal.
+
+The instance SHALL remain `active` during continuation (a new active run exists).
+
+#### Scenario: Run transitions to continued_as_new
+- **WHEN** a workflow returns the `ContinueAsNew` sentinel
+- **THEN** the run status transitions to `continued_as_new` with `completed_at = NOW()`
+
+#### Scenario: Instance stays active
+- **WHEN** a run transitions to `continued_as_new`
+- **THEN** the instance status remains `active`
+
+#### Scenario: Continued run is eligible for terminal handling
+- **WHEN** a run transitions to `continued_as_new`
+- **THEN** terminal read paths, purge checks, and retention candidate selection all treat it as terminal
+
+### Requirement: Continuation Creates Run N+1
+When a workflow returns the `ContinueAsNew` sentinel, the engine SHALL atomically create run N+1 within the same activation transaction.
+
+Run N+1 SHALL have `run_number = previous + 1`, the same `instance_id`, the same `definition_version`, and the continuation input.
+
+Run N+1 SHALL start with a single `workflow.started` history event and status `queued`.
+
+#### Scenario: Continuation run creation
+- **WHEN** run 1 returns `ContinueAsNew(newInput)`
+- **THEN** run 2 is created with `run_number = 2`, same instance, status `queued`
+- **AND** run 2's history starts with `workflow.started` containing `newInput`
+
+### Requirement: Run Chain Linkage
+The engine SHALL maintain bidirectional run chain linkage via `continued_from_run_id` and `continued_to_run_id` on `engine.runs`.
+
+`continued_to_run_id` SHALL be set on run N within the continuation transaction. `continued_from_run_id` SHALL be set on run N+1 at creation.
+
+#### Scenario: Chain linkage on continuation
+- **WHEN** run 1 continues as run 2
+- **THEN** run 1 has `continued_to_run_id = run2.id`
+- **AND** run 2 has `continued_from_run_id = run1.id`
+
+### Requirement: Latest Run Uses Highest Run Number
+Any per-instance "latest/current run" lookup SHALL order runs by `run_number` descending, using `id` as the tiebreaker.
+
+#### Scenario: Latest run resolves to continuation target
+- **WHEN** run 1 continues as run 2
+- **AND** both runs belong to the same instance
+- **THEN** the instance's latest/current run resolves to run 2 because it has the higher `run_number`
+
+### Requirement: Old Run Cleanup on Continuation
+When a run transitions to `CONTINUED_AS_NEW`, the engine SHALL cancel open activity tasks and discard open inbox items on the old run, using the same cleanup operations as cancellation.
+
+#### Scenario: Old run cleanup
+- **WHEN** run 1 transitions to `continued_as_new`
+- **THEN** run 1's open activity tasks are cancelled
+- **AND** run 1's open inbox items are discarded
+
+### Requirement: ContinueAsNew History Event
+The engine SHALL append a `workflow.continued_as_new` history event as the terminal event on the old run.
+
+The event payload SHALL contain the continuation input.
+
+#### Scenario: Terminal history event
+- **WHEN** a workflow returns `ContinueAsNew(newInput)`
+- **THEN** a `workflow.continued_as_new` event is appended to the old run's history with the continuation input

--- a/openspec/changes/add-engine-continue-as-new/specs/engine-trace-projection/spec.md
+++ b/openspec/changes/add-engine-continue-as-new/specs/engine-trace-projection/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: ContinuedAsNew Projection Mapping
+The projector SHALL map `continued_as_new` engine run status to projected raw trace status `completed` and root-span status `completed`.
+
+The `workflow.continued_as_new` event SHALL set `end_time` on the trace and root span.
+
+The terminal trace/root span projection for `continued_as_new` SHALL keep `output = null`; it SHALL NOT synthesize the failure-shaped payload used for failed terminal states.
+
+#### Scenario: Continued run trace status
+- **WHEN** a run transitions to `continued_as_new`
+- **THEN** the projected trace status is `completed`
+- **AND** the projected root-span status is `completed`
+- **AND** the projected trace/root `output` remains `null`
+- **AND** `end_time` is set on both the trace and root span
+
+### Requirement: Continuation Trace Shell Inherits Presentation Fields
+When run N continues as run N+1, the new trace shell SHALL inherit the previous run's session link and presentation fields (`name`, `user_id`, `tags`, `environment`, `release`, `metadata`).
+
+#### Scenario: ContinueAsNew inherits fields
+- **WHEN** run N continues as run N+1
+- **THEN** run N+1's trace shell inherits `name`, `user_id`, `tags`, `environment`, `release`, and `metadata` from run N's trace
+- **AND** run N+1 is linked to the same session as run N
+
+### Requirement: Continuation Trace Shell Created Immediately
+The new trace shell and root span SHALL be created within the continuation transaction, not deferred to the projector.
+
+The new trace shell SHALL have `engine_projection_state = up_to_date` and the new `workflow.started` event ID as both `engine_latest_history_id` and `engine_last_projected_history_id`.
+
+The continuation shell SHALL reproduce the same live-shell fields as `StartRun`: trace status `running`, root-span status `running`, `output = null`, trace/root input set to the continuation input, `engine_run_status = queued`, nil `engine_custom_status`, nil `engine_wait_state`, zero pending counts, `engine_instance_key`, and `engine_definition_name` / `engine_definition_version`.
+
+#### Scenario: Immediate trace shell creation
+- **WHEN** a continuation transaction commits
+- **THEN** the new trace shell exists in `public.traces` with `engine_projection_state = "up_to_date"`
+- **AND** the new root span exists in `public.spans`
+
+#### Scenario: Continuation shell uses continuation input
+- **WHEN** run N continues as run N+1 with continuation input X
+- **THEN** the new trace shell input is X
+- **AND** the new root span input is X
+- **AND** the old trace input is not copied onto the new shell
+
+#### Scenario: Missing previous trace shell fails continuation
+- **WHEN** run N attempts to continue as run N+1
+- **AND** the previous projected trace shell row is unexpectedly missing
+- **THEN** continuation fails as an invariant violation
+- **AND** the engine does not silently create a degraded fallback shell
+
+### Requirement: Signal Wait State Does Not Strand on Continuation
+When a run that is waiting on a signal transitions to `continued_as_new`, terminal projection SHALL clear the projected signal wait state on the old trace so the debugger does not retain a stale pending signal wait.
+
+A pure signal wait does not require a synthetic resolved-signal timeline event.
+
+#### Scenario: Signal wait clears on continuation
+- **WHEN** a run in a signal wait transitions to `continued_as_new`
+- **THEN** the projected `engine_wait_state` is cleared on the old trace
+- **AND** the debugger does not retain a stale pending signal wait for that run
+
+### Requirement: Activity and Timer Wait Cleanup Is Explicit on Continuation
+When a run transitions to `continued_as_new`, terminal projection SHALL use a continuation-specific cleanup reason for cancelled activity waits and discarded timer waits on the old trace.
+
+Those waits SHALL emit resolved wait events using that continuation cleanup reason.
+
+#### Scenario: Activity and timer waits resolve on continuation
+- **WHEN** a run with open activity and timer waits transitions to `continued_as_new`
+- **THEN** the old trace emits resolved wait events for those waits
+- **AND** the resolution value identifies continuation cleanup rather than cancellation or termination

--- a/openspec/changes/add-engine-continue-as-new/specs/engine-workflow-api/spec.md
+++ b/openspec/changes/add-engine-continue-as-new/specs/engine-workflow-api/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: ContinueAsNew Sentinel
+The engine workflow package SHALL expose `ContinueAsNew(input any) error` that returns a sentinel error recognized by the replay engine as a continuation request.
+
+The sentinel SHALL be detectable via `errors.Is(err, ErrContinueAsNew)` and the continuation input SHALL be extractable from the error.
+
+Returning the sentinel from the workflow `Run` function, or returning an error that wraps it, triggers continuation. Swallowing the sentinel, or otherwise failing to return it, is a programming error that produces a replay mismatch.
+
+#### Scenario: ContinueAsNew returned from workflow
+- **WHEN** a workflow returns `workflow.ContinueAsNew(newInput)`
+- **THEN** the replay engine detects the sentinel and produces a `decisionContinuedAsNew`
+- **AND** the continuation input is available in the decision
+
+#### Scenario: ContinueAsNew sentinel detection
+- **WHEN** an error wraps the `ErrContinueAsNew` sentinel
+- **THEN** `errors.Is(err, workflow.ErrContinueAsNew)` returns `true`
+
+### Requirement: ContinueAsNew Replay Handling
+On replay, if the history contains a `workflow.continued_as_new` event, the replay engine SHALL verify that the workflow returns the `ContinueAsNew` sentinel with matching input.
+
+Matching input SHALL use the same JSON-equivalence rule as existing replay payload comparisons: trimmed raw bytes match first; otherwise both payloads are decoded as JSON and compared for semantic equality.
+
+A mismatch (workflow completes normally or fails instead of continuing) SHALL produce a `workflow.replay_mismatch` event.
+
+#### Scenario: Replay matches continuation
+- **WHEN** history contains `workflow.continued_as_new` with input X
+- **AND** the workflow returns `ContinueAsNew(X)` on replay
+- **THEN** the replay cursor advances past the event and the decision is `continuedAsNew`
+
+#### Scenario: Replay matches semantically equivalent JSON
+- **WHEN** history contains `workflow.continued_as_new` with JSON input `{"a":1,"b":2}`
+- **AND** the workflow returns `ContinueAsNew({"b":2,"a":1})` on replay
+- **THEN** the replay treats the continuation input as matching
+
+#### Scenario: Replay mismatch on continuation
+- **WHEN** history contains `workflow.continued_as_new`
+- **AND** the workflow returns `nil` (completes) on replay
+- **THEN** a `workflow.replay_mismatch` event is produced

--- a/openspec/changes/add-engine-continue-as-new/tasks.md
+++ b/openspec/changes/add-engine-continue-as-new/tasks.md
@@ -1,0 +1,126 @@
+## 1. Schema and Generated Types
+
+- [x] 1.1 Add an engine migration: `ALTER TYPE engine.run_lifecycle_status ADD VALUE IF NOT EXISTS 'continued_as_new'`
+- [x] 1.2 Add an engine migration: add `continued_from_run_id UUID REFERENCES engine.runs(id)` and `continued_to_run_id UUID REFERENCES engine.runs(id)` to `engine.runs` (both nullable)
+- [x] 1.3 Add a platform migration updating `traces_engine_run_status_check` so `public.traces.engine_run_status` accepts lowercase `continued_as_new`
+- [x] 1.4 Run `make generate` so engine/platform sqlc output includes the new enum value and run-chain columns
+
+**Validation:** migrations apply cleanly; generated types compile; existing rows are unaffected; platform traces accept `continued_as_new`
+
+## 2. Workflow Authoring API and History Event
+
+- [x] 2.1 Add `ErrContinueAsNew` in `engine/pkg/workflow/context.go` following the replay-aware sentinel pattern used by `ErrCancelled`
+- [x] 2.2 Add `ContinueAsNew(input any) error` that marshals the input and returns a sentinel carrying the payload
+- [x] 2.3 Ensure `errors.Is(err, ErrContinueAsNew)` works through wrapping and the payload is recoverable via a typed error / accessor
+- [x] 2.4 Add `EventWorkflowContinuedAsNew = "workflow.continued_as_new"` plus payload registration/decoding in `engine/pkg/history/history.go`
+- [x] 2.5 Add unit tests for sentinel creation/extraction and history event encoding/decoding
+
+**Validation:** the sentinel round-trips correctly through wrapped errors; the continuation input is recoverable; the event serializes and deserializes correctly
+
+## 3. Engine Queries and Latest-Run Ordering
+
+- [x] 3.1 Add `TransitionRunToContinuedAsNew :one` in `engine/db/queries/runs.sql`: CAS on `status = 'running' AND claimed_by = $2`, set `status = 'continued_as_new'`, `completed_at = NOW()`, `continued_to_run_id = $3`, clear wait/claim fields, and return the updated row
+- [x] 3.2 Add `continued_from_run_id` support for the new run, either directly in `CreateRun` or through a dedicated update query
+- [x] 3.3 Update `GetLatestRunByInstance` to order by `run_number DESC, id DESC`
+- [x] 3.4 Update `ListRunsByInstance` to order by `run_number DESC, id DESC`
+- [x] 3.5 Run `make generate` and update any engine CLI/runtime callers that assume created-at ordering
+
+**Validation:** sqlc generation succeeds; continuation CAS queries compile; per-instance "latest run" lookups return the highest run number
+
+## 4. Replay and Activation Continuation Commit
+
+- [x] 4.1 Add `decisionContinuedAsNew` to the replay/activation decision kinds
+- [x] 4.2 In `workflowRunner.execute()`, detect `ErrContinueAsNew`, extract the continuation input, append `workflow.continued_as_new`, and return `decisionContinuedAsNew`
+- [x] 4.3 On replay, if history already contains `workflow.continued_as_new`, require the workflow to return the same continuation sentinel/input using the existing `equalJSON` rule (trimmed byte equality first, otherwise decoded semantic JSON equality), or emit a replay mismatch
+- [x] 4.4 Add a `decisionContinuedAsNew` branch in `engine/internal/workflow/activation.go` that, in one transaction:
+- [x] 4.5 Cancels open activity tasks on the old run and discards open inbox items on the old run
+- [x] 4.6 Transitions the old run to `continued_as_new`
+- [x] 4.7 Creates run N+1 on the same instance with `run_number = old + 1`, the same `definition_version`, and `continued_from_run_id = old_run.id`
+- [x] 4.8 Appends `workflow.started` on the new run with the continuation input
+- [x] 4.9 Keeps the instance `active` instead of moving it to a terminal instance status
+- [x] 4.10 Add replay and activation tests for first execution, replay match, replay mismatch, JSON-semantic replay equality (for example different object key order), and bidirectional run-chain linkage
+
+**Validation:** replay tests pass; continuation remains atomic; the old run is terminal and the new run is immediately current
+
+## 5. Continuation Trace Bootstrap
+
+- [x] 5.1 In the activation transaction, read the old run's projected trace shell to inherit session and presentation fields (`name`, `user_id`, `tags`, `environment`, `release`, `metadata`); if that trace row is unexpectedly missing, fail the activation as an invariant violation rather than creating a degraded fallback shell
+- [x] 5.2 Create the new trace shell and root span from the engine module continuation path using the exact live-shell fields that `StartRun` establishes: trace status `running`, root-span status `running`, `output = null`, trace/root input set to the continuation input, `engine_run_status = queued`, nil wait/custom status, zero pending counts, `engine_instance_key`, and `engine_definition_name` / `engine_definition_version`; do not require a helper extracted from `internal/api` or `internal/enginecontrol`
+- [x] 5.3 Set the new trace shell to `engine_projection_state = up_to_date` and use the new `workflow.started` history ID as both `engine_latest_history_id` and `engine_last_projected_history_id`
+- [x] 5.4 Add activation/integration tests covering inherited presentation fields, preserved session link, immediate trace-shell/root-span creation, the exact live-shell field values above, and invariant-violation behavior when the previous trace shell is missing
+
+**Validation:** continuation creates the new trace shell immediately; the new trace inherits the previous run's presentation fields; no cross-module helper refactor is required
+
+## 6. Terminal-Status Plumbing
+
+- [x] 6.1 Update terminal-status helpers in `internal/api/engine_control.go` and `internal/enginecontrol/service.go` so stored status `continued_as_new` is treated as terminal in read APIs and purge eligibility
+- [x] 6.2 Update retention candidate selection in `internal/store/engine_projection.go` so `continued_as_new` is eligible after the retention window
+- [x] 6.3 Update terminal projection helpers in `engine/pkg/projection/terminal.go` and `engine/internal/projector/` so `continued_as_new` maps to trace/root-span `completed`, keeps terminal trace/root `output = null`, uses a continuation-specific cleanup reason for discarded activity/timer waits, and clears projected signal wait state without leaving stale wait UI
+- [x] 6.4 Add tests covering terminal shells, purge/retention eligibility, projected terminal mapping for continued runs, null terminal output for `continued_as_new`, resolved activity/timer wait events under the continuation cleanup reason, and signal-wait cleanup semantics
+
+**Validation:** continued runs behave like terminal runs everywhere terminal-status sets are currently checked
+
+## 7. OpenAPI and Engine Response Mapping
+
+- [x] 7.1 Add uppercase `CONTINUED_AS_NEW` to the `EngineRunStatus` enum in `contracts/openapi/openapi.yaml`
+- [x] 7.2 Add nullable `continued_from_run_id`, `continued_to_run_id`, `continued_from_trace_id`, and `continued_to_trace_id` to `EngineRunSummary`, `EngineRunResponse`, and `EngineRunResultResponse`
+- [x] 7.3 Derive `continued_from_trace_id` / `continued_to_trace_id` from the corresponding run IDs using `engine:<run_id>` rather than adding `public.traces` columns
+- [x] 7.4 Keep `EngineRunResultResponse.result` reserved for the stored workflow result payload; `CONTINUED_AS_NEW` responses return `result = null`
+- [x] 7.5 Ensure `GET /v1/engine/instances/{instance_key}` returns the highest `run_number` as `current_run`
+- [x] 7.6 Add handler/mapper tests for continuation fields on `EngineRunSummary`, trace detail `engine`, instance `current_run`, run detail, and run result; also verify uppercase status output, null result on continued runs, and current-run selection after a continuation
+- [x] 7.7 Run `make generate` and verify generated Go, TypeScript, and Python bindings stay in sync
+
+**Validation:** OpenAPI generation succeeds; engine endpoints return uppercase `CONTINUED_AS_NEW`; continuation fields are present and trace IDs are derived correctly
+
+## 8. Trace Search Filter and Constraint Coverage
+
+- [x] 8.1 Add lowercase `continued_as_new` to the `/api/traces` `engine_run_status` query parameter enum in `contracts/openapi/openapi.yaml`
+- [x] 8.2 Update `internal/store/search.go` validation to accept lowercase `continued_as_new`
+- [x] 8.3 Add a trace search test showing `engine_run_status=continued_as_new` returns only continued runs
+
+**Validation:** the public trace-search contract and platform constraint both accept `continued_as_new`
+
+## 9. Python SDK
+
+- [x] 9.1 Add `CONTINUED_AS_NEW` to the generated/manual `EngineRunStatus` enum surface in `sdks/python/src/continua/types.py`
+- [x] 9.2 Add `EngineRunContinuationDepthError` in `sdks/python/src/continua/exceptions.py`
+- [x] 9.3 Extend engine run result/response models with continuation run IDs and derived trace IDs
+- [x] 9.4 Extend `wait_for_terminal` to accept `follow_continuations=False` and `max_continuations=32`
+- [x] 9.5 When `follow_continuations=True` and status is `CONTINUED_AS_NEW`, follow `continued_to_run_id` until a non-continuation terminal status is reached or the depth limit is exceeded
+- [x] 9.6 Add unit tests for default no-follow behavior, one-hop and multi-hop follow behavior, and depth-limit failure
+- [ ] 9.7 Run `cd sdks/python && uv run pytest`
+
+**Validation:** Python callers can opt into continuation following without changing the default per-run semantics
+
+## 10. Integration and Regression
+
+- [x] 10.1 Integration test: workflow calls `ContinueAsNew(newInput)` and run N becomes `CONTINUED_AS_NEW` while run N+1 is created with `run_number = old + 1`
+- [x] 10.2 Integration test: run-chain linkage is correct on both runs, instance reads return run N+1 as `current_run`, and trace detail `engine` summary exposes continuation chain fields without requiring a separate run-detail fetch
+- [x] 10.3 Integration test: run N+1 trace inherits session and presentation fields from run N
+- [x] 10.4 Integration test: run N+1 starts with fresh history (`workflow.started` only) and the continuation input
+- [x] 10.5 Integration test: run N's open activity tasks are cancelled and inbox items are discarded on continuation
+- [x] 10.6 Integration test: multi-hop continuation (run1 -> run2 -> run3) preserves run-chain linkage and highest-run ordering
+- [x] 10.7 Integration test: `GET /v1/engine/runs/{run_id}/result` on a continued run returns `CONTINUED_AS_NEW`, null `result`, and continuation chain fields
+- [x] 10.8 Integration test: purge/retention treats `CONTINUED_AS_NEW` as terminal
+- [x] 10.9 Integration test: `/api/traces?engine_run_status=continued_as_new` filters correctly
+- [x] 10.10 Integration test: Python `wait_for_terminal(follow_continuations=True)` follows a multi-hop chain and returns the final result
+- [x] 10.11 Integration test: Python `wait_for_terminal(..., max_continuations=1)` raises `EngineRunContinuationDepthError` on a deeper chain
+- [x] 10.12 Run `cd engine && go test ./...`
+- [x] 10.13 Run `go test ./internal/api/... ./internal/ingest/... ./internal/store/... ./internal/jobs/...`
+- [ ] 10.14 Run `pnpm --filter web test`
+- [ ] 10.15 Re-run `cd sdks/python && uv run pytest`
+
+**Validation:** continuation works end-to-end against real Postgres and does not regress existing engine/platform behavior
+
+---
+
+### Parallelization Notes
+
+- Tasks 1 and 2 can start in parallel
+- Task 3 depends on Task 1
+- Task 4 depends on Tasks 2 and 3
+- Task 5 depends on Task 4
+- Task 6 depends on Tasks 1, 4, and 5
+- Tasks 7 and 8 depend on Task 1 and can proceed in parallel with late engine work once the contracts are settled
+- Task 9 depends on Task 7
+- Task 10 is final

--- a/sdks/python/src/continua/__init__.py
+++ b/sdks/python/src/continua/__init__.py
@@ -26,6 +26,7 @@ from .engine_control import EngineControlClient
 from .exceptions import (
     AuthenticationError,
     ContinuaError,
+    EngineRunContinuationDepthError,
     EngineRunNotFoundError,
     EngineRunNotTerminalError,
     EngineRunWaitTimeoutError,
@@ -56,6 +57,7 @@ __all__ = [
     # Exceptions
     "ContinuaError",
     "AuthenticationError",
+    "EngineRunContinuationDepthError",
     "EngineRunNotFoundError",
     "EngineRunNotTerminalError",
     "EngineRunWaitTimeoutError",

--- a/sdks/python/src/continua/engine_control.py
+++ b/sdks/python/src/continua/engine_control.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from .exceptions import (
     AuthenticationError,
+    EngineRunContinuationDepthError,
     EngineRunNotFoundError,
     EngineRunNotTerminalError,
     EngineRunWaitTimeoutError,
@@ -28,6 +29,7 @@ from .types import (
     EngineRunHistoryResponse,
     EngineRunResponse,
     EngineRunResultResponse,
+    EngineRunStatus,
     EngineSignalRunRequest,
     EngineStartRunRequest,
     EngineStartRunResponse,
@@ -187,16 +189,34 @@ class EngineControlClient:
         *,
         timeout: float | None = None,
         poll_interval: float = 1.0,
+        follow_continuations: bool = False,
+        max_continuations: int = 32,
     ) -> EngineRunResultResponse:
         deadline = None if timeout is None else time.monotonic() + timeout
+        current_run_id: UUID | str = run_id
+        continuations_followed = 0
 
         while True:
             try:
-                return self.get_result(run_id)
+                response = self.get_result(current_run_id)
             except EngineRunNotTerminalError:
                 if deadline is not None and time.monotonic() >= deadline:
-                    raise EngineRunWaitTimeoutError(str(run_id), timeout)
+                    raise EngineRunWaitTimeoutError(str(current_run_id), timeout)
                 time.sleep(poll_interval)
+                continue
+
+            if (
+                follow_continuations
+                and response.status == EngineRunStatus.CONTINUED_AS_NEW
+                and response.continued_to_run_id is not None
+            ):
+                if continuations_followed >= max_continuations:
+                    raise EngineRunContinuationDepthError(str(run_id), max_continuations)
+                continuations_followed += 1
+                current_run_id = response.continued_to_run_id
+                continue
+
+            return response
 
     def _request_model(
         self,

--- a/sdks/python/src/continua/exceptions.py
+++ b/sdks/python/src/continua/exceptions.py
@@ -95,3 +95,16 @@ class EngineRunWaitTimeoutError(ContinuaError):
         super().__init__(message)
         self.run_id = run_id
         self.timeout = timeout
+
+
+class EngineRunContinuationDepthError(ContinuaError):
+    """Raised when continuation following exceeds the configured hop limit."""
+
+    def __init__(self, run_id: str, max_continuations: int) -> None:
+        message = (
+            f"Exceeded continuation depth while waiting for engine run {run_id} "
+            f"(max_continuations={max_continuations})"
+        )
+        super().__init__(message)
+        self.run_id = run_id
+        self.max_continuations = max_continuations

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -54,6 +54,7 @@ class EngineRunStatus(Enum):
     FAILED = "FAILED"
     CANCELLED = "CANCELLED"
     TERMINATED = "TERMINATED"
+    CONTINUED_AS_NEW = "CONTINUED_AS_NEW"
 
 
 class EngineTraceInfo(BaseModel):
@@ -124,6 +125,10 @@ class EngineFailureSummary(BaseModel):
 class EngineRunSummary(EngineTraceInfo):
     status: EngineRunStatus
     instance_key: str
+    continued_from_run_id: UUID | None = None
+    continued_to_run_id: UUID | None = None
+    continued_from_trace_id: str | None = None
+    continued_to_trace_id: str | None = None
     custom_status: dict[str, Any] | None = None
     wait_state: EngineWaitState | None = None
     pending_work: EnginePendingWork
@@ -227,6 +232,10 @@ class EngineRunResponse(EngineRunSummary):
 
 class EngineRunResultResponse(BaseModel):
     run_id: UUID
+    continued_from_run_id: UUID | None = None
+    continued_to_run_id: UUID | None = None
+    continued_from_trace_id: str | None = None
+    continued_to_trace_id: str | None = None
     status: EngineRunStatus
     result: Any = Field(
         ...,

--- a/sdks/python/tests/test_engine_control.py
+++ b/sdks/python/tests/test_engine_control.py
@@ -6,10 +6,19 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+RUN_ID = "8fb17dc9-6565-4f3e-b671-8fd437416534"
+NEXT_RUN_ID = "ca66395e-bcf5-4bab-83e1-84d4520f9463"
+FINAL_RUN_ID = "6ff13fd6-5025-46d7-aa8d-6b07fe8f5587"
 
-def _run_response(status: str = "QUEUED", projection_state: str = "up_to_date") -> dict[str, object]:
+
+def _run_response(
+    status: str = "QUEUED",
+    projection_state: str = "up_to_date",
+    *,
+    run_id: str = RUN_ID,
+) -> dict[str, object]:
     return {
-        "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+        "run_id": run_id,
         "instance_id": "f8a5bcbf-fc93-42fa-a2fb-e99bf76ed910",
         "instance_key": "instance-1",
         "definition_name": "checkout",
@@ -23,22 +32,40 @@ def _run_response(status: str = "QUEUED", projection_state: str = "up_to_date") 
     }
 
 
-def _result_response(status: str = "COMPLETED") -> dict[str, object]:
-    return {
-        "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
-        "status": status,
-        "result": {"ok": True} if status == "COMPLETED" else None,
-        "failure": None if status == "COMPLETED" else {
+def _result_response(
+    status: str = "COMPLETED",
+    *,
+    run_id: str = RUN_ID,
+    continued_from_run_id: str | None = None,
+    continued_to_run_id: str | None = None,
+) -> dict[str, object]:
+    failure = None
+    if status not in {"COMPLETED", "CONTINUED_AS_NEW"}:
+        failure = {
             "error_code": "failed",
             "error_message": "boom",
             "status": status.lower(),
-        },
+        }
+
+    return {
+        "run_id": run_id,
+        "continued_from_run_id": continued_from_run_id,
+        "continued_to_run_id": continued_to_run_id,
+        "continued_from_trace_id": (
+            f"engine:{continued_from_run_id}" if continued_from_run_id is not None else None
+        ),
+        "continued_to_trace_id": (
+            f"engine:{continued_to_run_id}" if continued_to_run_id is not None else None
+        ),
+        "status": status,
+        "result": {"ok": True} if status == "COMPLETED" else None,
+        "failure": failure,
     }
 
 
 def _control_response(wake_applied: bool = True) -> dict[str, object]:
     return {
-        "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+        "run_id": RUN_ID,
         "instance_key": "instance-1",
         "accepted": True,
         "wake_applied": wake_applied,
@@ -58,13 +85,13 @@ def test_get_run_decodes_typed_response():
         from continua.types import EngineRunStatus
 
         client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
-        response = client.get_run("8fb17dc9-6565-4f3e-b671-8fd437416534")
+        response = client.get_run(RUN_ID)
 
         assert response.instance_key == "instance-1"
         assert response.status == EngineRunStatus.QUEUED
         mock_client.request.assert_called_once_with(
             "GET",
-            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534",
+            f"/v1/engine/runs/{RUN_ID}",
             json=None,
             params=None,
             headers=None,
@@ -78,7 +105,7 @@ def test_start_sends_preview_header_and_decodes_response():
             status_code=200,
             json=MagicMock(
                 return_value={
-                    "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                    "run_id": RUN_ID,
                     "instance_id": "f8a5bcbf-fc93-42fa-a2fb-e99bf76ed910",
                     "instance_key": "instance-1",
                     "definition_name": "checkout",
@@ -122,12 +149,20 @@ def test_start_sends_preview_header_and_decodes_response():
 
 
 @pytest.mark.parametrize(
-    ("method_name", "args", "path", "response_body", "expected_headers", "expected_json", "expected_params"),
+    (
+        "method_name",
+        "args",
+        "path",
+        "response_body",
+        "expected_headers",
+        "expected_json",
+        "expected_params",
+    ),
     [
         (
             "signal",
-            ("8fb17dc9-6565-4f3e-b671-8fd437416534", {"signal_name": "approval", "payload": {"ok": True}}),
-            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/signal",
+            (RUN_ID, {"signal_name": "approval", "payload": {"ok": True}}),
+            f"/v1/engine/runs/{RUN_ID}/signal",
             _control_response(True),
             {"X-Continua-Engine-Preview": "1"},
             {"signal_name": "approval", "payload": {"ok": True}},
@@ -135,8 +170,8 @@ def test_start_sends_preview_header_and_decodes_response():
         ),
         (
             "cancel",
-            ("8fb17dc9-6565-4f3e-b671-8fd437416534",),
-            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/cancel",
+            (RUN_ID,),
+            f"/v1/engine/runs/{RUN_ID}/cancel",
             _control_response(False),
             {"X-Continua-Engine-Preview": "1"},
             None,
@@ -144,8 +179,8 @@ def test_start_sends_preview_header_and_decodes_response():
         ),
         (
             "suspend",
-            ("8fb17dc9-6565-4f3e-b671-8fd437416534",),
-            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/suspend",
+            (RUN_ID,),
+            f"/v1/engine/runs/{RUN_ID}/suspend",
             _run_response("SUSPENDED"),
             {"X-Continua-Engine-Preview": "1"},
             None,
@@ -153,8 +188,8 @@ def test_start_sends_preview_header_and_decodes_response():
         ),
         (
             "resume",
-            ("8fb17dc9-6565-4f3e-b671-8fd437416534",),
-            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/resume",
+            (RUN_ID,),
+            f"/v1/engine/runs/{RUN_ID}/resume",
             _run_response("QUEUED"),
             {"X-Continua-Engine-Preview": "1"},
             None,
@@ -162,8 +197,8 @@ def test_start_sends_preview_header_and_decodes_response():
         ),
         (
             "terminate",
-            ("8fb17dc9-6565-4f3e-b671-8fd437416534",),
-            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/terminate",
+            (RUN_ID,),
+            f"/v1/engine/runs/{RUN_ID}/terminate",
             _result_response("TERMINATED"),
             {"X-Continua-Engine-Preview": "1"},
             None,
@@ -188,10 +223,10 @@ def test_start_sends_preview_header_and_decodes_response():
         ),
         (
             "get_pending_work",
-            ("8fb17dc9-6565-4f3e-b671-8fd437416534",),
-            "/v1/engine/runs/8fb17dc9-6565-4f3e-b671-8fd437416534/pending-work",
+            (RUN_ID,),
+            f"/v1/engine/runs/{RUN_ID}/pending-work",
             {
-                "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                "run_id": RUN_ID,
                 "current_wait": None,
                 "activities": [],
                 "timers": [],
@@ -244,7 +279,7 @@ def test_purge_sends_preview_header_and_body():
             status_code=200,
             json=MagicMock(
                 return_value={
-                    "run_id": "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                    "run_id": RUN_ID,
                     "mode": "projection_only",
                     "projection_state": "summary_only",
                     "deleted": True,
@@ -257,7 +292,7 @@ def test_purge_sends_preview_header_and_body():
 
         client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
         response = client.purge(
-            "8fb17dc9-6565-4f3e-b671-8fd437416534",
+            RUN_ID,
             mode="projection_only",
         )
 
@@ -436,7 +471,7 @@ def test_get_result_maps_run_not_terminal_to_typed_error():
         client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
 
         with pytest.raises(EngineRunNotTerminalError, match="not yet"):
-            client.get_result("8fb17dc9-6565-4f3e-b671-8fd437416534")
+            client.get_result(RUN_ID)
 
 
 def test_get_run_maps_not_found_to_typed_error():
@@ -455,7 +490,7 @@ def test_get_run_maps_not_found_to_typed_error():
         client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
 
         with pytest.raises(EngineRunNotFoundError, match="missing"):
-            client.get_run("8fb17dc9-6565-4f3e-b671-8fd437416534")
+            client.get_run(RUN_ID)
 
 
 def test_wait_for_terminal_returns_terminal_result():
@@ -480,7 +515,7 @@ def test_wait_for_terminal_returns_terminal_result():
 
             client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
             response = client.wait_for_terminal(
-                "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                RUN_ID,
                 timeout=5.0,
                 poll_interval=0.01,
             )
@@ -512,7 +547,7 @@ def test_wait_for_terminal_times_out():
 
                 with pytest.raises(EngineRunWaitTimeoutError, match="Timed out waiting"):
                     client.wait_for_terminal(
-                        "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                        RUN_ID,
                         timeout=0.1,
                         poll_interval=0.01,
                     )
@@ -537,7 +572,7 @@ def test_wait_for_terminal_zero_timeout_raises_immediately():
 
                 with pytest.raises(EngineRunWaitTimeoutError):
                     client.wait_for_terminal(
-                        "8fb17dc9-6565-4f3e-b671-8fd437416534",
+                        RUN_ID,
                         timeout=0.0,
                         poll_interval=0.01,
                     )
@@ -559,6 +594,173 @@ def test_wait_for_terminal_returns_each_terminal_status(status: str):
         from continua.types import EngineRunStatus
 
         client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
-        response = client.wait_for_terminal("8fb17dc9-6565-4f3e-b671-8fd437416534")
+        response = client.wait_for_terminal(RUN_ID)
 
         assert response.status == EngineRunStatus(status)
+
+
+def test_wait_for_terminal_default_does_not_follow_continuations():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value=_result_response(
+                    "CONTINUED_AS_NEW",
+                    run_id=RUN_ID,
+                    continued_to_run_id=NEXT_RUN_ID,
+                )
+            ),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.types import EngineRunStatus
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.wait_for_terminal(RUN_ID)
+
+        assert response.status == EngineRunStatus.CONTINUED_AS_NEW
+        assert str(response.continued_to_run_id) == NEXT_RUN_ID
+        assert mock_client.request.call_count == 1
+
+
+def test_wait_for_terminal_follows_single_continuation():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        with patch("continua.engine_control.time.sleep") as mock_sleep:
+            mock_client = MagicMock()
+            mock_client.request.side_effect = [
+                MagicMock(
+                    status_code=200,
+                    json=MagicMock(
+                        return_value=_result_response(
+                            "CONTINUED_AS_NEW",
+                            run_id=RUN_ID,
+                            continued_to_run_id=NEXT_RUN_ID,
+                        )
+                    ),
+                ),
+                MagicMock(
+                    status_code=409,
+                    json=MagicMock(return_value={"code": "run_not_terminal", "message": "pending"}),
+                    text="pending",
+                ),
+                MagicMock(
+                    status_code=200,
+                    json=MagicMock(return_value=_result_response("COMPLETED", run_id=NEXT_RUN_ID)),
+                ),
+            ]
+            mock_client_class.return_value = mock_client
+
+            from continua import EngineControlClient
+            from continua.types import EngineRunStatus
+
+            client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+            response = client.wait_for_terminal(
+                RUN_ID,
+                timeout=5.0,
+                poll_interval=0.01,
+                follow_continuations=True,
+            )
+
+            assert response.status == EngineRunStatus.COMPLETED
+            assert str(response.run_id) == NEXT_RUN_ID
+            assert [call.args[1] for call in mock_client.request.call_args_list] == [
+                f"/v1/engine/runs/{RUN_ID}/result",
+                f"/v1/engine/runs/{NEXT_RUN_ID}/result",
+                f"/v1/engine/runs/{NEXT_RUN_ID}/result",
+            ]
+            mock_sleep.assert_called_once_with(0.01)
+
+
+def test_wait_for_terminal_follows_multiple_continuations():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.side_effect = [
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_result_response(
+                        "CONTINUED_AS_NEW",
+                        run_id=RUN_ID,
+                        continued_to_run_id=NEXT_RUN_ID,
+                    )
+                ),
+            ),
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_result_response(
+                        "CONTINUED_AS_NEW",
+                        run_id=NEXT_RUN_ID,
+                        continued_from_run_id=RUN_ID,
+                        continued_to_run_id=FINAL_RUN_ID,
+                    )
+                ),
+            ),
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_result_response(
+                        "COMPLETED",
+                        run_id=FINAL_RUN_ID,
+                        continued_from_run_id=NEXT_RUN_ID,
+                    )
+                ),
+            ),
+        ]
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.types import EngineRunStatus
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.wait_for_terminal(RUN_ID, follow_continuations=True)
+
+        assert response.status == EngineRunStatus.COMPLETED
+        assert str(response.run_id) == FINAL_RUN_ID
+        assert str(response.continued_from_run_id) == NEXT_RUN_ID
+
+
+def test_wait_for_terminal_raises_when_continuation_depth_is_exceeded():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.side_effect = [
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_result_response(
+                        "CONTINUED_AS_NEW",
+                        run_id=RUN_ID,
+                        continued_to_run_id=NEXT_RUN_ID,
+                    )
+                ),
+            ),
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_result_response(
+                        "CONTINUED_AS_NEW",
+                        run_id=NEXT_RUN_ID,
+                        continued_from_run_id=RUN_ID,
+                        continued_to_run_id=FINAL_RUN_ID,
+                    )
+                ),
+            ),
+        ]
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.exceptions import EngineRunContinuationDepthError
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+
+        with pytest.raises(
+            EngineRunContinuationDepthError,
+            match="max_continuations=1",
+        ):
+            client.wait_for_terminal(
+                RUN_ID,
+                follow_continuations=True,
+                max_continuations=1,
+            )

--- a/sdks/python/tests/test_engine_control_integration.py
+++ b/sdks/python/tests/test_engine_control_integration.py
@@ -4,6 +4,9 @@ These tests require a running Continua server with:
 - ENGINE_PUBLIC_API_ENABLED=true
 - a project using CONTINUA_API_KEY
 - a published engine definition checkout/v1
+- for continuation coverage, a published continue-as-new-capable definition
+  (defaults: continue-demo/v1) that starts with `{"cursor": 1}`, continues
+  twice, and then completes
 
 They reuse the same opt-in local-server style as the other Python integration tests.
 """
@@ -16,7 +19,11 @@ import uuid
 import httpx
 import pytest
 
-from continua import EngineControlClient, EngineRunNotFoundError
+from continua import (
+    EngineControlClient,
+    EngineRunContinuationDepthError,
+    EngineRunNotFoundError,
+)
 from continua.types import (
     EngineProjectionState,
     EnginePurgeMode,
@@ -26,6 +33,14 @@ from continua.types import (
 
 CONTINUA_ENDPOINT = os.environ.get("CONTINUA_ENDPOINT", "http://localhost:8081")
 CONTINUA_API_KEY = os.environ.get("CONTINUA_API_KEY", "test-api-key-12345")
+CONTINUA_CONTINUATION_DEFINITION_NAME = os.environ.get(
+    "CONTINUA_CONTINUATION_DEFINITION_NAME",
+    "continue-demo",
+)
+CONTINUA_CONTINUATION_DEFINITION_VERSION = os.environ.get(
+    "CONTINUA_CONTINUATION_DEFINITION_VERSION",
+    "v1",
+)
 
 
 def server_available() -> bool:
@@ -50,21 +65,45 @@ def _client() -> EngineControlClient:
     )
 
 
-def _start_checkout_run(client: EngineControlClient):
+def _start_run(
+    client: EngineControlClient,
+    *,
+    definition_name: str,
+    definition_version: str,
+    input: dict[str, object] | None = None,
+):
     try:
         return client.start(
             {
-                "definition_name": "checkout",
-                "definition_version": "v1",
+                "definition_name": definition_name,
+                "definition_version": definition_version,
                 "instance_key": f"py-engine-instance-{uuid.uuid4()}",
                 "request_key": f"py-engine-request-{uuid.uuid4()}",
+                "input": input,
             }
         )
     except EngineRunNotFoundError as exc:
         pytest.skip(
             "engine control integration requires ENGINE_PUBLIC_API_ENABLED=true "
-            f"and checkout/v1 to be published: {exc}"
+            f"and {definition_name}/{definition_version} to be published: {exc}"
         )
+
+
+def _start_checkout_run(client: EngineControlClient):
+    return _start_run(
+        client,
+        definition_name="checkout",
+        definition_version="v1",
+    )
+
+
+def _start_continuation_run(client: EngineControlClient):
+    return _start_run(
+        client,
+        definition_name=CONTINUA_CONTINUATION_DEFINITION_NAME,
+        definition_version=CONTINUA_CONTINUATION_DEFINITION_VERSION,
+        input={"cursor": 1},
+    )
 
 
 def test_engine_control_round_trip_terminate_purge_and_repair():
@@ -78,7 +117,7 @@ def test_engine_control_round_trip_terminate_purge_and_repair():
 
         instance = client.get_instance(started.instance_key)
         assert instance.instance_key == started.instance_key
-        assert instance.run.run_id == started.run_id
+        assert instance.current_run.run_id == started.run_id
 
         terminated = client.terminate(started.run_id)
         assert terminated.status == EngineRunStatus.TERMINATED
@@ -103,5 +142,52 @@ def test_engine_control_round_trip_terminate_purge_and_repair():
         expired_repair = client.repair(started.run_id)
         assert expired_repair.reason == EngineRepairReason.history_expired
         assert expired_repair.projection_state == EngineProjectionState.journal_expired
+    finally:
+        client.close()
+
+
+def test_engine_control_wait_for_terminal_follows_continuations():
+    client = _client()
+    try:
+        started = _start_continuation_run(client)
+
+        first = client.wait_for_terminal(started.run_id, timeout=10.0, poll_interval=0.1)
+        assert first.status == EngineRunStatus.CONTINUED_AS_NEW
+        assert first.continued_to_run_id is not None
+
+        second = client.wait_for_terminal(
+            first.continued_to_run_id,
+            timeout=10.0,
+            poll_interval=0.1,
+        )
+        assert second.status == EngineRunStatus.CONTINUED_AS_NEW
+        assert second.continued_to_run_id is not None
+
+        final = client.wait_for_terminal(
+            started.run_id,
+            timeout=10.0,
+            poll_interval=0.1,
+            follow_continuations=True,
+            max_continuations=4,
+        )
+        assert final.status == EngineRunStatus.COMPLETED
+        assert final.run_id == second.continued_to_run_id
+    finally:
+        client.close()
+
+
+def test_engine_control_wait_for_terminal_continuation_depth_limit():
+    client = _client()
+    try:
+        started = _start_continuation_run(client)
+
+        with pytest.raises(EngineRunContinuationDepthError):
+            client.wait_for_terminal(
+                started.run_id,
+                timeout=10.0,
+                poll_interval=0.1,
+                follow_continuations=True,
+                max_continuations=1,
+            )
     finally:
         client.close()

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "type-check": "tsc --noEmit",
-    "test": "vitest run --pool=forks",
+    "test": "vitest run --pool=forks --no-file-parallelism",
     "test:e2e": "playwright test",
     "test:e2e:update": "playwright test --update-snapshots",
     "profile:workspace": "node ./scripts/profile-visual-workspace.mjs",

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -2394,7 +2394,7 @@ describe('TraceDetailPage', () => {
         detail: () => jsonResponse(createRunningTraceDetail()),
         spans: () => jsonResponse({ spans: [] }),
         timeline: (url) => {
-          if (url.searchParams.get('after') === 'cursor-open-wait') {
+          if (url.searchParams.has('after')) {
             return createRunningTimelineResponse(currentPollEvents, currentPollCursor);
           }
 


### PR DESCRIPTION
## Summary
- add engine runtime support for workflow-authored ContinueAsNew with replay, activation, run chaining, and continuation trace bootstrap
- expose continued run metadata through engine APIs, trace search, retention/purge plumbing, and generated public contracts
- extend the Python engine control client with continuation following, depth guards, and integration coverage

## Testing
- make generate
- cd engine && go test ./...
- go test ./internal/api/... ./internal/ingest/... ./internal/store/... ./internal/jobs/...
- cd sdks/python && uv run python -m pytest tests/test_engine_control.py tests/test_engine_control_integration.py
- cd sdks/python && uv run --with ruff python -m ruff check tests/test_engine_control.py --select F601,E501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ContinueAsNew: workflows can atomically continue as a fresh run; run and trace responses expose continuation-chain fields (continued_from/continued_to run and trace IDs).
  * Added CONTINUED_AS_NEW lifecycle status; continued runs return that status and result=null.
  * Python SDK: wait_for_terminal can optionally follow continuations with a depth limit and dedicated error.

* **Behavior**
  * Continued runs project as completed with no output and clear pending wait state.
  * Trace search accepts filtering by continued_as_new.

* **Bug Fixes**
  * Deterministic latest-run selection now orders by run_number (then id).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->