### PR TITLE
Complete engine debugger operator surface

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -72,6 +72,13 @@ const (
 	CompareTraceHeaderStatusRUNNING   CompareTraceHeaderStatus = "RUNNING"
 )
 
+// Defines values for EngineProjectionBackfillAction.
+const (
+	EngineProjectionBackfillActionRepairRequested EngineProjectionBackfillAction = "repair_requested"
+	EngineProjectionBackfillActionSkipped         EngineProjectionBackfillAction = "skipped"
+	EngineProjectionBackfillActionWouldRepair     EngineProjectionBackfillAction = "would_repair"
+)
+
 // Defines values for EngineProjectionState.
 const (
 	CatchingUp     EngineProjectionState = "catching_up"
@@ -88,11 +95,11 @@ const (
 
 // Defines values for EngineRepairReason.
 const (
-	AlreadyCatchingUp EngineRepairReason = "already_catching_up"
-	AlreadyUpToDate   EngineRepairReason = "already_up_to_date"
-	HistoryExpired    EngineRepairReason = "history_expired"
-	NoEventsToProject EngineRepairReason = "no_events_to_project"
-	RepairRequested   EngineRepairReason = "repair_requested"
+	EngineRepairReasonAlreadyCatchingUp EngineRepairReason = "already_catching_up"
+	EngineRepairReasonAlreadyUpToDate   EngineRepairReason = "already_up_to_date"
+	EngineRepairReasonHistoryExpired    EngineRepairReason = "history_expired"
+	EngineRepairReasonNoEventsToProject EngineRepairReason = "no_events_to_project"
+	EngineRepairReasonRepairRequested   EngineRepairReason = "repair_requested"
 )
 
 // Defines values for EngineRunStatus.
@@ -435,6 +442,8 @@ type EngineControlResponse struct {
 
 // EngineFailureSummary defines model for EngineFailureSummary.
 type EngineFailureSummary struct {
+	// ErrorCode Stable reserved value: `definition_version_mismatch`. Clients may
+	// exact-match this value while still accepting arbitrary strings.
 	ErrorCode    string `json:"error_code"`
 	ErrorMessage string `json:"error_message"`
 	Status       string `json:"status"`
@@ -501,6 +510,42 @@ type EnginePendingWorkResponse struct {
 	RunId                openapi_types.UUID        `json:"run_id"`
 	Signals              []EnginePendingSignalItem `json:"signals"`
 	Timers               []EnginePendingTimerItem  `json:"timers"`
+}
+
+// EngineProjectionBackfillAction defines model for EngineProjectionBackfillAction.
+type EngineProjectionBackfillAction string
+
+// EngineProjectionBackfillRequest defines model for EngineProjectionBackfillRequest.
+type EngineProjectionBackfillRequest struct {
+	DryRun               *bool   `json:"dry_run,omitempty"`
+	EngineDefinitionName *string `json:"engine_definition_name,omitempty"`
+	EngineInstanceKey    *string `json:"engine_instance_key,omitempty"`
+
+	// EngineProjectionState Defaults to `summary_only` when omitted. Explicit `up_to_date`,
+	// `catching_up`, and `journal_expired` return zero eligible rows.
+	EngineProjectionState *EngineProjectionState `json:"engine_projection_state,omitempty"`
+	EngineRunStatus       *EngineRunStatus       `json:"engine_run_status,omitempty"`
+	Limit                 *int                   `json:"limit,omitempty"`
+	OlderThan             *time.Time             `json:"older_than,omitempty"`
+}
+
+// EngineProjectionBackfillResponse defines model for EngineProjectionBackfillResponse.
+type EngineProjectionBackfillResponse struct {
+	DryRun               bool                                `json:"dry_run"`
+	EligibleCount        int                                 `json:"eligible_count"`
+	Limit                int                                 `json:"limit"`
+	RepairRequestedCount int                                 `json:"repair_requested_count"`
+	Results              []EngineProjectionBackfillRunResult `json:"results"`
+	SkippedCount         int                                 `json:"skipped_count"`
+}
+
+// EngineProjectionBackfillRunResult defines model for EngineProjectionBackfillRunResult.
+type EngineProjectionBackfillRunResult struct {
+	Action          EngineProjectionBackfillAction `json:"action"`
+	ProjectionState EngineProjectionState          `json:"projection_state"`
+	Reason          *EngineRepairReason            `json:"reason,omitempty"`
+	RunId           openapi_types.UUID             `json:"run_id"`
+	TraceId         string                         `json:"trace_id"`
 }
 
 // EngineProjectionState defines model for EngineProjectionState.
@@ -1214,6 +1259,12 @@ type GetTraceEventsParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// BackfillEngineProjectionsParams defines parameters for BackfillEngineProjections.
+type BackfillEngineProjectionsParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
 // StartEngineRunParams defines parameters for StartEngineRun.
 type StartEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
@@ -1278,6 +1329,9 @@ type IngestParams struct {
 	// Any other value is rejected with `400 unsupported_async_version`.
 	XContinuaAsyncVersion *string `json:"X-Continua-Async-Version,omitempty"`
 }
+
+// BackfillEngineProjectionsJSONRequestBody defines body for BackfillEngineProjections for application/json ContentType.
+type BackfillEngineProjectionsJSONRequestBody = EngineProjectionBackfillRequest
 
 // StartEngineRunJSONRequestBody defines body for StartEngineRun for application/json ContentType.
 type StartEngineRunJSONRequestBody = EngineStartRunRequest
@@ -1463,6 +1517,9 @@ type ServerInterface interface {
 	// Get an engine instance and current run
 	// (GET /v1/engine/instances/{instance_key})
 	GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string)
+	// Preview or request bulk projection repair for engine runs
+	// (POST /v1/engine/projections/backfill)
+	BackfillEngineProjections(w http.ResponseWriter, r *http.Request, params BackfillEngineProjectionsParams)
 	// Start an engine workflow run
 	// (POST /v1/engine/runs)
 	StartEngineRun(w http.ResponseWriter, r *http.Request, params StartEngineRunParams)
@@ -1562,6 +1619,12 @@ func (_ Unimplemented) ListSpansByTrace(w http.ResponseWriter, r *http.Request, 
 // Get an engine instance and current run
 // (GET /v1/engine/instances/{instance_key})
 func (_ Unimplemented) GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Preview or request bulk projection repair for engine runs
+// (POST /v1/engine/projections/backfill)
+func (_ Unimplemented) BackfillEngineProjections(w http.ResponseWriter, r *http.Request, params BackfillEngineProjectionsParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2144,6 +2207,56 @@ func (siw *ServerInterfaceWrapper) GetEngineInstance(w http.ResponseWriter, r *h
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetEngineInstance(w, r, instanceKey)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// BackfillEngineProjections operation middleware
+func (siw *ServerInterfaceWrapper) BackfillEngineProjections(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params BackfillEngineProjectionsParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.BackfillEngineProjections(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2983,6 +3096,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/instances/{instance_key}", wrapper.GetEngineInstance)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/projections/backfill", wrapper.BackfillEngineProjections)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/engine/runs", wrapper.StartEngineRun)

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -203,6 +203,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/engine/projections/backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview or request bulk projection repair for engine runs
+         * @description Identifies engine-backed traces eligible for projection repair and, when
+         *     `dry_run=false`, reuses the existing per-run repair service to request
+         *     catch-up. When `engine_projection_state` is omitted, only `summary_only`
+         *     candidates are considered. Explicit `up_to_date`, `catching_up`, and
+         *     `journal_expired` filters return zero eligible rows because those states
+         *     are not valid backfill targets.
+         *
+         */
+        post: operations["backfillEngineProjections"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/engine/runs/{run_id}/signal": {
         parameters: {
             query?: never;
@@ -446,6 +472,8 @@ export interface components {
         /** @enum {string} */
         EngineProjectionState: "up_to_date" | "catching_up" | "summary_only" | "journal_expired";
         /** @enum {string} */
+        EngineProjectionBackfillAction: "would_repair" | "repair_requested" | "skipped";
+        /** @enum {string} */
         EnginePurgeMode: "projection_only" | "full";
         /** @enum {string} */
         EngineRepairReason: "already_up_to_date" | "history_expired" | "no_events_to_project" | "repair_requested" | "already_catching_up";
@@ -515,7 +543,41 @@ export interface components {
             /** Format: int64 */
             pending_inbox_items: number;
         };
+        EngineProjectionBackfillRequest: {
+            /** @default false */
+            dry_run: boolean;
+            /** @default 50 */
+            limit: number;
+            /** Format: date-time */
+            older_than?: string;
+            engine_instance_key?: string;
+            engine_definition_name?: string;
+            engine_run_status?: components["schemas"]["EngineRunStatus"];
+            /** @description Defaults to `summary_only` when omitted. Explicit `up_to_date`,
+             *     `catching_up`, and `journal_expired` return zero eligible rows.
+             *      */
+            engine_projection_state?: components["schemas"]["EngineProjectionState"];
+        };
+        EngineProjectionBackfillRunResult: {
+            /** Format: uuid */
+            run_id: string;
+            trace_id: string;
+            projection_state: components["schemas"]["EngineProjectionState"];
+            action: components["schemas"]["EngineProjectionBackfillAction"];
+            reason?: components["schemas"]["EngineRepairReason"];
+        };
+        EngineProjectionBackfillResponse: {
+            dry_run: boolean;
+            limit: number;
+            eligible_count: number;
+            repair_requested_count: number;
+            skipped_count: number;
+            results: components["schemas"]["EngineProjectionBackfillRunResult"][];
+        };
         EngineFailureSummary: {
+            /** @description Stable reserved value: `definition_version_mismatch`. Clients may
+             *     exact-match this value while still accepting arbitrary strings.
+             *      */
             error_code: string;
             error_message: string;
             status: string;
@@ -1648,6 +1710,60 @@ export interface operations {
                 };
             };
             /** @description Run not found or engine API disabled */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    backfillEngineProjections: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required preview header for mutating engine routes. */
+                "X-Continua-Engine-Preview": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["EngineProjectionBackfillRequest"];
+            };
+        };
+        responses: {
+            /** @description Backfill preview or apply result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EngineProjectionBackfillResponse"];
+                };
+            };
+            /** @description Invalid request body, limit above 100, or missing preview header */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Engine API disabled */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -447,6 +447,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /v1/engine/projections/backfill:
+    post:
+      operationId: backfillEngineProjections
+      summary: Preview or request bulk projection repair for engine runs
+      description: |
+        Identifies engine-backed traces eligible for projection repair and, when
+        `dry_run=false`, reuses the existing per-run repair service to request
+        catch-up. When `engine_projection_state` is omitted, only `summary_only`
+        candidates are considered. Explicit `up_to_date`, `catching_up`, and
+        `journal_expired` filters return zero eligible rows because those states
+        are not valid backfill targets.
+      tags:
+        - Engine
+      parameters:
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineProjectionBackfillRequest'
+      responses:
+        '200':
+          description: Backfill preview or apply result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineProjectionBackfillResponse'
+        '400':
+          description: Invalid request body, limit above 100, or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Engine API disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /v1/engine/runs/{run_id}/signal:
     post:
       operationId: signalEngineRun
@@ -1148,6 +1199,12 @@ components:
         - catching_up
         - summary_only
         - journal_expired
+    EngineProjectionBackfillAction:
+      type: string
+      enum:
+        - would_repair
+        - repair_requested
+        - skipped
     EnginePurgeMode:
       type: string
       enum:
@@ -1317,6 +1374,74 @@ components:
         pending_inbox_items:
           type: integer
           format: int64
+    EngineProjectionBackfillRequest:
+      type: object
+      properties:
+        dry_run:
+          type: boolean
+          default: false
+        limit:
+          type: integer
+          default: 50
+          maximum: 100
+        older_than:
+          type: string
+          format: date-time
+        engine_instance_key:
+          type: string
+        engine_definition_name:
+          type: string
+        engine_run_status:
+          $ref: '#/components/schemas/EngineRunStatus'
+        engine_projection_state:
+          allOf:
+            - $ref: '#/components/schemas/EngineProjectionState'
+          description: |
+            Defaults to `summary_only` when omitted. Explicit `up_to_date`,
+            `catching_up`, and `journal_expired` return zero eligible rows.
+    EngineProjectionBackfillRunResult:
+      type: object
+      required:
+        - run_id
+        - trace_id
+        - projection_state
+        - action
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        trace_id:
+          type: string
+        projection_state:
+          $ref: '#/components/schemas/EngineProjectionState'
+        action:
+          $ref: '#/components/schemas/EngineProjectionBackfillAction'
+        reason:
+          $ref: '#/components/schemas/EngineRepairReason'
+    EngineProjectionBackfillResponse:
+      type: object
+      required:
+        - dry_run
+        - limit
+        - eligible_count
+        - repair_requested_count
+        - skipped_count
+        - results
+      properties:
+        dry_run:
+          type: boolean
+        limit:
+          type: integer
+        eligible_count:
+          type: integer
+        repair_requested_count:
+          type: integer
+        skipped_count:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineProjectionBackfillRunResult'
     EngineFailureSummary:
       type: object
       required:
@@ -1326,6 +1451,9 @@ components:
       properties:
         error_code:
           type: string
+          description: |
+            Stable reserved value: `definition_version_mismatch`. Clients may
+            exact-match this value while still accepting arbitrary strings.
         error_message:
           type: string
         status:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -453,6 +453,57 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /v1/engine/projections/backfill:
+    post:
+      operationId: backfillEngineProjections
+      summary: Preview or request bulk projection repair for engine runs
+      description: |
+        Identifies engine-backed traces eligible for projection repair and, when
+        `dry_run=false`, reuses the existing per-run repair service to request
+        catch-up. When `engine_projection_state` is omitted, only `summary_only`
+        candidates are considered. Explicit `up_to_date`, `catching_up`, and
+        `journal_expired` filters return zero eligible rows because those states
+        are not valid backfill targets.
+      tags: [Engine]
+      parameters:
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineProjectionBackfillRequest'
+      responses:
+        '200':
+          description: Backfill preview or apply result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineProjectionBackfillResponse'
+        '400':
+          description: Invalid request body, limit above 100, or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Engine API disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /v1/engine/runs/{run_id}/signal:
     post:
       operationId: signalEngineRun
@@ -1132,6 +1183,10 @@ components:
       type: string
       enum: [up_to_date, catching_up, summary_only, journal_expired]
 
+    EngineProjectionBackfillAction:
+      type: string
+      enum: [would_repair, repair_requested, skipped]
+
     EnginePurgeMode:
       type: string
       enum: [projection_only, full]
@@ -1273,12 +1328,76 @@ components:
           type: integer
           format: int64
 
+    EngineProjectionBackfillRequest:
+      type: object
+      properties:
+        dry_run:
+          type: boolean
+          default: false
+        limit:
+          type: integer
+          default: 50
+          maximum: 100
+        older_than:
+          type: string
+          format: date-time
+        engine_instance_key:
+          type: string
+        engine_definition_name:
+          type: string
+        engine_run_status:
+          $ref: '#/components/schemas/EngineRunStatus'
+        engine_projection_state:
+          allOf:
+            - $ref: '#/components/schemas/EngineProjectionState'
+          description: |
+            Defaults to `summary_only` when omitted. Explicit `up_to_date`,
+            `catching_up`, and `journal_expired` return zero eligible rows.
+
+    EngineProjectionBackfillRunResult:
+      type: object
+      required: [run_id, trace_id, projection_state, action]
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        trace_id:
+          type: string
+        projection_state:
+          $ref: '#/components/schemas/EngineProjectionState'
+        action:
+          $ref: '#/components/schemas/EngineProjectionBackfillAction'
+        reason:
+          $ref: '#/components/schemas/EngineRepairReason'
+
+    EngineProjectionBackfillResponse:
+      type: object
+      required: [dry_run, limit, eligible_count, repair_requested_count, skipped_count, results]
+      properties:
+        dry_run:
+          type: boolean
+        limit:
+          type: integer
+        eligible_count:
+          type: integer
+        repair_requested_count:
+          type: integer
+        skipped_count:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineProjectionBackfillRunResult'
+
     EngineFailureSummary:
       type: object
       required: [error_code, error_message, status]
       properties:
         error_code:
           type: string
+          description: |
+            Stable reserved value: `definition_version_mismatch`. Clients may
+            exact-match this value while still accepting arbitrary strings.
         error_message:
           type: string
         status:

--- a/internal/api/engine_handlers.go
+++ b/internal/api/engine_handlers.go
@@ -274,7 +274,7 @@ func (s *Server) BackfillEngineProjections(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	result, err := s.engineSharedControl.BackfillProjections(r.Context(), projectID, backfillReq)
+	result, err := s.engineSharedControl.BackfillProjections(r.Context(), projectID, &backfillReq)
 	if err != nil {
 		writeEngineError(w, err, "Failed to backfill engine projections")
 		return

--- a/internal/api/engine_handlers.go
+++ b/internal/api/engine_handlers.go
@@ -3,10 +3,16 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/continua-ai/continua/internal/enginecontrol"
+)
+
+const (
+	defaultEngineProjectionBackfillLimit = 50
+	maxEngineProjectionBackfillLimit     = 100
 )
 
 func (s *Server) GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string) {
@@ -247,6 +253,36 @@ func (s *Server) RepairEngineRun(w http.ResponseWriter, r *http.Request, runID o
 	writeJSON(w, http.StatusOK, engineRepairResponseToAPI(&result))
 }
 
+func (s *Server) BackfillEngineProjections(w http.ResponseWriter, r *http.Request, _ BackfillEngineProjectionsParams) {
+	projectID, ok := projectIDOrUnauthorized(w, r)
+	if !ok {
+		return
+	}
+	if s.engineSharedControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var req EngineProjectionBackfillRequest
+	if !decodeOptionalJSONRequest(w, r, &req) {
+		return
+	}
+
+	backfillReq, err := engineProjectionBackfillRequestFromAPI(&req)
+	if err != nil {
+		writeEngineError(w, err, "Invalid engine projection backfill request")
+		return
+	}
+
+	result, err := s.engineSharedControl.BackfillProjections(r.Context(), projectID, backfillReq)
+	if err != nil {
+		writeEngineError(w, err, "Failed to backfill engine projections")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, engineProjectionBackfillResponseToAPI(&result))
+}
+
 func (s *Server) GetEngineRunPendingWork(w http.ResponseWriter, r *http.Request, runID openapi_types.UUID) {
 	projectID, ok := projectIDOrUnauthorized(w, r)
 	if !ok {
@@ -297,6 +333,102 @@ func (s *Server) SignalEngineRun(w http.ResponseWriter, r *http.Request, runID o
 	}
 
 	writeJSON(w, http.StatusOK, engineControlResponseToAPI(&result))
+}
+
+func engineProjectionBackfillRequestFromAPI(
+	req *EngineProjectionBackfillRequest,
+) (enginecontrol.ProjectionBackfillRequest, error) {
+	result := enginecontrol.ProjectionBackfillRequest{
+		Limit: defaultEngineProjectionBackfillLimit,
+	}
+	if req == nil {
+		return result, nil
+	}
+
+	if req.DryRun != nil {
+		result.DryRun = *req.DryRun
+	}
+	if req.Limit != nil {
+		if *req.Limit > maxEngineProjectionBackfillLimit {
+			return enginecontrol.ProjectionBackfillRequest{}, errInvalidEngineProjectionBackfillLimit(*req.Limit)
+		}
+		if *req.Limit > 0 {
+			result.Limit = *req.Limit
+		}
+	}
+	if req.OlderThan != nil {
+		result.OlderThan = req.OlderThan
+	}
+	if req.EngineInstanceKey != nil {
+		result.EngineInstanceKey = strings.TrimSpace(*req.EngineInstanceKey)
+	}
+	if req.EngineDefinitionName != nil {
+		result.EngineDefinitionName = strings.TrimSpace(*req.EngineDefinitionName)
+	}
+	if req.EngineRunStatus != nil {
+		normalizedStatus, err := normalizeEngineRunStatusValue(string(*req.EngineRunStatus))
+		if err != nil {
+			return enginecontrol.ProjectionBackfillRequest{}, err
+		}
+		result.EngineRunStatus = normalizedStatus
+	}
+	if req.EngineProjectionState != nil {
+		normalizedState, err := normalizeEngineProjectionStateValue(string(*req.EngineProjectionState))
+		if err != nil {
+			return enginecontrol.ProjectionBackfillRequest{}, err
+		}
+		result.EngineProjectionState = normalizedState
+	}
+
+	return result, nil
+}
+
+func errInvalidEngineProjectionBackfillLimit(_ int) error {
+	return &enginecontrol.APIError{
+		Code:       "invalid_request",
+		Message:    "limit must be 100 or less",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func normalizeEngineRunStatusValue(value string) (string, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(value))
+	switch EngineRunStatus(normalized) {
+	case "":
+		return "", nil
+	case EngineRunStatusQUEUED,
+		EngineRunStatusRUNNING,
+		EngineRunStatusWAITING,
+		EngineRunStatusSUSPENDED,
+		EngineRunStatusCOMPLETED,
+		EngineRunStatusFAILED,
+		EngineRunStatusCANCELLED,
+		EngineRunStatusTERMINATED,
+		EngineRunStatusCONTINUEDASNEW:
+		return normalized, nil
+	default:
+		return "", &enginecontrol.APIError{
+			Code:       "invalid_request",
+			Message:    "engine_run_status must be a valid EngineRunStatus value",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+}
+
+func normalizeEngineProjectionStateValue(value string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch EngineProjectionState(normalized) {
+	case "":
+		return "", nil
+	case UpToDate, CatchingUp, SummaryOnly, JournalExpired:
+		return normalized, nil
+	default:
+		return "", &enginecontrol.APIError{
+			Code:       "invalid_request",
+			Message:    "engine_projection_state must be a valid EngineProjectionState value",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
 }
 
 func engineStartRunRequestFromAPI(req *EngineStartRunRequest) (engineStartRunRequest, error) {

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -2341,7 +2341,7 @@ func TestBackfillEngineProjections_IncompatibleProjectionStatesReturnEmptyResult
 				server,
 				projectID,
 				&EngineProjectionBackfillRequest{
-					DryRun:               &dryRun,
+					DryRun:                &dryRun,
 					EngineProjectionState: &projectionState,
 				},
 			))

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -1986,7 +1986,7 @@ func TestRepairEngineRun_ReturnsExpectedReasons(t *testing.T) {
 		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "up_to_date", 5, 5)
 		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
 		assert.False(t, resp.Accepted)
-		assert.Equal(t, AlreadyUpToDate, resp.Reason)
+		assert.Equal(t, EngineRepairReasonAlreadyUpToDate, resp.Reason)
 		assert.Equal(t, UpToDate, resp.ProjectionState)
 	})
 
@@ -1997,7 +1997,7 @@ func TestRepairEngineRun_ReturnsExpectedReasons(t *testing.T) {
 		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", latestHistoryID, latestHistoryID-1)
 		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
 		assert.True(t, resp.Accepted)
-		assert.Equal(t, RepairRequested, resp.Reason)
+		assert.Equal(t, EngineRepairReasonRepairRequested, resp.Reason)
 		assert.Equal(t, CatchingUp, resp.ProjectionState)
 	})
 
@@ -2007,7 +2007,7 @@ func TestRepairEngineRun_ReturnsExpectedReasons(t *testing.T) {
 		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", latestHistoryID, latestHistoryID)
 		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
 		assert.False(t, resp.Accepted)
-		assert.Equal(t, NoEventsToProject, resp.Reason)
+		assert.Equal(t, EngineRepairReasonNoEventsToProject, resp.Reason)
 		assert.Equal(t, SummaryOnly, resp.ProjectionState)
 	})
 
@@ -2036,7 +2036,7 @@ func TestRepairEngineRun_ReturnsExpectedReasons(t *testing.T) {
 
 		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
 		assert.True(t, resp.Accepted)
-		assert.Equal(t, RepairRequested, resp.Reason)
+		assert.Equal(t, EngineRepairReasonRepairRequested, resp.Reason)
 		assert.Equal(t, CatchingUp, resp.ProjectionState)
 
 		var latestHistoryID int64
@@ -2054,7 +2054,7 @@ func TestRepairEngineRun_ReturnsExpectedReasons(t *testing.T) {
 		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "journal_expired", 9, 3)
 		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
 		assert.False(t, resp.Accepted)
-		assert.Equal(t, HistoryExpired, resp.Reason)
+		assert.Equal(t, EngineRepairReasonHistoryExpired, resp.Reason)
 		assert.Equal(t, JournalExpired, resp.ProjectionState)
 	})
 
@@ -2062,7 +2062,7 @@ func TestRepairEngineRun_ReturnsExpectedReasons(t *testing.T) {
 		setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "catching_up", 9, 3)
 		resp := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
 		assert.True(t, resp.Accepted)
-		assert.Equal(t, AlreadyCatchingUp, resp.Reason)
+		assert.Equal(t, EngineRepairReasonAlreadyCatchingUp, resp.Reason)
 		assert.Equal(t, CatchingUp, resp.ProjectionState)
 	})
 }
@@ -2086,6 +2086,273 @@ func TestRepairEngineRun_ReturnsNotFoundForMissingRunAndCrossProject(t *testing.
 	missing := invokeRepairEngineRun(t, server, projectID, uuid.New())
 	require.Equal(t, http.StatusNotFound, missing.Code)
 	assert.Equal(t, "not_found", decodeJSONBody[Error](t, missing).Code)
+}
+
+func TestBackfillEngineProjections_DryRunReturnsWouldRepairWithoutMutation(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-backfill-dry-run",
+		RequestKey:        "req-backfill-dry-run",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	latestHistoryID, err := engineQueries.GetLatestHistoryIDByRun(ctx, start.RunId)
+	require.NoError(t, err)
+	setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", latestHistoryID, latestHistoryID-1)
+
+	dryRun := true
+	resp := decodeJSONBody[EngineProjectionBackfillResponse](t, invokeBackfillEngineProjections(
+		t,
+		server,
+		projectID,
+		&EngineProjectionBackfillRequest{DryRun: &dryRun},
+	))
+
+	require.True(t, resp.DryRun)
+	assert.Equal(t, defaultEngineProjectionBackfillLimit, resp.Limit)
+	assert.Equal(t, 1, resp.EligibleCount)
+	assert.Equal(t, 0, resp.RepairRequestedCount)
+	assert.Equal(t, 0, resp.SkippedCount)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, start.RunId, resp.Results[0].RunId)
+	assert.Equal(t, start.TraceId, resp.Results[0].TraceId)
+	assert.Equal(t, SummaryOnly, resp.Results[0].ProjectionState)
+	assert.Equal(t, EngineProjectionBackfillActionWouldRepair, resp.Results[0].Action)
+	assert.Nil(t, resp.Results[0].Reason)
+
+	var projectionState string
+	err = platformStore.Pool().QueryRow(ctx, `
+		SELECT engine_projection_state
+		FROM traces
+		WHERE id = $1
+	`, trace.ID).Scan(&projectionState)
+	require.NoError(t, err)
+	assert.Equal(t, "summary_only", projectionState)
+}
+
+func TestBackfillEngineProjections_ApplyRequestsRepairAndFlipsState(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-backfill-apply",
+		RequestKey:        "req-backfill-apply",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	latestHistoryID, err := engineQueries.GetLatestHistoryIDByRun(ctx, start.RunId)
+	require.NoError(t, err)
+	setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", latestHistoryID, latestHistoryID-1)
+
+	limit := 10
+	resp := decodeJSONBody[EngineProjectionBackfillResponse](t, invokeBackfillEngineProjections(
+		t,
+		server,
+		projectID,
+		&EngineProjectionBackfillRequest{Limit: &limit},
+	))
+
+	require.False(t, resp.DryRun)
+	assert.Equal(t, limit, resp.Limit)
+	assert.Equal(t, 1, resp.EligibleCount)
+	assert.Equal(t, 1, resp.RepairRequestedCount)
+	assert.Equal(t, 0, resp.SkippedCount)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, EngineProjectionBackfillActionRepairRequested, resp.Results[0].Action)
+	require.NotNil(t, resp.Results[0].Reason)
+	assert.Equal(t, EngineRepairReasonRepairRequested, *resp.Results[0].Reason)
+	assert.Equal(t, CatchingUp, resp.Results[0].ProjectionState)
+
+	var projectionState string
+	err = platformStore.Pool().QueryRow(ctx, `
+		SELECT engine_projection_state
+		FROM traces
+		WHERE id = $1
+	`, trace.ID).Scan(&projectionState)
+	require.NoError(t, err)
+	assert.Equal(t, "catching_up", projectionState)
+}
+
+func TestBackfillEngineProjections_LimitAboveMaxReturnsBadRequest(t *testing.T) {
+	_, _, _, server, projectID := setupEngineHandlerTest(t)
+
+	limit := 101
+	rec := invokeBackfillEngineProjections(
+		t,
+		server,
+		projectID,
+		&EngineProjectionBackfillRequest{Limit: &limit},
+	)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	resp := decodeJSONBody[Error](t, rec)
+	assert.Equal(t, "invalid_request", resp.Code)
+	assert.Equal(t, "limit must be 100 or less", resp.Message)
+}
+
+func TestBackfillEngineProjections_OlderThanFiltersByProjectionUpdatedAt(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	oldStart := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-backfill-old",
+		RequestKey:        "req-backfill-old",
+	}))
+	newStart := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-backfill-new",
+		RequestKey:        "req-backfill-new",
+	}))
+
+	oldTrace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   oldStart.TraceId,
+	})
+	require.NoError(t, err)
+	newTrace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   newStart.TraceId,
+	})
+	require.NoError(t, err)
+
+	oldLatestHistoryID, err := engineQueries.GetLatestHistoryIDByRun(ctx, oldStart.RunId)
+	require.NoError(t, err)
+	newLatestHistoryID, err := engineQueries.GetLatestHistoryIDByRun(ctx, newStart.RunId)
+	require.NoError(t, err)
+
+	oldUpdatedAt := time.Date(2026, time.January, 1, 10, 0, 0, 0, time.UTC)
+	newUpdatedAt := time.Date(2026, time.January, 3, 10, 0, 0, 0, time.UTC)
+	cutoff := time.Date(2026, time.January, 2, 10, 0, 0, 0, time.UTC)
+
+	setEngineProjectionCheckpointAt(
+		t,
+		ctx,
+		platformStore,
+		oldTrace.ID,
+		"summary_only",
+		oldLatestHistoryID,
+		oldLatestHistoryID-1,
+		oldUpdatedAt,
+	)
+	setEngineProjectionCheckpointAt(
+		t,
+		ctx,
+		platformStore,
+		newTrace.ID,
+		"summary_only",
+		newLatestHistoryID,
+		newLatestHistoryID-1,
+		newUpdatedAt,
+	)
+
+	dryRun := true
+	resp := decodeJSONBody[EngineProjectionBackfillResponse](t, invokeBackfillEngineProjections(
+		t,
+		server,
+		projectID,
+		&EngineProjectionBackfillRequest{
+			DryRun:    &dryRun,
+			OlderThan: &cutoff,
+		},
+	))
+
+	assert.Equal(t, 1, resp.EligibleCount)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, oldStart.RunId, resp.Results[0].RunId)
+	assert.Equal(t, oldStart.TraceId, resp.Results[0].TraceId)
+}
+
+func TestBackfillEngineProjections_RepeatedCallsConvergeToZeroEligible(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-backfill-converge",
+		RequestKey:        "req-backfill-converge",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	latestHistoryID, err := engineQueries.GetLatestHistoryIDByRun(ctx, start.RunId)
+	require.NoError(t, err)
+	setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", latestHistoryID, latestHistoryID-1)
+
+	first := decodeJSONBody[EngineProjectionBackfillResponse](t, invokeBackfillEngineProjections(t, server, projectID, nil))
+	assert.Equal(t, 1, first.EligibleCount)
+	require.Len(t, first.Results, 1)
+	assert.Equal(t, EngineProjectionBackfillActionRepairRequested, first.Results[0].Action)
+
+	second := decodeJSONBody[EngineProjectionBackfillResponse](t, invokeBackfillEngineProjections(t, server, projectID, nil))
+	assert.Equal(t, 0, second.EligibleCount)
+	assert.Empty(t, second.Results)
+}
+
+func TestBackfillEngineProjections_IncompatibleProjectionStatesReturnEmptyResults(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-backfill-incompatible",
+		RequestKey:        "req-backfill-incompatible",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	latestHistoryID, err := engineQueries.GetLatestHistoryIDByRun(ctx, start.RunId)
+	require.NoError(t, err)
+	setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", latestHistoryID, latestHistoryID-1)
+
+	for _, projectionState := range []EngineProjectionState{UpToDate, CatchingUp, JournalExpired} {
+		t.Run(string(projectionState), func(t *testing.T) {
+			dryRun := true
+			resp := decodeJSONBody[EngineProjectionBackfillResponse](t, invokeBackfillEngineProjections(
+				t,
+				server,
+				projectID,
+				&EngineProjectionBackfillRequest{
+					DryRun:               &dryRun,
+					EngineProjectionState: &projectionState,
+				},
+			))
+
+			assert.True(t, resp.DryRun)
+			assert.Equal(t, 0, resp.EligibleCount)
+			assert.Equal(t, 0, resp.RepairRequestedCount)
+			assert.Equal(t, 0, resp.SkippedCount)
+			assert.Empty(t, resp.Results)
+		})
+	}
 }
 
 func TestRepairEngineRun_ProjectorEventuallyRebuildsPurgedDetail(t *testing.T) {
@@ -2144,7 +2411,7 @@ func TestRepairEngineRun_ProjectorEventuallyRebuildsPurgedDetail(t *testing.T) {
 
 	repair := decodeJSONBody[EngineRepairResponse](t, invokeRepairEngineRun(t, server, projectID, start.RunId))
 	assert.True(t, repair.Accepted)
-	assert.Equal(t, RepairRequested, repair.Reason)
+	assert.Equal(t, EngineRepairReasonRepairRequested, repair.Reason)
 	assert.Equal(t, CatchingUp, repair.ProjectionState)
 
 	engineServe := startExternalEngineServeProcess(t, projectID)
@@ -2808,6 +3075,32 @@ func invokeRepairEngineRun(t *testing.T, server *Server, projectID, runID uuid.U
 	return rec
 }
 
+func invokeBackfillEngineProjections(
+	t *testing.T,
+	server *Server,
+	projectID uuid.UUID,
+	reqBody *EngineProjectionBackfillRequest,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var body *bytes.Reader
+	if reqBody != nil {
+		payload, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+		body = bytes.NewReader(payload)
+	} else {
+		body = bytes.NewReader(nil)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/projections/backfill", body)
+	req.Header.Set(enginePreviewHeader, "1")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	rec := httptest.NewRecorder()
+
+	server.BackfillEngineProjections(rec, req, BackfillEngineProjectionsParams{XContinuaEnginePreview: "1"})
+	return rec
+}
+
 func invokeSignalEngineRun(
 	t *testing.T,
 	server *Server,
@@ -3122,15 +3415,40 @@ func setEngineProjectionCheckpoint(
 ) {
 	t.Helper()
 
+	setEngineProjectionCheckpointAt(
+		t,
+		ctx,
+		platformStore,
+		traceID,
+		projectionState,
+		latestHistoryID,
+		lastProjectedHistoryID,
+		time.Now().UTC(),
+	)
+}
+
+//nolint:revive // Keep testing.T first in test helper signatures.
+func setEngineProjectionCheckpointAt(
+	t *testing.T,
+	ctx context.Context,
+	platformStore *store.Store,
+	traceID uuid.UUID,
+	projectionState string,
+	latestHistoryID int64,
+	lastProjectedHistoryID int64,
+	updatedAt time.Time,
+) {
+	t.Helper()
+
 	_, err := platformStore.Pool().Exec(ctx, `
 		UPDATE traces
 		SET engine_projection_state = $2,
 		    engine_latest_history_id = $3,
 		    engine_last_projected_history_id = $4,
-		    engine_projection_updated_at = NOW(),
-		    updated_at = NOW()
+		    engine_projection_updated_at = $5,
+		    updated_at = $5
 		WHERE id = $1
-	`, traceID, projectionState, latestHistoryID, lastProjectedHistoryID)
+	`, traceID, projectionState, latestHistoryID, lastProjectedHistoryID, updatedAt)
 	require.NoError(t, err)
 }
 

--- a/internal/api/engine_mapper.go
+++ b/internal/api/engine_mapper.go
@@ -146,6 +146,41 @@ func engineRepairResponseToAPI(result *enginecontrol.RepairResult) EngineRepairR
 	}
 }
 
+func engineProjectionBackfillResponseToAPI(
+	result *enginecontrol.ProjectionBackfillResult,
+) EngineProjectionBackfillResponse {
+	response := EngineProjectionBackfillResponse{
+		DryRun:               result.DryRun,
+		EligibleCount:        result.EligibleCount,
+		Limit:                result.Limit,
+		RepairRequestedCount: result.RepairRequestedCount,
+		Results:              make([]EngineProjectionBackfillRunResult, 0, len(result.Results)),
+		SkippedCount:         result.SkippedCount,
+	}
+
+	for i := range result.Results {
+		response.Results = append(response.Results, engineProjectionBackfillRunResultToAPI(&result.Results[i]))
+	}
+
+	return response
+}
+
+func engineProjectionBackfillRunResultToAPI(
+	result *enginecontrol.ProjectionBackfillRunResult,
+) EngineProjectionBackfillRunResult {
+	apiResult := EngineProjectionBackfillRunResult{
+		Action:          EngineProjectionBackfillAction(result.Action),
+		ProjectionState: engineProjectionStateFromString(result.ProjectionState),
+		RunId:           result.RunID,
+		TraceId:         result.TraceID,
+	}
+	if result.Reason != nil {
+		reason := EngineRepairReason(*result.Reason)
+		apiResult.Reason = &reason
+	}
+	return apiResult
+}
+
 func enginePendingWorkResponseToAPI(result *enginePendingWorkResult) EnginePendingWorkResponse {
 	response := EnginePendingWorkResponse{
 		Activities:           make([]EnginePendingActivityItem, 0, len(result.Activities)),

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -72,6 +72,13 @@ const (
 	CompareTraceHeaderStatusRUNNING   CompareTraceHeaderStatus = "RUNNING"
 )
 
+// Defines values for EngineProjectionBackfillAction.
+const (
+	EngineProjectionBackfillActionRepairRequested EngineProjectionBackfillAction = "repair_requested"
+	EngineProjectionBackfillActionSkipped         EngineProjectionBackfillAction = "skipped"
+	EngineProjectionBackfillActionWouldRepair     EngineProjectionBackfillAction = "would_repair"
+)
+
 // Defines values for EngineProjectionState.
 const (
 	CatchingUp     EngineProjectionState = "catching_up"
@@ -88,11 +95,11 @@ const (
 
 // Defines values for EngineRepairReason.
 const (
-	AlreadyCatchingUp EngineRepairReason = "already_catching_up"
-	AlreadyUpToDate   EngineRepairReason = "already_up_to_date"
-	HistoryExpired    EngineRepairReason = "history_expired"
-	NoEventsToProject EngineRepairReason = "no_events_to_project"
-	RepairRequested   EngineRepairReason = "repair_requested"
+	EngineRepairReasonAlreadyCatchingUp EngineRepairReason = "already_catching_up"
+	EngineRepairReasonAlreadyUpToDate   EngineRepairReason = "already_up_to_date"
+	EngineRepairReasonHistoryExpired    EngineRepairReason = "history_expired"
+	EngineRepairReasonNoEventsToProject EngineRepairReason = "no_events_to_project"
+	EngineRepairReasonRepairRequested   EngineRepairReason = "repair_requested"
 )
 
 // Defines values for EngineRunStatus.
@@ -435,6 +442,8 @@ type EngineControlResponse struct {
 
 // EngineFailureSummary defines model for EngineFailureSummary.
 type EngineFailureSummary struct {
+	// ErrorCode Stable reserved value: `definition_version_mismatch`. Clients may
+	// exact-match this value while still accepting arbitrary strings.
 	ErrorCode    string `json:"error_code"`
 	ErrorMessage string `json:"error_message"`
 	Status       string `json:"status"`
@@ -501,6 +510,42 @@ type EnginePendingWorkResponse struct {
 	RunId                openapi_types.UUID        `json:"run_id"`
 	Signals              []EnginePendingSignalItem `json:"signals"`
 	Timers               []EnginePendingTimerItem  `json:"timers"`
+}
+
+// EngineProjectionBackfillAction defines model for EngineProjectionBackfillAction.
+type EngineProjectionBackfillAction string
+
+// EngineProjectionBackfillRequest defines model for EngineProjectionBackfillRequest.
+type EngineProjectionBackfillRequest struct {
+	DryRun               *bool   `json:"dry_run,omitempty"`
+	EngineDefinitionName *string `json:"engine_definition_name,omitempty"`
+	EngineInstanceKey    *string `json:"engine_instance_key,omitempty"`
+
+	// EngineProjectionState Defaults to `summary_only` when omitted. Explicit `up_to_date`,
+	// `catching_up`, and `journal_expired` return zero eligible rows.
+	EngineProjectionState *EngineProjectionState `json:"engine_projection_state,omitempty"`
+	EngineRunStatus       *EngineRunStatus       `json:"engine_run_status,omitempty"`
+	Limit                 *int                   `json:"limit,omitempty"`
+	OlderThan             *time.Time             `json:"older_than,omitempty"`
+}
+
+// EngineProjectionBackfillResponse defines model for EngineProjectionBackfillResponse.
+type EngineProjectionBackfillResponse struct {
+	DryRun               bool                                `json:"dry_run"`
+	EligibleCount        int                                 `json:"eligible_count"`
+	Limit                int                                 `json:"limit"`
+	RepairRequestedCount int                                 `json:"repair_requested_count"`
+	Results              []EngineProjectionBackfillRunResult `json:"results"`
+	SkippedCount         int                                 `json:"skipped_count"`
+}
+
+// EngineProjectionBackfillRunResult defines model for EngineProjectionBackfillRunResult.
+type EngineProjectionBackfillRunResult struct {
+	Action          EngineProjectionBackfillAction `json:"action"`
+	ProjectionState EngineProjectionState          `json:"projection_state"`
+	Reason          *EngineRepairReason            `json:"reason,omitempty"`
+	RunId           openapi_types.UUID             `json:"run_id"`
+	TraceId         string                         `json:"trace_id"`
 }
 
 // EngineProjectionState defines model for EngineProjectionState.
@@ -1214,6 +1259,12 @@ type GetTraceEventsParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// BackfillEngineProjectionsParams defines parameters for BackfillEngineProjections.
+type BackfillEngineProjectionsParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
 // StartEngineRunParams defines parameters for StartEngineRun.
 type StartEngineRunParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
@@ -1278,6 +1329,9 @@ type IngestParams struct {
 	// Any other value is rejected with `400 unsupported_async_version`.
 	XContinuaAsyncVersion *string `json:"X-Continua-Async-Version,omitempty"`
 }
+
+// BackfillEngineProjectionsJSONRequestBody defines body for BackfillEngineProjections for application/json ContentType.
+type BackfillEngineProjectionsJSONRequestBody = EngineProjectionBackfillRequest
 
 // StartEngineRunJSONRequestBody defines body for StartEngineRun for application/json ContentType.
 type StartEngineRunJSONRequestBody = EngineStartRunRequest
@@ -1463,6 +1517,9 @@ type ServerInterface interface {
 	// Get an engine instance and current run
 	// (GET /v1/engine/instances/{instance_key})
 	GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string)
+	// Preview or request bulk projection repair for engine runs
+	// (POST /v1/engine/projections/backfill)
+	BackfillEngineProjections(w http.ResponseWriter, r *http.Request, params BackfillEngineProjectionsParams)
 	// Start an engine workflow run
 	// (POST /v1/engine/runs)
 	StartEngineRun(w http.ResponseWriter, r *http.Request, params StartEngineRunParams)
@@ -1562,6 +1619,12 @@ func (_ Unimplemented) ListSpansByTrace(w http.ResponseWriter, r *http.Request, 
 // Get an engine instance and current run
 // (GET /v1/engine/instances/{instance_key})
 func (_ Unimplemented) GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Preview or request bulk projection repair for engine runs
+// (POST /v1/engine/projections/backfill)
+func (_ Unimplemented) BackfillEngineProjections(w http.ResponseWriter, r *http.Request, params BackfillEngineProjectionsParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2144,6 +2207,56 @@ func (siw *ServerInterfaceWrapper) GetEngineInstance(w http.ResponseWriter, r *h
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetEngineInstance(w, r, instanceKey)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// BackfillEngineProjections operation middleware
+func (siw *ServerInterfaceWrapper) BackfillEngineProjections(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params BackfillEngineProjectionsParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.BackfillEngineProjections(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2983,6 +3096,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/instances/{instance_key}", wrapper.GetEngineInstance)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/projections/backfill", wrapper.BackfillEngineProjections)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/engine/runs", wrapper.StartEngineRun)

--- a/internal/api/server_helpers.go
+++ b/internal/api/server_helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 
@@ -47,6 +48,21 @@ func writeEngineError(w http.ResponseWriter, err error, fallbackMessage string) 
 
 func decodeJSONRequest(w http.ResponseWriter, r *http.Request, dest any) bool {
 	if err := json.NewDecoder(r.Body).Decode(dest); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", "Failed to parse request body: "+err.Error())
+		return false
+	}
+	return true
+}
+
+func decodeOptionalJSONRequest(w http.ResponseWriter, r *http.Request, dest any) bool {
+	if r.Body == nil || r.ContentLength == 0 {
+		return true
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(dest); err != nil {
+		if errors.Is(err, io.EOF) {
+			return true
+		}
 		writeError(w, http.StatusBadRequest, "invalid_json", "Failed to parse request body: "+err.Error())
 		return false
 	}

--- a/internal/enginecontrol/service.go
+++ b/internal/enginecontrol/service.go
@@ -60,6 +60,41 @@ type RepairResult struct {
 	ProjectionState string
 }
 
+type ProjectionBackfillAction string
+
+const (
+	ProjectionBackfillActionWouldRepair     ProjectionBackfillAction = "would_repair"
+	ProjectionBackfillActionRepairRequested ProjectionBackfillAction = "repair_requested"
+	ProjectionBackfillActionSkipped         ProjectionBackfillAction = "skipped"
+)
+
+type ProjectionBackfillRequest struct {
+	DryRun                bool
+	Limit                 int
+	OlderThan             *time.Time
+	EngineInstanceKey     string
+	EngineDefinitionName  string
+	EngineRunStatus       string
+	EngineProjectionState string
+}
+
+type ProjectionBackfillRunResult struct {
+	RunID           uuid.UUID
+	TraceID         string
+	ProjectionState string
+	Action          ProjectionBackfillAction
+	Reason          *RepairReason
+}
+
+type ProjectionBackfillResult struct {
+	DryRun               bool
+	Limit                int
+	EligibleCount        int
+	RepairRequestedCount int
+	SkippedCount         int
+	Results              []ProjectionBackfillRunResult
+}
+
 type Service struct {
 	platform *store.Store
 }
@@ -237,6 +272,74 @@ func (s *Service) RepairRun(
 	return result, nil
 }
 
+func (s *Service) BackfillProjections(
+	ctx context.Context,
+	projectID uuid.UUID,
+	req ProjectionBackfillRequest,
+) (ProjectionBackfillResult, error) {
+	if s == nil || s.platform == nil {
+		return ProjectionBackfillResult{}, errors.New("engine control service is not configured")
+	}
+
+	result := ProjectionBackfillResult{
+		DryRun: req.DryRun,
+		Limit:  req.Limit,
+	}
+
+	projectionState := normalizeBackfillProjectionState(req.EngineProjectionState)
+	if !isBackfillTargetProjectionState(projectionState) {
+		return result, nil
+	}
+
+	candidates, err := s.platform.ListProjectionBackfillCandidates(ctx, store.ProjectionBackfillFilter{
+		ProjectID:             projectID,
+		OlderThan:             req.OlderThan,
+		EngineInstanceKey:     strings.TrimSpace(req.EngineInstanceKey),
+		EngineDefinitionName:  strings.TrimSpace(req.EngineDefinitionName),
+		EngineRunStatus:       strings.ToLower(strings.TrimSpace(req.EngineRunStatus)),
+		EngineProjectionState: projectionState,
+		Limit:                 req.Limit,
+	})
+	if err != nil {
+		return ProjectionBackfillResult{}, err
+	}
+
+	result.EligibleCount = len(candidates)
+	result.Results = make([]ProjectionBackfillRunResult, 0, len(candidates))
+	for _, candidate := range candidates {
+		runResult := ProjectionBackfillRunResult{
+			RunID:           candidate.RunID,
+			TraceID:         candidate.TraceID,
+			ProjectionState: candidate.ProjectionState,
+		}
+
+		if req.DryRun {
+			runResult.Action = ProjectionBackfillActionWouldRepair
+			result.Results = append(result.Results, runResult)
+			continue
+		}
+
+		repairResult, err := s.RepairRun(ctx, projectID, candidate.RunID)
+		if err != nil {
+			return ProjectionBackfillResult{}, err
+		}
+
+		runResult.ProjectionState = repairResult.ProjectionState
+		runResult.Reason = &repairResult.Reason
+		if repairResult.Reason == RepairReasonRequested {
+			runResult.Action = ProjectionBackfillActionRepairRequested
+			result.RepairRequestedCount++
+		} else {
+			runResult.Action = ProjectionBackfillActionSkipped
+			result.SkippedCount++
+		}
+
+		result.Results = append(result.Results, runResult)
+	}
+
+	return result, nil
+}
+
 func loadLockedRunTrace(
 	ctx context.Context,
 	tx *store.Tx,
@@ -271,6 +374,17 @@ func normalizedProjectionState(value *string) string {
 		return publicprojection.StateUpToDate.String()
 	}
 	return state
+}
+
+func normalizeBackfillProjectionState(value string) string {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		return trimmed
+	}
+	return publicprojection.StateSummaryOnly.String()
+}
+
+func isBackfillTargetProjectionState(value string) bool {
+	return strings.TrimSpace(value) == publicprojection.StateSummaryOnly.String()
 }
 
 func isTerminalRun(status enginedb.EngineRunLifecycleStatus) bool {

--- a/internal/enginecontrol/service.go
+++ b/internal/enginecontrol/service.go
@@ -275,10 +275,13 @@ func (s *Service) RepairRun(
 func (s *Service) BackfillProjections(
 	ctx context.Context,
 	projectID uuid.UUID,
-	req ProjectionBackfillRequest,
+	req *ProjectionBackfillRequest,
 ) (ProjectionBackfillResult, error) {
 	if s == nil || s.platform == nil {
 		return ProjectionBackfillResult{}, errors.New("engine control service is not configured")
+	}
+	if req == nil {
+		req = &ProjectionBackfillRequest{}
 	}
 
 	result := ProjectionBackfillResult{
@@ -291,7 +294,7 @@ func (s *Service) BackfillProjections(
 		return result, nil
 	}
 
-	candidates, err := s.platform.ListProjectionBackfillCandidates(ctx, store.ProjectionBackfillFilter{
+	candidates, err := s.platform.ListProjectionBackfillCandidates(ctx, &store.ProjectionBackfillFilter{
 		ProjectID:             projectID,
 		OlderThan:             req.OlderThan,
 		EngineInstanceKey:     strings.TrimSpace(req.EngineInstanceKey),

--- a/internal/store/engine_projection_backfill.go
+++ b/internal/store/engine_projection_backfill.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type ProjectionBackfillFilter struct {
+	ProjectID             uuid.UUID
+	OlderThan             *time.Time
+	EngineInstanceKey     string
+	EngineDefinitionName  string
+	EngineRunStatus       string
+	EngineProjectionState string
+	Limit                 int
+}
+
+type ProjectionBackfillCandidate struct {
+	RunID           uuid.UUID
+	TraceID         string
+	ProjectionState string
+}
+
+func (s *Store) ListProjectionBackfillCandidates(
+	ctx context.Context,
+	filter ProjectionBackfillFilter,
+) ([]ProjectionBackfillCandidate, error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	whereClauses := []string{
+		"t.project_id = $1",
+		"t.engine_run_id IS NOT NULL",
+		"COALESCE(t.engine_projection_state, 'up_to_date') = $2",
+		"hist.latest_retained_history_id > COALESCE(t.engine_last_projected_history_id, 0)",
+	}
+	args := []any{
+		filter.ProjectID,
+		strings.TrimSpace(filter.EngineProjectionState),
+	}
+	argNum := 3
+
+	if filter.OlderThan != nil {
+		whereClauses = append(whereClauses, fmt.Sprintf("t.engine_projection_updated_at < $%d", argNum))
+		args = append(args, *filter.OlderThan)
+		argNum++
+	}
+
+	if instanceKey := strings.TrimSpace(filter.EngineInstanceKey); instanceKey != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("t.engine_instance_key = $%d", argNum))
+		args = append(args, instanceKey)
+		argNum++
+	}
+
+	if definitionName := strings.TrimSpace(filter.EngineDefinitionName); definitionName != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("t.engine_definition_name = $%d", argNum))
+		args = append(args, definitionName)
+		argNum++
+	}
+
+	if runStatus := strings.ToLower(strings.TrimSpace(filter.EngineRunStatus)); runStatus != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("LOWER(t.engine_run_status) = $%d", argNum))
+		args = append(args, runStatus)
+		argNum++
+	}
+
+	args = append(args, limit)
+
+	rows, err := s.pool.Query(ctx, fmt.Sprintf(`
+		SELECT t.engine_run_id,
+		       t.trace_id,
+		       COALESCE(t.engine_projection_state, 'up_to_date') AS projection_state
+		FROM public.traces AS t
+		INNER JOIN engine.runs AS r
+		    ON r.project_id = t.project_id
+		   AND r.id = t.engine_run_id
+		INNER JOIN LATERAL (
+		    SELECT COALESCE(MAX(h.id), 0)::bigint AS latest_retained_history_id
+		    FROM engine.history AS h
+		    WHERE h.run_id = r.id
+		) AS hist ON true
+		WHERE %s
+		ORDER BY COALESCE(t.engine_projection_updated_at, t.updated_at, t.created_at) ASC, t.id ASC
+		LIMIT $%d
+	`, strings.Join(whereClauses, " AND "), argNum), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list projection backfill candidates: %w", err)
+	}
+	defer rows.Close()
+
+	candidates := make([]ProjectionBackfillCandidate, 0, limit)
+	for rows.Next() {
+		var candidate ProjectionBackfillCandidate
+		if err := rows.Scan(&candidate.RunID, &candidate.TraceID, &candidate.ProjectionState); err != nil {
+			return nil, fmt.Errorf("scan projection backfill candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate projection backfill candidates: %w", err)
+	}
+
+	return candidates, nil
+}

--- a/internal/store/engine_projection_backfill.go
+++ b/internal/store/engine_projection_backfill.go
@@ -27,8 +27,12 @@ type ProjectionBackfillCandidate struct {
 
 func (s *Store) ListProjectionBackfillCandidates(
 	ctx context.Context,
-	filter ProjectionBackfillFilter,
+	filter *ProjectionBackfillFilter,
 ) ([]ProjectionBackfillCandidate, error) {
+	if filter == nil {
+		filter = &ProjectionBackfillFilter{}
+	}
+
 	limit := filter.Limit
 	if limit <= 0 {
 		limit = 50

--- a/openspec/changes/add-engine-projection-bulk-backfill/design.md
+++ b/openspec/changes/add-engine-projection-bulk-backfill/design.md
@@ -1,0 +1,30 @@
+## Context
+Operators who have run retention cycles may have many `summary_only` traces with retained engine history that could be re-projected. The single-run `POST /v1/engine/runs/{run_id}/repair` endpoint works for individual runs but is impractical for bulk recovery. This change adds a bulk backfill endpoint that identifies eligible runs and triggers repairs in a single call.
+
+## Goals / Non-Goals
+- Goals:
+  - Single API call to identify and repair eligible `summary_only` runs
+  - Dry-run mode for safe previews without mutation
+  - Reuse existing repair service (no new projection writer, no new maintenance worker)
+  - Per-run result transparency with action and reason
+  - Python SDK convenience methods with bounded paging
+- Non-Goals:
+  - No `cmd/continua backfill` CLI command in this phase
+  - No traces-page bulk backfill UI
+  - No automatic/scheduled backfill worker
+  - No admin/operations UI
+
+## Decisions
+- **Reuse repair service**: The backfill endpoint iterates eligible runs and calls the existing `RepairRun()` for each. This avoids a second projection writer and preserves the single-writer invariant that the projector owns.
+- **Limit cap at 100**: Prevents unbounded DB work per request. The Python SDK provides a `backfill_projections_all()` paging helper with a configurable `max_total` (default 1000) for larger batches.
+- **Default to summary_only candidates**: If `engine_projection_state` is omitted, only `summary_only` runs are eligible. Explicitly requesting `up_to_date`, `catching_up`, or `journal_expired` returns zero eligible rows because those states are not valid backfill targets.
+- **Eligibility condition**: A run is eligible when it is `summary_only`, has a retained engine run/history shell, and the latest retained engine history ID is greater than `engine_last_projected_history_id`. This matches the existing repair-service checkpoint condition.
+- **Preview gate**: The endpoint requires `X-Continua-Engine-Preview: 1` header, matching existing engine mutating routes.
+- **Per-run result actions**: `would_repair` (dry-run eligible, no mutation), `repair_requested` (repair accepted in apply mode), `skipped` (race-time no-op in apply mode, with reason from repair service).
+
+## Risks / Trade-offs
+- **Lock contention**: Multiple concurrent backfill calls hitting the repair service could create CAS contention. Mitigation: the limit cap keeps batch sizes small, and the repair CAS prevents double-transitions safely.
+- **Stale eligibility**: A run may become ineligible between the eligibility query and the per-run repair call (e.g., another repair request). Mitigation: the per-run result reports `skipped` with the repair reason, and repeated calls converge to zero eligible.
+
+## Open Questions
+- None remaining; all resolved in review.

--- a/openspec/changes/add-engine-projection-bulk-backfill/proposal.md
+++ b/openspec/changes/add-engine-projection-bulk-backfill/proposal.md
@@ -1,0 +1,19 @@
+# Change: Add Engine Projection Bulk Backfill
+
+## Why
+When many engine traces have `summary_only` projection state after retention purges, operators need a way to request bulk repair without calling the single-run repair endpoint repeatedly. A bulk backfill API provides a one-call path to identify eligible runs and trigger repairs, with a dry-run mode for safe previews.
+
+## What Changes
+- Add preview-gated `POST /v1/engine/projections/backfill` endpoint
+- Support dry-run mode to preview eligible runs without mutating state
+- Support filtering by `older_than`, `engine_instance_key`, `engine_definition_name`, `engine_run_status`, and `engine_projection_state`
+- Default to `summary_only` candidates when `engine_projection_state` is omitted; return zero eligible rows for incompatible states (`up_to_date`, `catching_up`, `journal_expired`)
+- Enforce limit cap at 100 (default 50) with 400 for values above 100
+- Reuse existing repair service for apply-mode per-run processing; no new projection writer or maintenance worker
+- Return structured per-run results with `action` (would_repair, repair_requested, skipped) and optional `reason`
+- Add Python SDK `backfill_projections()` single-call method and `backfill_projections_all()` bounded paging helper
+- Defer: CLI command, traces-page bulk backfill UI, admin/operations UI
+
+## Impact
+- Affected specs: engine-projection-backfill-api, engine-python-backfill-client
+- Affected code: `contracts/openapi/openapi.yaml`, `internal/api/engine_handlers.go`, `internal/enginecontrol/service.go`, `internal/store/`, `sdks/python/src/continua/engine_control.py`, `sdks/python/src/continua/types.py`

--- a/openspec/changes/add-engine-projection-bulk-backfill/specs/engine-projection-backfill-api/spec.md
+++ b/openspec/changes/add-engine-projection-bulk-backfill/specs/engine-projection-backfill-api/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Bulk backfill endpoint
+The system SHALL provide `POST /v1/engine/projections/backfill` gated by the `X-Continua-Engine-Preview: 1` header. Requests without the preview header SHALL receive a 400 response.
+
+#### Scenario: Request without preview header is rejected
+- **WHEN** a POST is sent to `/v1/engine/projections/backfill` without the `X-Continua-Engine-Preview: 1` header
+- **THEN** the response status is 400
+
+#### Scenario: Request with preview header is accepted
+- **WHEN** a POST is sent with a valid body and the `X-Continua-Engine-Preview: 1` header
+- **THEN** the endpoint processes the request and returns a backfill response
+
+### Requirement: Backfill request parameters
+The request body SHALL accept: `dry_run` (boolean, defaults to false), `limit` (integer, defaults to 50, maximum 100), `older_than` (ISO 8601 timestamp), `engine_instance_key` (string), `engine_definition_name` (string), `engine_run_status` (EngineRunStatus), and `engine_projection_state` (EngineProjectionState). All fields are optional. Values of `limit` above 100 SHALL return a 400 response.
+
+#### Scenario: Limit above 100 returns 400
+- **WHEN** a backfill request has `limit=150`
+- **THEN** the response status is 400 with an error indicating the maximum limit is 100
+
+#### Scenario: Default limit is 50
+- **WHEN** a backfill request omits `limit`
+- **THEN** up to 50 eligible runs are processed
+
+#### Scenario: Default dry_run is false
+- **WHEN** a backfill request omits `dry_run`
+- **THEN** the endpoint runs in apply mode
+
+### Requirement: Default eligibility selection
+If `engine_projection_state` is omitted from the request, the endpoint SHALL select only `summary_only` candidates whose trace has a retained engine run/history shell and whose latest retained engine history ID is greater than `engine_last_projected_history_id`.
+
+#### Scenario: Omitted projection state selects summary_only candidates
+- **WHEN** a backfill request omits `engine_projection_state` and 5 `summary_only` traces have retained history ahead of their projection checkpoint
+- **THEN** those 5 traces are eligible
+
+#### Scenario: Non-engine traces are excluded
+- **WHEN** a backfill request omits `engine_projection_state` and no engine traces exist
+- **THEN** the response has `eligible_count=0` and empty results
+
+### Requirement: Incompatible projection state filters
+If `engine_projection_state` is explicitly set to `up_to_date`, `catching_up`, or `journal_expired`, the endpoint SHALL return zero eligible rows. This behavior SHALL be documented in the API description.
+
+#### Scenario: Explicit up_to_date filter returns zero results
+- **WHEN** a backfill request has `engine_projection_state=up_to_date`
+- **THEN** the response has `eligible_count=0` and empty `results`
+
+#### Scenario: Explicit journal_expired filter returns zero results
+- **WHEN** a backfill request has `engine_projection_state=journal_expired`
+- **THEN** the response has `eligible_count=0` and empty `results`
+
+### Requirement: Backfill response shape
+The response SHALL include: `dry_run` (boolean), `limit` (integer), `eligible_count` (integer), `repair_requested_count` (integer), `skipped_count` (integer), and `results` (array). Each result SHALL include `run_id` (UUID), `trace_id` (string), `projection_state` (EngineProjectionState), `action` (EngineProjectionBackfillAction), and optional `reason` (string).
+
+#### Scenario: Apply response includes counts and per-run results
+- **WHEN** a backfill request with `dry_run=false` processes 3 eligible runs where 2 accept repair and 1 is skipped
+- **THEN** the response has `eligible_count=3`, `repair_requested_count=2`, `skipped_count=1`, and 3 entries in `results`
+
+### Requirement: Backfill action values
+The `action` field SHALL use the enum `EngineProjectionBackfillAction` with values: `would_repair` (dry-run eligible run, no mutation), `repair_requested` (repair accepted in apply mode), `skipped` (race-time no-op in apply mode).
+
+#### Scenario: Dry-run returns would_repair actions
+- **WHEN** a backfill request with `dry_run=true` finds 2 eligible runs
+- **THEN** each result has `action=would_repair` and no state is mutated
+
+#### Scenario: Apply returns repair_requested for accepted repairs
+- **WHEN** a backfill request with `dry_run=false` processes a run whose repair is accepted
+- **THEN** the result has `action=repair_requested`
+
+#### Scenario: Apply returns skipped for race-time no-ops
+- **WHEN** a run becomes ineligible between the eligibility query and per-run repair (e.g., already transitioned to `catching_up`)
+- **THEN** the result has `action=skipped` with the repair service reason
+
+### Requirement: Backfill reason values
+The `reason` field, when present, SHALL use existing repair-service reason values: `already_up_to_date`, `history_expired`, `no_events_to_project`, `repair_requested`, `already_catching_up`.
+
+#### Scenario: Skipped run includes reason
+- **WHEN** a run is skipped because it is already catching up
+- **THEN** the result has `action=skipped` and `reason=already_catching_up`
+
+### Requirement: Backfill reuses repair service
+The apply path SHALL call the existing repair service (`RepairRun()`) for each eligible run. No direct projection writes and no new maintenance worker SHALL be introduced. This preserves the single-writer invariant.
+
+#### Scenario: Repeated backfill calls converge
+- **WHEN** a backfill request is repeated after all eligible runs have been repaired
+- **THEN** subsequent calls return `eligible_count=0` or all results as `skipped`
+
+### Requirement: older_than filtering
+The `older_than` parameter SHALL filter candidates by `engine_projection_updated_at`, selecting only runs whose projection was last updated before the given timestamp.
+
+#### Scenario: older_than filters by projection update time
+- **WHEN** a backfill request has `older_than=2026-01-01T00:00:00Z` and 3 runs have `engine_projection_updated_at` before that date while 2 have it after
+- **THEN** only the 3 older runs are eligible candidates

--- a/openspec/changes/add-engine-projection-bulk-backfill/specs/engine-python-backfill-client/spec.md
+++ b/openspec/changes/add-engine-projection-bulk-backfill/specs/engine-python-backfill-client/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Single-call backfill method
+The Python `EngineControlClient` SHALL provide a `backfill_projections()` method accepting keyword arguments: `dry_run`, `limit`, `older_than`, `engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state`. The method SHALL call `POST /v1/engine/projections/backfill` and return a typed `EngineProjectionBackfillResponse`.
+
+#### Scenario: Single backfill call returns typed response
+- **WHEN** `backfill_projections(dry_run=True, limit=10)` is called
+- **THEN** the method returns an `EngineProjectionBackfillResponse` with `eligible_count`, `results`, and other top-level fields
+
+#### Scenario: Backfill method sends preview header
+- **WHEN** `backfill_projections()` is called
+- **THEN** the request includes the `X-Continua-Engine-Preview: 1` header
+
+### Requirement: Bounded paging backfill helper
+The Python `EngineControlClient` SHALL provide a `backfill_projections_all()` method accepting `max_total` (default 1000) and the `backfill_projections()` filter keyword arguments. The method SHALL call `backfill_projections()` repeatedly in apply mode until no more eligible runs remain or `max_total` cumulative results are reached. Each page uses the same filter parameters.
+
+Because the backfill API has no cursor and dry-run calls do not mutate candidate eligibility, `backfill_projections_all(dry_run=True, ...)` SHALL reject with a clear `ValueError` instead of silently returning a truncated preview. Callers that need previews SHALL use `backfill_projections(dry_run=True, limit=...)`.
+
+#### Scenario: Paging helper stops at max_total
+- **WHEN** `backfill_projections_all(max_total=100, limit=50)` is called and more than 100 eligible runs exist
+- **THEN** the method makes 2 calls (50 + 50 = 100 cumulative results) and stops at `max_total`
+
+#### Scenario: Paging helper stops when no eligible runs remain
+- **WHEN** `backfill_projections_all(max_total=1000, limit=50)` is called and 30 eligible runs exist
+- **THEN** the method makes 1 call returning 30 results and stops because `eligible_count < limit` (no more eligible runs)
+
+#### Scenario: Paging helper returns aggregated results
+- **WHEN** `backfill_projections_all()` pages through 3 calls
+- **THEN** the returned response aggregates results from all pages
+
+#### Scenario: Paging helper rejects dry-run previews
+- **WHEN** `backfill_projections_all(dry_run=True, max_total=100, limit=50)` is called
+- **THEN** the method raises a `ValueError`
+- **AND** it does not call the backfill API
+
+### Requirement: Backfill response types
+The Python SDK SHALL define `EngineProjectionBackfillResponse`, `EngineProjectionBackfillRunResult`, and `EngineProjectionBackfillAction` types matching the API response shape.
+
+#### Scenario: Response type includes all fields
+- **WHEN** a backfill response is decoded
+- **THEN** the typed response has `dry_run`, `limit`, `eligible_count`, `repair_requested_count`, `skipped_count`, and `results` fields
+
+#### Scenario: Run result type includes action and reason
+- **WHEN** a run result is decoded
+- **THEN** it has `run_id`, `trace_id`, `projection_state`, `action`, and optional `reason` fields

--- a/openspec/changes/add-engine-projection-bulk-backfill/tasks.md
+++ b/openspec/changes/add-engine-projection-bulk-backfill/tasks.md
@@ -1,0 +1,20 @@
+## 1. API Contract
+- [x] 1.1 Add `POST /v1/engine/projections/backfill` path to `contracts/openapi/openapi.yaml` with preview-gate header requirement
+- [x] 1.2 Add `EngineProjectionBackfillRequest` schema with `dry_run`, `limit`, `older_than`, `engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state` fields
+- [x] 1.3 Add `EngineProjectionBackfillResponse` schema with `dry_run`, `limit`, `eligible_count`, `repair_requested_count`, `skipped_count`, `results` fields
+- [x] 1.4 Add `EngineProjectionBackfillRunResult` schema with `run_id`, `trace_id`, `projection_state`, `action`, `reason` fields
+- [x] 1.5 Add `EngineProjectionBackfillAction` enum with `would_repair`, `repair_requested`, `skipped` values
+- [x] 1.6 Run `make generate` and verify generated code compiles
+
+## 2. Backend Implementation
+- [x] 2.1 Add backfill eligibility query to store: select `summary_only` traces with retained history shell where latest retained engine history ID > `engine_last_projected_history_id`, supporting `older_than`, `engine_instance_key`, `engine_definition_name`, `engine_run_status` filters and `limit`
+- [x] 2.2 Add backfill handler in `internal/api/engine_handlers.go` with preview-gate validation, limit validation (400 for > 100, default 50), and dry-run/apply branching
+- [x] 2.3 Wire apply-mode per-run processing to the existing repair service `RepairRun()` method
+- [x] 2.4 Return incompatible `engine_projection_state` filters (`up_to_date`, `catching_up`, `journal_expired`) as zero eligible rows
+- [x] 2.5 Write Go integration tests: dry-run returns `would_repair` without mutation, apply returns `repair_requested` and flips state, limit cap returns 400, `older_than` filters correctly, convergent repeated calls reach zero eligible, incompatible projection-state filters return empty results
+
+## 3. Python SDK
+- [x] 3.1 Add `EngineProjectionBackfillResponse`, `EngineProjectionBackfillRunResult`, `EngineProjectionBackfillAction` types to `sdks/python/src/continua/types.py`
+- [x] 3.2 Add `backfill_projections(*, dry_run, limit, older_than, engine_instance_key, engine_definition_name, engine_run_status, engine_projection_state)` method to `EngineControlClient`
+- [x] 3.3 Add `backfill_projections_all(*, max_total=1000, **kwargs)` apply-mode paging helper that calls `backfill_projections()` repeatedly until no eligible runs remain or `max_total` is reached, and rejects `dry_run=True` because dry-run pagination cannot advance without an API cursor
+- [x] 3.4 Write pytest tests: single-call response decoding, paging helper stops at `max_total`, paging helper stops when eligible runs exhausted, dry-run paging rejection

--- a/openspec/changes/complete-engine-debugger-operator-surface/proposal.md
+++ b/openspec/changes/complete-engine-debugger-operator-surface/proposal.md
@@ -1,0 +1,18 @@
+# Change: Complete Engine Debugger Operator Surface
+
+## Why
+The backend engine control, pending-work, repair, purge, and continuation APIs are all landed, but the React debugger does not yet expose them. Operators cannot filter traces by engine attributes, inspect pending work, control runs, navigate continuation chains, or see projection mismatch warnings without direct API calls.
+
+## What Changes
+- Add URL-driven engine filters (`engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state`) to the traces page in a collapsible "Engine filters" section beneath the existing filter grid
+- Add `engine_projection_state` helper text identifying it as an operator-oriented/advanced filter
+- Add a separate pending-work query keyed as `['enginePendingWork', runId]` that polls on `TIMELINE_POLL_INTERVAL_MS` for active engine runs only
+- Add trace-detail controls for signal, cancel, suspend, resume, terminate, purge, and repair with state-gated enablement, confirmation where needed, and structured feedback
+- Add a mismatch warning banner when `trace.engine.failure.error_code === 'definition_version_mismatch'`
+- Add ContinueAsNew navigation links using `continued_from_trace_id` and `continued_to_trace_id`
+- Update `EngineRunStatus` to include `SUSPENDED`, `TERMINATED`, and `CONTINUED_AS_NEW`
+- Update `EngineRunSummary` to include continuation link fields
+
+## Impact
+- Affected specs: engine-debugger-filters, engine-debugger-controls, engine-debugger-pending-work, engine-debugger-operator-ux
+- Affected code: `web/src/pages/TracesPage.tsx`, `web/src/pages/TraceDetailPage.tsx`, `web/src/utils/tracesSearchParams.ts`, `web/src/api/client.ts`, and page-local components colocated with the trace detail page (not shared components unless reuse is demonstrated)

--- a/openspec/changes/complete-engine-debugger-operator-surface/specs/engine-debugger-controls/spec.md
+++ b/openspec/changes/complete-engine-debugger-operator-surface/specs/engine-debugger-controls/spec.md
@@ -1,0 +1,162 @@
+## ADDED Requirements
+
+### Requirement: Engine control actions in trace detail
+The trace detail page SHALL display engine control action buttons for signal, cancel, suspend, resume, terminate, purge, and repair when the trace has engine metadata (`trace.engine` is present). Control actions SHALL NOT be rendered for non-engine traces.
+
+#### Scenario: Control actions appear for engine-backed traces
+- **WHEN** a trace detail loads with `trace.engine` present
+- **THEN** engine control action buttons are rendered
+
+#### Scenario: Control actions are absent for non-engine traces
+- **WHEN** a trace detail loads without `trace.engine`
+- **THEN** no engine control action buttons are rendered
+
+### Requirement: Engine control mutation preview header
+All engine control mutation API wrappers (signal, cancel, suspend, resume, terminate, purge, repair) SHALL send the `X-Continua-Engine-Preview: 1` header. The pending-work read endpoint does not require this header.
+
+#### Scenario: Signal mutation sends preview header
+- **WHEN** the signal API wrapper is called
+- **THEN** the request includes the `X-Continua-Engine-Preview: 1` header
+
+#### Scenario: Pending-work read does not send preview header
+- **WHEN** the pending-work fetch is called
+- **THEN** the request does not include the preview header
+
+### Requirement: Engine control action state gating
+Each control action SHALL be enabled or disabled based on the current engine run status:
+- `signal` and `cancel`: enabled while the run is non-terminal, including `SUSPENDED`
+- `suspend`: enabled only for `QUEUED`, `RUNNING`, or `WAITING`
+- `resume`: enabled only for `SUSPENDED`
+- `terminate`: enabled for any non-terminal run including `SUSPENDED`
+- `purge`: enabled only for terminal runs (`COMPLETED`, `FAILED`, `CANCELLED`, `TERMINATED`, `CONTINUED_AS_NEW`)
+- `repair`: enabled for any engine-backed trace regardless of status
+
+#### Scenario: Suspend is disabled for a COMPLETED run
+- **WHEN** the engine run status is `COMPLETED`
+- **THEN** the suspend button is disabled
+
+#### Scenario: Resume is enabled only for SUSPENDED
+- **WHEN** the engine run status is `SUSPENDED`
+- **THEN** the resume button is enabled
+
+#### Scenario: Purge is disabled for non-terminal runs
+- **WHEN** the engine run status is `RUNNING`
+- **THEN** the purge button is disabled
+
+#### Scenario: Purge is enabled for CONTINUED_AS_NEW
+- **WHEN** the engine run status is `CONTINUED_AS_NEW`
+- **THEN** the purge button is enabled
+
+#### Scenario: Signal is enabled for SUSPENDED runs
+- **WHEN** the engine run status is `SUSPENDED`
+- **THEN** the signal button is enabled
+
+### Requirement: Signal modal with validation
+The signal action SHALL open a modal with a required `signal_name` text input that MUST be non-empty after trimming whitespace, and an optional `payload` text area. If a payload is provided, it MUST be valid JSON; invalid JSON SHALL prevent submission.
+
+#### Scenario: Signal modal validates JSON payload
+- **WHEN** a user enters `signal_name=approve` and payload `{invalid`
+- **THEN** the submit button is disabled and a validation error is shown
+
+#### Scenario: Signal modal allows empty payload
+- **WHEN** a user enters `signal_name=approve` with no payload
+- **THEN** the submit button is enabled
+
+#### Scenario: Signal modal rejects whitespace-only signal name
+- **WHEN** a user enters `signal_name` as `   ` (whitespace only)
+- **THEN** the submit button is disabled and a validation error is shown
+
+### Requirement: Confirmation for destructive control actions
+`cancel`, `terminate`, and `purge` SHALL require user confirmation before execution. `repair` SHALL NOT require confirmation; it sends the request immediately and displays informational feedback from the response.
+
+#### Scenario: Cancel requires confirmation
+- **WHEN** a user clicks the cancel button
+- **THEN** a confirmation dialog appears before the cancel request is sent
+
+#### Scenario: Repair does not require confirmation
+- **WHEN** a user clicks the repair button
+- **THEN** the repair request is sent immediately without a confirmation dialog
+
+### Requirement: Purge mode selection
+The purge confirmation dialog SHALL include a mode selection between `projection_only` (default) and `full`. The `full` mode SHALL be presented with a destructive warning because it purges retained engine history that cannot be recovered. The selected mode SHALL be sent as the `mode` field in the purge request body.
+
+#### Scenario: Purge defaults to projection_only mode
+- **WHEN** the purge confirmation dialog opens
+- **THEN** the `projection_only` mode is selected by default
+
+#### Scenario: Full purge mode shows destructive warning
+- **WHEN** a user selects `full` purge mode
+- **THEN** a destructive warning is displayed indicating retained engine history will be permanently deleted
+
+### Requirement: Purge feedback
+After a purge mutation, the UI SHALL display inline feedback in the control area using existing alert/status styling: `deleted=true` indicates the purge was applied; `deleted=false` indicates the target was already in the requested state. No global toast or notification system SHALL be introduced.
+
+#### Scenario: Purge shows applied feedback
+- **WHEN** the purge response returns `deleted=true`
+- **THEN** an inline success message in the control area indicates the purge was applied
+
+#### Scenario: Purge shows already-satisfied feedback
+- **WHEN** the purge response returns `deleted=false`
+- **THEN** an inline informational message in the control area indicates the purge was already satisfied
+
+### Requirement: Repair reason feedback
+After a repair mutation, the UI SHALL display inline feedback in the control area using existing alert/status styling based on the returned reason:
+- `repair_requested`: success message
+- `already_catching_up`: informational message
+- `already_up_to_date`: informational message
+- `no_events_to_project`: informational message
+- `history_expired`: warning message
+
+No global toast or notification system SHALL be introduced.
+
+#### Scenario: Repair shows success feedback
+- **WHEN** the repair response returns reason `repair_requested`
+- **THEN** an inline success message in the control area indicates repair was requested
+
+#### Scenario: Repair shows history_expired warning
+- **WHEN** the repair response returns reason `history_expired`
+- **THEN** an inline warning message in the control area indicates the event journal has expired and repair is not possible
+
+### Requirement: In-flight mutation pending state
+While a control mutation request is in flight, the active action button (and modal submit button, if applicable) SHALL be disabled to prevent double-submission. The control area SHALL show a submitting indicator. This is especially important for `signal`, where duplicate sends are semantically meaningful.
+
+#### Scenario: Signal button disabled during in-flight request
+- **WHEN** a signal mutation is in flight
+- **THEN** the signal modal submit button is disabled and a submitting indicator is shown
+
+#### Scenario: Purge button disabled during in-flight request
+- **WHEN** a purge mutation is in flight
+- **THEN** the purge button is disabled until the response arrives
+
+### Requirement: Single-slot inline feedback model
+The control area SHALL maintain a single feedback slot. Every mutation result -- whether success, informational, warning, or error -- SHALL replace whatever message currently occupies the slot. There is no stacking, accumulation, or auto-dismiss timer. The slot is cleared only by a new mutation result or by the user navigating away.
+
+#### Scenario: Success replaces previous error
+- **WHEN** a signal mutation failed (showing an error) and a subsequent retry succeeds
+- **THEN** the success message replaces the previous error message
+
+#### Scenario: Error replaces previous success
+- **WHEN** a repair succeeded (showing success feedback) and a subsequent signal mutation fails
+- **THEN** the signal error message replaces the previous repair success message
+
+#### Scenario: Informational replaces previous warning
+- **WHEN** a repair returned `history_expired` (showing a warning) and a subsequent repair returns `already_up_to_date`
+- **THEN** the informational message replaces the previous warning
+
+### Requirement: Mutation failure handling
+When a control mutation fails, the control area SHALL display an inline error message in the single feedback slot. The backend returns typed `409` conflict errors for normal race conditions (`run_terminal`, `run_not_terminal`, `run_not_suspendable`). On a `409` conflict, the debugger SHALL refetch the trace detail and pending-work queries so the control bar reflects the current run state.
+
+#### Scenario: 409 conflict shows inline error and refetches state
+- **WHEN** a suspend mutation returns `409` with code `run_not_suspendable`
+- **THEN** an inline error message is displayed in the control area and the trace detail and pending-work queries are refetched
+
+#### Scenario: Network error shows inline error
+- **WHEN** a terminate mutation fails due to a network error
+- **THEN** an inline error message is displayed in the control area
+
+### Requirement: Post-mutation query invalidation
+After any successful engine control mutation (signal, cancel, suspend, resume, terminate, purge, repair), the debugger SHALL invalidate and refetch the trace detail, timeline events, spans, pending-work, and trace-list TanStack Query caches.
+
+#### Scenario: Signal success triggers cache invalidation
+- **WHEN** a signal mutation succeeds
+- **THEN** TanStack Query invalidates and refetches trace detail, timeline, spans, pending-work, and trace-list queries

--- a/openspec/changes/complete-engine-debugger-operator-surface/specs/engine-debugger-filters/spec.md
+++ b/openspec/changes/complete-engine-debugger-operator-surface/specs/engine-debugger-filters/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: URL-driven engine trace filters
+The traces page SHALL support four URL-driven engine filter parameters: `engine_instance_key` (text input), `engine_definition_name` (text input), `engine_run_status` (select with human-readable labels), and `engine_projection_state` (select from EngineProjectionState values). These filters SHALL be sent as query parameters to `GET /api/traces` and additive with existing filters.
+
+The allowed `engine_run_status` query values and `engine_projection_state` query values are owned by the backend `engine-trace-search` capability and the OpenAPI contract (`contracts/openapi/openapi.yaml`). This spec does not redefine them. The frontend SHALL derive its select options from the current OpenAPI enum values (at time of writing: `queued`, `running`, `waiting`, `suspended`, `completed`, `failed`, `cancelled`, `terminated`, `continued_as_new` for run status; `up_to_date`, `catching_up`, `summary_only`, `journal_expired` for projection state). If the backend adds or removes values, the frontend select options update accordingly.
+
+#### Scenario: Engine filters are applied from URL on page load
+- **WHEN** the traces page loads with `?engine_run_status=running&engine_definition_name=my-workflow` in the URL
+- **THEN** the engine filter inputs display the corresponding human-readable labels and the trace list fetches with those lowercase query parameters
+
+#### Scenario: Engine filter changes update the URL
+- **WHEN** a user sets `engine_instance_key` to `order-123`
+- **THEN** the URL is updated to include `engine_instance_key=order-123` and the trace list refetches
+
+### Requirement: Engine filters in collapsible section
+Engine filters SHALL be rendered in a collapsible "Engine filters" section beneath the existing filter grid. The section SHALL be collapsed by default and auto-expand when any engine filter parameter is present in the URL.
+
+#### Scenario: Engine filters section auto-expands with active filters
+- **WHEN** the page loads with `?engine_projection_state=summary_only`
+- **THEN** the Engine filters section is expanded and the `engine_projection_state` select shows "summary_only"
+
+#### Scenario: Engine filters section is collapsed by default
+- **WHEN** the traces page loads with no engine filter parameters in the URL
+- **THEN** the Engine filters section is collapsed
+
+### Requirement: Engine projection state helper text
+The `engine_projection_state` filter control SHALL display helper text identifying it as an operator-oriented/advanced filter useful for inspecting projection health across engine traces.
+
+#### Scenario: Projection state filter shows helper text
+- **WHEN** the Engine filters section is expanded
+- **THEN** the `engine_projection_state` select displays helper text explaining its operator-focused purpose
+
+### Requirement: Engine filter chip behavior
+Active engine filters SHALL produce removable chips in the existing filter chip row. Removing a chip SHALL clear the corresponding URL parameter and refetch the trace list.
+
+#### Scenario: Engine filter chip is displayed and removable
+- **WHEN** `engine_run_status=waiting` is active
+- **THEN** a chip showing the human-readable label (e.g., "Engine status: Waiting") appears in the filter chip row
+- **AND** clicking the chip's remove button clears `engine_run_status` from the URL and refetches
+
+### Requirement: Engine filters preserve existing filter behavior
+Engine filter URL serialization, hydration, canonical query-string construction, additive updates, and browser back/forward support SHALL follow the same patterns as existing trace filters (`status`, `session_id`, `user_id`, etc.).
+
+#### Scenario: Back/forward navigation restores engine filters
+- **WHEN** a user sets `engine_definition_name=payments`, then navigates to another page, then presses browser back
+- **THEN** the traces page restores `engine_definition_name=payments` and displays the correct filter state

--- a/openspec/changes/complete-engine-debugger-operator-surface/specs/engine-debugger-operator-ux/spec.md
+++ b/openspec/changes/complete-engine-debugger-operator-surface/specs/engine-debugger-operator-ux/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Updated engine run status types
+The web frontend `EngineRunStatus` type SHALL include `SUSPENDED`, `TERMINATED`, and `CONTINUED_AS_NEW` in addition to the existing values (`QUEUED`, `RUNNING`, `WAITING`, `COMPLETED`, `FAILED`, `CANCELLED`). The `EngineRunSummary` interface SHALL include `continued_from_run_id`, `continued_to_run_id`, `continued_from_trace_id`, and `continued_to_trace_id` optional string fields matching the OpenAPI `EngineRunSummary` schema.
+
+#### Scenario: EngineRunStatus includes all backend values
+- **WHEN** the frontend type definitions are compiled
+- **THEN** `EngineRunStatus` includes all nine values: `QUEUED`, `RUNNING`, `WAITING`, `SUSPENDED`, `COMPLETED`, `FAILED`, `CANCELLED`, `TERMINATED`, `CONTINUED_AS_NEW`
+
+### Requirement: Definition version mismatch banner
+The trace detail page SHALL render a warning banner when `trace.engine.failure.error_code === 'definition_version_mismatch'`. The comparison SHALL use exact string matching against the `error_code` field. The banner SHALL NOT appear for other error codes or when no failure is present.
+
+#### Scenario: Mismatch banner shown for definition_version_mismatch
+- **WHEN** `trace.engine.failure.error_code` is `'definition_version_mismatch'`
+- **THEN** a warning banner is displayed stating "This run failed because the engine definition version could not be matched during activation."
+
+#### Scenario: Mismatch banner not shown for other error codes
+- **WHEN** `trace.engine.failure.error_code` is `'timeout'`
+- **THEN** no mismatch banner is displayed
+
+#### Scenario: No banner when no failure present
+- **WHEN** `trace.engine.failure` is undefined
+- **THEN** no mismatch banner is displayed
+
+### Requirement: ContinueAsNew navigation links
+The trace detail page SHALL render navigation links from `continued_from_trace_id` (link to previous trace) and `continued_to_trace_id` (link to next trace) when those fields are present in the engine run summary. Links SHALL navigate to `/traces/{trace_id}` and preserve the current `returnTo` location state, following the existing debugger navigation pattern for trace, session, and compare flows.
+
+#### Scenario: Previous run link shown
+- **WHEN** `engine.continued_from_trace_id` is present
+- **THEN** a "Previous run" navigation link is rendered pointing to the previous trace
+
+#### Scenario: Next run link shown
+- **WHEN** `engine.continued_to_trace_id` is present
+- **THEN** a "Next run" navigation link is rendered pointing to the continued trace
+
+#### Scenario: Continuation link preserves returnTo
+- **WHEN** the trace detail page has a `returnTo` location state (e.g., `/sessions/abc`) and the user clicks a continuation link
+- **THEN** the navigation to the continued trace carries the same `returnTo` state so the back destination is preserved
+
+#### Scenario: No continuation links when absent
+- **WHEN** `engine.continued_from_trace_id` and `engine.continued_to_trace_id` are both absent
+- **THEN** no continuation navigation links are rendered
+
+### Requirement: definition_version_mismatch is a stable reserved error code
+The `definition_version_mismatch` value SHALL be treated as a stable reserved `EngineFailureSummary.error_code` value for exact-match UI behavior. The `error_code` field itself SHALL remain an open string type that accepts arbitrary values. The OpenAPI schema description for `EngineFailureSummary.error_code` SHALL document `definition_version_mismatch` as a reserved value that clients may match against.
+
+#### Scenario: error_code remains an open string
+- **WHEN** an engine failure has `error_code` set to `'custom_application_error'`
+- **THEN** the value is accepted without validation because `error_code` is an open string
+
+#### Scenario: OpenAPI documents reserved error code
+- **WHEN** the OpenAPI spec is reviewed
+- **THEN** the `EngineFailureSummary.error_code` field description lists `definition_version_mismatch` as a stable reserved value

--- a/openspec/changes/complete-engine-debugger-operator-surface/specs/engine-debugger-pending-work/spec.md
+++ b/openspec/changes/complete-engine-debugger-operator-surface/specs/engine-debugger-pending-work/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Separate pending-work query
+The trace detail page SHALL issue a separate TanStack Query keyed as `['enginePendingWork', runId]` that calls `GET /v1/engine/runs/{run_id}/pending-work`. This query SHALL NOT piggyback on existing timeline or span fetches.
+
+#### Scenario: Pending-work query is separate from timeline
+- **WHEN** the trace detail page loads for an engine-backed trace with `trace.engine.run_id`
+- **THEN** a separate pending-work query is issued independently of timeline and span queries
+
+### Requirement: Pending-work polling interval
+The pending-work query SHALL use `TIMELINE_POLL_INTERVAL_MS` as its `refetchInterval`. It SHALL NOT share, modify, or depend on the timeline polling interval or poll cursor.
+
+#### Scenario: Pending-work polls at TIMELINE_POLL_INTERVAL_MS
+- **WHEN** pending-work polling is active
+- **THEN** it refetches every `TIMELINE_POLL_INTERVAL_MS` milliseconds (3000ms in production, 25ms in test)
+
+### Requirement: Pending-work polling enablement
+Pending-work polling SHALL be enabled only while `trace.engine.status` is `QUEUED`, `RUNNING`, `WAITING`, or `SUSPENDED`. It SHALL be disabled for terminal statuses (`COMPLETED`, `FAILED`, `CANCELLED`, `TERMINATED`, `CONTINUED_AS_NEW`). Existing raw timeline/span polling SHALL NOT be widened; those remain governed by the raw trace status `RUNNING`.
+
+#### Scenario: Pending-work polling active for WAITING run
+- **WHEN** the engine run status is `WAITING`
+- **THEN** pending-work polling is enabled
+
+#### Scenario: Pending-work polling disabled for COMPLETED run
+- **WHEN** the engine run status is `COMPLETED`
+- **THEN** pending-work polling is disabled
+
+#### Scenario: Timeline polling not widened for SUSPENDED runs
+- **WHEN** the engine run status is `SUSPENDED` and the raw trace status is not `RUNNING`
+- **THEN** pending-work polling is enabled but raw timeline/span polling remains disabled
+
+### Requirement: Pending-work detail rendering
+The trace detail page SHALL render pending-work detail including: current wait description, activities list, timers list, and signals list. Empty lists SHALL show an appropriate empty-state message. Query errors or unavailable data SHALL show a degraded-state fallback.
+
+#### Scenario: Pending-work displays activities and timers
+- **WHEN** the pending-work response includes 2 activities and 1 timer
+- **THEN** the activities section shows 2 items and the timers section shows 1 item
+
+#### Scenario: Empty pending-work shows empty state
+- **WHEN** the pending-work response has empty activities, timers, and signals arrays
+- **THEN** each section shows an appropriate empty-state message
+
+#### Scenario: Pending-work query error shows degraded state
+- **WHEN** the pending-work query fails
+- **THEN** the pending-work section shows a fallback message instead of empty lists

--- a/openspec/changes/complete-engine-debugger-operator-surface/tasks.md
+++ b/openspec/changes/complete-engine-debugger-operator-surface/tasks.md
@@ -1,0 +1,42 @@
+## 1. Type and Client Updates
+- [x] 1.1 Update `EngineRunStatus` type in `web/src/api/client.ts` to include `SUSPENDED`, `TERMINATED`, `CONTINUED_AS_NEW`
+- [x] 1.2 Add `continued_from_run_id`, `continued_to_run_id`, `continued_from_trace_id`, `continued_to_trace_id` to `EngineRunSummary` interface
+- [x] 1.3 Add engine control mutation functions to `web/src/api/client.ts`: `signalEngineRun`, `cancelEngineRun`, `suspendEngineRun`, `resumeEngineRun`, `terminateEngineRun`, `purgeEngineRun`, `repairEngineRun`; all mutation wrappers MUST send `X-Continua-Engine-Preview: 1` header
+- [x] 1.4 Add `fetchEnginePendingWork(runId)` API client function calling `GET /v1/engine/runs/{run_id}/pending-work` (no preview header required for this read endpoint)
+
+## 2. Engine Trace Filters
+- [x] 2.1 Add `engine_instance_key`, `engine_definition_name`, `engine_run_status`, `engine_projection_state` to `FetchTracesParams` and URL serialization in `tracesSearchParams.ts`; `engine_run_status` uses lowercase query values (`queued`, `running`, etc.) with human-readable labels in the select control
+- [x] 2.2 Add filter chip derivation for engine filters in `deriveActiveChips()` with human-readable labels (e.g., "Engine status: Waiting")
+- [x] 2.3 Add collapsible "Engine filters" section to TracesPage beneath existing filter grid; auto-expand when any engine filter is active
+- [x] 2.4 Add `engine_projection_state` helper text in the Engine filters section identifying it as operator-oriented/advanced
+- [x] 2.5 Write Vitest tests for engine filter serialization, hydration, chip derivation, lowercase query values, and section auto-expand behavior
+
+## 3. Pending-Work Query and Display
+- [x] 3.1 Add `useEnginePendingWork(runId, engineStatus)` hook with `['enginePendingWork', runId]` query key and `TIMELINE_POLL_INTERVAL_MS` refetchInterval
+- [x] 3.2 Gate polling enablement on engine status `QUEUED`, `RUNNING`, `WAITING`, or `SUSPENDED`; do not widen existing timeline/span polling
+- [x] 3.3 Add PendingWorkPanel component (colocated with trace detail page, not in shared components) rendering current wait, activities, timers, signals with empty and degraded states
+- [x] 3.4 Integrate PendingWorkPanel into TraceDetailPage for engine-backed traces
+- [x] 3.5 Write Vitest tests for polling enablement logic, query key structure, and rendering states
+
+## 4. Engine Control Actions
+- [x] 4.1 Add EngineControlBar component (colocated with trace detail page) with state-gated action buttons; purge enablement includes `CONTINUED_AS_NEW` alongside other terminal statuses
+- [x] 4.2 Add SignalModal with required `signal_name` (non-empty after trim; whitespace-only is rejected) and optional JSON payload validation
+- [x] 4.3 Add confirmation dialogs for cancel, terminate, and purge; purge dialog includes mode selection (`projection_only` default, `full` with destructive warning)
+- [x] 4.4 Add inline repair feedback in the control area using existing alert/status styling: `repair_requested` success, `already_catching_up`/`already_up_to_date`/`no_events_to_project` info, `history_expired` warning; no global toast system
+- [x] 4.5 Add inline purge feedback in the control area: `deleted=true` means applied, `deleted=false` means already satisfied; no global toast system
+- [x] 4.6 Add in-flight mutation pending state: disable active action button and modal submit while request is in flight, show submitting indicator
+- [x] 4.7 Add mutation failure handling: display inline error in control area for failed mutations, refetch trace detail and pending-work on `409` conflict responses, new error replaces any previous success/info/warning feedback
+- [x] 4.8 Add post-mutation TanStack Query invalidation for trace detail, timeline, spans, pending-work, and trace-list queries on success
+- [x] 4.9 Integrate EngineControlBar into TraceDetailPage for engine-backed traces
+- [x] 4.10 Write Vitest tests for action state gating (including CONTINUED_AS_NEW for purge), signal trim validation, purge mode selection, confirmation flows, single-slot feedback model (success replacing error, error replacing success, info replacing warning), in-flight pending state, 409 conflict error handling, and query invalidation
+
+## 5. Operator UX
+- [x] 5.1 Add definition version mismatch banner to TraceDetailPage with exact-match on `error_code === 'definition_version_mismatch'`; banner copy: "This run failed because the engine definition version could not be matched during activation."
+- [x] 5.2 Add ContinueAsNew navigation links from `continued_from_trace_id` and `continued_to_trace_id`; preserve `returnTo` location state through continuation hops
+- [x] 5.3 Add `definition_version_mismatch` as a documented reserved value in the `EngineFailureSummary.error_code` OpenAPI schema description to keep contract and spec aligned
+- [x] 5.4 Run `make generate` after the OpenAPI description change and verify generated code compiles
+- [x] 5.5 Write Vitest tests for mismatch banner exact-match behavior, banner copy, continuation link rendering, and returnTo preservation through continuation hops
+
+## 6. Verification
+- [x] 6.1 Run `pnpm --filter web test` and confirm all new and existing web tests pass
+- [x] 6.2 Run `go test ./internal/api/...` to confirm the OpenAPI description change does not break backend tests

--- a/sdks/python/src/continua/engine_control.py
+++ b/sdks/python/src/continua/engine_control.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -22,6 +23,10 @@ from .types import (
     EngineControlResponse,
     EngineInstanceResponse,
     EnginePendingWorkResponse,
+    EngineProjectionBackfillRequest,
+    EngineProjectionBackfillResponse,
+    EngineProjectionBackfillRunResult,
+    EngineProjectionState,
     EnginePurgeMode,
     EnginePurgeRequest,
     EnginePurgeResponse,
@@ -181,6 +186,87 @@ class EngineControlClient:
             f"/v1/engine/runs/{run_id}/repair",
             EngineRepairResponse,
             headers=_PREVIEW_HEADERS,
+        )
+
+    def backfill_projections(
+        self,
+        *,
+        dry_run: bool = False,
+        limit: int | None = None,
+        older_than: datetime | str | None = None,
+        engine_instance_key: str | None = None,
+        engine_definition_name: str | None = None,
+        engine_run_status: EngineRunStatus | str | None = None,
+        engine_projection_state: EngineProjectionState | str | None = None,
+    ) -> EngineProjectionBackfillResponse:
+        request = EngineProjectionBackfillRequest(
+            dry_run=dry_run,
+            limit=limit,
+            older_than=older_than,
+            engine_instance_key=engine_instance_key,
+            engine_definition_name=engine_definition_name,
+            engine_run_status=engine_run_status,
+            engine_projection_state=engine_projection_state,
+        )
+        return self._request_model(
+            "POST",
+            "/v1/engine/projections/backfill",
+            EngineProjectionBackfillResponse,
+            json=request.model_dump(mode="json", exclude_none=True),
+            headers=_PREVIEW_HEADERS,
+        )
+
+    def backfill_projections_all(
+        self,
+        *,
+        max_total: int = 1000,
+        dry_run: bool = False,
+        limit: int | None = None,
+        older_than: datetime | str | None = None,
+        engine_instance_key: str | None = None,
+        engine_definition_name: str | None = None,
+        engine_run_status: EngineRunStatus | str | None = None,
+        engine_projection_state: EngineProjectionState | str | None = None,
+    ) -> EngineProjectionBackfillResponse:
+        if dry_run:
+            raise ValueError(
+                "backfill_projections_all() cannot page dry-run previews because "
+                "the backfill API has no cursor and dry-run calls do not mutate "
+                "eligibility; call backfill_projections(dry_run=True, limit=...) "
+                "for a bounded preview."
+            )
+
+        page_limit = limit or 50
+        remaining = max_total
+        aggregate_results: list[EngineProjectionBackfillRunResult] = []
+        aggregate_repair_requested_count = 0
+        aggregate_skipped_count = 0
+
+        while remaining > 0:
+            response = self.backfill_projections(
+                dry_run=False,
+                limit=min(page_limit, remaining),
+                older_than=older_than,
+                engine_instance_key=engine_instance_key,
+                engine_definition_name=engine_definition_name,
+                engine_run_status=engine_run_status,
+                engine_projection_state=engine_projection_state,
+            )
+            aggregate_results.extend(response.results)
+            aggregate_repair_requested_count += response.repair_requested_count
+            aggregate_skipped_count += response.skipped_count
+            remaining -= len(response.results)
+
+            if len(response.results) < response.limit:
+                break
+
+        return EngineProjectionBackfillResponse(
+            dry_run=dry_run,
+            limit=page_limit,
+            eligible_count=len(aggregate_results),
+            repair_requested_count=aggregate_repair_requested_count,
+            skipped_count=aggregate_skipped_count,
+            results=aggregate_results,
         )
 
     def wait_for_terminal(

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -32,6 +32,12 @@ class EngineProjectionState(Enum):
     journal_expired = "journal_expired"
 
 
+class EngineProjectionBackfillAction(Enum):
+    would_repair = "would_repair"
+    repair_requested = "repair_requested"
+    skipped = "skipped"
+
+
 class EnginePurgeMode(Enum):
     projection_only = "projection_only"
     full = "full"
@@ -116,8 +122,41 @@ class EnginePendingWorkResponse(BaseModel):
     pending_inbox_items: int
 
 
+class EngineProjectionBackfillRequest(BaseModel):
+    dry_run: bool | None = False
+    limit: int | None = Field(50, le=100)
+    older_than: AwareDatetime | None = None
+    engine_instance_key: str | None = None
+    engine_definition_name: str | None = None
+    engine_run_status: EngineRunStatus | None = None
+    engine_projection_state: EngineProjectionState | None = Field(
+        None,
+        description="Defaults to `summary_only` when omitted. Explicit `up_to_date`,\n`catching_up`, and `journal_expired` return zero eligible rows.\n",
+    )
+
+
+class EngineProjectionBackfillRunResult(BaseModel):
+    run_id: UUID
+    trace_id: str
+    projection_state: EngineProjectionState
+    action: EngineProjectionBackfillAction
+    reason: EngineRepairReason | None = None
+
+
+class EngineProjectionBackfillResponse(BaseModel):
+    dry_run: bool
+    limit: int
+    eligible_count: int
+    repair_requested_count: int
+    skipped_count: int
+    results: list[EngineProjectionBackfillRunResult]
+
+
 class EngineFailureSummary(BaseModel):
-    error_code: str
+    error_code: str = Field(
+        ...,
+        description="Stable reserved value: `definition_version_mismatch`. Clients may\nexact-match this value while still accepting arbitrary strings.\n",
+    )
     error_message: str
     status: str
 

--- a/sdks/python/tests/test_engine_control.py
+++ b/sdks/python/tests/test_engine_control.py
@@ -72,6 +72,40 @@ def _control_response(wake_applied: bool = True) -> dict[str, object]:
     }
 
 
+def _backfill_response(
+    *,
+    dry_run: bool,
+    limit: int,
+    start_index: int,
+    count: int,
+    action: str,
+    reason: str | None = None,
+) -> dict[str, object]:
+    results = []
+    for index in range(start_index, start_index + count):
+        result: dict[str, object] = {
+            "run_id": f"00000000-0000-0000-0000-{index:012d}",
+            "trace_id": f"engine:trace-{index}",
+            "projection_state": "summary_only" if action == "would_repair" else "catching_up",
+            "action": action,
+        }
+        if reason is not None:
+            result["reason"] = reason
+        results.append(result)
+
+    repair_requested_count = count if action == "repair_requested" else 0
+    skipped_count = count if action == "skipped" else 0
+
+    return {
+        "dry_run": dry_run,
+        "limit": limit,
+        "eligible_count": count,
+        "repair_requested_count": repair_requested_count,
+        "skipped_count": skipped_count,
+        "results": results,
+    }
+
+
 def test_get_run_decodes_typed_response():
     with patch("continua.engine_control.httpx.Client") as mock_client_class:
         mock_client = MagicMock()
@@ -434,6 +468,194 @@ def test_repair_decodes_all_supported_reasons(
         assert response.reason == EngineRepairReason(reason)
         assert response.accepted is accepted
         assert response.projection_state == EngineProjectionState(projection_state)
+
+
+def test_backfill_projections_decodes_typed_response_and_sends_preview_header():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value=_backfill_response(
+                    dry_run=True,
+                    limit=10,
+                    start_index=1,
+                    count=2,
+                    action="would_repair",
+                )
+            ),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+        from continua.types import EngineProjectionBackfillAction
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.backfill_projections(dry_run=True, limit=10)
+
+        assert response.dry_run is True
+        assert response.eligible_count == 2
+        assert response.results[0].action == EngineProjectionBackfillAction.would_repair
+        mock_client.request.assert_called_once_with(
+            "POST",
+            "/v1/engine/projections/backfill",
+            json={"dry_run": True, "limit": 10},
+            params=None,
+            headers={"X-Continua-Engine-Preview": "1"},
+        )
+
+
+def test_backfill_projections_all_rejects_dry_run_paging():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+
+        with pytest.raises(ValueError, match="cannot page dry-run previews"):
+            client.backfill_projections_all(dry_run=True, max_total=100, limit=50)
+
+        mock_client.request.assert_not_called()
+
+
+def test_backfill_projections_all_stops_at_max_total():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.side_effect = [
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_backfill_response(
+                        dry_run=False,
+                        limit=50,
+                        start_index=1,
+                        count=50,
+                        action="repair_requested",
+                        reason="repair_requested",
+                    )
+                ),
+            ),
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_backfill_response(
+                        dry_run=False,
+                        limit=50,
+                        start_index=51,
+                        count=50,
+                        action="repair_requested",
+                        reason="repair_requested",
+                    )
+                ),
+            ),
+        ]
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.backfill_projections_all(max_total=100, limit=50)
+
+        assert response.eligible_count == 100
+        assert response.repair_requested_count == 100
+        assert response.skipped_count == 0
+        assert len(response.results) == 100
+        assert mock_client.request.call_count == 2
+
+
+def test_backfill_projections_all_stops_when_eligible_runs_are_exhausted():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value=_backfill_response(
+                    dry_run=False,
+                    limit=50,
+                    start_index=1,
+                    count=30,
+                    action="repair_requested",
+                    reason="repair_requested",
+                )
+            ),
+        )
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.backfill_projections_all(max_total=1000, limit=50)
+
+        assert response.eligible_count == 30
+        assert response.repair_requested_count == 30
+        assert len(response.results) == 30
+        assert mock_client.request.call_count == 1
+
+
+def test_backfill_projections_all_returns_aggregated_results():
+    with patch("continua.engine_control.httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.request.side_effect = [
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_backfill_response(
+                        dry_run=False,
+                        limit=2,
+                        start_index=1,
+                        count=2,
+                        action="repair_requested",
+                        reason="repair_requested",
+                    )
+                ),
+            ),
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_backfill_response(
+                        dry_run=False,
+                        limit=2,
+                        start_index=3,
+                        count=2,
+                        action="skipped",
+                        reason="already_catching_up",
+                    )
+                ),
+            ),
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value=_backfill_response(
+                        dry_run=False,
+                        limit=1,
+                        start_index=5,
+                        count=1,
+                        action="repair_requested",
+                        reason="repair_requested",
+                    )
+                ),
+            ),
+        ]
+        mock_client_class.return_value = mock_client
+
+        from continua import EngineControlClient
+
+        client = EngineControlClient(api_key="test-key", endpoint="http://localhost:8080")
+        response = client.backfill_projections_all(max_total=5, limit=2)
+
+        assert response.eligible_count == 5
+        assert response.repair_requested_count == 3
+        assert response.skipped_count == 2
+        assert [item.trace_id for item in response.results] == [
+            "engine:trace-1",
+            "engine:trace-2",
+            "engine:trace-3",
+            "engine:trace-4",
+            "engine:trace-5",
+        ]
+        assert mock_client.request.call_args_list[-1].kwargs["json"]["limit"] == 1
 
 
 def test_purge_maps_run_not_terminal_to_typed_error():

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -14,6 +14,8 @@ import {
 
 const API_KEY_STORAGE_KEY = 'continua_api_key';
 const API_KEY_EVENT_NAME = 'continua:api-key-change';
+const ENGINE_PREVIEW_HEADER = 'X-Continua-Engine-Preview';
+const ENGINE_PREVIEW_HEADER_VALUE = '1';
 
 export type { FetchTracesParams } from '../utils/tracesSearchParams';
 export type {
@@ -154,9 +156,21 @@ export type EngineRunStatus =
   | 'QUEUED'
   | 'RUNNING'
   | 'WAITING'
+  | 'SUSPENDED'
   | 'COMPLETED'
   | 'FAILED'
-  | 'CANCELLED';
+  | 'CANCELLED'
+  | 'TERMINATED'
+  | 'CONTINUED_AS_NEW';
+
+export type EngineRepairReason =
+  | 'already_up_to_date'
+  | 'history_expired'
+  | 'no_events_to_project'
+  | 'repair_requested'
+  | 'already_catching_up';
+
+export type EnginePurgeMode = 'projection_only' | 'full';
 
 export interface EngineTraceInfo {
   run_id: string;
@@ -180,6 +194,39 @@ export interface EnginePendingWork {
   pending_inbox_items: number;
 }
 
+export interface EnginePendingActivityItem {
+  task_id: string;
+  activity_key: string;
+  activity_type: string;
+  status: string;
+  available_at: string;
+  attempt_count: number;
+}
+
+export interface EnginePendingTimerItem {
+  inbox_id: string;
+  timer_key: string;
+  status: string;
+  available_at: string;
+}
+
+export interface EnginePendingSignalItem {
+  inbox_id: string;
+  signal_name: string;
+  status: string;
+  available_at: string;
+}
+
+export interface EnginePendingWorkResponse {
+  run_id: string;
+  current_wait: EngineWaitState | null;
+  activities: EnginePendingActivityItem[];
+  timers: EnginePendingTimerItem[];
+  signals: EnginePendingSignalItem[];
+  pending_activity_tasks: number;
+  pending_inbox_items: number;
+}
+
 export interface EngineFailureSummary {
   error_code: string;
   error_message: string;
@@ -189,6 +236,10 @@ export interface EngineFailureSummary {
 export interface EngineRunSummary {
   run_id: string;
   instance_key: string;
+  continued_from_run_id?: string;
+  continued_to_run_id?: string;
+  continued_from_trace_id?: string;
+  continued_to_trace_id?: string;
   definition_name: string;
   definition_version: string;
   projection_state: EngineProjectionState;
@@ -201,6 +252,47 @@ export interface EngineRunSummary {
   result?: JsonValue;
   failure?: EngineFailureSummary;
   wait_state?: EngineWaitState;
+}
+
+export interface EngineRunResponse extends EngineRunSummary {
+  instance_id: string;
+}
+
+export interface EngineRunResultResponse {
+  run_id: string;
+  continued_from_run_id?: string;
+  continued_to_run_id?: string;
+  continued_from_trace_id?: string;
+  continued_to_trace_id?: string;
+  status: EngineRunStatus;
+  result: JsonValue | null;
+  failure?: EngineFailureSummary;
+}
+
+export interface EngineControlResponse {
+  run_id: string;
+  instance_key: string;
+  accepted: boolean;
+  wake_applied: boolean;
+}
+
+export interface EngineSignalRunRequest {
+  signal_name: string;
+  payload?: JsonValue;
+}
+
+export interface EnginePurgeResponse {
+  run_id: string;
+  mode: EnginePurgeMode;
+  projection_state: EngineProjectionState;
+  deleted: boolean;
+}
+
+export interface EngineRepairResponse {
+  run_id: string;
+  accepted: boolean;
+  reason: EngineRepairReason;
+  projection_state: EngineProjectionState;
 }
 
 export interface Trace {
@@ -547,4 +639,86 @@ export async function fetchSessionComparison(
   });
 
   return fetchAPI<SessionCompareResponse>(`/api/sessions/${sessionId}/compare?${params.toString()}`);
+}
+
+function withEnginePreviewHeader(options: RequestInit = {}): RequestInit {
+  return {
+    ...options,
+    headers: {
+      [ENGINE_PREVIEW_HEADER]: ENGINE_PREVIEW_HEADER_VALUE,
+      ...options.headers,
+    },
+  };
+}
+
+function withJsonBody(body?: unknown): RequestInit {
+  if (body === undefined) {
+    return { method: 'POST' };
+  }
+
+  return {
+    method: 'POST',
+    body: JSON.stringify(body),
+  };
+}
+
+export async function signalEngineRun(
+  runId: string,
+  request: EngineSignalRunRequest
+): Promise<EngineControlResponse> {
+  return fetchAPI<EngineControlResponse>(
+    `/v1/engine/runs/${runId}/signal`,
+    withEnginePreviewHeader(withJsonBody(request))
+  );
+}
+
+export async function cancelEngineRun(runId: string): Promise<EngineControlResponse> {
+  return fetchAPI<EngineControlResponse>(
+    `/v1/engine/runs/${runId}/cancel`,
+    withEnginePreviewHeader(withJsonBody())
+  );
+}
+
+export async function suspendEngineRun(runId: string): Promise<EngineRunResponse> {
+  return fetchAPI<EngineRunResponse>(
+    `/v1/engine/runs/${runId}/suspend`,
+    withEnginePreviewHeader(withJsonBody())
+  );
+}
+
+export async function resumeEngineRun(runId: string): Promise<EngineRunResponse> {
+  return fetchAPI<EngineRunResponse>(
+    `/v1/engine/runs/${runId}/resume`,
+    withEnginePreviewHeader(withJsonBody())
+  );
+}
+
+export async function terminateEngineRun(runId: string): Promise<EngineRunResultResponse> {
+  return fetchAPI<EngineRunResultResponse>(
+    `/v1/engine/runs/${runId}/terminate`,
+    withEnginePreviewHeader(withJsonBody())
+  );
+}
+
+export async function purgeEngineRun(
+  runId: string,
+  mode: EnginePurgeMode
+): Promise<EnginePurgeResponse> {
+  return fetchAPI<EnginePurgeResponse>(
+    `/v1/engine/runs/${runId}/purge`,
+    withEnginePreviewHeader(withJsonBody({ mode }))
+  );
+}
+
+export async function repairEngineRun(runId: string): Promise<EngineRepairResponse> {
+  return fetchAPI<EngineRepairResponse>(
+    `/v1/engine/runs/${runId}/repair`,
+    withEnginePreviewHeader(withJsonBody())
+  );
+}
+
+export async function fetchEnginePendingWork(
+  runId: string
+): Promise<EnginePendingWorkResponse> {
+  return fetchAPI<EnginePendingWorkResponse>(`/v1/engine/runs/${runId}/pending-work`);
 }

--- a/web/src/pages/EngineControlBar.tsx
+++ b/web/src/pages/EngineControlBar.tsx
@@ -1,0 +1,687 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  ApiError,
+  cancelEngineRun,
+  purgeEngineRun,
+  repairEngineRun,
+  resumeEngineRun,
+  signalEngineRun,
+  suspendEngineRun,
+  terminateEngineRun,
+  type EnginePurgeMode,
+  type EngineRepairReason,
+  type EngineRunStatus,
+  type EngineRunSummary,
+  type JsonValue,
+} from '../api/client';
+
+type EngineAction =
+  | 'signal'
+  | 'cancel'
+  | 'suspend'
+  | 'resume'
+  | 'terminate'
+  | 'purge'
+  | 'repair';
+
+type FeedbackTone = 'success' | 'info' | 'warning' | 'error';
+
+interface FeedbackState {
+  tone: FeedbackTone;
+  title: string;
+  message: string;
+}
+
+interface EngineControlBarProps {
+  engine: EngineRunSummary;
+  traceId: string;
+}
+
+const NON_TERMINAL_ENGINE_STATUSES: ReadonlySet<EngineRunStatus> = new Set([
+  'QUEUED',
+  'RUNNING',
+  'WAITING',
+  'SUSPENDED',
+]);
+
+const PURGEABLE_ENGINE_STATUSES: ReadonlySet<EngineRunStatus> = new Set([
+  'COMPLETED',
+  'FAILED',
+  'CANCELLED',
+  'TERMINATED',
+  'CONTINUED_AS_NEW',
+]);
+
+const ACTION_LABELS: Record<EngineAction, string> = {
+  signal: 'Signal',
+  cancel: 'Cancel',
+  suspend: 'Suspend',
+  resume: 'Resume',
+  terminate: 'Terminate',
+  purge: 'Purge',
+  repair: 'Repair',
+};
+
+export function EngineControlBar({
+  engine,
+  traceId,
+}: EngineControlBarProps) {
+  const queryClient = useQueryClient();
+  const [pendingAction, setPendingAction] = useState<EngineAction | null>(null);
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [isSignalModalOpen, setIsSignalModalOpen] = useState(false);
+  const [signalName, setSignalName] = useState('');
+  const [signalPayload, setSignalPayload] = useState('');
+  const [confirmAction, setConfirmAction] = useState<
+    'cancel' | 'terminate' | 'purge' | null
+  >(null);
+  const [purgeMode, setPurgeMode] =
+    useState<EnginePurgeMode>('projection_only');
+
+  const signalNameTrimmed = signalName.trim();
+  const signalPayloadTrimmed = signalPayload.trim();
+  const parsedSignalPayload = useMemo(() => {
+    if (!signalPayloadTrimmed) {
+      return { value: undefined as JsonValue | undefined, error: null };
+    }
+
+    try {
+      return {
+        value: JSON.parse(signalPayloadTrimmed) as JsonValue,
+        error: null,
+      };
+    } catch {
+      return {
+        value: undefined,
+        error: 'Payload must be valid JSON.',
+      };
+    }
+  }, [signalPayloadTrimmed]);
+
+  const isBusy = pendingAction !== null;
+  const signalEnabled = NON_TERMINAL_ENGINE_STATUSES.has(engine.status);
+  const cancelEnabled = NON_TERMINAL_ENGINE_STATUSES.has(engine.status);
+  const suspendEnabled =
+    engine.status === 'QUEUED' ||
+    engine.status === 'RUNNING' ||
+    engine.status === 'WAITING';
+  const resumeEnabled = engine.status === 'SUSPENDED';
+  const terminateEnabled = NON_TERMINAL_ENGINE_STATUSES.has(engine.status);
+  const purgeEnabled = PURGEABLE_ENGINE_STATUSES.has(engine.status);
+  const signalSubmitDisabled =
+    isBusy || !signalNameTrimmed || parsedSignalPayload.error !== null;
+
+  async function invalidateEngineQueries() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['trace', traceId] }),
+      queryClient.invalidateQueries({ queryKey: ['timeline', traceId] }),
+      queryClient.invalidateQueries({ queryKey: ['spans', traceId] }),
+      queryClient.invalidateQueries({
+        queryKey: ['enginePendingWork', engine.run_id],
+      }),
+      queryClient.invalidateQueries({ queryKey: ['traces'] }),
+    ]);
+  }
+
+  async function refreshConflictState() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['trace', traceId] }),
+      queryClient.invalidateQueries({
+        queryKey: ['enginePendingWork', engine.run_id],
+      }),
+    ]);
+  }
+
+  async function runAction(
+    action: EngineAction,
+    request: () => Promise<FeedbackState>
+  ) {
+    setPendingAction(action);
+
+    try {
+      const nextFeedback = await request();
+      setFeedback(nextFeedback);
+      await invalidateEngineQueries();
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 409) {
+        await refreshConflictState();
+      }
+
+      setFeedback({
+        tone: 'error',
+        title: `${ACTION_LABELS[action]} failed`,
+        message: error instanceof Error ? error.message : 'Request failed.',
+      });
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function handleSignalSubmit() {
+    if (signalSubmitDisabled) {
+      return;
+    }
+
+    await runAction('signal', async () => {
+      const response = await signalEngineRun(engine.run_id, {
+        signal_name: signalNameTrimmed,
+        payload: parsedSignalPayload.value,
+      });
+      setIsSignalModalOpen(false);
+      setSignalName('');
+      setSignalPayload('');
+
+      return response.accepted
+        ? {
+            tone: 'success',
+            title: 'Signal accepted',
+            message: response.wake_applied
+              ? 'The signal was delivered and the engine run was woken.'
+              : 'The signal was delivered to the engine run.',
+          }
+        : {
+            tone: 'info',
+            title: 'Signal recorded',
+            message: 'The signal request completed without waking the run.',
+          };
+    });
+  }
+
+  async function handleConfirmedAction() {
+    if (!confirmAction) {
+      return;
+    }
+
+    if (confirmAction === 'cancel') {
+      await runAction('cancel', async () => {
+        const response = await cancelEngineRun(engine.run_id);
+        setConfirmAction(null);
+
+        return response.accepted
+          ? {
+              tone: 'success',
+              title: 'Cancel requested',
+              message: response.wake_applied
+                ? 'Cancel was requested and the engine run was woken.'
+                : 'Cancel was requested for the engine run.',
+            }
+          : {
+              tone: 'info',
+              title: 'Cancel already satisfied',
+              message: 'The engine run was already in a state that did not change.',
+            };
+      });
+      return;
+    }
+
+    if (confirmAction === 'terminate') {
+      await runAction('terminate', async () => {
+        await terminateEngineRun(engine.run_id);
+        setConfirmAction(null);
+
+        return {
+          tone: 'success',
+          title: 'Run terminated',
+          message: 'The engine run was terminated.',
+        };
+      });
+      return;
+    }
+
+    await runAction('purge', async () => {
+      const response = await purgeEngineRun(engine.run_id, purgeMode);
+      setConfirmAction(null);
+      setPurgeMode('projection_only');
+
+      return response.deleted
+        ? {
+            tone: 'success',
+            title: 'Purge applied',
+            message:
+              purgeMode === 'full'
+                ? 'Projection state and retained engine history were purged.'
+                : 'Projection state was purged for this engine run.',
+          }
+        : {
+            tone: 'info',
+            title: 'Purge already satisfied',
+            message:
+              purgeMode === 'full'
+                ? 'Retained history was already removed for this engine run.'
+                : 'Projection state was already absent for this engine run.',
+          };
+    });
+  }
+
+  async function handleRepair() {
+    await runAction('repair', async () => {
+      const response = await repairEngineRun(engine.run_id);
+      return repairFeedbackForReason(response.reason);
+    });
+  }
+
+  async function handleSuspend() {
+    await runAction('suspend', async () => {
+      await suspendEngineRun(engine.run_id);
+      return {
+        tone: 'success',
+        title: 'Run suspended',
+        message: 'The engine run is now suspended.',
+      };
+    });
+  }
+
+  async function handleResume() {
+    await runAction('resume', async () => {
+      await resumeEngineRun(engine.run_id);
+      return {
+        tone: 'success',
+        title: 'Run resumed',
+        message: 'The engine run resumed execution.',
+      };
+    });
+  }
+
+  return (
+    <section className="app-surface p-4 sm:p-5">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+        <div>
+          <div className="app-overline">Engine controls</div>
+          <h2 className="mt-2 text-xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+            Drive the engine run from the debugger
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-[var(--continua-text-secondary)]">
+            Send signals, request state transitions, repair projections, or
+            purge retained engine data from the current trace.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2 xl:justify-end">
+          <ActionButton
+            action="signal"
+            disabled={!signalEnabled || isBusy}
+            isPending={pendingAction === 'signal'}
+            onClick={() => setIsSignalModalOpen(true)}
+          />
+          <ActionButton
+            action="cancel"
+            disabled={!cancelEnabled || isBusy}
+            isPending={pendingAction === 'cancel'}
+            onClick={() => setConfirmAction('cancel')}
+          />
+          <ActionButton
+            action="suspend"
+            disabled={!suspendEnabled || isBusy}
+            isPending={pendingAction === 'suspend'}
+            onClick={() => void handleSuspend()}
+          />
+          <ActionButton
+            action="resume"
+            disabled={!resumeEnabled || isBusy}
+            isPending={pendingAction === 'resume'}
+            onClick={() => void handleResume()}
+          />
+          <ActionButton
+            action="terminate"
+            disabled={!terminateEnabled || isBusy}
+            isPending={pendingAction === 'terminate'}
+            onClick={() => setConfirmAction('terminate')}
+          />
+          <ActionButton
+            action="purge"
+            disabled={!purgeEnabled || isBusy}
+            isPending={pendingAction === 'purge'}
+            onClick={() => setConfirmAction('purge')}
+          />
+          <ActionButton
+            action="repair"
+            disabled={isBusy}
+            isPending={pendingAction === 'repair'}
+            onClick={() => void handleRepair()}
+          />
+        </div>
+      </div>
+
+      {isBusy ? (
+        <div className="mt-4 rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-3 py-2 text-sm text-[var(--continua-text-secondary)]">
+          Submitting {pendingAction ? ACTION_LABELS[pendingAction].toLowerCase() : 'request'}...
+        </div>
+      ) : null}
+
+      {feedback ? (
+        <EngineControlFeedback feedback={feedback} />
+      ) : null}
+
+      {isSignalModalOpen ? (
+        <ModalShell
+          title="Send signal"
+          description="Signal names are required. Payload is optional JSON."
+          onClose={() => {
+            if (!isBusy) {
+              setIsSignalModalOpen(false);
+            }
+          }}
+        >
+          <div className="space-y-4">
+            <div>
+              <label
+                htmlFor="engine-signal-name"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
+              >
+                Signal name
+              </label>
+              <input
+                id="engine-signal-name"
+                type="text"
+                value={signalName}
+                onChange={(event) => setSignalName(event.target.value)}
+                placeholder="e.g. approval_received"
+                className="app-input"
+              />
+              {!signalNameTrimmed ? (
+                <p className="mt-1 text-xs text-red-600 dark:text-red-300">
+                  Signal name is required.
+                </p>
+              ) : null}
+            </div>
+
+            <div>
+              <label
+                htmlFor="engine-signal-payload"
+                className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
+              >
+                Payload (JSON)
+              </label>
+              <textarea
+                id="engine-signal-payload"
+                rows={6}
+                value={signalPayload}
+                onChange={(event) => setSignalPayload(event.target.value)}
+                placeholder='{"approved": true}'
+                className="app-input resize-y"
+              />
+              {parsedSignalPayload.error ? (
+                <p className="mt-1 text-xs text-red-600 dark:text-red-300">
+                  {parsedSignalPayload.error}
+                </p>
+              ) : (
+                <p className="mt-1 text-xs text-[var(--continua-text-muted)]">
+                  Leave blank to send the signal without a payload.
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-wrap justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setIsSignalModalOpen(false)}
+                disabled={isBusy}
+                className="app-button-secondary"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleSignalSubmit()}
+                disabled={signalSubmitDisabled}
+                className="app-button-primary disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {pendingAction === 'signal' ? 'Submitting...' : 'Send signal'}
+              </button>
+            </div>
+          </div>
+        </ModalShell>
+      ) : null}
+
+      {confirmAction ? (
+        <ModalShell
+          title={confirmDialogTitle(confirmAction)}
+          description={confirmDialogDescription(confirmAction)}
+          onClose={() => {
+            if (!isBusy) {
+              setConfirmAction(null);
+              setPurgeMode('projection_only');
+            }
+          }}
+        >
+          <div className="space-y-4">
+            {confirmAction === 'purge' ? (
+              <fieldset>
+                <legend className="text-sm font-medium text-[var(--continua-text-secondary)]">
+                  Purge mode
+                </legend>
+                <div className="mt-3 space-y-3">
+                  <label className="flex items-start gap-3 rounded-[1rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-3">
+                    <input
+                      type="radio"
+                      name="purge-mode"
+                      value="projection_only"
+                      checked={purgeMode === 'projection_only'}
+                      onChange={() => setPurgeMode('projection_only')}
+                      disabled={isBusy}
+                    />
+                    <span>
+                      <span className="block text-sm font-semibold text-[var(--continua-text-primary)]">
+                        Projection only
+                      </span>
+                      <span className="mt-1 block text-sm text-[var(--continua-text-secondary)]">
+                        Remove derived projection state and keep retained engine
+                        history.
+                      </span>
+                    </span>
+                  </label>
+                  <label className="flex items-start gap-3 rounded-[1rem] border border-amber-300/50 bg-amber-100/60 p-3 text-amber-950 dark:border-amber-300/20 dark:bg-amber-400/10 dark:text-amber-100">
+                    <input
+                      type="radio"
+                      name="purge-mode"
+                      value="full"
+                      checked={purgeMode === 'full'}
+                      onChange={() => setPurgeMode('full')}
+                      disabled={isBusy}
+                    />
+                    <span>
+                      <span className="block text-sm font-semibold">
+                        Full purge
+                      </span>
+                      <span className="mt-1 block text-sm opacity-90">
+                        Permanently delete retained engine history. This cannot
+                        be recovered.
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              </fieldset>
+            ) : null}
+
+            <div className="flex flex-wrap justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setConfirmAction(null);
+                  setPurgeMode('projection_only');
+                }}
+                disabled={isBusy}
+                className="app-button-secondary"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleConfirmedAction()}
+                disabled={isBusy}
+                className="app-button-primary disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {confirmAction === pendingAction
+                  ? 'Submitting...'
+                  : confirmDialogConfirmLabel(confirmAction)}
+              </button>
+            </div>
+          </div>
+        </ModalShell>
+      ) : null}
+    </section>
+  );
+}
+
+function ActionButton({
+  action,
+  disabled,
+  isPending,
+  onClick,
+}: {
+  action: EngineAction;
+  disabled: boolean;
+  isPending: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="app-button-secondary disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {isPending ? 'Submitting...' : ACTION_LABELS[action]}
+    </button>
+  );
+}
+
+function EngineControlFeedback({
+  feedback,
+}: {
+  feedback: FeedbackState;
+}) {
+  const toneClasses =
+    feedback.tone === 'success'
+      ? 'border-emerald-300/50 bg-emerald-100/70 text-emerald-950 dark:border-emerald-300/20 dark:bg-emerald-400/10 dark:text-emerald-100'
+      : feedback.tone === 'warning'
+        ? 'border-amber-300/50 bg-amber-100/70 text-amber-950 dark:border-amber-300/20 dark:bg-amber-400/10 dark:text-amber-100'
+        : feedback.tone === 'info'
+          ? 'border-sky-300/50 bg-sky-100/70 text-sky-950 dark:border-sky-300/20 dark:bg-sky-400/10 dark:text-sky-100'
+          : 'border-red-300/50 bg-red-100/70 text-red-950 dark:border-red-300/20 dark:bg-red-400/10 dark:text-red-100';
+
+  return (
+    <div
+      role={feedback.tone === 'error' ? 'alert' : 'status'}
+      className={`mt-4 rounded-[1.25rem] border px-4 py-3 text-sm ${toneClasses}`}
+    >
+      <p className="font-semibold">{feedback.title}</p>
+      <p className="mt-1">{feedback.message}</p>
+    </div>
+  );
+}
+
+function ModalShell({
+  title,
+  description,
+  onClose,
+  children,
+}: {
+  title: string;
+  description: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="app-overlay-enter fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4 backdrop-blur-sm">
+      <button
+        type="button"
+        aria-label={`Close ${title.toLowerCase()} dialog`}
+        className="absolute inset-0"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="relative z-10 w-full max-w-xl rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface)] p-5 shadow-[var(--continua-shadow-soft)]"
+      >
+        <div className="mb-4">
+          <div className="app-overline">Engine action</div>
+          <h3 className="mt-2 text-xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+            {title}
+          </h3>
+          <p className="mt-2 text-sm leading-6 text-[var(--continua-text-secondary)]">
+            {description}
+          </p>
+        </div>
+
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function repairFeedbackForReason(reason: EngineRepairReason): FeedbackState {
+  switch (reason) {
+    case 'repair_requested':
+      return {
+        tone: 'success',
+        title: 'Repair requested',
+        message: 'Projection repair was requested for this engine run.',
+      };
+    case 'already_catching_up':
+      return {
+        tone: 'info',
+        title: 'Already catching up',
+        message: 'Projection repair is already in progress for this engine run.',
+      };
+    case 'already_up_to_date':
+      return {
+        tone: 'info',
+        title: 'Already up to date',
+        message: 'Projection state is already current for this engine run.',
+      };
+    case 'no_events_to_project':
+      return {
+        tone: 'info',
+        title: 'No events to project',
+        message: 'There are no retained engine events left to project.',
+      };
+    case 'history_expired':
+      return {
+        tone: 'warning',
+        title: 'History expired',
+        message:
+          'The event journal has expired, so projection repair is not possible.',
+      };
+  }
+}
+
+function confirmDialogTitle(action: 'cancel' | 'terminate' | 'purge'): string {
+  switch (action) {
+    case 'cancel':
+      return 'Cancel run';
+    case 'terminate':
+      return 'Terminate run';
+    case 'purge':
+      return 'Purge retained engine data';
+  }
+}
+
+function confirmDialogDescription(
+  action: 'cancel' | 'terminate' | 'purge'
+): string {
+  switch (action) {
+    case 'cancel':
+      return 'Confirm before requesting cancellation for this engine run.';
+    case 'terminate':
+      return 'Confirm before forcefully terminating this engine run.';
+    case 'purge':
+      return 'Choose how much retained engine state to purge before continuing.';
+  }
+}
+
+function confirmDialogConfirmLabel(
+  action: 'cancel' | 'terminate' | 'purge'
+): string {
+  switch (action) {
+    case 'cancel':
+      return 'Confirm cancel';
+    case 'terminate':
+      return 'Confirm terminate';
+    case 'purge':
+      return 'Confirm purge';
+  }
+}

--- a/web/src/pages/EnginePendingWorkPanel.test.tsx
+++ b/web/src/pages/EnginePendingWorkPanel.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EnginePendingWorkPanel } from './EnginePendingWorkPanel';
+
+describe('EnginePendingWorkPanel', () => {
+  it('renders current wait plus activity, timer, and signal details', () => {
+    render(
+      <EnginePendingWorkPanel
+        data={{
+          run_id: 'run-1',
+          current_wait: {
+            kind: 'signal',
+            signal_name: 'approval',
+          },
+          activities: [
+            {
+              task_id: 'task-1',
+              activity_key: 'charge-card',
+              activity_type: 'payments.charge',
+              status: 'scheduled',
+              available_at: '2026-03-14T10:00:00.000Z',
+              attempt_count: 2,
+            },
+            {
+              task_id: 'task-2',
+              activity_key: 'send-email',
+              activity_type: 'notifications.email',
+              status: 'queued',
+              available_at: '2026-03-14T10:01:00.000Z',
+              attempt_count: 1,
+            },
+          ],
+          timers: [
+            {
+              inbox_id: 'timer-1',
+              timer_key: 'approval-timeout',
+              status: 'scheduled',
+              available_at: '2026-03-14T10:05:00.000Z',
+            },
+          ],
+          signals: [
+            {
+              inbox_id: 'signal-1',
+              signal_name: 'manual_override',
+              status: 'queued',
+              available_at: '2026-03-14T10:02:00.000Z',
+            },
+          ],
+          pending_activity_tasks: 2,
+          pending_inbox_items: 2,
+        }}
+        isError={false}
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText('Waiting on signal')).toBeInTheDocument();
+    expect(screen.getByText('approval')).toBeInTheDocument();
+    expect(screen.getByText('payments.charge · charge-card')).toBeInTheDocument();
+    expect(screen.getByText('approval-timeout')).toBeInTheDocument();
+    expect(screen.getByText('manual_override')).toBeInTheDocument();
+    expect(screen.getByText('Activities: 2')).toBeInTheDocument();
+    expect(screen.getByText('Inbox: 2')).toBeInTheDocument();
+  });
+
+  it('renders empty states for each pending-work section', () => {
+    render(
+      <EnginePendingWorkPanel
+        data={{
+          run_id: 'run-1',
+          current_wait: null,
+          activities: [],
+          timers: [],
+          signals: [],
+          pending_activity_tasks: 0,
+          pending_inbox_items: 0,
+        }}
+        isError={false}
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText('No active wait reported.')).toBeInTheDocument();
+    expect(screen.getByText('No pending activities.')).toBeInTheDocument();
+    expect(screen.getByText('No pending timers.')).toBeInTheDocument();
+    expect(screen.getByText('No pending signals.')).toBeInTheDocument();
+  });
+
+  it('renders a degraded state when the pending-work query fails', () => {
+    render(
+      <EnginePendingWorkPanel
+        data={undefined}
+        isError={true}
+        isLoading={false}
+        errorMessage="backend exploded"
+      />
+    );
+
+    expect(
+      screen.getByText('Pending work is temporarily unavailable. backend exploded')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No pending activities.')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/EnginePendingWorkPanel.tsx
+++ b/web/src/pages/EnginePendingWorkPanel.tsx
@@ -1,0 +1,217 @@
+import { type ReactNode } from 'react';
+import {
+  type EnginePendingWorkResponse,
+} from '../api/client';
+import { formatRelativeTime, formatTimestamp } from '../utils/format';
+import { describeEngineWaitState } from './engineWaitState';
+
+interface EnginePendingWorkPanelProps {
+  data: EnginePendingWorkResponse | undefined;
+  isError: boolean;
+  isLoading: boolean;
+  errorMessage?: string | null;
+}
+
+export function EnginePendingWorkPanel({
+  data,
+  isError,
+  isLoading,
+  errorMessage,
+}: EnginePendingWorkPanelProps) {
+  const waitSummary = describeEngineWaitState(data?.current_wait);
+
+  return (
+    <section className="rounded-[1.5rem] border border-[var(--continua-border-strong)] bg-[var(--continua-surface)] p-4 shadow-[var(--continua-shadow-soft)]">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
+            Pending work
+          </div>
+          <h2 className="mt-2 text-base font-semibold text-[var(--continua-text-primary)]">
+            Engine wait state and queued work
+          </h2>
+          <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">
+            Inspect outstanding activities, timers, and signals without relying
+            on the projected timeline alone.
+          </p>
+        </div>
+
+        {data ? (
+          <div className="flex flex-wrap gap-2 text-xs text-[var(--continua-text-secondary)]">
+            <PendingWorkCountPill
+              label="Activities"
+              value={data.pending_activity_tasks}
+            />
+            <PendingWorkCountPill
+              label="Inbox"
+              value={data.pending_inbox_items}
+            />
+          </div>
+        ) : null}
+      </div>
+
+      {isError ? (
+        <div className="app-alert-error mt-4">
+          Pending work is temporarily unavailable.
+          {errorMessage ? ` ${errorMessage}` : ''}
+        </div>
+      ) : (
+        <>
+          <div className="mt-4 rounded-[1.25rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-4">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
+              Current wait
+            </div>
+            {isLoading && !data ? (
+              <p className="mt-2 text-sm text-[var(--continua-text-secondary)]">
+                Loading pending work...
+              </p>
+            ) : waitSummary ? (
+              <>
+                <h3 className="mt-2 text-sm font-semibold text-[var(--continua-text-primary)]">
+                  {waitSummary.heading}
+                </h3>
+                <p className="mt-1 text-sm text-[var(--continua-text-secondary)]">
+                  {waitSummary.detail}
+                </p>
+              </>
+            ) : (
+              <p className="mt-2 text-sm text-[var(--continua-text-secondary)]">
+                No active wait reported.
+              </p>
+            )}
+          </div>
+
+          <div className="mt-4 grid gap-4 xl:grid-cols-3">
+            <PendingWorkList
+              title="Activities"
+              emptyMessage="No pending activities."
+              items={data?.activities ?? []}
+              getKey={(item) => item.task_id}
+              renderItem={(item, key) => (
+                <PendingWorkCard
+                  key={key}
+                  title={`${item.activity_type} · ${item.activity_key}`}
+                  metadata={[
+                    `Status: ${item.status}`,
+                    `Available ${formatPendingAvailability(item.available_at)}`,
+                    `Attempts: ${item.attempt_count}`,
+                  ]}
+                  keyValue={`Task ${item.task_id}`}
+                />
+              )}
+            />
+            <PendingWorkList
+              title="Timers"
+              emptyMessage="No pending timers."
+              items={data?.timers ?? []}
+              getKey={(item) => item.inbox_id}
+              renderItem={(item, key) => (
+                <PendingWorkCard
+                  key={key}
+                  title={item.timer_key}
+                  metadata={[
+                    `Status: ${item.status}`,
+                    `Available ${formatPendingAvailability(item.available_at)}`,
+                  ]}
+                  keyValue={`Inbox ${item.inbox_id}`}
+                />
+              )}
+            />
+            <PendingWorkList
+              title="Signals"
+              emptyMessage="No pending signals."
+              items={data?.signals ?? []}
+              getKey={(item) => item.inbox_id}
+              renderItem={(item, key) => (
+                <PendingWorkCard
+                  key={key}
+                  title={item.signal_name}
+                  metadata={[
+                    `Status: ${item.status}`,
+                    `Available ${formatPendingAvailability(item.available_at)}`,
+                  ]}
+                  keyValue={`Inbox ${item.inbox_id}`}
+                />
+              )}
+            />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function PendingWorkCountPill({
+  label,
+  value,
+}: {
+  label: string;
+  value: number;
+}) {
+  return (
+    <span className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2.5 py-1">
+      {label}: {value}
+    </span>
+  );
+}
+
+function PendingWorkList<Item>({
+  title,
+  emptyMessage,
+  items,
+  getKey,
+  renderItem,
+}: {
+  title: string;
+  emptyMessage: string;
+  items: Item[];
+  getKey: (item: Item) => string;
+  renderItem: (item: Item, key: string) => ReactNode;
+}) {
+  return (
+    <div className="rounded-[1.25rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-4">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-muted)]">
+        {title}
+      </div>
+      {items.length === 0 ? (
+        <p className="mt-3 text-sm text-[var(--continua-text-secondary)]">
+          {emptyMessage}
+        </p>
+      ) : (
+        <div className="mt-3 space-y-3">
+          {items.map((item) => renderItem(item, getKey(item)))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PendingWorkCard({
+  title,
+  metadata,
+  keyValue,
+}: {
+  title: string;
+  metadata: string[];
+  keyValue: string;
+}) {
+  return (
+    <article className="rounded-[1rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] p-3">
+      <h3 className="text-sm font-semibold text-[var(--continua-text-primary)]">
+        {title}
+      </h3>
+      <p className="mt-1 font-mono text-xs text-[var(--continua-text-muted)]">
+        {keyValue}
+      </p>
+      <ul className="mt-3 space-y-1 text-sm text-[var(--continua-text-secondary)]">
+        {metadata.map((entry) => (
+          <li key={entry}>{entry}</li>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+function formatPendingAvailability(value: string): string {
+  return `${formatTimestamp(value)} (${formatRelativeTime(value)})`;
+}

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -1,6 +1,6 @@
 import { act } from 'react';
 import { focusManager, onlineManager } from '@tanstack/react-query';
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -42,11 +42,99 @@ function createRunningTraceDetail(
   };
 }
 
+function createEngineTraceDetail({
+  engineOverrides = {},
+  traceOverrides = {},
+}: {
+  engineOverrides?: Partial<NonNullable<TraceDetail['engine']>>;
+  traceOverrides?: Partial<TraceDetail>;
+} = {}): TraceDetail {
+  return createRunningTraceDetail({
+    ...traceOverrides,
+    engine: {
+      run_id: '123e4567-e89b-12d3-a456-426614174103',
+      instance_key: 'instance-1',
+      definition_name: 'checkout',
+      definition_version: 'v1',
+      projection_state: 'summary_only',
+      status: 'WAITING',
+      created_at: '2026-03-14T10:00:00.000Z',
+      updated_at: '2026-03-14T10:00:05.000Z',
+      pending_work: {
+        pending_activity_tasks: 1,
+        pending_inbox_items: 2,
+      },
+      wait_state: {
+        kind: 'signal',
+        signal_name: 'approval',
+      },
+      ...engineOverrides,
+    },
+  });
+}
+
+function createPendingWorkResponse(
+  overrides: Partial<{
+    current_wait: Record<string, unknown> | null;
+    activities: Array<Record<string, unknown>>;
+    timers: Array<Record<string, unknown>>;
+    signals: Array<Record<string, unknown>>;
+    pending_activity_tasks: number;
+    pending_inbox_items: number;
+  }> = {}
+) {
+  return {
+    run_id: '123e4567-e89b-12d3-a456-426614174103',
+    current_wait: {
+      kind: 'signal',
+      signal_name: 'approval',
+    },
+    activities: [
+      {
+        task_id: 'task-1',
+        activity_key: 'charge-card',
+        activity_type: 'payments.charge',
+        status: 'scheduled',
+        available_at: '2026-03-14T10:01:00.000Z',
+        attempt_count: 2,
+      },
+    ],
+    timers: [
+      {
+        inbox_id: 'timer-1',
+        timer_key: 'approval-timeout',
+        status: 'scheduled',
+        available_at: '2026-03-14T10:02:00.000Z',
+      },
+    ],
+    signals: [
+      {
+        inbox_id: 'signal-1',
+        signal_name: 'manual_override',
+        status: 'queued',
+        available_at: '2026-03-14T10:03:00.000Z',
+      },
+    ],
+    pending_activity_tasks: 1,
+    pending_inbox_items: 2,
+    ...overrides,
+  };
+}
+
 function countRequests(pathname: string): number {
   return fetchMock.mock.calls.filter(([input]) => {
     const url = new URL(readRequestUrl(input), 'http://localhost');
     return url.pathname === pathname;
   }).length;
+}
+
+function getRequestCallsMatching(pattern: RegExp) {
+  return fetchMock.mock.calls.flatMap(([input, init]) => {
+    const url = new URL(readRequestUrl(input), 'http://localhost');
+    return pattern.test(url.pathname)
+      ? [{ url, init: init as RequestInit | undefined }]
+      : [];
+  });
 }
 
 function createWaitEvent({
@@ -228,6 +316,520 @@ describe('TraceDetailPage', () => {
     expect(screen.queryByText('Projection summary only')).not.toBeInTheDocument();
     expect(screen.queryByText('Projection journal expired')).not.toBeInTheDocument();
     expect(screen.queryByText('Waiting on signal')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Signal' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Pending work')).not.toBeInTheDocument();
+  });
+
+  it('renders pending work details and engine controls for engine-backed traces', async () => {
+    const rootSpan = createSpan({ span_id: 'engine-control-root', name: 'Engine control root' });
+    const runId = '123e4567-e89b-12d3-a456-426614174103';
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse(
+            createEngineTraceDetail({
+              engineOverrides: { projection_state: 'catching_up' },
+            })
+          ),
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+            engine: {
+              projection_state: 'catching_up',
+            },
+          }),
+        enginePendingWork: () => jsonResponse(createPendingWorkResponse()),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Drive the engine run from the debugger' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Engine wait state and queued work')).toBeInTheDocument();
+    expect(screen.getByText('payments.charge · charge-card')).toBeInTheDocument();
+    expect(screen.getByText('approval-timeout')).toBeInTheDocument();
+    expect(screen.getByText('manual_override')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Signal' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Suspend' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Resume' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Purge' })).toBeDisabled();
+    expect(countRequests(`/v1/engine/runs/${runId}/pending-work`)).toBeGreaterThan(0);
+  });
+
+  it.each([
+    {
+      status: 'WAITING',
+      enabled: ['Signal', 'Cancel', 'Suspend', 'Terminate', 'Repair'],
+      disabled: ['Resume', 'Purge'],
+    },
+    {
+      status: 'SUSPENDED',
+      enabled: ['Signal', 'Cancel', 'Resume', 'Terminate', 'Repair'],
+      disabled: ['Suspend', 'Purge'],
+    },
+    {
+      status: 'COMPLETED',
+      enabled: ['Purge', 'Repair'],
+      disabled: ['Signal', 'Cancel', 'Suspend', 'Resume', 'Terminate'],
+    },
+    {
+      status: 'CONTINUED_AS_NEW',
+      enabled: ['Purge', 'Repair'],
+      disabled: ['Signal', 'Cancel', 'Suspend', 'Resume', 'Terminate'],
+    },
+  ] as const)(
+    'gates engine actions for $status runs',
+    async ({ status, enabled, disabled }) => {
+      const rootSpan = createSpan({ span_id: `root-${status}`, name: `Root ${status}` });
+
+      fetchMock.mockImplementation(
+        buildFetchHandler({
+          detail: () =>
+            jsonResponse(
+              createEngineTraceDetail({
+                engineOverrides: { status },
+                traceOverrides: {
+                  status: status === 'WAITING' || status === 'SUSPENDED'
+                    ? 'RUNNING'
+                    : 'FAILED',
+                },
+              })
+            ),
+          spans: () => jsonResponse({ spans: [rootSpan] }),
+          timeline: () =>
+            jsonResponse({
+              events: [],
+              trace_status:
+                status === 'WAITING' || status === 'SUSPENDED'
+                  ? 'RUNNING'
+                  : 'FAILED',
+              has_more: false,
+            }),
+        })
+      );
+
+      renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+      expect(await screen.findByRole('button', { name: 'Repair' })).toBeInTheDocument();
+
+      enabled.forEach((label) => {
+        expect(screen.getByRole('button', { name: label })).toBeEnabled();
+      });
+      disabled.forEach((label) => {
+        expect(screen.getByRole('button', { name: label })).toBeDisabled();
+      });
+    }
+  );
+
+  it('validates signal input, shows in-flight state, sends preview headers, and invalidates caches on success', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({ span_id: 'signal-root', name: 'Signal root' });
+    const deferred = createDeferredResponse();
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createEngineTraceDetail()),
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+          }),
+        enginePendingWork: () => jsonResponse(createPendingWorkResponse()),
+        engineAction: (url) => {
+          if (url.pathname.endsWith('/signal')) {
+            return deferred.promise;
+          }
+
+          return jsonResponse({ code: 'not_found', message: 'unexpected action' }, 404);
+        },
+      })
+    );
+
+    const view = renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+    const invalidateSpy = vi.spyOn(view.queryClient, 'invalidateQueries');
+
+    expect(await screen.findByRole('button', { name: 'Signal' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Signal' }));
+
+    const signalNameInput = screen.getByLabelText('Signal name');
+    const payloadInput = screen.getByLabelText('Payload (JSON)');
+    const sendButton = screen.getByRole('button', { name: 'Send signal' });
+
+    expect(sendButton).toBeDisabled();
+    await user.type(signalNameInput, '   ');
+    expect(screen.getByText('Signal name is required.')).toBeInTheDocument();
+    expect(sendButton).toBeDisabled();
+
+    await user.clear(signalNameInput);
+    await user.type(signalNameInput, ' approve ');
+    fireEvent.change(payloadInput, { target: { value: '{invalid' } });
+    expect(screen.getByText('Payload must be valid JSON.')).toBeInTheDocument();
+    expect(sendButton).toBeDisabled();
+
+    fireEvent.change(payloadInput, {
+      target: { value: '{"approved":true}' },
+    });
+    expect(sendButton).toBeEnabled();
+
+    await user.click(sendButton);
+    expect(sendButton).toBeDisabled();
+    expect(
+      screen.getAllByRole('button', { name: 'Submitting...' }).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByText('Submitting signal...')).toBeInTheDocument();
+
+    const signalCalls = getRequestCallsMatching(/\/v1\/engine\/runs\/[^/]+\/signal$/);
+    expect(signalCalls).toHaveLength(1);
+    expect(signalCalls[0]?.init?.headers).toMatchObject({
+      'X-Continua-Engine-Preview': '1',
+      'X-API-Key': 'test-key',
+    });
+    expect(signalCalls[0]?.init?.body).toBe(
+      JSON.stringify({
+        signal_name: 'approve',
+        payload: { approved: true },
+      })
+    );
+
+    deferred.resolve(
+      jsonResponse({
+        run_id: '123e4567-e89b-12d3-a456-426614174103',
+        instance_key: 'instance-1',
+        accepted: true,
+        wake_applied: true,
+      })
+    );
+
+    expect(await screen.findByText('Signal accepted')).toBeInTheDocument();
+    expect(screen.queryByText('Signal name is required.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Payload must be valid JSON.')).not.toBeInTheDocument();
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['trace', TRACE_ONE.id],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['timeline', TRACE_ONE.id],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['spans', TRACE_ONE.id],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['enginePendingWork', '123e4567-e89b-12d3-a456-426614174103'],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['traces'],
+    });
+  });
+
+  it('supports full purge mode for CONTINUED_AS_NEW runs and sends the selected mode', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({ span_id: 'purge-root', name: 'Purge root' });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse(
+            createEngineTraceDetail({
+              engineOverrides: { status: 'CONTINUED_AS_NEW' },
+              traceOverrides: { status: 'COMPLETED' },
+            })
+          ),
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'COMPLETED',
+            has_more: false,
+          }),
+        engineAction: (url) => {
+          if (url.pathname.endsWith('/purge')) {
+            return jsonResponse({
+              run_id: '123e4567-e89b-12d3-a456-426614174103',
+              mode: 'full',
+              projection_state: 'journal_expired',
+              deleted: true,
+            });
+          }
+
+          return jsonResponse({ code: 'not_found', message: 'unexpected action' }, 404);
+        },
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    const purgeButton = await screen.findByRole('button', { name: 'Purge' });
+    expect(purgeButton).toBeEnabled();
+    await user.click(purgeButton);
+
+    expect(screen.getByRole('radio', { name: /Projection only/i })).toBeChecked();
+    await user.click(screen.getByRole('radio', { name: /Full purge/i }));
+    expect(
+      screen.getByText('Permanently delete retained engine history. This cannot be recovered.')
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Confirm purge' }));
+
+    expect(await screen.findByText('Purge applied')).toBeInTheDocument();
+
+    const purgeCalls = getRequestCallsMatching(/\/v1\/engine\/runs\/[^/]+\/purge$/);
+    expect(purgeCalls).toHaveLength(1);
+    expect(purgeCalls[0]?.init?.headers).toMatchObject({
+      'X-Continua-Engine-Preview': '1',
+      'X-API-Key': 'test-key',
+    });
+    expect(purgeCalls[0]?.init?.body).toBe(JSON.stringify({ mode: 'full' }));
+  });
+
+  it('replaces control feedback messages instead of stacking them', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({ span_id: 'feedback-root', name: 'Feedback root' });
+    let repairCallCount = 0;
+    let signalCallCount = 0;
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createEngineTraceDetail()),
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+          }),
+        engineAction: (url) => {
+          if (url.pathname.endsWith('/repair')) {
+            repairCallCount += 1;
+
+            if (repairCallCount === 1) {
+              return jsonResponse({
+                run_id: '123e4567-e89b-12d3-a456-426614174103',
+                accepted: true,
+                reason: 'repair_requested',
+                projection_state: 'catching_up',
+              });
+            }
+
+            if (repairCallCount === 2) {
+              return jsonResponse({
+                run_id: '123e4567-e89b-12d3-a456-426614174103',
+                accepted: false,
+                reason: 'history_expired',
+                projection_state: 'journal_expired',
+              });
+            }
+
+            return jsonResponse({
+              run_id: '123e4567-e89b-12d3-a456-426614174103',
+              accepted: false,
+              reason: 'already_up_to_date',
+              projection_state: 'up_to_date',
+            });
+          }
+
+          if (url.pathname.endsWith('/signal')) {
+            signalCallCount += 1;
+            if (signalCallCount === 1) {
+              return jsonResponse(
+                { code: 'error', message: 'Signal delivery failed' },
+                500
+              );
+            }
+
+            return jsonResponse({
+              run_id: '123e4567-e89b-12d3-a456-426614174103',
+              instance_key: 'instance-1',
+              accepted: true,
+              wake_applied: false,
+            });
+          }
+
+          return jsonResponse({ code: 'not_found', message: 'unexpected action' }, 404);
+        },
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(await screen.findByRole('button', { name: 'Repair' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Repair' }));
+    expect(await screen.findByText('Repair requested')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Signal' }));
+    await user.type(screen.getByLabelText('Signal name'), 'approve');
+    await user.click(screen.getByRole('button', { name: 'Send signal' }));
+    expect(await screen.findByText('Signal failed')).toBeInTheDocument();
+    expect(screen.queryByText('Repair requested')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Send signal' }));
+    expect(await screen.findByText('Signal accepted')).toBeInTheDocument();
+    expect(screen.queryByText('Signal failed')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Repair' }));
+    expect(await screen.findByText('History expired')).toBeInTheDocument();
+    expect(screen.queryByText('Signal accepted')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Repair' }));
+    expect(await screen.findByText('Already up to date')).toBeInTheDocument();
+    expect(screen.queryByText('History expired')).not.toBeInTheDocument();
+  });
+
+  it('shows inline conflict errors and refetches trace detail plus pending work on 409 responses', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({ span_id: 'conflict-root', name: 'Conflict root' });
+    const runId = '123e4567-e89b-12d3-a456-426614174103';
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(createEngineTraceDetail()),
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'RUNNING',
+            has_more: false,
+          }),
+        enginePendingWork: () => jsonResponse(createPendingWorkResponse()),
+        engineAction: (url) => {
+          if (url.pathname.endsWith('/suspend')) {
+            return jsonResponse(
+              {
+                code: 'run_not_suspendable',
+                message: 'Run is not suspendable',
+              },
+              409
+            );
+          }
+
+          return jsonResponse({ code: 'not_found', message: 'unexpected action' }, 404);
+        },
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    expect(await screen.findByRole('button', { name: 'Suspend' })).toBeInTheDocument();
+    const initialDetailRequests = countRequests(`/api/traces/${TRACE_ONE.id}`);
+    const initialPendingRequests = countRequests(
+      `/v1/engine/runs/${runId}/pending-work`
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Suspend' }));
+
+    expect(await screen.findByText('Suspend failed')).toBeInTheDocument();
+    expect(screen.getByText('Run is not suspendable')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(countRequests(`/api/traces/${TRACE_ONE.id}`)).toBeGreaterThan(
+        initialDetailRequests
+      );
+      expect(countRequests(`/v1/engine/runs/${runId}/pending-work`)).toBeGreaterThan(
+        initialPendingRequests
+      );
+    });
+  });
+
+  it('shows the exact-match mismatch banner and preserves returnTo through continuation links', async () => {
+    const user = userEvent.setup();
+    const rootSpan = createSpan({ span_id: 'continue-root', name: 'Continue root' });
+
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: (url) => {
+          const traceId = url.pathname.split('/').at(-1);
+
+          if (traceId === TRACE_ONE.id) {
+            return jsonResponse(
+              createEngineTraceDetail({
+                engineOverrides: {
+                  failure: {
+                    error_code: 'definition_version_mismatch',
+                    error_message: 'missing definition version',
+                    status: 'FAILED',
+                  },
+                  continued_from_trace_id: 'trace-prev',
+                  continued_to_trace_id: 'trace-next',
+                  status: 'FAILED',
+                },
+                traceOverrides: {
+                  status: 'FAILED',
+                  error_count: 1,
+                },
+              })
+            );
+          }
+
+          if (traceId === 'trace-next') {
+            return jsonResponse(
+              createEngineTraceDetail({
+                engineOverrides: {
+                  failure: {
+                    error_code: 'other_error',
+                    error_message: 'other failure',
+                    status: 'FAILED',
+                  },
+                },
+                traceOverrides: {
+                  ...TRACE_DETAIL,
+                  id: 'trace-next',
+                  name: 'Continued Trace',
+                  status: 'FAILED',
+                  error_count: 1,
+                },
+              })
+            );
+          }
+
+          return jsonResponse(createEngineTraceDetail());
+        },
+        spans: () => jsonResponse({ spans: [rootSpan] }),
+        timeline: () =>
+          jsonResponse({
+            events: [],
+            trace_status: 'FAILED',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([
+      {
+        pathname: `/traces/${TRACE_ONE.id}`,
+        state: { returnTo: `/sessions/${SESSION_ID}?sort_by=started_at&offset=20` },
+      },
+    ]);
+
+    expect(
+      await screen.findByText(
+        'This run failed because the engine definition version could not be matched during activation.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Previous run' })).toHaveAttribute(
+      'href',
+      '/traces/trace-prev'
+    );
+    expect(screen.getByRole('link', { name: 'Next run →' })).toHaveAttribute(
+      'href',
+      '/traces/trace-next'
+    );
+
+    await user.click(screen.getByRole('link', { name: 'Next run →' }));
+
+    expect(await screen.findByText('Continued Trace')).toBeInTheDocument();
+    expect(screen.queryByText('Definition version mismatch')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '← Session' })).toHaveAttribute(
+      'href',
+      `/sessions/${SESSION_ID}?sort_by=started_at&offset=20`
+    );
   });
 
   it('shows the auth recovery banner when the trace request returns 401', async () => {

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -1150,7 +1150,7 @@ describe('TraceDetailPage', () => {
     );
 
     await user.click(
-      screen.getByRole('button', {
+      await screen.findByRole('button', {
         name: /Mobile reasoning child.*Choose a mobile tool\?/i,
       })
     );

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -15,7 +15,6 @@ import {
   fetchSpans,
   fetchTrace,
   isAuthError,
-  type EngineWaitState,
   type Span,
   type TimelineEvent,
   type TraceDetail,
@@ -43,10 +42,14 @@ import { useRequireApiKey } from '../hooks/useRequireApiKey';
 import { useTraceDetailSearchParams } from '../hooks/useTraceDetailSearchParams';
 import { useWorkspaceState } from '../hooks/useWorkspaceState';
 import type { RetrySafetyAssessment } from '../utils/retrySafety';
+import { EngineControlBar } from './EngineControlBar';
+import { EnginePendingWorkPanel } from './EnginePendingWorkPanel';
+import { describeEngineWaitState } from './engineWaitState';
 import {
   TIMELINE_POLL_INTERVAL_MS,
   useTraceTimeline,
 } from './useTraceTimeline';
+import { useEnginePendingWork } from './useEnginePendingWork';
 import { useRetrySafetyAnalysis } from './useRetrySafetyAnalysis';
 import { useWaitStallAnalysis } from './useWaitStallAnalysis';
 import {
@@ -88,42 +91,6 @@ const DESKTOP_MEDIA_QUERY = '(min-width: 1024px)';
 
 function queryErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'Unknown error';
-}
-
-function describeEngineWaitState(waitState?: EngineWaitState): {
-  heading: string;
-  detail: string;
-} | null {
-  if (!waitState?.kind) {
-    return null;
-  }
-
-  switch (waitState.kind) {
-    case 'activity':
-      return {
-        heading: 'Waiting on activity',
-        detail: waitState.activity_type
-          ? `${waitState.activity_type}${waitState.activity_key ? ` · ${waitState.activity_key}` : ''}`
-          : (waitState.activity_key ?? 'Activity work'),
-      };
-    case 'timer':
-      return {
-        heading: 'Waiting on timer',
-        detail: waitState.due_at
-          ? `Scheduled for ${formatTimestamp(waitState.due_at)}`
-          : (waitState.timer_key ?? 'Timer wait'),
-      };
-    case 'signal':
-      return {
-        heading: 'Waiting on signal',
-        detail: waitState.signal_name ?? 'Signal receipt',
-      };
-    default:
-      return {
-        heading: 'Waiting on engine state',
-        detail: waitState.kind,
-      };
-  }
 }
 
 export function TraceDetailPage() {
@@ -173,6 +140,10 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
     refetchOnReconnect: false,
   });
   const trace = traceQuery.data ?? null;
+  const pendingWorkQuery = useEnginePendingWork(
+    trace?.engine?.run_id,
+    trace?.engine?.status
+  );
   const spans = spansQuery.data?.spans ?? EMPTY_SPANS;
   const timelineAuthError = isAuthError(timeline.rawError);
   const timelineStatus = trace ? timeline.traceStatus ?? trace.status : timeline.traceStatus;
@@ -299,6 +270,16 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
 
   const detailsContent = (
     <TraceDetailsSurface
+      pendingWorkContent={
+        trace.engine ? (
+          <EnginePendingWorkPanel
+            data={pendingWorkQuery.data}
+            isError={pendingWorkQuery.isError}
+            isLoading={pendingWorkQuery.isLoading}
+            errorMessage={queryErrorMessage(pendingWorkQuery.error)}
+          />
+        ) : null
+      }
       runningStateAssessment={waitStallAssessment}
       timelineStatus={timelineStatus}
       failureAnalysis={failureAnalysis}
@@ -376,6 +357,30 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
               ) : null}
             </div>
 
+            {trace.engine?.continued_from_trace_id ||
+            trace.engine?.continued_to_trace_id ? (
+              <div className="mt-4 flex flex-wrap gap-2 text-sm">
+                {trace.engine.continued_from_trace_id ? (
+                  <Link
+                    to={`/traces/${trace.engine.continued_from_trace_id}`}
+                    state={{ returnTo }}
+                    className="inline-flex items-center rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-3 py-1.5 font-medium text-[var(--continua-text-secondary)] transition hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-accent)]"
+                  >
+                    ← Previous run
+                  </Link>
+                ) : null}
+                {trace.engine.continued_to_trace_id ? (
+                  <Link
+                    to={`/traces/${trace.engine.continued_to_trace_id}`}
+                    state={{ returnTo }}
+                    className="inline-flex items-center rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-3 py-1.5 font-medium text-[var(--continua-text-secondary)] transition hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-accent)]"
+                  >
+                    Next run →
+                  </Link>
+                ) : null}
+              </div>
+            ) : null}
+
             {trace.engine?.status === 'WAITING' ? (
               <EngineWaitStateSummary engine={trace.engine} />
             ) : null}
@@ -418,6 +423,15 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
       ) : null}
 
       <EngineProjectionBanner projectionState={trace.engine?.projection_state} />
+      {trace.engine?.failure?.error_code === 'definition_version_mismatch' ? (
+        <DefinitionVersionMismatchBanner />
+      ) : null}
+      {trace.engine ? (
+        <EngineControlBar
+          engine={trace.engine}
+          traceId={traceId}
+        />
+      ) : null}
 
       <div className="min-h-[42rem] flex-1">
         <TraceWorkspace
@@ -493,6 +507,18 @@ function EngineWaitStateSummary({
         </span>
       </div>
       <p className="mt-1 text-sm leading-6">{summary.detail}</p>
+    </section>
+  );
+}
+
+function DefinitionVersionMismatchBanner() {
+  return (
+    <section className="rounded-[1.25rem] border border-amber-300/50 bg-amber-100/70 px-4 py-3 text-sm text-amber-950 shadow-[var(--continua-shadow-soft)] dark:border-amber-300/20 dark:bg-amber-400/10 dark:text-amber-100">
+      <p className="font-semibold">Definition version mismatch</p>
+      <p className="mt-1">
+        This run failed because the engine definition version could not be
+        matched during activation.
+      </p>
     </section>
   );
 }
@@ -648,6 +674,7 @@ function getReturnToDestination(state: unknown): string {
 }
 
 function TraceDetailsSurface({
+  pendingWorkContent,
   runningStateAssessment,
   timelineStatus,
   failureAnalysis,
@@ -659,6 +686,7 @@ function TraceDetailsSurface({
   spanIndex,
   events,
 }: {
+  pendingWorkContent: ReactNode;
   runningStateAssessment: WaitStallAssessment | null;
   timelineStatus: 'RUNNING' | 'COMPLETED' | 'FAILED' | null;
   failureAnalysis: ReturnType<typeof buildFailureAnalysis>;
@@ -673,6 +701,8 @@ function TraceDetailsSurface({
   return (
     <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-transparent p-4">
       <div className="space-y-4">
+        {pendingWorkContent}
+
         {timelineStatus === 'FAILED' ? (
           <FailureSummary
             summary={failureAnalysis.summary}

--- a/web/src/pages/TracesPage.test.tsx
+++ b/web/src/pages/TracesPage.test.tsx
@@ -178,6 +178,45 @@ describe('TracesPage', () => {
     expect(screen.getByLabelText('Only show traces with errors')).toBeChecked();
   });
 
+  it('keeps engine filters collapsed by default and auto-expands them from the URL', async () => {
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const firstView = renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Show engine filters' })
+    ).toHaveAttribute('aria-expanded', 'false');
+    expect(
+      screen.queryByLabelText('Engine Instance Key')
+    ).not.toBeInTheDocument();
+    firstView.unmount();
+
+    renderTraceRoutes([
+      '/traces?engine_definition_name=checkout&engine_run_status=waiting&engine_projection_state=summary_only',
+    ]);
+
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    await waitForListFetch(
+      '?limit=20&engine_definition_name=checkout&engine_run_status=waiting&engine_projection_state=summary_only'
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Hide engine filters' })
+    ).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByLabelText('Engine Definition Name')).toHaveValue(
+      'checkout'
+    );
+    expect(screen.getByLabelText('Engine Status')).toHaveValue('waiting');
+    expect(screen.getByLabelText('Projection State')).toHaveValue(
+      'summary_only'
+    );
+    expect(
+      screen.getByText(
+        'Advanced operator filter for inspecting projection health across engine traces.'
+      )
+    ).toBeInTheDocument();
+  });
+
   it('commits text filters after debounce and immediately on Enter', async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(buildFetchHandler());
@@ -199,6 +238,48 @@ describe('TracesPage', () => {
     await user.type(searchInput, 'errors');
     await user.keyboard('{Enter}');
     await waitForListFetch('?limit=20&q=errors');
+  });
+
+  it('commits engine filters with lowercase query values and removable chips', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    renderTraceRoutes(['/traces']);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show engine filters' }));
+
+    fetchMock.mockClear();
+    const instanceKeyInput = screen.getByLabelText('Engine Instance Key');
+    await user.type(instanceKeyInput, 'order-123');
+    await waitForDebounce();
+    await waitForListFetch('?limit=20&engine_instance_key=order-123');
+
+    await user.selectOptions(screen.getByLabelText('Engine Status'), 'suspended');
+    await waitForListFetch(
+      '?limit=20&engine_instance_key=order-123&engine_run_status=suspended'
+    );
+
+    await user.selectOptions(
+      screen.getByLabelText('Projection State'),
+      'summary_only'
+    );
+    await waitForListFetch(
+      '?limit=20&engine_instance_key=order-123&engine_run_status=suspended&engine_projection_state=summary_only'
+    );
+
+    expect(screen.getByText('Engine status:')).toBeInTheDocument();
+    expect(screen.getAllByText('Suspended').length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('button', { name: 'Clear Engine status filter' })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Clear Engine status filter' })
+    );
+    await waitForListFetch(
+      '?limit=20&engine_instance_key=order-123&engine_projection_state=summary_only'
+    );
   });
 
   it('does not commit text filters on blur before debounce elapses', async () => {
@@ -523,6 +604,9 @@ describe('TracesPage', () => {
     const userIdInput = screen.getByLabelText('User ID');
     const minDurationInput = screen.getByLabelText('Min Duration (ms)');
     const hasErrorsCheckbox = screen.getByLabelText('Only show traces with errors');
+    const toggleEngineFilters = screen.getByRole('button', {
+      name: 'Show engine filters',
+    });
     const clearSearch = screen.getByRole('button', { name: 'Clear Search filter' });
     const clearErrors = screen.getByRole('button', { name: 'Clear Errors filter' });
     const clearSession = screen.getByRole('button', { name: 'Clear Session filter' });
@@ -554,6 +638,8 @@ describe('TracesPage', () => {
     expect(minDurationInput).toHaveFocus();
     await user.tab();
     expect(hasErrorsCheckbox).toHaveFocus();
+    await user.tab();
+    expect(toggleEngineFilters).toHaveFocus();
     await user.tab();
     expect(clearSearch).toHaveFocus();
     await user.tab();

--- a/web/src/pages/TracesPage.tsx
+++ b/web/src/pages/TracesPage.tsx
@@ -13,6 +13,10 @@ import { DEFAULT_PAGE_SIZE, getLastValidOffset } from '../utils/pagination';
 import {
   buildCanonicalQueryString,
   deriveActiveChips,
+  ENGINE_PROJECTION_STATE_FILTER_VALUES,
+  ENGINE_RUN_STATUS_FILTER_VALUES,
+  formatEngineProjectionStateLabel,
+  formatEngineRunStatusLabel,
   isoToLocalDateInputValue,
   localDateToISOEnd,
   localDateToISOStart,
@@ -125,11 +129,19 @@ function TracesContent() {
   const { filters, setFilters, clearAll, clearChip } = useTracesSearchParams();
   const [searchDraft, setSearchDraft] = useState(filters.q ?? '');
   const [userIdDraft, setUserIdDraft] = useState(filters.user_id ?? '');
+  const [engineInstanceKeyDraft, setEngineInstanceKeyDraft] = useState(
+    filters.engine_instance_key ?? ''
+  );
+  const [engineDefinitionNameDraft, setEngineDefinitionNameDraft] = useState(
+    filters.engine_definition_name ?? ''
+  );
   const [minDurationDraft, setMinDurationDraft] = useState(
     filters.min_duration_ms?.toString() ?? ''
   );
   const searchFocus = useDraftFocus();
   const userIdFocus = useDraftFocus();
+  const engineInstanceKeyFocus = useDraftFocus();
+  const engineDefinitionNameFocus = useDraftFocus();
   const minDurationFocus = useDraftFocus();
 
   useEffect(() => {
@@ -139,6 +151,14 @@ function TracesContent() {
   useEffect(() => {
     setUserIdDraft(filters.user_id ?? '');
   }, [filters.user_id]);
+
+  useEffect(() => {
+    setEngineInstanceKeyDraft(filters.engine_instance_key ?? '');
+  }, [filters.engine_instance_key]);
+
+  useEffect(() => {
+    setEngineDefinitionNameDraft(filters.engine_definition_name ?? '');
+  }, [filters.engine_definition_name]);
 
   useEffect(() => {
     setMinDurationDraft(filters.min_duration_ms?.toString() ?? '');
@@ -158,6 +178,27 @@ function TracesContent() {
       const normalizedValue = normalizeTrimmedDraft(value);
       setUserIdDraft(normalizedValue);
       setFilters({ user_id: normalizedValue || undefined }, 'push');
+    },
+    [setFilters]
+  );
+
+  const commitEngineInstanceKey = useCallback(
+    (value: string) => {
+      const normalizedValue = normalizeTrimmedDraft(value);
+      setEngineInstanceKeyDraft(normalizedValue);
+      setFilters({ engine_instance_key: normalizedValue || undefined }, 'push');
+    },
+    [setFilters]
+  );
+
+  const commitEngineDefinitionName = useCallback(
+    (value: string) => {
+      const normalizedValue = normalizeTrimmedDraft(value);
+      setEngineDefinitionNameDraft(normalizedValue);
+      setFilters(
+        { engine_definition_name: normalizedValue || undefined },
+        'push'
+      );
     },
     [setFilters]
   );
@@ -193,6 +234,22 @@ function TracesContent() {
   });
 
   useDebouncedDraftCommit({
+    draftValue: engineInstanceKeyDraft,
+    committedValue: filters.engine_instance_key ?? '',
+    onCommit: commitEngineInstanceKey,
+    isActive: engineInstanceKeyFocus.isFocused,
+    normalizeForComparison: normalizeTrimmedDraft,
+  });
+
+  useDebouncedDraftCommit({
+    draftValue: engineDefinitionNameDraft,
+    committedValue: filters.engine_definition_name ?? '',
+    onCommit: commitEngineDefinitionName,
+    isActive: engineDefinitionNameFocus.isFocused,
+    normalizeForComparison: normalizeTrimmedDraft,
+  });
+
+  useDebouncedDraftCommit({
     draftValue: minDurationDraft,
     committedValue: filters.min_duration_ms?.toString() ?? '',
     onCommit: commitMinDuration,
@@ -205,6 +262,15 @@ function TracesContent() {
   const dateRangeError = getDateRangeError(startDate, endDate);
   const activeChips = deriveActiveChips(filters);
   const hasActiveFilters = activeChips.length > 0;
+  const hasActiveEngineFilters = Boolean(
+    filters.engine_instance_key ||
+      filters.engine_definition_name ||
+      filters.engine_run_status ||
+      filters.engine_projection_state
+  );
+  const [areEngineFiltersExpanded, setAreEngineFiltersExpanded] = useState(
+    hasActiveEngineFilters
+  );
   const isSearchActive = Boolean(filters.q);
   const queryParams = { ...filters };
   const canonicalQueryString = buildCanonicalQueryString(queryParams);
@@ -218,6 +284,12 @@ function TracesContent() {
   const traces = tracesQuery.data?.traces ?? EMPTY_TRACES;
   const total = tracesQuery.data?.total ?? 0;
   const currentListUrl = `${location.pathname}${location.search}`;
+
+  useEffect(() => {
+    if (hasActiveEngineFilters) {
+      setAreEngineFiltersExpanded(true);
+    }
+  }, [hasActiveEngineFilters]);
 
   useEffect(() => {
     if (traces.length !== 0 || total === 0 || filters.offset === 0) {
@@ -477,6 +549,165 @@ function TracesContent() {
                 <span>Has errors</span>
               </label>
             </div>
+          </div>
+
+          <div className="mt-4 rounded-[1.25rem] border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-[var(--continua-text-secondary)]">
+                  Engine filters
+                </h2>
+                <p className="mt-1 text-sm text-[var(--continua-text-muted)]">
+                  Narrow engine-backed traces by instance, definition, run
+                  status, or projection health.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                aria-controls="trace-engine-filters"
+                aria-expanded={areEngineFiltersExpanded}
+                onClick={() =>
+                  setAreEngineFiltersExpanded((expanded) => !expanded)
+                }
+                className="app-button-secondary shrink-0"
+              >
+                {areEngineFiltersExpanded ? 'Hide engine filters' : 'Show engine filters'}
+              </button>
+            </div>
+
+            {areEngineFiltersExpanded ? (
+              <div
+                id="trace-engine-filters"
+                className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+              >
+                <div>
+                  <label
+                    htmlFor="trace-engine-instance-key"
+                    className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
+                  >
+                    Engine Instance Key
+                  </label>
+                  <input
+                    id="trace-engine-instance-key"
+                    type="text"
+                    value={engineInstanceKeyDraft}
+                    onChange={(event) =>
+                      setEngineInstanceKeyDraft(event.target.value)
+                    }
+                    onFocus={engineInstanceKeyFocus.onFocus}
+                    onBlur={engineInstanceKeyFocus.onBlur}
+                    onKeyDown={(event) =>
+                      handleEnterCommit(
+                        event,
+                        commitEngineInstanceKey,
+                        engineInstanceKeyDraft
+                      )
+                    }
+                    placeholder="Filter by instance key"
+                    className="app-input"
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="trace-engine-definition-name"
+                    className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
+                  >
+                    Engine Definition Name
+                  </label>
+                  <input
+                    id="trace-engine-definition-name"
+                    type="text"
+                    value={engineDefinitionNameDraft}
+                    onChange={(event) =>
+                      setEngineDefinitionNameDraft(event.target.value)
+                    }
+                    onFocus={engineDefinitionNameFocus.onFocus}
+                    onBlur={engineDefinitionNameFocus.onBlur}
+                    onKeyDown={(event) =>
+                      handleEnterCommit(
+                        event,
+                        commitEngineDefinitionName,
+                        engineDefinitionNameDraft
+                      )
+                    }
+                    placeholder="Filter by definition name"
+                    className="app-input"
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="trace-engine-run-status"
+                    className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
+                  >
+                    Engine Status
+                  </label>
+                  <select
+                    id="trace-engine-run-status"
+                    value={filters.engine_run_status ?? ''}
+                    onChange={(event) =>
+                      setFilters(
+                        {
+                          engine_run_status: event.target.value
+                            ? (event.target.value as (typeof ENGINE_RUN_STATUS_FILTER_VALUES)[number])
+                            : undefined,
+                        },
+                        'push'
+                      )
+                    }
+                    className="app-select"
+                  >
+                    <option value="">All engine statuses</option>
+                    {ENGINE_RUN_STATUS_FILTER_VALUES.map((value) => (
+                      <option key={value} value={value}>
+                        {formatEngineRunStatusLabel(value)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="trace-engine-projection-state"
+                    className="mb-1 block text-sm font-medium text-[var(--continua-text-secondary)]"
+                  >
+                    Projection State
+                  </label>
+                  <select
+                    id="trace-engine-projection-state"
+                    value={filters.engine_projection_state ?? ''}
+                    onChange={(event) =>
+                      setFilters(
+                        {
+                          engine_projection_state: event.target.value
+                            ? (event.target.value as (typeof ENGINE_PROJECTION_STATE_FILTER_VALUES)[number])
+                            : undefined,
+                        },
+                        'push'
+                      )
+                    }
+                    aria-describedby="trace-engine-projection-state-hint"
+                    className="app-select"
+                  >
+                    <option value="">All projection states</option>
+                    {ENGINE_PROJECTION_STATE_FILTER_VALUES.map((value) => (
+                      <option key={value} value={value}>
+                        {formatEngineProjectionStateLabel(value)}
+                      </option>
+                    ))}
+                  </select>
+                  <p
+                    id="trace-engine-projection-state-hint"
+                    className="mt-1 text-xs text-[var(--continua-text-muted)]"
+                  >
+                    Advanced operator filter for inspecting projection health
+                    across engine traces.
+                  </p>
+                </div>
+              </div>
+            ) : null}
           </div>
 
           {dateRangeError && (

--- a/web/src/pages/engineWaitState.ts
+++ b/web/src/pages/engineWaitState.ts
@@ -1,0 +1,42 @@
+import { type EngineWaitState } from '../api/client';
+import { formatTimestamp } from '../utils/format';
+
+export interface EngineWaitStateSummary {
+  heading: string;
+  detail: string;
+}
+
+export function describeEngineWaitState(
+  waitState?: EngineWaitState | null
+): EngineWaitStateSummary | null {
+  if (!waitState?.kind) {
+    return null;
+  }
+
+  switch (waitState.kind) {
+    case 'activity':
+      return {
+        heading: 'Waiting on activity',
+        detail: waitState.activity_type
+          ? `${waitState.activity_type}${waitState.activity_key ? ` · ${waitState.activity_key}` : ''}`
+          : (waitState.activity_key ?? 'Activity work'),
+      };
+    case 'timer':
+      return {
+        heading: 'Waiting on timer',
+        detail: waitState.due_at
+          ? `Scheduled for ${formatTimestamp(waitState.due_at)}`
+          : (waitState.timer_key ?? 'Timer wait'),
+      };
+    case 'signal':
+      return {
+        heading: 'Waiting on signal',
+        detail: waitState.signal_name ?? 'Signal receipt',
+      };
+    default:
+      return {
+        heading: 'Waiting on engine state',
+        detail: waitState.kind,
+      };
+  }
+}

--- a/web/src/pages/testUtils.tsx
+++ b/web/src/pages/testUtils.tsx
@@ -57,7 +57,10 @@ export {
 
 export type RequestInput = string | URL | Request;
 
-export type JsonHandler = (url: URL) => Promise<Response> | Response;
+export type JsonHandler = (
+  url: URL,
+  init?: RequestInit
+) => Promise<Response> | Response;
 
 export function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -77,6 +80,8 @@ export function buildFetchHandler({
   sessionNarrative,
   spans,
   timeline,
+  enginePendingWork,
+  engineAction,
 }: {
   list?: JsonHandler;
   detail?: JsonHandler;
@@ -86,13 +91,15 @@ export function buildFetchHandler({
   sessionNarrative?: JsonHandler;
   spans?: JsonHandler;
   timeline?: JsonHandler;
+  enginePendingWork?: JsonHandler;
+  engineAction?: JsonHandler;
 } = {}) {
-  return async (input: RequestInput) => {
+  return async (input: RequestInput, init?: RequestInit) => {
     const url = new URL(readRequestUrl(input), 'http://localhost');
 
     if (url.pathname === '/api/traces') {
       return (
-        list?.(url) ??
+        list?.(url, init) ??
         jsonResponse({
           traces: [TRACE_ONE, TRACE_TWO],
           total: 2,
@@ -101,12 +108,12 @@ export function buildFetchHandler({
     }
 
     if (/^\/api\/traces\/[^/]+\/spans$/.test(url.pathname)) {
-      return spans?.(url) ?? jsonResponse({ spans: [] });
+      return spans?.(url, init) ?? jsonResponse({ spans: [] });
     }
 
     if (/^\/api\/traces\/[^/]+\/events$/.test(url.pathname)) {
       return (
-        timeline?.(url) ??
+        timeline?.(url, init) ??
         jsonResponse({
           events: [],
           trace_status: 'COMPLETED',
@@ -117,7 +124,7 @@ export function buildFetchHandler({
 
     if (/^\/api\/traces\/[^/]+$/.test(url.pathname)) {
       if (detail) {
-        return detail(url);
+        return detail(url, init);
       }
 
       const traceId = url.pathname.split('/').at(-1);
@@ -148,7 +155,7 @@ export function buildFetchHandler({
 
     if (url.pathname === '/api/sessions') {
       return (
-        sessionsList?.(url) ??
+        sessionsList?.(url, init) ??
         jsonResponse({
           sessions: [SESSION_ONE, SESSION_TWO],
           total: 2,
@@ -158,7 +165,7 @@ export function buildFetchHandler({
 
     if (/^\/api\/sessions\/[^/]+\/narrative$/.test(url.pathname)) {
       if (sessionNarrative) {
-        return sessionNarrative(url);
+        return sessionNarrative(url, init);
       }
 
       const sessionId = url.pathname.split('/').at(-2);
@@ -173,7 +180,7 @@ export function buildFetchHandler({
 
     if (/^\/api\/sessions\/[^/]+\/compare$/.test(url.pathname)) {
       if (sessionCompare) {
-        return sessionCompare(url);
+        return sessionCompare(url, init);
       }
 
       return jsonResponse({ code: 'not_found', message: 'Resource not found' }, 404);
@@ -181,7 +188,7 @@ export function buildFetchHandler({
 
     if (/^\/api\/sessions\/[^/]+$/.test(url.pathname)) {
       if (sessionDetail) {
-        return sessionDetail(url);
+        return sessionDetail(url, init);
       }
 
       const sessionId = url.pathname.split('/').at(-1);
@@ -194,7 +201,95 @@ export function buildFetchHandler({
       return jsonResponse({ code: 'not_found', message: 'Resource not found' }, 404);
     }
 
+    if (/^\/v1\/engine\/runs\/[^/]+\/pending-work$/.test(url.pathname)) {
+      if (enginePendingWork) {
+        return enginePendingWork(url, init);
+      }
+
+      const runId = url.pathname.split('/').at(-2);
+      return jsonResponse({
+        run_id: runId,
+        current_wait: null,
+        activities: [],
+        timers: [],
+        signals: [],
+        pending_activity_tasks: 0,
+        pending_inbox_items: 0,
+      });
+    }
+
+    if (
+      /^\/v1\/engine\/runs\/[^/]+\/(signal|cancel|suspend|resume|terminate|purge|repair)$/.test(
+        url.pathname
+      )
+    ) {
+      if (engineAction) {
+        return engineAction(url, init);
+      }
+
+      const runId = url.pathname.split('/')[4];
+      const action = url.pathname.split('/').at(-1);
+
+      switch (action) {
+        case 'signal':
+        case 'cancel':
+          return jsonResponse({
+            run_id: runId,
+            instance_key: 'instance-1',
+            accepted: true,
+            wake_applied: false,
+          });
+        case 'suspend':
+          return jsonResponse(createEngineRunResponse(runId, 'SUSPENDED'));
+        case 'resume':
+          return jsonResponse(createEngineRunResponse(runId, 'RUNNING'));
+        case 'terminate':
+          return jsonResponse({
+            run_id: runId,
+            status: 'TERMINATED',
+            result: null,
+          });
+        case 'purge':
+          return jsonResponse({
+            run_id: runId,
+            mode: 'projection_only',
+            projection_state: 'summary_only',
+            deleted: true,
+          });
+        case 'repair':
+          return jsonResponse({
+            run_id: runId,
+            accepted: true,
+            reason: 'repair_requested',
+            projection_state: 'catching_up',
+          });
+        default:
+          break;
+      }
+    }
+
     throw new Error(`Unhandled request: ${url.pathname}${url.search}`);
+  };
+}
+
+function createEngineRunResponse(
+  runId: string | undefined,
+  status: 'RUNNING' | 'SUSPENDED'
+) {
+  return {
+    run_id: runId,
+    instance_id: 'instance-id-1',
+    instance_key: 'instance-1',
+    definition_name: 'checkout',
+    definition_version: 'v1',
+    projection_state: 'summary_only',
+    status,
+    created_at: '2026-03-14T10:00:00.000Z',
+    updated_at: '2026-03-14T10:00:05.000Z',
+    pending_work: {
+      pending_activity_tasks: 0,
+      pending_inbox_items: 0,
+    },
   };
 }
 

--- a/web/src/pages/useEnginePendingWork.test.tsx
+++ b/web/src/pages/useEnginePendingWork.test.tsx
@@ -1,0 +1,142 @@
+import { type ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearApiKey, setApiKey } from '../api/client';
+import { shouldPollEnginePendingWork, useEnginePendingWork } from './useEnginePendingWork';
+import { TIMELINE_POLL_INTERVAL_MS } from './useTraceTimeline';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        run_id: 'run-1',
+        current_wait: null,
+        activities: [],
+        timers: [],
+        signals: [],
+        pending_activity_tasks: 0,
+        pending_inbox_items: 0,
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  setApiKey('test-key');
+});
+
+afterEach(() => {
+  clearApiKey();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('useEnginePendingWork', () => {
+  it.each([
+    ['QUEUED', true],
+    ['RUNNING', true],
+    ['WAITING', true],
+    ['SUSPENDED', true],
+    ['COMPLETED', false],
+    ['FAILED', false],
+    ['CANCELLED', false],
+    ['TERMINATED', false],
+    ['CONTINUED_AS_NEW', false],
+    [undefined, false],
+  ] as const)(
+    'returns %s polling state as %s',
+    (status, expected) => {
+      expect(shouldPollEnginePendingWork(status)).toBe(expected);
+    }
+  );
+
+  it('uses the enginePendingWork query key, polls active statuses, and omits the preview header', async () => {
+    const queryClient = createQueryClient();
+    const wrapper = createWrapper(queryClient);
+
+    const { result } = renderHook(
+      () => useEnginePendingWork('run-1', 'WAITING'),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.run_id).toBe('run-1');
+    });
+
+    expect(queryClient.getQueryState(['enginePendingWork', 'run-1'])).toBeDefined();
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(0);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/v1/engine/runs/run-1/pending-work');
+    expect(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers
+    ).toMatchObject({
+      'Content-Type': 'application/json',
+      'X-API-Key': 'test-key',
+    });
+    expect(
+      ((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers as Record<
+        string,
+        string
+      > | undefined)?.['X-Continua-Engine-Preview']
+    ).toBeUndefined();
+
+    const initialCallCount = fetchMock.mock.calls.length;
+
+    await act(async () => {
+      await new Promise((resolve) =>
+        setTimeout(resolve, TIMELINE_POLL_INTERVAL_MS + 20)
+      );
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(initialCallCount);
+    });
+  });
+
+  it('does not poll terminal statuses after the initial fetch', async () => {
+    const queryClient = createQueryClient();
+    const wrapper = createWrapper(queryClient);
+
+    renderHook(() => useEnginePendingWork('run-1', 'COMPLETED'), { wrapper });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await new Promise((resolve) =>
+        setTimeout(resolve, TIMELINE_POLL_INTERVAL_MS + 20)
+      );
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/pages/useEnginePendingWork.ts
+++ b/web/src/pages/useEnginePendingWork.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  fetchEnginePendingWork,
+  type EnginePendingWorkResponse,
+  type EngineRunStatus,
+} from '../api/client';
+import { TIMELINE_POLL_INTERVAL_MS } from './useTraceTimeline';
+
+const ENGINE_PENDING_WORK_POLL_STATUSES: ReadonlySet<EngineRunStatus> = new Set([
+  'QUEUED',
+  'RUNNING',
+  'WAITING',
+  'SUSPENDED',
+]);
+
+export function shouldPollEnginePendingWork(
+  engineStatus?: EngineRunStatus | null
+): boolean {
+  return Boolean(
+    engineStatus && ENGINE_PENDING_WORK_POLL_STATUSES.has(engineStatus)
+  );
+}
+
+export function useEnginePendingWork(
+  runId: string | undefined,
+  engineStatus: EngineRunStatus | undefined
+) {
+  const pollingEnabled = shouldPollEnginePendingWork(engineStatus);
+
+  return useQuery<EnginePendingWorkResponse>({
+    queryKey: ['enginePendingWork', runId],
+    queryFn: () => {
+      if (!runId) {
+        throw new Error('Engine run ID is required to fetch pending work');
+      }
+
+      return fetchEnginePendingWork(runId);
+    },
+    enabled: Boolean(runId),
+    refetchInterval: pollingEnabled ? TIMELINE_POLL_INTERVAL_MS : false,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/web/src/utils/tracesSearchParams.test.ts
+++ b/web/src/utils/tracesSearchParams.test.ts
@@ -133,6 +133,81 @@ describe('tracesSearchParams', () => {
     });
   });
 
+  it('round-trips engine filter params with lowercase query values', () => {
+    const parsed = parseTracesParams(
+      new URLSearchParams({
+        engine_instance_key: '  order-123  ',
+        engine_definition_name: '  checkout  ',
+        engine_run_status: 'SUSPENDED',
+        engine_projection_state: 'SUMMARY_ONLY',
+      })
+    );
+
+    expect(parsed).toMatchObject({
+      limit: 20,
+      offset: 0,
+      engine_instance_key: 'order-123',
+      engine_definition_name: 'checkout',
+      engine_run_status: 'suspended',
+      engine_projection_state: 'summary_only',
+    });
+
+    expect(serializeTracesParams(parsed).toString()).toBe(
+      [
+        'engine_instance_key=order-123',
+        'engine_definition_name=checkout',
+        'engine_run_status=suspended',
+        'engine_projection_state=summary_only',
+      ].join('&')
+    );
+    expect(buildCanonicalQueryString(parsed)).toBe(
+      'limit=20&engine_instance_key=order-123&engine_definition_name=checkout&engine_run_status=suspended&engine_projection_state=summary_only'
+    );
+  });
+
+  it('derives human-readable engine filter chips and clears them individually', () => {
+    const state = parseTracesParams(
+      new URLSearchParams({
+        offset: '20',
+        engine_instance_key: 'order-123',
+        engine_definition_name: 'checkout',
+        engine_run_status: 'waiting',
+        engine_projection_state: 'summary_only',
+      })
+    );
+
+    expect(deriveActiveChips(state)).toEqual([
+      {
+        key: 'engine_instance_key',
+        label: 'Engine instance',
+        value: 'order-123',
+      },
+      {
+        key: 'engine_definition_name',
+        label: 'Engine definition',
+        value: 'checkout',
+      },
+      {
+        key: 'engine_run_status',
+        label: 'Engine status',
+        value: 'Waiting',
+      },
+      {
+        key: 'engine_projection_state',
+        label: 'Projection state',
+        value: 'Summary only',
+      },
+    ]);
+
+    expect(clearChip(state, 'engine_run_status')).toMatchObject({
+      limit: 20,
+      offset: 0,
+      engine_instance_key: 'order-123',
+      engine_definition_name: 'checkout',
+      engine_projection_state: 'summary_only',
+    });
+  });
+
   it('builds identical canonical strings for equivalent params', () => {
     const first = buildCanonicalQueryString(
       parseTracesParams(

--- a/web/src/utils/tracesSearchParams.ts
+++ b/web/src/utils/tracesSearchParams.ts
@@ -1,8 +1,62 @@
+import type { operations } from '@continua/contracts/generated/typescript/api';
+
 import { DEFAULT_PAGE_SIZE, normalizeUiPageSize } from './pagination';
 
 export type TraceStatusFilter = 'running' | 'completed' | 'failed';
 export type TraceSortBy = 'started_at';
 export type SortDirection = 'asc' | 'desc';
+
+type ListTracesQuery = NonNullable<
+  operations['listTraces']['parameters']['query']
+>;
+
+export type EngineRunStatusFilter = NonNullable<
+  ListTracesQuery['engine_run_status']
+>;
+export type EngineProjectionStateFilter = NonNullable<
+  ListTracesQuery['engine_projection_state']
+>;
+
+function objectKeys<T extends object>(value: T): Array<Extract<keyof T, string>> {
+  return Object.keys(value) as Array<Extract<keyof T, string>>;
+}
+
+// OpenAPI generation emits type unions, not runtime enum arrays. These maps are
+// the runtime option source, while `satisfies` keeps them exhaustive.
+const ENGINE_RUN_STATUS_LABELS = {
+  queued: 'Queued',
+  running: 'Running',
+  waiting: 'Waiting',
+  suspended: 'Suspended',
+  completed: 'Completed',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+  terminated: 'Terminated',
+  continued_as_new: 'Continued as new',
+} satisfies Record<EngineRunStatusFilter, string>;
+
+export const ENGINE_RUN_STATUS_FILTER_VALUES = objectKeys(ENGINE_RUN_STATUS_LABELS);
+
+const ENGINE_PROJECTION_STATE_LABELS = {
+  up_to_date: 'Up to date',
+  catching_up: 'Catching up',
+  summary_only: 'Summary only',
+  journal_expired: 'Journal expired',
+} satisfies Record<EngineProjectionStateFilter, string>;
+
+export const ENGINE_PROJECTION_STATE_FILTER_VALUES = objectKeys(
+  ENGINE_PROJECTION_STATE_LABELS
+);
+
+export function formatEngineRunStatusLabel(value: EngineRunStatusFilter): string {
+  return ENGINE_RUN_STATUS_LABELS[value];
+}
+
+export function formatEngineProjectionStateLabel(
+  value: EngineProjectionStateFilter
+): string {
+  return ENGINE_PROJECTION_STATE_LABELS[value];
+}
 
 export interface FetchTracesParams {
   limit?: number;
@@ -15,6 +69,10 @@ export interface FetchTracesParams {
   start_time_from?: string;
   start_time_to?: string;
   user_id?: string;
+  engine_instance_key?: string;
+  engine_definition_name?: string;
+  engine_run_status?: EngineRunStatusFilter;
+  engine_projection_state?: EngineProjectionStateFilter;
   has_errors?: boolean;
   min_duration_ms?: number;
 }
@@ -30,6 +88,10 @@ export interface TracesFilterState {
   start_time_from?: string;
   start_time_to?: string;
   user_id?: string;
+  engine_instance_key?: string;
+  engine_definition_name?: string;
+  engine_run_status?: EngineRunStatusFilter;
+  engine_projection_state?: EngineProjectionStateFilter;
   has_errors?: boolean;
   min_duration_ms?: number;
 }
@@ -53,6 +115,12 @@ type NormalizableTracesParams = {
 };
 
 const VALID_STATUSES = new Set<TraceStatusFilter>(['running', 'completed', 'failed']);
+const VALID_ENGINE_RUN_STATUSES = new Set<EngineRunStatusFilter>(
+  ENGINE_RUN_STATUS_FILTER_VALUES
+);
+const VALID_ENGINE_PROJECTION_STATES = new Set<EngineProjectionStateFilter>(
+  ENGINE_PROJECTION_STATE_FILTER_VALUES
+);
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const DATE_INPUT_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -70,6 +138,10 @@ const CANONICAL_PARAM_ORDER: Array<keyof FetchTracesParams> = [
   'start_time_from',
   'start_time_to',
   'user_id',
+  'engine_instance_key',
+  'engine_definition_name',
+  'engine_run_status',
+  'engine_projection_state',
   'has_errors',
   'min_duration_ms',
 ];
@@ -88,6 +160,34 @@ function normalizeStatus(value: string | null | undefined): TraceStatusFilter | 
   const normalized = candidate === 'error' ? 'failed' : candidate;
   return VALID_STATUSES.has(normalized as TraceStatusFilter)
     ? (normalized as TraceStatusFilter)
+    : undefined;
+}
+
+function normalizeEngineRunStatus(
+  value: string | null | undefined
+): EngineRunStatusFilter | undefined {
+  const candidate = value?.trim().toLowerCase();
+  if (!candidate) {
+    return undefined;
+  }
+
+  return VALID_ENGINE_RUN_STATUSES.has(candidate as EngineRunStatusFilter)
+    ? (candidate as EngineRunStatusFilter)
+    : undefined;
+}
+
+function normalizeEngineProjectionState(
+  value: string | null | undefined
+): EngineProjectionStateFilter | undefined {
+  const candidate = value?.trim().toLowerCase();
+  if (!candidate) {
+    return undefined;
+  }
+
+  return VALID_ENGINE_PROJECTION_STATES.has(
+    candidate as EngineProjectionStateFilter
+  )
+    ? (candidate as EngineProjectionStateFilter)
     : undefined;
 }
 
@@ -171,6 +271,12 @@ function normalizeTracesParams(
     start_time_from: normalizeISODateTime(params.start_time_from),
     start_time_to: normalizeISODateTime(params.start_time_to),
     user_id: normalizeOptionalText(params.user_id),
+    engine_instance_key: normalizeOptionalText(params.engine_instance_key),
+    engine_definition_name: normalizeOptionalText(params.engine_definition_name),
+    engine_run_status: normalizeEngineRunStatus(params.engine_run_status),
+    engine_projection_state: normalizeEngineProjectionState(
+      params.engine_projection_state
+    ),
     has_errors: normalizeBooleanTrue(params.has_errors),
     min_duration_ms: normalizePositiveInteger(params.min_duration_ms),
   };
@@ -214,6 +320,18 @@ function toQueryEntries(
   }
   if (params.user_id) {
     entries.push(['user_id', params.user_id]);
+  }
+  if (params.engine_instance_key) {
+    entries.push(['engine_instance_key', params.engine_instance_key]);
+  }
+  if (params.engine_definition_name) {
+    entries.push(['engine_definition_name', params.engine_definition_name]);
+  }
+  if (params.engine_run_status) {
+    entries.push(['engine_run_status', params.engine_run_status]);
+  }
+  if (params.engine_projection_state) {
+    entries.push(['engine_projection_state', params.engine_projection_state]);
   }
   if (params.has_errors) {
     entries.push(['has_errors', 'true']);
@@ -266,6 +384,12 @@ export function parseTracesParams(searchParams: URLSearchParams): TracesFilterSt
     start_time_from: searchParams.get('start_time_from') ?? undefined,
     start_time_to: searchParams.get('start_time_to') ?? undefined,
     user_id: searchParams.get('user_id') ?? undefined,
+    engine_instance_key: searchParams.get('engine_instance_key') ?? undefined,
+    engine_definition_name:
+      searchParams.get('engine_definition_name') ?? undefined,
+    engine_run_status: searchParams.get('engine_run_status') ?? undefined,
+    engine_projection_state:
+      searchParams.get('engine_projection_state') ?? undefined,
     has_errors: searchParams.get('has_errors') ?? undefined,
     min_duration_ms: searchParams.get('min_duration_ms') ?? undefined,
   });
@@ -281,6 +405,10 @@ export function parseTracesParams(searchParams: URLSearchParams): TracesFilterSt
     start_time_from: normalized.start_time_from,
     start_time_to: normalized.start_time_to,
     user_id: normalized.user_id,
+    engine_instance_key: normalized.engine_instance_key,
+    engine_definition_name: normalized.engine_definition_name,
+    engine_run_status: normalized.engine_run_status,
+    engine_projection_state: normalized.engine_projection_state,
     has_errors: normalized.has_errors,
     min_duration_ms: normalized.min_duration_ms,
   };
@@ -373,6 +501,36 @@ export function deriveActiveChips(state: TracesFilterState): Chip[] {
   if (normalized.user_id) {
     chips.push({ key: 'user_id', label: 'User', value: normalized.user_id });
   }
+  if (normalized.engine_instance_key) {
+    chips.push({
+      key: 'engine_instance_key',
+      label: 'Engine instance',
+      value: normalized.engine_instance_key,
+    });
+  }
+  if (normalized.engine_definition_name) {
+    chips.push({
+      key: 'engine_definition_name',
+      label: 'Engine definition',
+      value: normalized.engine_definition_name,
+    });
+  }
+  if (normalized.engine_run_status) {
+    chips.push({
+      key: 'engine_run_status',
+      label: 'Engine status',
+      value: formatEngineRunStatusLabel(normalized.engine_run_status),
+    });
+  }
+  if (normalized.engine_projection_state) {
+    chips.push({
+      key: 'engine_projection_state',
+      label: 'Projection state',
+      value: formatEngineProjectionStateLabel(
+        normalized.engine_projection_state
+      ),
+    });
+  }
   if (normalized.has_errors) {
     chips.push({ key: 'has_errors', label: 'Errors', value: 'Only traces with errors' });
   }
@@ -407,6 +565,17 @@ export function clearChip(
       return resetOffset({ ...normalized, start_time_to: undefined });
     case 'user_id':
       return resetOffset({ ...normalized, user_id: undefined });
+    case 'engine_instance_key':
+      return resetOffset({ ...normalized, engine_instance_key: undefined });
+    case 'engine_definition_name':
+      return resetOffset({ ...normalized, engine_definition_name: undefined });
+    case 'engine_run_status':
+      return resetOffset({ ...normalized, engine_run_status: undefined });
+    case 'engine_projection_state':
+      return resetOffset({
+        ...normalized,
+        engine_projection_state: undefined,
+      });
     case 'has_errors':
       return resetOffset({ ...normalized, has_errors: undefined });
     case 'min_duration_ms':


### PR DESCRIPTION
## Summary
- Add preview-gated engine projection bulk backfill support with backend API, store query, generated contracts, and Python SDK helpers.
- Add debugger operator surfaces for engine filters, pending work, controls, continuation navigation, and mismatch warnings.
- Update OpenSpec tasks/spec deltas to reflect the implemented backfill and debugger operator behavior.

## Validation
- make generate
- pnpm --filter web type-check
- pnpm --filter web test -- src/utils/tracesSearchParams.test.ts src/pages/TracesPage.test.tsx
- pnpm --filter web test
- go test ./internal/api/...
- uv run python -m pytest tests/test_engine_control.py
- openspec validate add-engine-projection-bulk-backfill --strict
- openspec validate complete-engine-debugger-operator-surface --strict

Note: OpenSpec validation passed; restricted local network produced only telemetry flush warnings after validation completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added bulk engine projection backfill endpoint to repair eligible engine runs with dry-run preview capability
* Added engine debugger controls for operator actions (signal, suspend, resume, cancel, terminate, purge, repair)
* Added engine pending-work monitoring with polling on trace detail pages
* Extended trace list with advanced engine filters (instance key, definition name, run status, projection state)
* Added support for engine run continuation tracking and navigation
* Added definition version mismatch detection and warning banner

<!-- end of auto-generated comment: release notes by coderabbit.ai -->