### PR TITLE
Add remote activity execution and Python worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,4 @@ tmp/
 # Claude Code session state (per-user, not shared)
 .claude/hooks/state/
 Study/
-continua
+/continua

--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -568,6 +568,59 @@ type EnginePurgeResponse struct {
 	RunId           openapi_types.UUID    `json:"run_id"`
 }
 
+// EngineRemoteActivityClaimRequest defines model for EngineRemoteActivityClaimRequest.
+type EngineRemoteActivityClaimRequest struct {
+	ActivityTypes []string `json:"activity_types"`
+
+	// LeaseDuration Requested lease duration, e.g. 60s or 5m. The server clamps the effective value.
+	LeaseDuration *string `json:"lease_duration,omitempty"`
+	MaxTasks      *int    `json:"max_tasks,omitempty"`
+	WorkerId      string  `json:"worker_id"`
+}
+
+// EngineRemoteActivityClaimResponse defines model for EngineRemoteActivityClaimResponse.
+type EngineRemoteActivityClaimResponse struct {
+	Tasks []EngineRemoteActivityTask `json:"tasks"`
+}
+
+// EngineRemoteActivityCompleteRequest defines model for EngineRemoteActivityCompleteRequest.
+type EngineRemoteActivityCompleteRequest struct {
+	// Output Activity output payload (any valid JSON)
+	Output   interface{} `json:"output"`
+	WorkerId string      `json:"worker_id"`
+}
+
+// EngineRemoteActivityFailRequest defines model for EngineRemoteActivityFailRequest.
+type EngineRemoteActivityFailRequest struct {
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"error_message"`
+	NonRetryable *bool  `json:"non_retryable,omitempty"`
+	WorkerId     string `json:"worker_id"`
+}
+
+// EngineRemoteActivityHeartbeatRequest defines model for EngineRemoteActivityHeartbeatRequest.
+type EngineRemoteActivityHeartbeatRequest struct {
+	WorkerId string `json:"worker_id"`
+}
+
+// EngineRemoteActivityHeartbeatResponse defines model for EngineRemoteActivityHeartbeatResponse.
+type EngineRemoteActivityHeartbeatResponse struct {
+	EffectiveLeaseDurationMs int64     `json:"effective_lease_duration_ms"`
+	LeaseExpiresAt           time.Time `json:"lease_expires_at"`
+}
+
+// EngineRemoteActivityTask defines model for EngineRemoteActivityTask.
+type EngineRemoteActivityTask struct {
+	ActivityKey              string `json:"activity_key"`
+	ActivityType             string `json:"activity_type"`
+	EffectiveLeaseDurationMs int64  `json:"effective_lease_duration_ms"`
+
+	// Input Activity input payload (any valid JSON)
+	Input          interface{}        `json:"input"`
+	LeaseExpiresAt time.Time          `json:"lease_expires_at"`
+	TaskId         openapi_types.UUID `json:"task_id"`
+}
+
 // EngineRepairReason defines model for EngineRepairReason.
 type EngineRepairReason string
 
@@ -1290,6 +1343,30 @@ type GetTraceEventsParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// ClaimRemoteActivityTasksParams defines parameters for ClaimRemoteActivityTasks.
+type ClaimRemoteActivityTasksParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// CompleteRemoteActivityTaskParams defines parameters for CompleteRemoteActivityTask.
+type CompleteRemoteActivityTaskParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// FailRemoteActivityTaskParams defines parameters for FailRemoteActivityTask.
+type FailRemoteActivityTaskParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// HeartbeatRemoteActivityTaskParams defines parameters for HeartbeatRemoteActivityTask.
+type HeartbeatRemoteActivityTaskParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
 // BackfillEngineProjectionsParams defines parameters for BackfillEngineProjections.
 type BackfillEngineProjectionsParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
@@ -1360,6 +1437,18 @@ type IngestParams struct {
 	// Any other value is rejected with `400 unsupported_async_version`.
 	XContinuaAsyncVersion *string `json:"X-Continua-Async-Version,omitempty"`
 }
+
+// ClaimRemoteActivityTasksJSONRequestBody defines body for ClaimRemoteActivityTasks for application/json ContentType.
+type ClaimRemoteActivityTasksJSONRequestBody = EngineRemoteActivityClaimRequest
+
+// CompleteRemoteActivityTaskJSONRequestBody defines body for CompleteRemoteActivityTask for application/json ContentType.
+type CompleteRemoteActivityTaskJSONRequestBody = EngineRemoteActivityCompleteRequest
+
+// FailRemoteActivityTaskJSONRequestBody defines body for FailRemoteActivityTask for application/json ContentType.
+type FailRemoteActivityTaskJSONRequestBody = EngineRemoteActivityFailRequest
+
+// HeartbeatRemoteActivityTaskJSONRequestBody defines body for HeartbeatRemoteActivityTask for application/json ContentType.
+type HeartbeatRemoteActivityTaskJSONRequestBody = EngineRemoteActivityHeartbeatRequest
 
 // BackfillEngineProjectionsJSONRequestBody defines body for BackfillEngineProjections for application/json ContentType.
 type BackfillEngineProjectionsJSONRequestBody = EngineProjectionBackfillRequest
@@ -1560,6 +1649,18 @@ type ServerInterface interface {
 	// List spans for a trace
 	// (GET /api/traces/{id}/spans)
 	ListSpansByTrace(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Claim remote engine activity tasks
+	// (POST /v1/engine/activities/claim)
+	ClaimRemoteActivityTasks(w http.ResponseWriter, r *http.Request, params ClaimRemoteActivityTasksParams)
+	// Complete a remote activity task
+	// (POST /v1/engine/activities/{id}/complete)
+	CompleteRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params CompleteRemoteActivityTaskParams)
+	// Fail or retry a remote activity task
+	// (POST /v1/engine/activities/{id}/fail)
+	FailRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params FailRemoteActivityTaskParams)
+	// Renew a remote activity task lease
+	// (POST /v1/engine/activities/{id}/heartbeat)
+	HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params HeartbeatRemoteActivityTaskParams)
 	// Get an engine instance and current run
 	// (GET /v1/engine/instances/{instance_key})
 	GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string)
@@ -1659,6 +1760,30 @@ func (_ Unimplemented) GetTraceEvents(w http.ResponseWriter, r *http.Request, id
 // List spans for a trace
 // (GET /api/traces/{id}/spans)
 func (_ Unimplemented) ListSpansByTrace(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Claim remote engine activity tasks
+// (POST /v1/engine/activities/claim)
+func (_ Unimplemented) ClaimRemoteActivityTasks(w http.ResponseWriter, r *http.Request, params ClaimRemoteActivityTasksParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Complete a remote activity task
+// (POST /v1/engine/activities/{id}/complete)
+func (_ Unimplemented) CompleteRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params CompleteRemoteActivityTaskParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Fail or retry a remote activity task
+// (POST /v1/engine/activities/{id}/fail)
+func (_ Unimplemented) FailRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params FailRemoteActivityTaskParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Renew a remote activity task lease
+// (POST /v1/engine/activities/{id}/heartbeat)
+func (_ Unimplemented) HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params HeartbeatRemoteActivityTaskParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2270,6 +2395,233 @@ func (siw *ServerInterfaceWrapper) ListSpansByTrace(w http.ResponseWriter, r *ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListSpansByTrace(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ClaimRemoteActivityTasks operation middleware
+func (siw *ServerInterfaceWrapper) ClaimRemoteActivityTasks(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ClaimRemoteActivityTasksParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ClaimRemoteActivityTasks(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CompleteRemoteActivityTask operation middleware
+func (siw *ServerInterfaceWrapper) CompleteRemoteActivityTask(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params CompleteRemoteActivityTaskParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CompleteRemoteActivityTask(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// FailRemoteActivityTask operation middleware
+func (siw *ServerInterfaceWrapper) FailRemoteActivityTask(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params FailRemoteActivityTaskParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.FailRemoteActivityTask(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// HeartbeatRemoteActivityTask operation middleware
+func (siw *ServerInterfaceWrapper) HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params HeartbeatRemoteActivityTaskParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.HeartbeatRemoteActivityTask(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3187,6 +3539,18 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/traces/{id}/spans", wrapper.ListSpansByTrace)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/activities/claim", wrapper.ClaimRemoteActivityTasks)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/activities/{id}/complete", wrapper.CompleteRemoteActivityTask)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/activities/{id}/fail", wrapper.FailRemoteActivityTask)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/activities/{id}/heartbeat", wrapper.HeartbeatRemoteActivityTask)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/instances/{instance_key}", wrapper.GetEngineInstance)

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -64,6 +64,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/engine/activities/claim": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Claim remote engine activity tasks */
+        post: operations["claimRemoteActivityTasks"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/engine/activities/{id}/heartbeat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Renew a remote activity task lease */
+        post: operations["heartbeatRemoteActivityTask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/engine/activities/{id}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Complete a remote activity task */
+        post: operations["completeRemoteActivityTask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/engine/activities/{id}/fail": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Fail or retry a remote activity task */
+        post: operations["failRemoteActivityTask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/engine/instances/{instance_key}": {
         parameters: {
             query?: never;
@@ -520,6 +588,49 @@ export interface components {
             available_at: string;
             /** Format: int32 */
             attempt_count: number;
+        };
+        EngineRemoteActivityClaimRequest: {
+            worker_id: string;
+            activity_types: string[];
+            /** @description Requested lease duration, e.g. 60s or 5m. The server clamps the effective value. */
+            lease_duration?: string;
+            max_tasks?: number;
+        };
+        EngineRemoteActivityTask: {
+            /** Format: uuid */
+            task_id: string;
+            activity_key: string;
+            activity_type: string;
+            /** @description Activity input payload (any valid JSON) */
+            input: unknown;
+            /** Format: date-time */
+            lease_expires_at: string;
+            /** Format: int64 */
+            effective_lease_duration_ms: number;
+        };
+        EngineRemoteActivityClaimResponse: {
+            tasks: components["schemas"]["EngineRemoteActivityTask"][];
+        };
+        EngineRemoteActivityHeartbeatRequest: {
+            worker_id: string;
+        };
+        EngineRemoteActivityHeartbeatResponse: {
+            /** Format: date-time */
+            lease_expires_at: string;
+            /** Format: int64 */
+            effective_lease_duration_ms: number;
+        };
+        EngineRemoteActivityCompleteRequest: {
+            worker_id: string;
+            /** @description Activity output payload (any valid JSON) */
+            output: unknown;
+        };
+        EngineRemoteActivityFailRequest: {
+            worker_id: string;
+            error_code: string;
+            error_message: string;
+            /** @default false */
+            non_retryable: boolean;
         };
         EnginePendingTimerItem: {
             /** Format: uuid */
@@ -1388,6 +1499,242 @@ export interface operations {
                 };
             };
             /** @description Duplicate, in-progress, or conflicting request */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    claimRemoteActivityTasks: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required preview header for mutating engine routes. */
+                "X-Continua-Engine-Preview": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EngineRemoteActivityClaimRequest"];
+            };
+        };
+        responses: {
+            /** @description Claimed remote activity tasks */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EngineRemoteActivityClaimResponse"];
+                };
+            };
+            /** @description Invalid request or missing preview header */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    heartbeatRemoteActivityTask: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required preview header for mutating engine routes. */
+                "X-Continua-Engine-Preview": string;
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EngineRemoteActivityHeartbeatRequest"];
+            };
+        };
+        responses: {
+            /** @description Renewed remote activity lease */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EngineRemoteActivityHeartbeatResponse"];
+                };
+            };
+            /** @description Invalid request or missing preview header */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Activity task not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Activity task is not currently owned by this remote worker */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    completeRemoteActivityTask: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required preview header for mutating engine routes. */
+                "X-Continua-Engine-Preview": string;
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EngineRemoteActivityCompleteRequest"];
+            };
+        };
+        responses: {
+            /** @description Activity task completed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid request or missing preview header */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Activity task not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Activity task is not currently owned by this remote worker */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    failRemoteActivityTask: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required preview header for mutating engine routes. */
+                "X-Continua-Engine-Preview": string;
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EngineRemoteActivityFailRequest"];
+            };
+        };
+        responses: {
+            /** @description Activity task failed or requeued */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid request or missing preview header */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Activity task not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Activity task is not currently owned by this remote worker */
             409: {
                 headers: {
                     [name: string]: unknown;

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -157,6 +157,204 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /v1/engine/activities/claim:
+    post:
+      operationId: claimRemoteActivityTasks
+      summary: Claim remote engine activity tasks
+      tags:
+        - Engine
+      parameters:
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineRemoteActivityClaimRequest'
+      responses:
+        '200':
+          description: Claimed remote activity tasks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineRemoteActivityClaimResponse'
+        '400':
+          description: Invalid request or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/engine/activities/{id}/heartbeat:
+    post:
+      operationId: heartbeatRemoteActivityTask
+      summary: Renew a remote activity task lease
+      tags:
+        - Engine
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineRemoteActivityHeartbeatRequest'
+      responses:
+        '200':
+          description: Renewed remote activity lease
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineRemoteActivityHeartbeatResponse'
+        '400':
+          description: Invalid request or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Activity task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Activity task is not currently owned by this remote worker
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/engine/activities/{id}/complete:
+    post:
+      operationId: completeRemoteActivityTask
+      summary: Complete a remote activity task
+      tags:
+        - Engine
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineRemoteActivityCompleteRequest'
+      responses:
+        '204':
+          description: Activity task completed
+        '400':
+          description: Invalid request or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Activity task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Activity task is not currently owned by this remote worker
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/engine/activities/{id}/fail:
+    post:
+      operationId: failRemoteActivityTask
+      summary: Fail or retry a remote activity task
+      tags:
+        - Engine
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineRemoteActivityFailRequest'
+      responses:
+        '204':
+          description: Activity task failed or requeued
+        '400':
+          description: Invalid request or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Activity task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Activity task is not currently owned by this remote worker
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /v1/engine/instances/{instance_key}:
     get:
       operationId: getEngineInstance
@@ -1346,6 +1544,119 @@ components:
         attempt_count:
           type: integer
           format: int32
+    EngineRemoteActivityClaimRequest:
+      type: object
+      required:
+        - worker_id
+        - activity_types
+      properties:
+        worker_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        activity_types:
+          type: array
+          minItems: 1
+          maxItems: 50
+          items:
+            type: string
+            minLength: 1
+            maxLength: 256
+        lease_duration:
+          type: string
+          description: Requested lease duration, e.g. 60s or 5m. The server clamps the effective value.
+        max_tasks:
+          type: integer
+          minimum: 1
+          maximum: 50
+    EngineRemoteActivityTask:
+      type: object
+      required:
+        - task_id
+        - activity_key
+        - activity_type
+        - input
+        - lease_expires_at
+        - effective_lease_duration_ms
+      properties:
+        task_id:
+          type: string
+          format: uuid
+        activity_key:
+          type: string
+        activity_type:
+          type: string
+        input:
+          description: Activity input payload (any valid JSON)
+        lease_expires_at:
+          type: string
+          format: date-time
+        effective_lease_duration_ms:
+          type: integer
+          format: int64
+    EngineRemoteActivityClaimResponse:
+      type: object
+      required:
+        - tasks
+      properties:
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineRemoteActivityTask'
+    EngineRemoteActivityHeartbeatRequest:
+      type: object
+      required:
+        - worker_id
+      properties:
+        worker_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+    EngineRemoteActivityHeartbeatResponse:
+      type: object
+      required:
+        - lease_expires_at
+        - effective_lease_duration_ms
+      properties:
+        lease_expires_at:
+          type: string
+          format: date-time
+        effective_lease_duration_ms:
+          type: integer
+          format: int64
+    EngineRemoteActivityCompleteRequest:
+      type: object
+      required:
+        - worker_id
+        - output
+      properties:
+        worker_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        output:
+          description: Activity output payload (any valid JSON)
+    EngineRemoteActivityFailRequest:
+      type: object
+      required:
+        - worker_id
+        - error_code
+        - error_message
+      properties:
+        worker_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        error_code:
+          type: string
+          minLength: 1
+          maxLength: 128
+        error_message:
+          type: string
+          maxLength: 4096
+        non_retryable:
+          type: boolean
+          default: false
     EnginePendingTimerItem:
       type: object
       required:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -163,6 +163,204 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /v1/engine/activities/claim:
+    post:
+      operationId: claimRemoteActivityTasks
+      summary: Claim remote engine activity tasks
+      tags: [Engine]
+      parameters:
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineRemoteActivityClaimRequest'
+      responses:
+        '200':
+          description: Claimed remote activity tasks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineRemoteActivityClaimResponse'
+        '400':
+          description: Invalid request or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/engine/activities/{id}/heartbeat:
+    post:
+      operationId: heartbeatRemoteActivityTask
+      summary: Renew a remote activity task lease
+      tags: [Engine]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineRemoteActivityHeartbeatRequest'
+      responses:
+        '200':
+          description: Renewed remote activity lease
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineRemoteActivityHeartbeatResponse'
+        '400':
+          description: Invalid request or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Activity task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Activity task is not currently owned by this remote worker
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/engine/activities/{id}/complete:
+    post:
+      operationId: completeRemoteActivityTask
+      summary: Complete a remote activity task
+      tags: [Engine]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineRemoteActivityCompleteRequest'
+      responses:
+        '204':
+          description: Activity task completed
+        '400':
+          description: Invalid request or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Activity task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Activity task is not currently owned by this remote worker
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/engine/activities/{id}/fail:
+    post:
+      operationId: failRemoteActivityTask
+      summary: Fail or retry a remote activity task
+      tags: [Engine]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: X-Continua-Engine-Preview
+          in: header
+          required: true
+          description: Required preview header for mutating engine routes.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngineRemoteActivityFailRequest'
+      responses:
+        '204':
+          description: Activity task failed or requeued
+        '400':
+          description: Invalid request or missing preview header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized - missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Activity task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Activity task is not currently owned by this remote worker
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /v1/engine/instances/{instance_key}:
     get:
       operationId: getEngineInstance
@@ -1311,6 +1509,115 @@ components:
         attempt_count:
           type: integer
           format: int32
+
+    EngineRemoteActivityClaimRequest:
+      type: object
+      required: [worker_id, activity_types]
+      properties:
+        worker_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        activity_types:
+          type: array
+          minItems: 1
+          maxItems: 50
+          items:
+            type: string
+            minLength: 1
+            maxLength: 256
+        lease_duration:
+          type: string
+          description: Requested lease duration, e.g. 60s or 5m. The server clamps the effective value.
+        max_tasks:
+          type: integer
+          minimum: 1
+          maximum: 50
+
+    EngineRemoteActivityTask:
+      type: object
+      required:
+        - task_id
+        - activity_key
+        - activity_type
+        - input
+        - lease_expires_at
+        - effective_lease_duration_ms
+      properties:
+        task_id:
+          type: string
+          format: uuid
+        activity_key:
+          type: string
+        activity_type:
+          type: string
+        input:
+          description: Activity input payload (any valid JSON)
+        lease_expires_at:
+          type: string
+          format: date-time
+        effective_lease_duration_ms:
+          type: integer
+          format: int64
+
+    EngineRemoteActivityClaimResponse:
+      type: object
+      required: [tasks]
+      properties:
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineRemoteActivityTask'
+
+    EngineRemoteActivityHeartbeatRequest:
+      type: object
+      required: [worker_id]
+      properties:
+        worker_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+
+    EngineRemoteActivityHeartbeatResponse:
+      type: object
+      required: [lease_expires_at, effective_lease_duration_ms]
+      properties:
+        lease_expires_at:
+          type: string
+          format: date-time
+        effective_lease_duration_ms:
+          type: integer
+          format: int64
+
+    EngineRemoteActivityCompleteRequest:
+      type: object
+      required: [worker_id, output]
+      properties:
+        worker_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        output:
+          description: Activity output payload (any valid JSON)
+
+    EngineRemoteActivityFailRequest:
+      type: object
+      required: [worker_id, error_code, error_message]
+      properties:
+        worker_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        error_code:
+          type: string
+          minLength: 1
+          maxLength: 128
+        error_message:
+          type: string
+          maxLength: 4096
+        non_retryable:
+          type: boolean
+          default: false
 
     EnginePendingTimerItem:
       type: object

--- a/engine/db/gen/go/activity_tasks.sql.go
+++ b/engine/db/gen/go/activity_tasks.sql.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const cancelOpenActivityTasksByRun = `-- name: CancelOpenActivityTasksByRun :many
@@ -22,7 +23,7 @@ SET status = 'cancelled',
     updated_at = NOW()
 WHERE run_id = $1
   AND status IN ('queued', 'claimed')
-RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 func (q *Queries) CancelOpenActivityTasksByRun(ctx context.Context, runID uuid.UUID) ([]EngineActivityTask, error) {
@@ -59,6 +60,8 @@ func (q *Queries) CancelOpenActivityTasksByRun(ctx context.Context, runID uuid.U
 			&i.InitialBackoffMs,
 			&i.MaxBackoffMs,
 			&i.BackoffMultiplier,
+			&i.ExecutionTarget,
+			&i.LeaseDurationMs,
 		); err != nil {
 			return nil, err
 		}
@@ -76,18 +79,20 @@ SET status = 'claimed',
     claimed_by = $1,
     claimed_at = NOW(),
     lease_expires_at = NOW() + ($2::bigint * INTERVAL '1 microsecond'),
+    lease_duration_ms = $2::bigint / 1000,
     attempt_count = attempt_count + 1,
     updated_at = NOW()
 WHERE id = (
     SELECT id
     FROM engine.activity_tasks
-    WHERE (status = 'queued' AND available_at <= NOW())
-       OR (status = 'claimed' AND lease_expires_at IS NOT NULL AND lease_expires_at < NOW())
+    WHERE execution_target = 'local'
+      AND ((status = 'queued' AND available_at <= NOW())
+        OR (status = 'claimed' AND lease_expires_at IS NOT NULL AND lease_expires_at < NOW()))
     ORDER BY available_at ASC, id ASC
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 type ClaimNextActivityTaskParams struct {
@@ -123,6 +128,8 @@ func (q *Queries) ClaimNextActivityTask(ctx context.Context, arg ClaimNextActivi
 		&i.InitialBackoffMs,
 		&i.MaxBackoffMs,
 		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
 	)
 	return i, err
 }
@@ -133,19 +140,21 @@ SET status = 'claimed',
     claimed_by = $1,
     claimed_at = NOW(),
     lease_expires_at = NOW() + ($2::bigint * INTERVAL '1 microsecond'),
+    lease_duration_ms = $2::bigint / 1000,
     attempt_count = attempt_count + 1,
     updated_at = NOW()
 WHERE id = (
     SELECT candidate.id
     FROM engine.activity_tasks AS candidate
     WHERE candidate.project_id = $3
+      AND candidate.execution_target = 'local'
       AND ((candidate.status = 'queued' AND candidate.available_at <= NOW())
         OR (candidate.status = 'claimed' AND candidate.lease_expires_at IS NOT NULL AND candidate.lease_expires_at < NOW()))
     ORDER BY candidate.available_at ASC, candidate.id ASC
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 type ClaimNextActivityTaskByProjectParams struct {
@@ -182,8 +191,97 @@ func (q *Queries) ClaimNextActivityTaskByProject(ctx context.Context, arg ClaimN
 		&i.InitialBackoffMs,
 		&i.MaxBackoffMs,
 		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
 	)
 	return i, err
+}
+
+const claimRemoteActivityTasks = `-- name: ClaimRemoteActivityTasks :many
+WITH candidates AS (
+    SELECT candidate.id
+    FROM engine.activity_tasks AS candidate
+    WHERE candidate.project_id = $3
+      AND candidate.execution_target = 'remote'
+      AND candidate.activity_type = ANY($4::text[])
+      AND ((candidate.status = 'queued' AND candidate.available_at <= NOW())
+        OR (candidate.status = 'claimed' AND candidate.lease_expires_at IS NOT NULL AND candidate.lease_expires_at < NOW()))
+    ORDER BY candidate.available_at ASC, candidate.id ASC
+    LIMIT $5::int
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE engine.activity_tasks AS task
+SET status = 'claimed',
+    claimed_by = $1,
+    claimed_at = NOW(),
+    lease_expires_at = NOW() + ($2::bigint * INTERVAL '1 millisecond'),
+    lease_duration_ms = $2,
+    attempt_count = task.attempt_count + 1,
+    updated_at = NOW()
+FROM candidates
+WHERE task.id = candidates.id
+RETURNING task.id, task.project_id, task.instance_id, task.run_id, task.history_id, task.activity_key, task.activity_type, task.input, task.output, task.status, task.available_at, task.attempt_count, task.claimed_by, task.claimed_at, task.lease_expires_at, task.last_error_code, task.last_error_message, task.completed_at, task.created_at, task.updated_at, task.max_attempts, task.initial_backoff_ms, task.max_backoff_ms, task.backoff_multiplier, task.execution_target, task.lease_duration_ms
+`
+
+type ClaimRemoteActivityTasksParams struct {
+	ClaimedBy       *string   `json:"claimed_by"`
+	LeaseDurationMs *int64    `json:"lease_duration_ms"`
+	ProjectFilterID uuid.UUID `json:"project_filter_id"`
+	ActivityTypes   []string  `json:"activity_types"`
+	MaxTasks        int32     `json:"max_tasks"`
+}
+
+func (q *Queries) ClaimRemoteActivityTasks(ctx context.Context, arg ClaimRemoteActivityTasksParams) ([]EngineActivityTask, error) {
+	rows, err := q.db.Query(ctx, claimRemoteActivityTasks,
+		arg.ClaimedBy,
+		arg.LeaseDurationMs,
+		arg.ProjectFilterID,
+		arg.ActivityTypes,
+		arg.MaxTasks,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineActivityTask{}
+	for rows.Next() {
+		var i EngineActivityTask
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.ActivityKey,
+			&i.ActivityType,
+			&i.Input,
+			&i.Output,
+			&i.Status,
+			&i.AvailableAt,
+			&i.AttemptCount,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.LastErrorCode,
+			&i.LastErrorMessage,
+			&i.CompletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.MaxAttempts,
+			&i.InitialBackoffMs,
+			&i.MaxBackoffMs,
+			&i.BackoffMultiplier,
+			&i.ExecutionTarget,
+			&i.LeaseDurationMs,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const clearActivityTaskHistoryByRun = `-- name: ClearActivityTaskHistoryByRun :execrows
@@ -214,7 +312,7 @@ SET status = 'completed',
 WHERE id = $1
   AND status = 'claimed'
   AND claimed_by = $2
-RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 type CompleteActivityTaskParams struct {
@@ -251,6 +349,73 @@ func (q *Queries) CompleteActivityTask(ctx context.Context, arg CompleteActivity
 		&i.InitialBackoffMs,
 		&i.MaxBackoffMs,
 		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
+	)
+	return i, err
+}
+
+const completeRemoteActivityTask = `-- name: CompleteRemoteActivityTask :one
+UPDATE engine.activity_tasks
+SET status = 'completed',
+    output = $1,
+    completed_at = NOW(),
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $2
+  AND project_id = $3
+  AND execution_target = 'remote'
+  AND status = 'claimed'
+  AND claimed_by = $4
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
+`
+
+type CompleteRemoteActivityTaskParams struct {
+	Output    []byte    `json:"output"`
+	ID        uuid.UUID `json:"id"`
+	ProjectID uuid.UUID `json:"project_id"`
+	ClaimedBy *string   `json:"claimed_by"`
+}
+
+func (q *Queries) CompleteRemoteActivityTask(ctx context.Context, arg CompleteRemoteActivityTaskParams) (EngineActivityTask, error) {
+	row := q.db.QueryRow(ctx, completeRemoteActivityTask,
+		arg.Output,
+		arg.ID,
+		arg.ProjectID,
+		arg.ClaimedBy,
+	)
+	var i EngineActivityTask
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunID,
+		&i.HistoryID,
+		&i.ActivityKey,
+		&i.ActivityType,
+		&i.Input,
+		&i.Output,
+		&i.Status,
+		&i.AvailableAt,
+		&i.AttemptCount,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.CompletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.MaxAttempts,
+		&i.InitialBackoffMs,
+		&i.MaxBackoffMs,
+		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
 	)
 	return i, err
 }
@@ -279,13 +444,14 @@ INSERT INTO engine.activity_tasks (
     activity_type,
     input,
     available_at,
+    execution_target,
     max_attempts,
     initial_backoff_ms,
     max_backoff_ms,
     backoff_multiplier
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 type CreateActivityTaskParams struct {
@@ -297,6 +463,7 @@ type CreateActivityTaskParams struct {
 	ActivityType      string    `json:"activity_type"`
 	Input             []byte    `json:"input"`
 	AvailableAt       time.Time `json:"available_at"`
+	ExecutionTarget   string    `json:"execution_target"`
 	MaxAttempts       int32     `json:"max_attempts"`
 	InitialBackoffMs  *int64    `json:"initial_backoff_ms"`
 	MaxBackoffMs      *int64    `json:"max_backoff_ms"`
@@ -313,6 +480,7 @@ func (q *Queries) CreateActivityTask(ctx context.Context, arg CreateActivityTask
 		arg.ActivityType,
 		arg.Input,
 		arg.AvailableAt,
+		arg.ExecutionTarget,
 		arg.MaxAttempts,
 		arg.InitialBackoffMs,
 		arg.MaxBackoffMs,
@@ -344,6 +512,8 @@ func (q *Queries) CreateActivityTask(ctx context.Context, arg CreateActivityTask
 		&i.InitialBackoffMs,
 		&i.MaxBackoffMs,
 		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
 	)
 	return i, err
 }
@@ -361,7 +531,7 @@ SET status = 'failed',
 WHERE id = $1
   AND status = 'claimed'
   AND claimed_by = $2
-RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 type FailActivityTaskParams struct {
@@ -404,12 +574,82 @@ func (q *Queries) FailActivityTask(ctx context.Context, arg FailActivityTaskPara
 		&i.InitialBackoffMs,
 		&i.MaxBackoffMs,
 		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
+	)
+	return i, err
+}
+
+const failRemoteActivityTask = `-- name: FailRemoteActivityTask :one
+UPDATE engine.activity_tasks
+SET status = 'failed',
+    last_error_code = $1,
+    last_error_message = $2,
+    completed_at = NOW(),
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $3
+  AND project_id = $4
+  AND execution_target = 'remote'
+  AND status = 'claimed'
+  AND claimed_by = $5
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
+`
+
+type FailRemoteActivityTaskParams struct {
+	LastErrorCode    *string   `json:"last_error_code"`
+	LastErrorMessage *string   `json:"last_error_message"`
+	ID               uuid.UUID `json:"id"`
+	ProjectID        uuid.UUID `json:"project_id"`
+	ClaimedBy        *string   `json:"claimed_by"`
+}
+
+func (q *Queries) FailRemoteActivityTask(ctx context.Context, arg FailRemoteActivityTaskParams) (EngineActivityTask, error) {
+	row := q.db.QueryRow(ctx, failRemoteActivityTask,
+		arg.LastErrorCode,
+		arg.LastErrorMessage,
+		arg.ID,
+		arg.ProjectID,
+		arg.ClaimedBy,
+	)
+	var i EngineActivityTask
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunID,
+		&i.HistoryID,
+		&i.ActivityKey,
+		&i.ActivityType,
+		&i.Input,
+		&i.Output,
+		&i.Status,
+		&i.AvailableAt,
+		&i.AttemptCount,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.CompletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.MaxAttempts,
+		&i.InitialBackoffMs,
+		&i.MaxBackoffMs,
+		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
 	)
 	return i, err
 }
 
 const getActivityTask = `-- name: GetActivityTask :one
-SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 FROM engine.activity_tasks
 WHERE id = $1
 `
@@ -442,12 +682,61 @@ func (q *Queries) GetActivityTask(ctx context.Context, id uuid.UUID) (EngineActi
 		&i.InitialBackoffMs,
 		&i.MaxBackoffMs,
 		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
+	)
+	return i, err
+}
+
+const getActivityTaskByProjectForUpdate = `-- name: GetActivityTaskByProjectForUpdate :one
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
+FROM engine.activity_tasks
+WHERE id = $1
+  AND project_id = $2
+FOR UPDATE
+`
+
+type GetActivityTaskByProjectForUpdateParams struct {
+	ID        uuid.UUID `json:"id"`
+	ProjectID uuid.UUID `json:"project_id"`
+}
+
+func (q *Queries) GetActivityTaskByProjectForUpdate(ctx context.Context, arg GetActivityTaskByProjectForUpdateParams) (EngineActivityTask, error) {
+	row := q.db.QueryRow(ctx, getActivityTaskByProjectForUpdate, arg.ID, arg.ProjectID)
+	var i EngineActivityTask
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunID,
+		&i.HistoryID,
+		&i.ActivityKey,
+		&i.ActivityType,
+		&i.Input,
+		&i.Output,
+		&i.Status,
+		&i.AvailableAt,
+		&i.AttemptCount,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.CompletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.MaxAttempts,
+		&i.InitialBackoffMs,
+		&i.MaxBackoffMs,
+		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
 	)
 	return i, err
 }
 
 const getActivityTaskByRunAndKey = `-- name: GetActivityTaskByRunAndKey :one
-SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 FROM engine.activity_tasks
 WHERE run_id = $1
   AND activity_key = $2
@@ -486,12 +775,107 @@ func (q *Queries) GetActivityTaskByRunAndKey(ctx context.Context, arg GetActivit
 		&i.InitialBackoffMs,
 		&i.MaxBackoffMs,
 		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
+	)
+	return i, err
+}
+
+const getActivityTaskRemoteConflictState = `-- name: GetActivityTaskRemoteConflictState :one
+SELECT id, project_id, execution_target, status, claimed_by, lease_expires_at, completed_at
+FROM engine.activity_tasks
+WHERE id = $1
+  AND project_id = $2
+`
+
+type GetActivityTaskRemoteConflictStateParams struct {
+	ID        uuid.UUID `json:"id"`
+	ProjectID uuid.UUID `json:"project_id"`
+}
+
+type GetActivityTaskRemoteConflictStateRow struct {
+	ID              uuid.UUID                `json:"id"`
+	ProjectID       uuid.UUID                `json:"project_id"`
+	ExecutionTarget string                   `json:"execution_target"`
+	Status          EngineActivityTaskStatus `json:"status"`
+	ClaimedBy       *string                  `json:"claimed_by"`
+	LeaseExpiresAt  pgtype.Timestamptz       `json:"lease_expires_at"`
+	CompletedAt     pgtype.Timestamptz       `json:"completed_at"`
+}
+
+func (q *Queries) GetActivityTaskRemoteConflictState(ctx context.Context, arg GetActivityTaskRemoteConflictStateParams) (GetActivityTaskRemoteConflictStateRow, error) {
+	row := q.db.QueryRow(ctx, getActivityTaskRemoteConflictState, arg.ID, arg.ProjectID)
+	var i GetActivityTaskRemoteConflictStateRow
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.ExecutionTarget,
+		&i.Status,
+		&i.ClaimedBy,
+		&i.LeaseExpiresAt,
+		&i.CompletedAt,
+	)
+	return i, err
+}
+
+const heartbeatRemoteActivityTask = `-- name: HeartbeatRemoteActivityTask :one
+UPDATE engine.activity_tasks
+SET lease_expires_at = NOW() + (lease_duration_ms * INTERVAL '1 millisecond'),
+    updated_at = NOW()
+WHERE id = $1
+  AND project_id = $2
+  AND execution_target = 'remote'
+  AND status = 'claimed'
+  AND claimed_by = $3
+  AND lease_duration_ms IS NOT NULL
+  AND lease_duration_ms > 0
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
+`
+
+type HeartbeatRemoteActivityTaskParams struct {
+	ID        uuid.UUID `json:"id"`
+	ProjectID uuid.UUID `json:"project_id"`
+	ClaimedBy *string   `json:"claimed_by"`
+}
+
+func (q *Queries) HeartbeatRemoteActivityTask(ctx context.Context, arg HeartbeatRemoteActivityTaskParams) (EngineActivityTask, error) {
+	row := q.db.QueryRow(ctx, heartbeatRemoteActivityTask, arg.ID, arg.ProjectID, arg.ClaimedBy)
+	var i EngineActivityTask
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunID,
+		&i.HistoryID,
+		&i.ActivityKey,
+		&i.ActivityType,
+		&i.Input,
+		&i.Output,
+		&i.Status,
+		&i.AvailableAt,
+		&i.AttemptCount,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.CompletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.MaxAttempts,
+		&i.InitialBackoffMs,
+		&i.MaxBackoffMs,
+		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
 	)
 	return i, err
 }
 
 const listActivityTasksByRun = `-- name: ListActivityTasksByRun :many
-SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 FROM engine.activity_tasks
 WHERE run_id = $1
 ORDER BY created_at ASC, id ASC
@@ -531,6 +915,8 @@ func (q *Queries) ListActivityTasksByRun(ctx context.Context, runID uuid.UUID) (
 			&i.InitialBackoffMs,
 			&i.MaxBackoffMs,
 			&i.BackoffMultiplier,
+			&i.ExecutionTarget,
+			&i.LeaseDurationMs,
 		); err != nil {
 			return nil, err
 		}
@@ -543,7 +929,7 @@ func (q *Queries) ListActivityTasksByRun(ctx context.Context, runID uuid.UUID) (
 }
 
 const listCancelledActivityTasksByRun = `-- name: ListCancelledActivityTasksByRun :many
-SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 FROM engine.activity_tasks
 WHERE run_id = $1
   AND status = 'cancelled'
@@ -584,6 +970,8 @@ func (q *Queries) ListCancelledActivityTasksByRun(ctx context.Context, runID uui
 			&i.InitialBackoffMs,
 			&i.MaxBackoffMs,
 			&i.BackoffMultiplier,
+			&i.ExecutionTarget,
+			&i.LeaseDurationMs,
 		); err != nil {
 			return nil, err
 		}
@@ -596,7 +984,7 @@ func (q *Queries) ListCancelledActivityTasksByRun(ctx context.Context, runID uui
 }
 
 const listOpenActivityTasksByRun = `-- name: ListOpenActivityTasksByRun :many
-SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+SELECT id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 FROM engine.activity_tasks
 WHERE run_id = $1
   AND status IN ('queued', 'claimed')
@@ -637,6 +1025,8 @@ func (q *Queries) ListOpenActivityTasksByRun(ctx context.Context, runID uuid.UUI
 			&i.InitialBackoffMs,
 			&i.MaxBackoffMs,
 			&i.BackoffMultiplier,
+			&i.ExecutionTarget,
+			&i.LeaseDurationMs,
 		); err != nil {
 			return nil, err
 		}
@@ -659,7 +1049,7 @@ SET status = 'queued',
 WHERE id = $2
   AND status = 'claimed'
   AND claimed_by = $3
-RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 type RetryActivityTaskParams struct {
@@ -696,6 +1086,78 @@ func (q *Queries) RetryActivityTask(ctx context.Context, arg RetryActivityTaskPa
 		&i.InitialBackoffMs,
 		&i.MaxBackoffMs,
 		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
+	)
+	return i, err
+}
+
+const retryRemoteActivityTask = `-- name: RetryRemoteActivityTask :one
+UPDATE engine.activity_tasks
+SET status = 'queued',
+    available_at = NOW() + ($1::bigint * INTERVAL '1 millisecond'),
+    last_error_code = $2,
+    last_error_message = $3,
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $4
+  AND project_id = $5
+  AND execution_target = 'remote'
+  AND status = 'claimed'
+  AND claimed_by = $6
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
+`
+
+type RetryRemoteActivityTaskParams struct {
+	RetryDelayMs     int64     `json:"retry_delay_ms"`
+	LastErrorCode    *string   `json:"last_error_code"`
+	LastErrorMessage *string   `json:"last_error_message"`
+	ID               uuid.UUID `json:"id"`
+	ProjectID        uuid.UUID `json:"project_id"`
+	ClaimedBy        *string   `json:"claimed_by"`
+}
+
+func (q *Queries) RetryRemoteActivityTask(ctx context.Context, arg RetryRemoteActivityTaskParams) (EngineActivityTask, error) {
+	row := q.db.QueryRow(ctx, retryRemoteActivityTask,
+		arg.RetryDelayMs,
+		arg.LastErrorCode,
+		arg.LastErrorMessage,
+		arg.ID,
+		arg.ProjectID,
+		arg.ClaimedBy,
+	)
+	var i EngineActivityTask
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunID,
+		&i.HistoryID,
+		&i.ActivityKey,
+		&i.ActivityType,
+		&i.Input,
+		&i.Output,
+		&i.Status,
+		&i.AvailableAt,
+		&i.AttemptCount,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.CompletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.MaxAttempts,
+		&i.InitialBackoffMs,
+		&i.MaxBackoffMs,
+		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
 	)
 	return i, err
 }

--- a/engine/db/gen/go/models.go
+++ b/engine/db/gen/go/models.go
@@ -310,6 +310,8 @@ type EngineActivityTask struct {
 	InitialBackoffMs  *int64                   `json:"initial_backoff_ms"`
 	MaxBackoffMs      *int64                   `json:"max_backoff_ms"`
 	BackoffMultiplier *float64                 `json:"backoff_multiplier"`
+	ExecutionTarget   string                   `json:"execution_target"`
+	LeaseDurationMs   *int64                   `json:"lease_duration_ms"`
 }
 
 type EngineChildWorkflow struct {

--- a/engine/db/migrations/postgres/000011_remote_activity_execution_target.down.sql
+++ b/engine/db/migrations/postgres/000011_remote_activity_execution_target.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS engine.idx_engine_activity_tasks_claim_remote;
+DROP INDEX IF EXISTS engine.idx_engine_activity_tasks_claim_local;
+
+ALTER TABLE engine.activity_tasks
+    DROP CONSTRAINT IF EXISTS engine_activity_tasks_execution_target_check,
+    DROP COLUMN IF EXISTS lease_duration_ms,
+    DROP COLUMN IF EXISTS execution_target;

--- a/engine/db/migrations/postgres/000011_remote_activity_execution_target.up.sql
+++ b/engine/db/migrations/postgres/000011_remote_activity_execution_target.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE engine.activity_tasks
+    ADD COLUMN execution_target TEXT NOT NULL DEFAULT 'local',
+    ADD COLUMN lease_duration_ms BIGINT,
+    ADD CONSTRAINT engine_activity_tasks_execution_target_check
+        CHECK (execution_target IN ('local', 'remote'));
+
+CREATE INDEX idx_engine_activity_tasks_claim_local
+    ON engine.activity_tasks(status, available_at, lease_expires_at)
+    WHERE execution_target = 'local' AND status IN ('queued', 'claimed');
+
+CREATE INDEX idx_engine_activity_tasks_claim_remote
+    ON engine.activity_tasks(project_id, activity_type, status, available_at, lease_expires_at)
+    WHERE execution_target = 'remote' AND status IN ('queued', 'claimed');

--- a/engine/db/queries/activity_tasks.sql
+++ b/engine/db/queries/activity_tasks.sql
@@ -8,12 +8,13 @@ INSERT INTO engine.activity_tasks (
     activity_type,
     input,
     available_at,
+    execution_target,
     max_attempts,
     initial_backoff_ms,
     max_backoff_ms,
     backoff_multiplier
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 RETURNING *;
 
 -- name: GetActivityTask :one
@@ -59,13 +60,15 @@ SET status = 'claimed',
     claimed_by = sqlc.arg(claimed_by),
     claimed_at = NOW(),
     lease_expires_at = NOW() + (sqlc.arg(lease_duration_micros)::bigint * INTERVAL '1 microsecond'),
+    lease_duration_ms = sqlc.arg(lease_duration_micros)::bigint / 1000,
     attempt_count = attempt_count + 1,
     updated_at = NOW()
 WHERE id = (
     SELECT id
     FROM engine.activity_tasks
-    WHERE (status = 'queued' AND available_at <= NOW())
-       OR (status = 'claimed' AND lease_expires_at IS NOT NULL AND lease_expires_at < NOW())
+    WHERE execution_target = 'local'
+      AND ((status = 'queued' AND available_at <= NOW())
+        OR (status = 'claimed' AND lease_expires_at IS NOT NULL AND lease_expires_at < NOW()))
     ORDER BY available_at ASC, id ASC
     LIMIT 1
     FOR UPDATE SKIP LOCKED
@@ -78,18 +81,129 @@ SET status = 'claimed',
     claimed_by = sqlc.arg(claimed_by),
     claimed_at = NOW(),
     lease_expires_at = NOW() + (sqlc.arg(lease_duration_micros)::bigint * INTERVAL '1 microsecond'),
+    lease_duration_ms = sqlc.arg(lease_duration_micros)::bigint / 1000,
     attempt_count = attempt_count + 1,
     updated_at = NOW()
 WHERE id = (
     SELECT candidate.id
     FROM engine.activity_tasks AS candidate
     WHERE candidate.project_id = sqlc.arg(project_filter_id)
+      AND candidate.execution_target = 'local'
       AND ((candidate.status = 'queued' AND candidate.available_at <= NOW())
         OR (candidate.status = 'claimed' AND candidate.lease_expires_at IS NOT NULL AND candidate.lease_expires_at < NOW()))
     ORDER BY candidate.available_at ASC, candidate.id ASC
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
+RETURNING *;
+
+-- name: ClaimRemoteActivityTasks :many
+WITH candidates AS (
+    SELECT candidate.id
+    FROM engine.activity_tasks AS candidate
+    WHERE candidate.project_id = sqlc.arg(project_filter_id)
+      AND candidate.execution_target = 'remote'
+      AND candidate.activity_type = ANY(sqlc.arg(activity_types)::text[])
+      AND ((candidate.status = 'queued' AND candidate.available_at <= NOW())
+        OR (candidate.status = 'claimed' AND candidate.lease_expires_at IS NOT NULL AND candidate.lease_expires_at < NOW()))
+    ORDER BY candidate.available_at ASC, candidate.id ASC
+    LIMIT sqlc.arg(max_tasks)::int
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE engine.activity_tasks AS task
+SET status = 'claimed',
+    claimed_by = sqlc.arg(claimed_by),
+    claimed_at = NOW(),
+    lease_expires_at = NOW() + (sqlc.arg(lease_duration_ms)::bigint * INTERVAL '1 millisecond'),
+    lease_duration_ms = sqlc.arg(lease_duration_ms),
+    attempt_count = task.attempt_count + 1,
+    updated_at = NOW()
+FROM candidates
+WHERE task.id = candidates.id
+RETURNING task.*;
+
+-- name: GetActivityTaskRemoteConflictState :one
+SELECT id, project_id, execution_target, status, claimed_by, lease_expires_at, completed_at
+FROM engine.activity_tasks
+WHERE id = $1
+  AND project_id = $2;
+
+-- name: GetActivityTaskByProjectForUpdate :one
+SELECT *
+FROM engine.activity_tasks
+WHERE id = $1
+  AND project_id = $2
+FOR UPDATE;
+
+-- name: HeartbeatRemoteActivityTask :one
+UPDATE engine.activity_tasks
+SET lease_expires_at = NOW() + (lease_duration_ms * INTERVAL '1 millisecond'),
+    updated_at = NOW()
+WHERE id = sqlc.arg(id)
+  AND project_id = sqlc.arg(project_id)
+  AND execution_target = 'remote'
+  AND status = 'claimed'
+  AND claimed_by = sqlc.arg(claimed_by)
+  AND lease_duration_ms IS NOT NULL
+  AND lease_duration_ms > 0
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
+RETURNING *;
+
+-- name: CompleteRemoteActivityTask :one
+UPDATE engine.activity_tasks
+SET status = 'completed',
+    output = sqlc.arg(output),
+    completed_at = NOW(),
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = sqlc.arg(id)
+  AND project_id = sqlc.arg(project_id)
+  AND execution_target = 'remote'
+  AND status = 'claimed'
+  AND claimed_by = sqlc.arg(claimed_by)
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
+RETURNING *;
+
+-- name: RetryRemoteActivityTask :one
+UPDATE engine.activity_tasks
+SET status = 'queued',
+    available_at = NOW() + (sqlc.arg(retry_delay_ms)::bigint * INTERVAL '1 millisecond'),
+    last_error_code = sqlc.arg(last_error_code),
+    last_error_message = sqlc.arg(last_error_message),
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = sqlc.arg(id)
+  AND project_id = sqlc.arg(project_id)
+  AND execution_target = 'remote'
+  AND status = 'claimed'
+  AND claimed_by = sqlc.arg(claimed_by)
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
+RETURNING *;
+
+-- name: FailRemoteActivityTask :one
+UPDATE engine.activity_tasks
+SET status = 'failed',
+    last_error_code = sqlc.arg(last_error_code),
+    last_error_message = sqlc.arg(last_error_message),
+    completed_at = NOW(),
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = sqlc.arg(id)
+  AND project_id = sqlc.arg(project_id)
+  AND execution_target = 'remote'
+  AND status = 'claimed'
+  AND claimed_by = sqlc.arg(claimed_by)
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
 RETURNING *;
 
 -- name: CompleteActivityTask :one

--- a/engine/internal/activity/worker.go
+++ b/engine/internal/activity/worker.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math"
 	"time"
 
 	"github.com/google/uuid"
@@ -187,16 +186,16 @@ func computeRetryDelayMS(task *enginedb.EngineActivityTask) (int64, error) {
 	if task == nil {
 		return 0, errors.New("activity task is required")
 	}
-	if task.InitialBackoffMs == nil || task.MaxBackoffMs == nil || task.BackoffMultiplier == nil {
-		return 0, fmt.Errorf("activity task %s is missing retry policy fields", task.ID)
+	retryDelayMS, err := publicworkflow.ComputeActivityRetryDelayMS(
+		task.AttemptCount,
+		task.InitialBackoffMs,
+		task.MaxBackoffMs,
+		task.BackoffMultiplier,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("activity task %s retry policy: %w", task.ID, err)
 	}
-
-	exponent := float64(task.AttemptCount - 1)
-	rawDelayMS := float64(*task.InitialBackoffMs) * math.Pow(*task.BackoffMultiplier, exponent)
-	if maxBackoffMS := float64(*task.MaxBackoffMs); rawDelayMS > maxBackoffMS {
-		rawDelayMS = maxBackoffMS
-	}
-	return int64(math.Ceil(rawDelayMS)), nil
+	return retryDelayMS, nil
 }
 
 func (w *Worker) failTask(

--- a/engine/internal/activity/worker_test.go
+++ b/engine/internal/activity/worker_test.go
@@ -731,6 +731,7 @@ func createRunWithPendingActivityConfig(
 		ActivityType:      cfg.activityType,
 		Input:             mustJSON(t, map[string]string{"step": "work"}),
 		AvailableAt:       time.Now().UTC(),
+		ExecutionTarget:   "local",
 		MaxAttempts:       cfg.maxAttempts,
 		InitialBackoffMs:  cfg.initialBackoffMS,
 		MaxBackoffMs:      cfg.maxBackoffMS,

--- a/engine/internal/projector/projector_test.go
+++ b/engine/internal/projector/projector_test.go
@@ -689,15 +689,16 @@ func TestProjectorPollOnce_TerminatedHistoryProjectsFailureAndCleanup(t *testing
 	})
 
 	if _, err := fixture.store.CreateActivityTask(fixture.ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    fixture.projectID,
-		InstanceID:   fixture.instance.ID,
-		RunID:        fixture.run.ID,
-		HistoryID:    &activityHistory.ID,
-		ActivityKey:  "ship-order",
-		ActivityType: "demo.ship",
-		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
-		AvailableAt:  baseTime.Add(time.Minute),
-		MaxAttempts:  1,
+		ProjectID:       fixture.projectID,
+		InstanceID:      fixture.instance.ID,
+		RunID:           fixture.run.ID,
+		HistoryID:       &activityHistory.ID,
+		ActivityKey:     "ship-order",
+		ActivityType:    "demo.ship",
+		Input:           mustJSON(t, map[string]any{"order_id": "ord-123"}),
+		AvailableAt:     baseTime.Add(time.Minute),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	}); err != nil {
 		t.Fatalf("CreateActivityTask() error = %v", err)
 	}
@@ -1100,14 +1101,15 @@ func TestProjectorPollOnce_ContinuedAsNewProjectsCompletedTerminalShell(t *testi
 	completedAt := time.Now().UTC().Round(time.Microsecond)
 
 	if _, err := fixture.store.CreateActivityTask(fixture.ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    fixture.projectID,
-		InstanceID:   fixture.instance.ID,
-		RunID:        fixture.run.ID,
-		ActivityKey:  "ship-order",
-		ActivityType: "demo.ship",
-		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
-		AvailableAt:  completedAt.Add(-time.Minute),
-		MaxAttempts:  1,
+		ProjectID:       fixture.projectID,
+		InstanceID:      fixture.instance.ID,
+		RunID:           fixture.run.ID,
+		ActivityKey:     "ship-order",
+		ActivityType:    "demo.ship",
+		Input:           mustJSON(t, map[string]any{"order_id": "ord-123"}),
+		AvailableAt:     completedAt.Add(-time.Minute),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	}); err != nil {
 		t.Fatalf("CreateActivityTask() error = %v", err)
 	}
@@ -1244,15 +1246,16 @@ func TestProjectorPollOnce_TerminatedCleanupSkipsAlreadyCompletedActivities(t *t
 		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
 	})
 	activityTask, err := fixture.store.CreateActivityTask(fixture.ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    fixture.projectID,
-		InstanceID:   fixture.instance.ID,
-		RunID:        fixture.run.ID,
-		HistoryID:    &activityHistory.ID,
-		ActivityKey:  "ship-order",
-		ActivityType: "demo.ship",
-		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
-		AvailableAt:  baseTime,
-		MaxAttempts:  1,
+		ProjectID:       fixture.projectID,
+		InstanceID:      fixture.instance.ID,
+		RunID:           fixture.run.ID,
+		HistoryID:       &activityHistory.ID,
+		ActivityKey:     "ship-order",
+		ActivityType:    "demo.ship",
+		Input:           mustJSON(t, map[string]any{"order_id": "ord-123"}),
+		AvailableAt:     baseTime,
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	})
 	if err != nil {
 		t.Fatalf("CreateActivityTask() error = %v", err)

--- a/engine/internal/store/activity_tasks.go
+++ b/engine/internal/store/activity_tasks.go
@@ -69,6 +69,41 @@ func (o *storeOps) ClaimNextActivityTask(
 	}))
 }
 
+func (o *storeOps) ClaimRemoteActivityTasks(
+	ctx context.Context,
+	projectID uuid.UUID,
+	workerID string,
+	activityTypes []string,
+	maxTasks int32,
+	leaseDuration time.Duration,
+) ([]enginedb.EngineActivityTask, error) {
+	leaseDurationMS := leaseDuration.Milliseconds()
+	return o.q.ClaimRemoteActivityTasks(ctx, enginedb.ClaimRemoteActivityTasksParams{
+		ProjectFilterID: projectID,
+		ClaimedBy:       nullableWorkerID(workerID),
+		ActivityTypes:   activityTypes,
+		MaxTasks:        maxTasks,
+		LeaseDurationMs: &leaseDurationMS,
+	})
+}
+
+func (o *storeOps) HeartbeatRemoteActivityTask(
+	ctx context.Context,
+	projectID uuid.UUID,
+	id uuid.UUID,
+	claimedBy string,
+) (enginedb.EngineActivityTask, error) {
+	task, err := o.q.HeartbeatRemoteActivityTask(ctx, enginedb.HeartbeatRemoteActivityTaskParams{
+		ID:        id,
+		ProjectID: projectID,
+		ClaimedBy: nullableWorkerID(claimedBy),
+	})
+	if err == nil {
+		return task, nil
+	}
+	return enginedb.EngineActivityTask{}, o.classifyRemoteActivityTaskCASMiss(ctx, projectID, id, err)
+}
+
 func (o *storeOps) CompleteActivityTask(
 	ctx context.Context,
 	id uuid.UUID,
@@ -84,6 +119,25 @@ func (o *storeOps) CompleteActivityTask(
 		return task, nil
 	}
 	return enginedb.EngineActivityTask{}, o.classifyActivityTaskCASMiss(ctx, id, err)
+}
+
+func (o *storeOps) CompleteRemoteActivityTask(
+	ctx context.Context,
+	projectID uuid.UUID,
+	id uuid.UUID,
+	claimedBy string,
+	output []byte,
+) (enginedb.EngineActivityTask, error) {
+	task, err := o.q.CompleteRemoteActivityTask(ctx, enginedb.CompleteRemoteActivityTaskParams{
+		ID:        id,
+		ProjectID: projectID,
+		ClaimedBy: nullableWorkerID(claimedBy),
+		Output:    output,
+	})
+	if err == nil {
+		return task, nil
+	}
+	return enginedb.EngineActivityTask{}, o.classifyRemoteActivityTaskCASMiss(ctx, projectID, id, err)
 }
 
 func (o *storeOps) FailActivityTask(
@@ -103,6 +157,50 @@ func (o *storeOps) FailActivityTask(
 		return task, nil
 	}
 	return enginedb.EngineActivityTask{}, o.classifyActivityTaskCASMiss(ctx, id, err)
+}
+
+func (o *storeOps) RetryRemoteActivityTask(
+	ctx context.Context,
+	projectID uuid.UUID,
+	id uuid.UUID,
+	claimedBy string,
+	retryDelayMS int64,
+	errorCode *string,
+	errorMessage *string,
+) (enginedb.EngineActivityTask, error) {
+	task, err := o.q.RetryRemoteActivityTask(ctx, enginedb.RetryRemoteActivityTaskParams{
+		ID:               id,
+		ProjectID:        projectID,
+		ClaimedBy:        nullableWorkerID(claimedBy),
+		RetryDelayMs:     retryDelayMS,
+		LastErrorCode:    errorCode,
+		LastErrorMessage: errorMessage,
+	})
+	if err == nil {
+		return task, nil
+	}
+	return enginedb.EngineActivityTask{}, o.classifyRemoteActivityTaskCASMiss(ctx, projectID, id, err)
+}
+
+func (o *storeOps) FailRemoteActivityTask(
+	ctx context.Context,
+	projectID uuid.UUID,
+	id uuid.UUID,
+	claimedBy string,
+	errorCode *string,
+	errorMessage *string,
+) (enginedb.EngineActivityTask, error) {
+	task, err := o.q.FailRemoteActivityTask(ctx, enginedb.FailRemoteActivityTaskParams{
+		ID:               id,
+		ProjectID:        projectID,
+		ClaimedBy:        nullableWorkerID(claimedBy),
+		LastErrorCode:    errorCode,
+		LastErrorMessage: errorMessage,
+	})
+	if err == nil {
+		return task, nil
+	}
+	return enginedb.EngineActivityTask{}, o.classifyRemoteActivityTaskCASMiss(ctx, projectID, id, err)
 }
 
 func (o *storeOps) RetryActivityTask(
@@ -136,6 +234,26 @@ func (o *storeOps) classifyActivityTaskCASMiss(ctx context.Context, id uuid.UUID
 
 	if _, lookupErr := o.GetActivityTask(ctx, id); lookupErr != nil {
 		return lookupErr
+	}
+	return ErrStaleClaim
+}
+
+func (o *storeOps) classifyRemoteActivityTaskCASMiss(
+	ctx context.Context,
+	projectID uuid.UUID,
+	id uuid.UUID,
+	err error,
+) error {
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return normalizeError(err)
+	}
+
+	_, lookupErr := o.q.GetActivityTaskRemoteConflictState(ctx, enginedb.GetActivityTaskRemoteConflictStateParams{
+		ID:        id,
+		ProjectID: projectID,
+	})
+	if lookupErr != nil {
+		return normalizeError(lookupErr)
 	}
 	return ErrStaleClaim
 }

--- a/engine/internal/store/constraints_test.go
+++ b/engine/internal/store/constraints_test.go
@@ -38,30 +38,32 @@ func TestConstraintViolationsMapToErrAlreadyExists(t *testing.T) {
 	}
 
 	_, err = ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    projectID,
-		InstanceID:   instance.ID,
-		RunID:        run.ID,
-		HistoryID:    &history.ID,
-		ActivityKey:  "activity-1",
-		ActivityType: "email.send",
-		Input:        []byte(`{"to":"user@example.com"}`),
-		AvailableAt:  time.Now(),
-		MaxAttempts:  1,
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &history.ID,
+		ActivityKey:     "activity-1",
+		ActivityType:    "email.send",
+		Input:           []byte(`{"to":"user@example.com"}`),
+		AvailableAt:     time.Now(),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	})
 	if err != nil {
 		t.Fatalf("CreateActivityTask() error = %v", err)
 	}
 
 	_, err = ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    projectID,
-		InstanceID:   instance.ID,
-		RunID:        run.ID,
-		HistoryID:    &history.ID,
-		ActivityKey:  "activity-1",
-		ActivityType: "email.send",
-		Input:        []byte(`{"to":"user@example.com"}`),
-		AvailableAt:  time.Now(),
-		MaxAttempts:  1,
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &history.ID,
+		ActivityKey:     "activity-1",
+		ActivityType:    "email.send",
+		Input:           []byte(`{"to":"user@example.com"}`),
+		AvailableAt:     time.Now(),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	})
 	if !errors.Is(err, ErrAlreadyExists) {
 		t.Fatalf("expected activity uniqueness error, got %v", err)

--- a/engine/internal/store/leases_test.go
+++ b/engine/internal/store/leases_test.go
@@ -56,15 +56,16 @@ func TestClaimNextActivityTaskLeaseLifecycle(t *testing.T) {
 	history := ts.createHistory(t, projectID, instance.ID, run.ID, 1, "activity.scheduled")
 
 	task, err := ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    projectID,
-		InstanceID:   instance.ID,
-		RunID:        run.ID,
-		HistoryID:    &history.ID,
-		ActivityKey:  "activity-1",
-		ActivityType: "email.send",
-		Input:        []byte(`{"to":"user@example.com"}`),
-		AvailableAt:  time.Now().Add(-time.Minute),
-		MaxAttempts:  1,
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &history.ID,
+		ActivityKey:     "activity-1",
+		ActivityType:    "email.send",
+		Input:           []byte(`{"to":"user@example.com"}`),
+		AvailableAt:     time.Now().Add(-time.Minute),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	})
 	if err != nil {
 		t.Fatalf("CreateActivityTask() error = %v", err)
@@ -97,6 +98,83 @@ func TestClaimNextActivityTaskLeaseLifecycle(t *testing.T) {
 	}
 	if reclaimed.ID != task.ID || reclaimed.AttemptCount != 2 {
 		t.Fatalf("expected reclaimed activity task with attempt_count=2, got id=%s attempts=%d", reclaimed.ID, reclaimed.AttemptCount)
+	}
+}
+
+func TestLocalAndRemoteActivityTaskClaimIsolation(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	instance := ts.createInstance(t, projectID, "instance-activity-targets")
+	run := ts.createRun(t, instance, 1)
+	history := ts.createHistory(t, projectID, instance.ID, run.ID, 1, "activity.scheduled")
+
+	remoteTask, err := ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &history.ID,
+		ActivityKey:     "remote-activity",
+		ActivityType:    "email.send",
+		Input:           []byte(`{"to":"remote@example.com"}`),
+		AvailableAt:     time.Now().Add(-time.Minute),
+		ExecutionTarget: "remote",
+		MaxAttempts:     1,
+	})
+	if err != nil {
+		t.Fatalf("CreateActivityTask(remote) error = %v", err)
+	}
+	localTask, err := ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &history.ID,
+		ActivityKey:     "local-activity",
+		ActivityType:    "email.send",
+		Input:           []byte(`{"to":"local@example.com"}`),
+		AvailableAt:     time.Now().Add(-time.Minute),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
+	})
+	if err != nil {
+		t.Fatalf("CreateActivityTask(local) error = %v", err)
+	}
+
+	claimedLocal, err := ts.store.ClaimNextActivityTask(ts.ctx, "local-worker", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextActivityTask() error = %v", err)
+	}
+	if claimedLocal.ID != localTask.ID {
+		t.Fatalf("expected local worker to claim local task %s, got %s", localTask.ID, claimedLocal.ID)
+	}
+
+	claimedRemote, err := ts.store.ClaimRemoteActivityTasks(
+		ts.ctx,
+		projectID,
+		"remote-worker",
+		[]string{"email.send"},
+		10,
+		time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("ClaimRemoteActivityTasks() error = %v", err)
+	}
+	if len(claimedRemote) != 1 || claimedRemote[0].ID != remoteTask.ID {
+		t.Fatalf("expected remote worker to claim remote task %s, got %+v", remoteTask.ID, claimedRemote)
+	}
+
+	empty, err := ts.store.ClaimRemoteActivityTasks(
+		ts.ctx,
+		projectID,
+		"remote-worker",
+		[]string{"image.process"},
+		10,
+		time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("ClaimRemoteActivityTasks(unmatched) error = %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected unmatched remote type claim to return no tasks, got %+v", empty)
 	}
 }
 

--- a/engine/internal/store/runtime_store_test.go
+++ b/engine/internal/store/runtime_store_test.go
@@ -55,15 +55,16 @@ func TestActivityTaskCASRejectsStaleClaim(t *testing.T) {
 	history := ts.createHistory(t, projectID, instance.ID, run.ID, 1, "activity.scheduled")
 
 	task, err := ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    projectID,
-		InstanceID:   instance.ID,
-		RunID:        run.ID,
-		HistoryID:    &history.ID,
-		ActivityKey:  "activity-1",
-		ActivityType: "demo.echo",
-		Input:        []byte(`{"name":"Ada"}`),
-		AvailableAt:  time.Now().Add(-time.Minute),
-		MaxAttempts:  1,
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &history.ID,
+		ActivityKey:     "activity-1",
+		ActivityType:    "demo.echo",
+		Input:           []byte(`{"name":"Ada"}`),
+		AvailableAt:     time.Now().Add(-time.Minute),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	})
 	if err != nil {
 		t.Fatalf("CreateActivityTask() error = %v", err)

--- a/engine/internal/workflow/activation.go
+++ b/engine/internal/workflow/activation.go
@@ -232,6 +232,7 @@ func (a *Activator) commitDecision(
 			ActivityType:      decision.NewActivity.Scheduled.ActivityType,
 			Input:             decision.NewActivity.Scheduled.Input,
 			AvailableAt:       run.ReadyAt,
+			ExecutionTarget:   decision.NewActivity.Options.ExecutionTarget,
 			MaxAttempts:       decision.NewActivity.Options.MaxAttempts,
 			InitialBackoffMs:  decision.NewActivity.Options.InitialBackoffMS,
 			MaxBackoffMs:      decision.NewActivity.Options.MaxBackoffMS,

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -302,14 +302,15 @@ func TestActivatorContinueAsNewCreatesNewRunAndInheritedTraceShell(t *testing.T)
 	updateProjectedTraceShellFields(t, ctx, db.Pool, run.ID, sessionID)
 
 	if _, err := store.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    run.ProjectID,
-		InstanceID:   run.InstanceID,
-		RunID:        run.ID,
-		ActivityKey:  "stale-activity",
-		ActivityType: "demo.activity",
-		Input:        mustJSON(t, map[string]any{"order_id": "ord-123"}),
-		AvailableAt:  time.Now().Add(-time.Minute),
-		MaxAttempts:  1,
+		ProjectID:       run.ProjectID,
+		InstanceID:      run.InstanceID,
+		RunID:           run.ID,
+		ActivityKey:     "stale-activity",
+		ActivityType:    "demo.activity",
+		Input:           mustJSON(t, map[string]any{"order_id": "ord-123"}),
+		AvailableAt:     time.Now().Add(-time.Minute),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	}); err != nil {
 		t.Fatalf("CreateActivityTask() error = %v", err)
 	}
@@ -1611,6 +1612,7 @@ func TestActivatorPersistsActivityRetryOptions(t *testing.T) {
 
 			var output map[string]string
 			return ctx.ActivityWithOptions("fetch", "demo.activity", input, &output, publicworkflow.ActivityOptions{
+				ExecutionTarget: publicworkflow.ActivityExecutionTargetRemote,
 				RetryPolicy: &publicworkflow.RetryPolicy{
 					MaxAttempts:       3,
 					InitialBackoff:    1500 * time.Millisecond,
@@ -1652,6 +1654,9 @@ func TestActivatorPersistsActivityRetryOptions(t *testing.T) {
 	}
 	if task.BackoffMultiplier == nil || *task.BackoffMultiplier != 2.5 {
 		t.Fatalf("expected backoff_multiplier=2.5, got %+v", task)
+	}
+	if task.ExecutionTarget != publicworkflow.ActivityExecutionTargetRemote {
+		t.Fatalf("expected execution_target=remote, got %+v", task)
 	}
 }
 
@@ -1708,6 +1713,9 @@ func TestActivatorDefaultsActivityRetryOptionsToSingleAttempt(t *testing.T) {
 	}
 	if task.InitialBackoffMs != nil || task.MaxBackoffMs != nil || task.BackoffMultiplier != nil {
 		t.Fatalf("expected nil backoff columns for Activity(), got %+v", task)
+	}
+	if task.ExecutionTarget != publicworkflow.ActivityExecutionTargetLocal {
+		t.Fatalf("expected execution_target=local, got %+v", task)
 	}
 }
 

--- a/engine/pkg/workflow/activity_options.go
+++ b/engine/pkg/workflow/activity_options.go
@@ -3,7 +3,14 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"math"
+	"strings"
 	"time"
+)
+
+const (
+	ActivityExecutionTargetLocal  = "local"
+	ActivityExecutionTargetRemote = "remote"
 )
 
 type RetryPolicy struct {
@@ -14,7 +21,8 @@ type RetryPolicy struct {
 }
 
 type ActivityOptions struct {
-	RetryPolicy *RetryPolicy
+	RetryPolicy     *RetryPolicy
+	ExecutionTarget string
 }
 
 type NormalizedActivityOptions struct {
@@ -22,6 +30,7 @@ type NormalizedActivityOptions struct {
 	InitialBackoffMS  *int64
 	MaxBackoffMS      *int64
 	BackoffMultiplier *float64
+	ExecutionTarget   string
 }
 
 type nonRetryableError struct {
@@ -55,8 +64,17 @@ func IsNonRetryable(err error) bool {
 }
 
 func NormalizeActivityOptions(opts ActivityOptions) (NormalizedActivityOptions, error) {
+	executionTarget, err := normalizeExecutionTarget(opts.ExecutionTarget)
+	if err != nil {
+		return NormalizedActivityOptions{}, err
+	}
+
+	normalized := NormalizedActivityOptions{
+		MaxAttempts:     1,
+		ExecutionTarget: executionTarget,
+	}
 	if opts.RetryPolicy == nil {
-		return NormalizedActivityOptions{MaxAttempts: 1}, nil
+		return normalized, nil
 	}
 
 	policy := opts.RetryPolicy
@@ -64,9 +82,7 @@ func NormalizeActivityOptions(opts ActivityOptions) (NormalizedActivityOptions, 
 		return NormalizedActivityOptions{}, fmt.Errorf("workflow: retry policy max_attempts must be >= 1")
 	}
 
-	normalized := NormalizedActivityOptions{
-		MaxAttempts: int32(policy.MaxAttempts),
-	}
+	normalized.MaxAttempts = int32(policy.MaxAttempts)
 	if policy.MaxAttempts == 1 {
 		return normalized, nil
 	}
@@ -90,4 +106,38 @@ func NormalizeActivityOptions(opts ActivityOptions) (NormalizedActivityOptions, 
 	multiplier := policy.BackoffMultiplier
 	normalized.BackoffMultiplier = &multiplier
 	return normalized, nil
+}
+
+func normalizeExecutionTarget(target string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(target))
+	if normalized == "" {
+		return ActivityExecutionTargetLocal, nil
+	}
+	switch normalized {
+	case ActivityExecutionTargetLocal, ActivityExecutionTargetRemote:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("workflow: activity execution_target must be %q or %q", ActivityExecutionTargetLocal, ActivityExecutionTargetRemote)
+	}
+}
+
+func ComputeActivityRetryDelayMS(
+	attemptCount int32,
+	initialBackoffMS *int64,
+	maxBackoffMS *int64,
+	backoffMultiplier *float64,
+) (int64, error) {
+	if attemptCount < 1 {
+		return 0, fmt.Errorf("workflow: activity retry attempt_count must be >= 1")
+	}
+	if initialBackoffMS == nil || maxBackoffMS == nil || backoffMultiplier == nil {
+		return 0, fmt.Errorf("workflow: activity retry policy fields are required")
+	}
+
+	exponent := float64(attemptCount - 1)
+	rawDelayMS := float64(*initialBackoffMS) * math.Pow(*backoffMultiplier, exponent)
+	if maxBackoff := float64(*maxBackoffMS); rawDelayMS > maxBackoff {
+		rawDelayMS = maxBackoff
+	}
+	return int64(math.Ceil(rawDelayMS)), nil
 }

--- a/engine/pkg/workflow/activity_options_test.go
+++ b/engine/pkg/workflow/activity_options_test.go
@@ -15,6 +15,9 @@ func TestNormalizeActivityOptions(t *testing.T) {
 		if normalized.MaxAttempts != 1 {
 			t.Fatalf("expected max_attempts=1, got %d", normalized.MaxAttempts)
 		}
+		if normalized.ExecutionTarget != ActivityExecutionTargetLocal {
+			t.Fatalf("expected execution_target=local, got %q", normalized.ExecutionTarget)
+		}
 		if normalized.InitialBackoffMS != nil || normalized.MaxBackoffMS != nil || normalized.BackoffMultiplier != nil {
 			t.Fatalf("expected empty retry columns for default options, got %+v", normalized)
 		}
@@ -40,6 +43,19 @@ func TestNormalizeActivityOptions(t *testing.T) {
 		}
 		if normalized.BackoffMultiplier == nil || *normalized.BackoffMultiplier != 2.5 {
 			t.Fatalf("expected backoff_multiplier=2.5, got %+v", normalized.BackoffMultiplier)
+		}
+		if normalized.ExecutionTarget != ActivityExecutionTargetLocal {
+			t.Fatalf("expected execution_target=local, got %q", normalized.ExecutionTarget)
+		}
+	})
+
+	t.Run("normalizes execution target", func(t *testing.T) {
+		normalized, err := NormalizeActivityOptions(ActivityOptions{ExecutionTarget: " remote "})
+		if err != nil {
+			t.Fatalf("NormalizeActivityOptions() error = %v", err)
+		}
+		if normalized.ExecutionTarget != ActivityExecutionTargetRemote {
+			t.Fatalf("expected execution_target=remote, got %q", normalized.ExecutionTarget)
 		}
 	})
 
@@ -78,6 +94,10 @@ func TestNormalizeActivityOptions(t *testing.T) {
 					MaxBackoff:        2 * time.Second,
 					BackoffMultiplier: 0.5,
 				}},
+			},
+			{
+				name: "invalid execution target",
+				opts: ActivityOptions{ExecutionTarget: "gpu_cluster"},
 			},
 		}
 

--- a/internal/api/engine_activities.go
+++ b/internal/api/engine_activities.go
@@ -1,0 +1,613 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	publichistory "github.com/continua-ai/continua/engine/pkg/history"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+	"github.com/continua-ai/continua/internal/store"
+)
+
+const (
+	remoteActivityWorkerIDMaxLength     = 128
+	remoteActivityTypeMaxLength         = 256
+	remoteActivityErrorCodeMaxLength    = 128
+	remoteActivityErrorMessageMaxLength = 4096
+
+	remoteActivityDefaultMaxTasks  = 10
+	remoteActivityMaxTasks         = 50
+	remoteActivityMaxActivityTypes = 50
+
+	remoteActivityMinLease     = 10 * time.Second
+	remoteActivityDefaultLease = 60 * time.Second
+	remoteActivityMaxLease     = 5 * time.Minute
+)
+
+type remoteActivityClaimRequest struct {
+	WorkerID      string
+	ActivityTypes []string
+	MaxTasks      int32
+	LeaseDuration time.Duration
+}
+
+type remoteActivityClaimResult struct {
+	Tasks []enginedb.EngineActivityTask
+}
+
+type remoteActivityFailRequest struct {
+	WorkerID     string
+	ErrorCode    string
+	ErrorMessage string
+	NonRetryable bool
+}
+
+func (s *Server) ClaimRemoteActivityTasks(
+	w http.ResponseWriter,
+	r *http.Request,
+	_ ClaimRemoteActivityTasksParams,
+) {
+	projectID, ok := projectIDOrUnauthorized(w, r)
+	if !ok {
+		return
+	}
+	if s.engineControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var req EngineRemoteActivityClaimRequest
+	if !decodeJSONRequest(w, r, &req) {
+		return
+	}
+	claimReq, err := remoteActivityClaimRequestFromAPI(&req)
+	if err != nil {
+		writeEngineError(w, err, "Failed to validate remote activity claim request")
+		return
+	}
+
+	result, err := s.engineControl.ClaimRemoteActivityTasks(r.Context(), projectID, claimReq)
+	if err != nil {
+		writeEngineError(w, err, "Failed to claim remote activity tasks")
+		return
+	}
+
+	resp := EngineRemoteActivityClaimResponse{Tasks: make([]EngineRemoteActivityTask, 0, len(result.Tasks))}
+	for i := range result.Tasks {
+		task, mapErr := remoteActivityTaskToAPI(&result.Tasks[i])
+		if mapErr != nil {
+			writeEngineError(w, mapErr, "Failed to map remote activity tasks")
+			return
+		}
+		resp.Tasks = append(resp.Tasks, task)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) HeartbeatRemoteActivityTask(
+	w http.ResponseWriter,
+	r *http.Request,
+	id openapi_types.UUID,
+	_ HeartbeatRemoteActivityTaskParams,
+) {
+	projectID, ok := projectIDOrUnauthorized(w, r)
+	if !ok {
+		return
+	}
+	if s.engineControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var req EngineRemoteActivityHeartbeatRequest
+	if !decodeJSONRequest(w, r, &req) {
+		return
+	}
+	workerID, err := validateRemoteActivityWorkerID(req.WorkerId)
+	if err != nil {
+		writeEngineError(w, err, "Failed to validate remote activity heartbeat request")
+		return
+	}
+
+	task, err := s.engineControl.HeartbeatRemoteActivityTask(r.Context(), projectID, id, workerID)
+	if err != nil {
+		writeEngineError(w, err, "Failed to heartbeat remote activity task")
+		return
+	}
+	writeJSON(w, http.StatusOK, EngineRemoteActivityHeartbeatResponse{
+		LeaseExpiresAt:           remoteActivityLeaseExpiresAt(&task),
+		EffectiveLeaseDurationMs: remoteActivityLeaseDurationMS(&task),
+	})
+}
+
+func (s *Server) CompleteRemoteActivityTask(
+	w http.ResponseWriter,
+	r *http.Request,
+	id openapi_types.UUID,
+	_ CompleteRemoteActivityTaskParams,
+) {
+	projectID, ok := projectIDOrUnauthorized(w, r)
+	if !ok {
+		return
+	}
+	if s.engineControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var req EngineRemoteActivityCompleteRequest
+	if !decodeJSONRequest(w, r, &req) {
+		return
+	}
+	workerID, err := validateRemoteActivityWorkerID(req.WorkerId)
+	if err != nil {
+		writeEngineError(w, err, "Failed to validate remote activity complete request")
+		return
+	}
+	output, err := marshalRemoteActivityJSON(req.Output)
+	if err != nil {
+		writeEngineError(w, err, "Failed to validate remote activity complete request")
+		return
+	}
+
+	if err := s.engineControl.CompleteRemoteActivityTask(r.Context(), projectID, id, workerID, output); err != nil {
+		writeEngineError(w, err, "Failed to complete remote activity task")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) FailRemoteActivityTask(
+	w http.ResponseWriter,
+	r *http.Request,
+	id openapi_types.UUID,
+	_ FailRemoteActivityTaskParams,
+) {
+	projectID, ok := projectIDOrUnauthorized(w, r)
+	if !ok {
+		return
+	}
+	if s.engineControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var req EngineRemoteActivityFailRequest
+	if !decodeJSONRequest(w, r, &req) {
+		return
+	}
+	failReq, err := remoteActivityFailRequestFromAPI(&req)
+	if err != nil {
+		writeEngineError(w, err, "Failed to validate remote activity fail request")
+		return
+	}
+
+	if err := s.engineControl.FailRemoteActivityTask(r.Context(), projectID, id, failReq); err != nil {
+		writeEngineError(w, err, "Failed to fail remote activity task")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *engineControlService) ClaimRemoteActivityTasks(
+	ctx context.Context,
+	projectID uuid.UUID,
+	req remoteActivityClaimRequest,
+) (remoteActivityClaimResult, error) {
+	leaseDurationMS := req.LeaseDuration.Milliseconds()
+	tasks, err := s.engine.ClaimRemoteActivityTasks(ctx, enginedb.ClaimRemoteActivityTasksParams{
+		ProjectFilterID: projectID,
+		ClaimedBy:       &req.WorkerID,
+		ActivityTypes:   req.ActivityTypes,
+		MaxTasks:        req.MaxTasks,
+		LeaseDurationMs: &leaseDurationMS,
+	})
+	if err != nil {
+		return remoteActivityClaimResult{}, err
+	}
+	return remoteActivityClaimResult{Tasks: tasks}, nil
+}
+
+func (s *engineControlService) HeartbeatRemoteActivityTask(
+	ctx context.Context,
+	projectID uuid.UUID,
+	taskID uuid.UUID,
+	workerID string,
+) (enginedb.EngineActivityTask, error) {
+	task, err := s.engine.HeartbeatRemoteActivityTask(ctx, enginedb.HeartbeatRemoteActivityTaskParams{
+		ID:        taskID,
+		ProjectID: projectID,
+		ClaimedBy: &workerID,
+	})
+	if err == nil {
+		return task, nil
+	}
+	return enginedb.EngineActivityTask{}, classifyRemoteActivityOwnershipMiss(ctx, s.engine, projectID, taskID, err)
+}
+
+func (s *engineControlService) CompleteRemoteActivityTask(
+	ctx context.Context,
+	projectID uuid.UUID,
+	taskID uuid.UUID,
+	workerID string,
+	output []byte,
+) error {
+	tx, err := s.platform.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	engineTx := enginedb.New(tx.Tx())
+	task, err := engineTx.CompleteRemoteActivityTask(ctx, enginedb.CompleteRemoteActivityTaskParams{
+		ID:        taskID,
+		ProjectID: projectID,
+		ClaimedBy: &workerID,
+		Output:    output,
+	})
+	if err != nil {
+		return classifyRemoteActivityOwnershipMiss(ctx, engineTx, projectID, taskID, err)
+	}
+
+	if err := wakeAndSyncRemoteActivityRun(ctx, tx, engineTx, task.RunID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *engineControlService) FailRemoteActivityTask(
+	ctx context.Context,
+	projectID uuid.UUID,
+	taskID uuid.UUID,
+	req remoteActivityFailRequest,
+) error {
+	tx, err := s.platform.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	engineTx := enginedb.New(tx.Tx())
+	task, err := engineTx.GetActivityTaskByProjectForUpdate(ctx, enginedb.GetActivityTaskByProjectForUpdateParams{
+		ID:        taskID,
+		ProjectID: projectID,
+	})
+	if err != nil {
+		return classifyRemoteActivityOwnershipMiss(ctx, engineTx, projectID, taskID, err)
+	}
+	if !remoteActivityTaskOwnedByWorker(&task, req.WorkerID, time.Now()) {
+		return remoteActivityOwnershipConflict()
+	}
+
+	if !req.NonRetryable && task.AttemptCount < task.MaxAttempts {
+		retried, retryErr := retryRemoteActivityTask(ctx, engineTx, projectID, &task, req)
+		if retryErr != nil {
+			return retryErr
+		}
+		payload, retryErr := publichistory.MarshalPayload(publichistory.ActivityRetryScheduledPayload{
+			ActivityKey:     retried.ActivityKey,
+			ActivityType:    retried.ActivityType,
+			FailedAttempt:   retried.AttemptCount,
+			NextAvailableAt: retried.AvailableAt,
+			ErrorCode:       req.ErrorCode,
+			ErrorMessage:    req.ErrorMessage,
+		})
+		if retryErr != nil {
+			return retryErr
+		}
+		run, retryErr := engineTx.GetRunForUpdate(ctx, retried.RunID)
+		if retryErr != nil {
+			return retryErr
+		}
+		appended, retryErr := appendLockedRunHistoryEvent(ctx, engineTx, &run, publichistory.EventActivityRetryScheduled, payload)
+		if retryErr != nil {
+			return retryErr
+		}
+		if retryErr := updateProjectedTraceLatestHistory(ctx, tx, retried.RunID, appended.ID); retryErr != nil {
+			return retryErr
+		}
+		return tx.Commit(ctx)
+	}
+
+	failed, err := engineTx.FailRemoteActivityTask(ctx, enginedb.FailRemoteActivityTaskParams{
+		ID:               task.ID,
+		ProjectID:        projectID,
+		ClaimedBy:        &req.WorkerID,
+		LastErrorCode:    &req.ErrorCode,
+		LastErrorMessage: &req.ErrorMessage,
+	})
+	if err != nil {
+		return classifyRemoteActivityOwnershipMiss(ctx, engineTx, projectID, taskID, err)
+	}
+	if err := wakeAndSyncRemoteActivityRun(ctx, tx, engineTx, failed.RunID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func remoteActivityClaimRequestFromAPI(req *EngineRemoteActivityClaimRequest) (remoteActivityClaimRequest, error) {
+	if req == nil {
+		return remoteActivityClaimRequest{}, invalidRemoteActivityRequest("request body is required")
+	}
+	workerID, err := validateRemoteActivityWorkerID(req.WorkerId)
+	if err != nil {
+		return remoteActivityClaimRequest{}, err
+	}
+	activityTypes, err := validateRemoteActivityTypes(req.ActivityTypes)
+	if err != nil {
+		return remoteActivityClaimRequest{}, err
+	}
+	leaseDuration, err := clampRemoteActivityLease(req.LeaseDuration)
+	if err != nil {
+		return remoteActivityClaimRequest{}, err
+	}
+
+	return remoteActivityClaimRequest{
+		WorkerID:      workerID,
+		ActivityTypes: activityTypes,
+		MaxTasks:      clampRemoteActivityMaxTasks(req.MaxTasks),
+		LeaseDuration: leaseDuration,
+	}, nil
+}
+
+func remoteActivityFailRequestFromAPI(req *EngineRemoteActivityFailRequest) (remoteActivityFailRequest, error) {
+	if req == nil {
+		return remoteActivityFailRequest{}, invalidRemoteActivityRequest("request body is required")
+	}
+	workerID, err := validateRemoteActivityWorkerID(req.WorkerId)
+	if err != nil {
+		return remoteActivityFailRequest{}, err
+	}
+	errorCode, err := validateBoundedTrimmedRemoteActivityField("error_code", req.ErrorCode, remoteActivityErrorCodeMaxLength)
+	if err != nil {
+		return remoteActivityFailRequest{}, err
+	}
+	return remoteActivityFailRequest{
+		WorkerID:     workerID,
+		ErrorCode:    errorCode,
+		ErrorMessage: truncateRunes(req.ErrorMessage, remoteActivityErrorMessageMaxLength),
+		NonRetryable: req.NonRetryable != nil && *req.NonRetryable,
+	}, nil
+}
+
+func validateRemoteActivityWorkerID(workerID string) (string, error) {
+	return validateBoundedTrimmedRemoteActivityField("worker_id", workerID, remoteActivityWorkerIDMaxLength)
+}
+
+func validateRemoteActivityTypes(activityTypes []string) ([]string, error) {
+	if len(activityTypes) == 0 {
+		return nil, invalidRemoteActivityRequest("activity_types must contain at least one activity type")
+	}
+	if len(activityTypes) > remoteActivityMaxActivityTypes {
+		return nil, invalidRemoteActivityRequest(fmt.Sprintf("activity_types must contain at most %d activity types", remoteActivityMaxActivityTypes))
+	}
+	normalized := make([]string, 0, len(activityTypes))
+	for _, activityType := range activityTypes {
+		trimmed, err := validateBoundedTrimmedRemoteActivityField("activity_type", activityType, remoteActivityTypeMaxLength)
+		if err != nil {
+			return nil, err
+		}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized, nil
+}
+
+func validateBoundedTrimmedRemoteActivityField(name, value string, maxLength int) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", invalidRemoteActivityRequest(name + " must be non-empty")
+	}
+	if utf8.RuneCountInString(trimmed) > maxLength {
+		return "", invalidRemoteActivityRequest(fmt.Sprintf("%s must be at most %d characters", name, maxLength))
+	}
+	return trimmed, nil
+}
+
+func clampRemoteActivityMaxTasks(maxTasks *int) int32 {
+	if maxTasks == nil {
+		return remoteActivityDefaultMaxTasks
+	}
+	if *maxTasks < 1 {
+		return 1
+	}
+	if *maxTasks > remoteActivityMaxTasks {
+		return remoteActivityMaxTasks
+	}
+	return int32(*maxTasks)
+}
+
+func clampRemoteActivityLease(raw *string) (time.Duration, error) {
+	if raw == nil {
+		return remoteActivityDefaultLease, nil
+	}
+	trimmed := strings.TrimSpace(*raw)
+	if trimmed == "" {
+		return 0, invalidRemoteActivityRequest("lease_duration must be a valid duration")
+	}
+	duration, err := time.ParseDuration(trimmed)
+	if err != nil {
+		return 0, invalidRemoteActivityRequest("lease_duration must be a valid duration")
+	}
+	switch {
+	case duration < remoteActivityMinLease:
+		return remoteActivityMinLease, nil
+	case duration > remoteActivityMaxLease:
+		return remoteActivityMaxLease, nil
+	default:
+		return duration, nil
+	}
+}
+
+func remoteActivityTaskToAPI(task *enginedb.EngineActivityTask) (EngineRemoteActivityTask, error) {
+	if task == nil {
+		return EngineRemoteActivityTask{}, errors.New("remote activity task is required")
+	}
+	input, err := decodeRemoteActivityJSON(task.Input)
+	if err != nil {
+		return EngineRemoteActivityTask{}, err
+	}
+	return EngineRemoteActivityTask{
+		TaskId:                   task.ID,
+		ActivityKey:              task.ActivityKey,
+		ActivityType:             task.ActivityType,
+		Input:                    input,
+		LeaseExpiresAt:           remoteActivityLeaseExpiresAt(task),
+		EffectiveLeaseDurationMs: remoteActivityLeaseDurationMS(task),
+	}, nil
+}
+
+func remoteActivityLeaseExpiresAt(task *enginedb.EngineActivityTask) time.Time {
+	if task != nil && task.LeaseExpiresAt.Valid {
+		return task.LeaseExpiresAt.Time
+	}
+	return time.Time{}
+}
+
+func remoteActivityLeaseDurationMS(task *enginedb.EngineActivityTask) int64 {
+	if task != nil && task.LeaseDurationMs != nil {
+		return *task.LeaseDurationMs
+	}
+	return 0
+}
+
+func decodeRemoteActivityJSON(raw []byte) (interface{}, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var value interface{}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func marshalRemoteActivityJSON(value interface{}) ([]byte, error) {
+	if value == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(value)
+}
+
+func truncateRunes(value string, maxLength int) string {
+	if utf8.RuneCountInString(value) <= maxLength {
+		return value
+	}
+	runes := []rune(value)
+	return string(runes[:maxLength])
+}
+
+func remoteActivityTaskOwnedByWorker(task *enginedb.EngineActivityTask, workerID string, now time.Time) bool {
+	if task == nil || task.ExecutionTarget != publicworkflow.ActivityExecutionTargetRemote {
+		return false
+	}
+	if task.Status != enginedb.EngineActivityTaskStatusClaimed {
+		return false
+	}
+	if task.ClaimedBy == nil || *task.ClaimedBy != workerID {
+		return false
+	}
+	return task.LeaseExpiresAt.Valid && task.LeaseExpiresAt.Time.After(now)
+}
+
+func retryRemoteActivityTask(
+	ctx context.Context,
+	engineTx *enginedb.Queries,
+	projectID uuid.UUID,
+	task *enginedb.EngineActivityTask,
+	req remoteActivityFailRequest,
+) (enginedb.EngineActivityTask, error) {
+	if task == nil {
+		return enginedb.EngineActivityTask{}, errors.New("remote activity task is required")
+	}
+	retryDelayMS, err := publicworkflow.ComputeActivityRetryDelayMS(
+		task.AttemptCount,
+		task.InitialBackoffMs,
+		task.MaxBackoffMs,
+		task.BackoffMultiplier,
+	)
+	if err != nil {
+		return enginedb.EngineActivityTask{}, fmt.Errorf("remote activity task %s retry policy: %w", task.ID, err)
+	}
+
+	retried, err := engineTx.RetryRemoteActivityTask(ctx, enginedb.RetryRemoteActivityTaskParams{
+		ID:               task.ID,
+		ProjectID:        projectID,
+		ClaimedBy:        &req.WorkerID,
+		RetryDelayMs:     retryDelayMS,
+		LastErrorCode:    &req.ErrorCode,
+		LastErrorMessage: &req.ErrorMessage,
+	})
+	if err != nil {
+		return enginedb.EngineActivityTask{}, classifyRemoteActivityOwnershipMiss(ctx, engineTx, projectID, task.ID, err)
+	}
+	return retried, nil
+}
+
+func wakeAndSyncRemoteActivityRun(
+	ctx context.Context,
+	tx *store.Tx,
+	engineTx *enginedb.Queries,
+	runID uuid.UUID,
+) error {
+	run, err := engineTx.WakeWaitingRun(ctx, runID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		run, err = engineTx.GetRun(ctx, runID)
+	}
+	if err != nil {
+		return err
+	}
+	return syncProjectedTraceSummary(ctx, tx, engineTx, &run)
+}
+
+func classifyRemoteActivityOwnershipMiss(
+	ctx context.Context,
+	engineTx *enginedb.Queries,
+	projectID uuid.UUID,
+	taskID uuid.UUID,
+	err error,
+) error {
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return err
+	}
+	if _, lookupErr := engineTx.GetActivityTaskRemoteConflictState(ctx, enginedb.GetActivityTaskRemoteConflictStateParams{
+		ID:        taskID,
+		ProjectID: projectID,
+	}); lookupErr != nil {
+		if errors.Is(lookupErr, pgx.ErrNoRows) {
+			return &engineAPIError{
+				Code:       "not_found",
+				Message:    "activity task not found",
+				HTTPStatus: http.StatusNotFound,
+			}
+		}
+		return lookupErr
+	}
+	return remoteActivityOwnershipConflict()
+}
+
+func remoteActivityOwnershipConflict() error {
+	return &engineAPIError{
+		Code:       "activity_task_conflict",
+		Message:    "activity task is not currently owned by this remote worker",
+		HTTPStatus: http.StatusConflict,
+	}
+}
+
+func invalidRemoteActivityRequest(message string) error {
+	return &engineAPIError{
+		Code:       "invalid_request",
+		Message:    message,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/internal/api/engine_activities_test.go
+++ b/internal/api/engine_activities_test.go
@@ -1,0 +1,631 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	platformdb "github.com/continua-ai/continua/db/gen/go/platform"
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	publichistory "github.com/continua-ai/continua/engine/pkg/history"
+	"github.com/continua-ai/continua/internal/api/middleware"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+type remoteActivityTestTask struct {
+	Instance enginedb.EngineInstance
+	Run      enginedb.EngineRun
+	Task     enginedb.EngineActivityTask
+}
+
+type createRemoteActivityTestTaskParams struct {
+	ProjectID       uuid.UUID
+	ActivityKey     string
+	ActivityType    string
+	ExecutionTarget string
+	AvailableAt     time.Time
+	MaxAttempts     int32
+	Waiting         bool
+}
+
+func TestRemoteActivityClaimHeartbeatAndScoping(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	otherProjectID := testutil.CreateTestProject(t, ctx, platformStore.Queries())
+	now := time.Now().UTC()
+
+	local := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       projectID,
+		ActivityKey:     "local-task",
+		ActivityType:    "email.send",
+		ExecutionTarget: "local",
+		AvailableAt:     now.Add(-time.Minute),
+		MaxAttempts:     1,
+	})
+	remote := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       projectID,
+		ActivityKey:     "remote-task",
+		ActivityType:    "email.send",
+		ExecutionTarget: "remote",
+		AvailableAt:     now.Add(-time.Minute),
+		MaxAttempts:     1,
+	})
+	future := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       projectID,
+		ActivityKey:     "future-task",
+		ActivityType:    "email.send",
+		ExecutionTarget: "remote",
+		AvailableAt:     now.Add(time.Hour),
+		MaxAttempts:     1,
+	})
+	crossProject := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       otherProjectID,
+		ActivityKey:     "cross-project-task",
+		ActivityType:    "email.send",
+		ExecutionTarget: "remote",
+		AvailableAt:     now.Add(-time.Minute),
+		MaxAttempts:     1,
+	})
+
+	claimRec := invokeClaimRemoteActivityTasks(t, server, projectID, EngineRemoteActivityClaimRequest{
+		WorkerId:      " worker-a ",
+		ActivityTypes: []string{" email.send "},
+		LeaseDuration: testutil.Ptr("3s"),
+		MaxTasks:      testutil.Ptr(50),
+	})
+	require.Equal(t, http.StatusOK, claimRec.Code)
+	claimResp := decodeJSONBody[EngineRemoteActivityClaimResponse](t, claimRec)
+	require.Len(t, claimResp.Tasks, 1)
+	assert.Equal(t, remote.Task.ID, claimResp.Tasks[0].TaskId)
+	assert.Equal(t, int64(10000), claimResp.Tasks[0].EffectiveLeaseDurationMs)
+
+	claimedRemote, err := engineQueries.GetActivityTask(ctx, remote.Task.ID)
+	require.NoError(t, err)
+	require.NotNil(t, claimedRemote.ClaimedBy)
+	assert.Equal(t, "worker-a", *claimedRemote.ClaimedBy)
+	assert.Equal(t, int32(1), claimedRemote.AttemptCount)
+	require.NotNil(t, claimedRemote.LeaseDurationMs)
+	assert.Equal(t, int64(10000), *claimedRemote.LeaseDurationMs)
+
+	localAfter, err := engineQueries.GetActivityTask(ctx, local.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineActivityTaskStatusQueued, localAfter.Status)
+	futureAfter, err := engineQueries.GetActivityTask(ctx, future.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineActivityTaskStatusQueued, futureAfter.Status)
+	crossAfter, err := engineQueries.GetActivityTask(ctx, crossProject.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineActivityTaskStatusQueued, crossAfter.Status)
+
+	emptyRec := invokeClaimRemoteActivityTasks(t, server, projectID, EngineRemoteActivityClaimRequest{
+		WorkerId:      "worker-a",
+		ActivityTypes: []string{"image.process"},
+	})
+	require.Equal(t, http.StatusOK, emptyRec.Code)
+	assert.Empty(t, decodeJSONBody[EngineRemoteActivityClaimResponse](t, emptyRec).Tasks)
+
+	heartbeatRec := invokeHeartbeatRemoteActivityTask(t, server, projectID, remote.Task.ID, "worker-a")
+	require.Equal(t, http.StatusOK, heartbeatRec.Code)
+	heartbeatResp := decodeJSONBody[EngineRemoteActivityHeartbeatResponse](t, heartbeatRec)
+	assert.Equal(t, int64(10000), heartbeatResp.EffectiveLeaseDurationMs)
+	assert.True(t, heartbeatResp.LeaseExpiresAt.After(time.Now()))
+
+	require.Equal(t, http.StatusConflict, invokeHeartbeatRemoteActivityTask(t, server, projectID, remote.Task.ID, "worker-b").Code)
+	require.Equal(t, http.StatusConflict, invokeHeartbeatRemoteActivityTask(t, server, projectID, local.Task.ID, "worker-a").Code)
+	require.Equal(t, http.StatusNotFound, invokeHeartbeatRemoteActivityTask(t, server, projectID, crossProject.Task.ID, "worker-a").Code)
+	require.Equal(t, http.StatusNotFound, invokeHeartbeatRemoteActivityTask(t, server, projectID, uuid.New(), "worker-a").Code)
+
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE engine.activity_tasks
+		SET lease_expires_at = NOW() - INTERVAL '1 minute'
+		WHERE id = $1
+	`, remote.Task.ID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusConflict, invokeHeartbeatRemoteActivityTask(t, server, projectID, remote.Task.ID, "worker-a").Code)
+
+	reclaimRec := invokeClaimRemoteActivityTasks(t, server, projectID, EngineRemoteActivityClaimRequest{
+		WorkerId:      "worker-b",
+		ActivityTypes: []string{"email.send"},
+	})
+	require.Equal(t, http.StatusOK, reclaimRec.Code)
+	reclaimResp := decodeJSONBody[EngineRemoteActivityClaimResponse](t, reclaimRec)
+	require.Len(t, reclaimResp.Tasks, 1)
+	assert.Equal(t, remote.Task.ID, reclaimResp.Tasks[0].TaskId)
+	reclaimed, err := engineQueries.GetActivityTask(ctx, remote.Task.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reclaimed.ClaimedBy)
+	assert.Equal(t, "worker-b", *reclaimed.ClaimedBy)
+	assert.Equal(t, int32(2), reclaimed.AttemptCount)
+
+	staleCompleteRec := invokeCompleteRemoteActivityTask(t, server, projectID, remote.Task.ID, EngineRemoteActivityCompleteRequest{
+		WorkerId: "worker-a",
+		Output:   map[string]any{"stale": true},
+	})
+	require.Equal(t, http.StatusConflict, staleCompleteRec.Code)
+
+	maxLeaseTask := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       projectID,
+		ActivityKey:     "max-lease-task",
+		ActivityType:    "video.render",
+		ExecutionTarget: "remote",
+		AvailableAt:     now.Add(-time.Minute),
+		MaxAttempts:     1,
+	})
+	maxLeaseRec := invokeClaimRemoteActivityTasks(t, server, projectID, EngineRemoteActivityClaimRequest{
+		WorkerId:      "worker-max",
+		ActivityTypes: []string{maxLeaseTask.Task.ActivityType},
+		LeaseDuration: testutil.Ptr("10m"),
+	})
+	require.Equal(t, http.StatusOK, maxLeaseRec.Code)
+	maxLeaseResp := decodeJSONBody[EngineRemoteActivityClaimResponse](t, maxLeaseRec)
+	require.Len(t, maxLeaseResp.Tasks, 1)
+	assert.Equal(t, int64(300000), maxLeaseResp.Tasks[0].EffectiveLeaseDurationMs)
+
+	localFailRec := invokeFailRemoteActivityTask(t, server, projectID, local.Task.ID, EngineRemoteActivityFailRequest{
+		WorkerId:     "worker-a",
+		ErrorCode:    "local_target",
+		ErrorMessage: "local target",
+	})
+	require.Equal(t, http.StatusConflict, localFailRec.Code)
+}
+
+func TestRemoteActivityClaimRequestValidation(t *testing.T) {
+	_, _, _, server, projectID := setupEngineHandlerTest(t)
+	longWorkerID := strings.Repeat("w", 129)
+	longActivityType := strings.Repeat("a", 257)
+	tooManyActivityTypes := make([]string, remoteActivityMaxActivityTypes+1)
+	for i := range tooManyActivityTypes {
+		tooManyActivityTypes[i] = "activity." + strconv.Itoa(i)
+	}
+
+	testCases := []struct {
+		name string
+		req  EngineRemoteActivityClaimRequest
+	}{
+		{name: "blank worker", req: EngineRemoteActivityClaimRequest{WorkerId: " ", ActivityTypes: []string{"email.send"}}},
+		{name: "long worker", req: EngineRemoteActivityClaimRequest{WorkerId: longWorkerID, ActivityTypes: []string{"email.send"}}},
+		{name: "empty activity types", req: EngineRemoteActivityClaimRequest{WorkerId: "worker-a"}},
+		{name: "too many activity types", req: EngineRemoteActivityClaimRequest{WorkerId: "worker-a", ActivityTypes: tooManyActivityTypes}},
+		{name: "blank activity type", req: EngineRemoteActivityClaimRequest{WorkerId: "worker-a", ActivityTypes: []string{" "}}},
+		{name: "long activity type", req: EngineRemoteActivityClaimRequest{WorkerId: "worker-a", ActivityTypes: []string{longActivityType}}},
+		{name: "invalid lease", req: EngineRemoteActivityClaimRequest{WorkerId: "worker-a", ActivityTypes: []string{"email.send"}, LeaseDuration: testutil.Ptr("soon")}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := invokeClaimRemoteActivityTasks(t, server, projectID, tc.req)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Equal(t, "invalid_request", decodeJSONBody[Error](t, rec).Code)
+		})
+	}
+
+	taskID := uuid.New()
+	require.Equal(t, http.StatusBadRequest, invokeHeartbeatRemoteActivityTask(t, server, projectID, taskID, " ").Code)
+	require.Equal(t, http.StatusBadRequest, invokeCompleteRemoteActivityTask(t, server, projectID, taskID, EngineRemoteActivityCompleteRequest{
+		WorkerId: longWorkerID,
+		Output:   map[string]any{"ok": true},
+	}).Code)
+	require.Equal(t, http.StatusBadRequest, invokeFailRemoteActivityTask(t, server, projectID, taskID, EngineRemoteActivityFailRequest{
+		WorkerId:     " ",
+		ErrorCode:    "failed",
+		ErrorMessage: "failed",
+	}).Code)
+}
+
+func TestRemoteActivityRoutesRequireAuthAndPreview(t *testing.T) {
+	ctx, platformStore, _, server, _ := setupEngineHandlerTest(t)
+	apiKey := "remote-activity-router-" + uuid.NewString()
+	_, err := platformStore.Queries().CreateProject(ctx, platformdb.CreateProjectParams{
+		Name:       "remote-activity-router-" + uuid.NewString()[:8],
+		ApiKeyHash: hashTestAPIKey(apiKey),
+	})
+	require.NoError(t, err)
+	handler := NewRouter(server, platformStore)
+	body := []byte(`{"worker_id":"worker-a","activity_types":["email.send"]}`)
+
+	t.Run("missing api key is rejected before handler", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/engine/activities/claim", bytes.NewReader(body))
+		req.Header.Set(enginePreviewHeader, "1")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Equal(t, "missing_api_key", decodeJSONBody[map[string]string](t, rec)["code"])
+	})
+
+	t.Run("preview header is required", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/engine/activities/claim", bytes.NewReader(body))
+		req.Header.Set("X-API-Key", apiKey)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "preview_header_required", decodeJSONBody[Error](t, rec).Code)
+	})
+
+	t.Run("authenticated preview request reaches claim handler", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/engine/activities/claim", bytes.NewReader(body))
+		req.Header.Set("X-API-Key", apiKey)
+		req.Header.Set(enginePreviewHeader, "1")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Empty(t, decodeJSONBody[EngineRemoteActivityClaimResponse](t, rec).Tasks)
+	})
+}
+
+func TestRemoteActivityCompleteAndDuplicateConflict(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	fixture := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       projectID,
+		ActivityKey:     "complete-task",
+		ActivityType:    "email.send",
+		ExecutionTarget: "remote",
+		AvailableAt:     time.Now().Add(-time.Minute),
+		MaxAttempts:     1,
+		Waiting:         true,
+	})
+	claimRemoteActivityForTest(t, server, projectID, "worker-a", fixture.Task.ActivityType)
+
+	completeRec := invokeCompleteRemoteActivityTask(t, server, projectID, fixture.Task.ID, EngineRemoteActivityCompleteRequest{
+		WorkerId: "worker-a",
+		Output:   map[string]any{"ok": true},
+	})
+	require.Equal(t, http.StatusNoContent, completeRec.Code)
+
+	task, err := engineQueries.GetActivityTask(ctx, fixture.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineActivityTaskStatusCompleted, task.Status)
+	assert.JSONEq(t, `{"ok":true}`, string(task.Output))
+
+	run, err := engineQueries.GetRun(ctx, fixture.Run.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineRunLifecycleStatusQueued, run.Status)
+
+	duplicateRec := invokeCompleteRemoteActivityTask(t, server, projectID, fixture.Task.ID, EngineRemoteActivityCompleteRequest{
+		WorkerId: "worker-a",
+		Output:   map[string]any{"ok": false},
+	})
+	require.Equal(t, http.StatusConflict, duplicateRec.Code)
+	require.Equal(t, http.StatusConflict, invokeHeartbeatRemoteActivityTask(t, server, projectID, fixture.Task.ID, "worker-a").Code)
+	unchanged, err := engineQueries.GetActivityTask(ctx, fixture.Task.ID)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ok":true}`, string(unchanged.Output))
+
+	failCompletedRec := invokeFailRemoteActivityTask(t, server, projectID, fixture.Task.ID, EngineRemoteActivityFailRequest{
+		WorkerId:     "worker-a",
+		ErrorCode:    "already_completed",
+		ErrorMessage: "already completed",
+	})
+	require.Equal(t, http.StatusConflict, failCompletedRec.Code)
+
+	otherProjectID := testutil.CreateTestProject(t, ctx, platformStore.Queries())
+	crossProjectRec := invokeCompleteRemoteActivityTask(t, server, otherProjectID, fixture.Task.ID, EngineRemoteActivityCompleteRequest{
+		WorkerId: "worker-a",
+		Output:   map[string]any{"ok": true},
+	})
+	require.Equal(t, http.StatusNotFound, crossProjectRec.Code)
+
+	missingCompleteRec := invokeCompleteRemoteActivityTask(t, server, projectID, uuid.New(), EngineRemoteActivityCompleteRequest{
+		WorkerId: "worker-a",
+		Output:   map[string]any{"ok": true},
+	})
+	require.Equal(t, http.StatusNotFound, missingCompleteRec.Code)
+}
+
+func TestRemoteActivityFailRetryAndNonRetryable(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	retryFixture := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       projectID,
+		ActivityKey:     "retry-task",
+		ActivityType:    "email.send",
+		ExecutionTarget: "remote",
+		AvailableAt:     time.Now().Add(-time.Minute),
+		MaxAttempts:     3,
+		Waiting:         true,
+	})
+	claimRemoteActivityForTest(t, server, projectID, "worker-a", retryFixture.Task.ActivityType)
+
+	longMessage := strings.Repeat("m", remoteActivityErrorMessageMaxLength+10)
+	retryRec := invokeFailRemoteActivityTask(t, server, projectID, retryFixture.Task.ID, EngineRemoteActivityFailRequest{
+		WorkerId:     "worker-a",
+		ErrorCode:    "temporary_error",
+		ErrorMessage: longMessage,
+	})
+	require.Equal(t, http.StatusNoContent, retryRec.Code)
+
+	retried, err := engineQueries.GetActivityTask(ctx, retryFixture.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineActivityTaskStatusQueued, retried.Status)
+	assert.Equal(t, "temporary_error", *retried.LastErrorCode)
+	require.NotNil(t, retried.LastErrorMessage)
+	assert.Len(t, *retried.LastErrorMessage, remoteActivityErrorMessageMaxLength)
+	assert.True(t, retried.AvailableAt.After(time.Now()))
+
+	historyRows, err := engineQueries.GetHistoryByRun(ctx, retryFixture.Run.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, historyRows)
+	assert.Equal(t, publichistory.EventActivityRetryScheduled, historyRows[len(historyRows)-1].EventType)
+
+	duplicateRetryRec := invokeFailRemoteActivityTask(t, server, projectID, retryFixture.Task.ID, EngineRemoteActivityFailRequest{
+		WorkerId:     "worker-a",
+		ErrorCode:    "temporary_error",
+		ErrorMessage: "again",
+	})
+	require.Equal(t, http.StatusConflict, duplicateRetryRec.Code)
+
+	staleFixture := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       projectID,
+		ActivityKey:     "stale-fail-task",
+		ActivityType:    "report.build",
+		ExecutionTarget: "remote",
+		AvailableAt:     time.Now().Add(-time.Minute),
+		MaxAttempts:     1,
+		Waiting:         true,
+	})
+	claimRemoteActivityForTest(t, server, projectID, "stale-worker", staleFixture.Task.ActivityType)
+	_, err = platformStore.Pool().Exec(ctx, `
+		UPDATE engine.activity_tasks
+		SET lease_expires_at = NOW() - INTERVAL '1 minute'
+		WHERE id = $1
+	`, staleFixture.Task.ID)
+	require.NoError(t, err)
+	claimRemoteActivityForTest(t, server, projectID, "fresh-worker", staleFixture.Task.ActivityType)
+	staleFailRec := invokeFailRemoteActivityTask(t, server, projectID, staleFixture.Task.ID, EngineRemoteActivityFailRequest{
+		WorkerId:     "stale-worker",
+		ErrorCode:    "stale",
+		ErrorMessage: "stale",
+	})
+	require.Equal(t, http.StatusConflict, staleFailRec.Code)
+
+	earlyReclaim := invokeClaimRemoteActivityTasks(t, server, projectID, EngineRemoteActivityClaimRequest{
+		WorkerId:      "worker-b",
+		ActivityTypes: []string{retryFixture.Task.ActivityType},
+	})
+	require.Equal(t, http.StatusOK, earlyReclaim.Code)
+	assert.Empty(t, decodeJSONBody[EngineRemoteActivityClaimResponse](t, earlyReclaim).Tasks)
+
+	nonRetryableFixture := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       projectID,
+		ActivityKey:     "non-retryable-task",
+		ActivityType:    "image.process",
+		ExecutionTarget: "remote",
+		AvailableAt:     time.Now().Add(-time.Minute),
+		MaxAttempts:     3,
+		Waiting:         true,
+	})
+	claimRemoteActivityForTest(t, server, projectID, "worker-c", nonRetryableFixture.Task.ActivityType)
+
+	terminalRec := invokeFailRemoteActivityTask(t, server, projectID, nonRetryableFixture.Task.ID, EngineRemoteActivityFailRequest{
+		WorkerId:     "worker-c",
+		ErrorCode:    "bad_input",
+		ErrorMessage: "invalid",
+		NonRetryable: testutil.Ptr(true),
+	})
+	require.Equal(t, http.StatusNoContent, terminalRec.Code)
+	failed, err := engineQueries.GetActivityTask(ctx, nonRetryableFixture.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineActivityTaskStatusFailed, failed.Status)
+
+	exhaustedFixture := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+		ProjectID:       projectID,
+		ActivityKey:     "retry-exhausted-task",
+		ActivityType:    "once.only",
+		ExecutionTarget: "remote",
+		AvailableAt:     time.Now().Add(-time.Minute),
+		MaxAttempts:     1,
+		Waiting:         true,
+	})
+	claimRemoteActivityForTest(t, server, projectID, "worker-d", exhaustedFixture.Task.ActivityType)
+	exhaustedRec := invokeFailRemoteActivityTask(t, server, projectID, exhaustedFixture.Task.ID, EngineRemoteActivityFailRequest{
+		WorkerId:     "worker-d",
+		ErrorCode:    "still_retryable",
+		ErrorMessage: "attempts exhausted",
+	})
+	require.Equal(t, http.StatusNoContent, exhaustedRec.Code)
+	exhausted, err := engineQueries.GetActivityTask(ctx, exhaustedFixture.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineActivityTaskStatusFailed, exhausted.Status)
+	assert.Equal(t, "still_retryable", *exhausted.LastErrorCode)
+
+	invalidCodeRec := invokeFailRemoteActivityTask(t, server, projectID, nonRetryableFixture.Task.ID, EngineRemoteActivityFailRequest{
+		WorkerId:     "worker-c",
+		ErrorCode:    strings.Repeat("e", remoteActivityErrorCodeMaxLength+1),
+		ErrorMessage: "invalid",
+	})
+	require.Equal(t, http.StatusBadRequest, invalidCodeRec.Code)
+
+	otherProjectID := testutil.CreateTestProject(t, ctx, platformStore.Queries())
+	crossProjectFailRec := invokeFailRemoteActivityTask(t, server, otherProjectID, nonRetryableFixture.Task.ID, EngineRemoteActivityFailRequest{
+		WorkerId:     "worker-c",
+		ErrorCode:    "cross_project",
+		ErrorMessage: "cross project",
+	})
+	require.Equal(t, http.StatusNotFound, crossProjectFailRec.Code)
+
+	missingFailRec := invokeFailRemoteActivityTask(t, server, projectID, uuid.New(), EngineRemoteActivityFailRequest{
+		WorkerId:     "worker-c",
+		ErrorCode:    "missing",
+		ErrorMessage: "missing",
+	})
+	require.Equal(t, http.StatusNotFound, missingFailRec.Code)
+}
+
+//nolint:revive // Keep testing.T first in shared test helper signatures.
+func createRemoteActivityTestTask(
+	t *testing.T,
+	ctx context.Context,
+	platformStore *store.Store,
+	engineQueries *enginedb.Queries,
+	params createRemoteActivityTestTaskParams,
+) remoteActivityTestTask {
+	t.Helper()
+
+	instance, err := engineQueries.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      params.ProjectID,
+		InstanceKey:    "remote-activity-" + params.ActivityKey + "-" + uuid.NewString(),
+		DefinitionName: "remote.activity.test",
+		Metadata:       []byte(`{"source":"test"}`),
+	})
+	require.NoError(t, err)
+	run, err := engineQueries.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:          params.ProjectID,
+		InstanceID:         instance.ID,
+		RunNumber:          1,
+		DefinitionVersion:  "v1",
+		ReadyAt:            time.Now().Add(-time.Minute),
+		ContinuedFromRunID: pgtype.UUID{},
+	})
+	require.NoError(t, err)
+	startedHistory := appendEngineHistoryEvent(t, ctx, engineQueries, params.ProjectID, instance.ID, run.ID, 1, publichistory.EventWorkflowStarted, publichistory.WorkflowStartedPayload{
+		DefinitionName:    instance.DefinitionName,
+		DefinitionVersion: run.DefinitionVersion,
+		InstanceKey:       instance.InstanceKey,
+		Input:             []byte(`{"source":"test"}`),
+	})
+	createEngineProjectedTraceShell(t, ctx, platformStore, instance, run, startedHistory.ID, startedHistory.CreatedAt)
+	if params.Waiting {
+		setEngineRunWaiting(t, ctx, platformStore, run.ID, map[string]any{"remote": true})
+	}
+	activityHistory := appendEngineHistoryEvent(t, ctx, engineQueries, params.ProjectID, instance.ID, run.ID, 2, publichistory.EventActivityScheduled, publichistory.ActivityScheduledPayload{
+		ActivityKey:  params.ActivityKey,
+		ActivityType: params.ActivityType,
+		Input:        []byte(`{"source":"test"}`),
+	})
+
+	maxAttempts := params.MaxAttempts
+	if maxAttempts == 0 {
+		maxAttempts = 1
+	}
+	var initialBackoffMS *int64
+	var maxBackoffMS *int64
+	var backoffMultiplier *float64
+	if maxAttempts > 1 {
+		initialBackoffMS = testutil.Ptr(int64(1000))
+		maxBackoffMS = testutil.Ptr(int64(5000))
+		backoffMultiplier = testutil.Ptr(2.0)
+	}
+	task, err := engineQueries.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:         params.ProjectID,
+		InstanceID:        instance.ID,
+		RunID:             run.ID,
+		HistoryID:         &activityHistory.ID,
+		ActivityKey:       params.ActivityKey,
+		ActivityType:      params.ActivityType,
+		Input:             []byte(`{"source":"test"}`),
+		AvailableAt:       params.AvailableAt,
+		ExecutionTarget:   params.ExecutionTarget,
+		MaxAttempts:       maxAttempts,
+		InitialBackoffMs:  initialBackoffMS,
+		MaxBackoffMs:      maxBackoffMS,
+		BackoffMultiplier: backoffMultiplier,
+	})
+	require.NoError(t, err)
+
+	return remoteActivityTestTask{Instance: instance, Run: run, Task: task}
+}
+
+func claimRemoteActivityForTest(t *testing.T, server *Server, projectID uuid.UUID, workerID, activityType string) {
+	t.Helper()
+	rec := invokeClaimRemoteActivityTasks(t, server, projectID, EngineRemoteActivityClaimRequest{
+		WorkerId:      workerID,
+		ActivityTypes: []string{activityType},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeJSONBody[EngineRemoteActivityClaimResponse](t, rec)
+	require.Len(t, resp.Tasks, 1)
+}
+
+func invokeClaimRemoteActivityTasks(
+	t *testing.T,
+	server *Server,
+	projectID uuid.UUID,
+	reqBody EngineRemoteActivityClaimRequest,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/activities/claim", bytes.NewReader(body))
+	req.Header.Set(enginePreviewHeader, "1")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	rec := httptest.NewRecorder()
+
+	server.ClaimRemoteActivityTasks(rec, req, ClaimRemoteActivityTasksParams{XContinuaEnginePreview: "1"})
+	return rec
+}
+
+func invokeHeartbeatRemoteActivityTask(
+	t *testing.T,
+	server *Server,
+	projectID uuid.UUID,
+	taskID uuid.UUID,
+	workerID string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(EngineRemoteActivityHeartbeatRequest{WorkerId: workerID})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/activities/"+taskID.String()+"/heartbeat", bytes.NewReader(body))
+	req.Header.Set(enginePreviewHeader, "1")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	rec := httptest.NewRecorder()
+
+	server.HeartbeatRemoteActivityTask(rec, req, taskID, HeartbeatRemoteActivityTaskParams{XContinuaEnginePreview: "1"})
+	return rec
+}
+
+func invokeCompleteRemoteActivityTask(
+	t *testing.T,
+	server *Server,
+	projectID uuid.UUID,
+	taskID uuid.UUID,
+	reqBody EngineRemoteActivityCompleteRequest,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/activities/"+taskID.String()+"/complete", bytes.NewReader(body))
+	req.Header.Set(enginePreviewHeader, "1")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	rec := httptest.NewRecorder()
+
+	server.CompleteRemoteActivityTask(rec, req, taskID, CompleteRemoteActivityTaskParams{XContinuaEnginePreview: "1"})
+	return rec
+}
+
+func invokeFailRemoteActivityTask(
+	t *testing.T,
+	server *Server,
+	projectID uuid.UUID,
+	taskID uuid.UUID,
+	reqBody EngineRemoteActivityFailRequest,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/activities/"+taskID.String()+"/fail", bytes.NewReader(body))
+	req.Header.Set(enginePreviewHeader, "1")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	rec := httptest.NewRecorder()
+
+	server.FailRemoteActivityTask(rec, req, taskID, FailRemoteActivityTaskParams{XContinuaEnginePreview: "1"})
+	return rec
+}

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -2557,27 +2557,29 @@ func TestGetEngineRunPendingWork_ReturnsTypedOpenWorkAndExcludesCancelRows(t *te
 	})
 
 	_, err = engineQueries.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    projectID,
-		InstanceID:   run.InstanceID,
-		RunID:        runID,
-		HistoryID:    &activityHistoryB.ID,
-		ActivityKey:  "approval-b",
-		ActivityType: "demo.activity",
-		Input:        []byte(`{"step":"b"}`),
-		AvailableAt:  baseTime.Add(2 * time.Minute),
-		MaxAttempts:  1,
+		ProjectID:       projectID,
+		InstanceID:      run.InstanceID,
+		RunID:           runID,
+		HistoryID:       &activityHistoryB.ID,
+		ActivityKey:     "approval-b",
+		ActivityType:    "demo.activity",
+		Input:           []byte(`{"step":"b"}`),
+		AvailableAt:     baseTime.Add(2 * time.Minute),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	})
 	require.NoError(t, err)
 	_, err = engineQueries.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    projectID,
-		InstanceID:   run.InstanceID,
-		RunID:        runID,
-		HistoryID:    &activityHistoryA.ID,
-		ActivityKey:  "approval-a",
-		ActivityType: "demo.activity",
-		Input:        []byte(`{"step":"a"}`),
-		AvailableAt:  baseTime.Add(1 * time.Minute),
-		MaxAttempts:  1,
+		ProjectID:       projectID,
+		InstanceID:      run.InstanceID,
+		RunID:           runID,
+		HistoryID:       &activityHistoryA.ID,
+		ActivityKey:     "approval-a",
+		ActivityType:    "demo.activity",
+		Input:           []byte(`{"step":"a"}`),
+		AvailableAt:     baseTime.Add(1 * time.Minute),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	})
 	require.NoError(t, err)
 
@@ -3613,15 +3615,16 @@ func createPendingWorkForRun(
 	require.NotEmpty(t, history)
 
 	_, err = engineQueries.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
-		ProjectID:    projectID,
-		InstanceID:   run.InstanceID,
-		RunID:        runID,
-		HistoryID:    &history[0].ID,
-		ActivityKey:  "approval-task",
-		ActivityType: "demo.activity",
-		Input:        []byte(`{"ok":true}`),
-		AvailableAt:  history[0].CreatedAt,
-		MaxAttempts:  1,
+		ProjectID:       projectID,
+		InstanceID:      run.InstanceID,
+		RunID:           runID,
+		HistoryID:       &history[0].ID,
+		ActivityKey:     "approval-task",
+		ActivityType:    "demo.activity",
+		Input:           []byte(`{"ok":true}`),
+		AvailableAt:     history[0].CreatedAt,
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
 	})
 	require.NoError(t, err)
 

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -568,6 +568,59 @@ type EnginePurgeResponse struct {
 	RunId           openapi_types.UUID    `json:"run_id"`
 }
 
+// EngineRemoteActivityClaimRequest defines model for EngineRemoteActivityClaimRequest.
+type EngineRemoteActivityClaimRequest struct {
+	ActivityTypes []string `json:"activity_types"`
+
+	// LeaseDuration Requested lease duration, e.g. 60s or 5m. The server clamps the effective value.
+	LeaseDuration *string `json:"lease_duration,omitempty"`
+	MaxTasks      *int    `json:"max_tasks,omitempty"`
+	WorkerId      string  `json:"worker_id"`
+}
+
+// EngineRemoteActivityClaimResponse defines model for EngineRemoteActivityClaimResponse.
+type EngineRemoteActivityClaimResponse struct {
+	Tasks []EngineRemoteActivityTask `json:"tasks"`
+}
+
+// EngineRemoteActivityCompleteRequest defines model for EngineRemoteActivityCompleteRequest.
+type EngineRemoteActivityCompleteRequest struct {
+	// Output Activity output payload (any valid JSON)
+	Output   interface{} `json:"output"`
+	WorkerId string      `json:"worker_id"`
+}
+
+// EngineRemoteActivityFailRequest defines model for EngineRemoteActivityFailRequest.
+type EngineRemoteActivityFailRequest struct {
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"error_message"`
+	NonRetryable *bool  `json:"non_retryable,omitempty"`
+	WorkerId     string `json:"worker_id"`
+}
+
+// EngineRemoteActivityHeartbeatRequest defines model for EngineRemoteActivityHeartbeatRequest.
+type EngineRemoteActivityHeartbeatRequest struct {
+	WorkerId string `json:"worker_id"`
+}
+
+// EngineRemoteActivityHeartbeatResponse defines model for EngineRemoteActivityHeartbeatResponse.
+type EngineRemoteActivityHeartbeatResponse struct {
+	EffectiveLeaseDurationMs int64     `json:"effective_lease_duration_ms"`
+	LeaseExpiresAt           time.Time `json:"lease_expires_at"`
+}
+
+// EngineRemoteActivityTask defines model for EngineRemoteActivityTask.
+type EngineRemoteActivityTask struct {
+	ActivityKey              string `json:"activity_key"`
+	ActivityType             string `json:"activity_type"`
+	EffectiveLeaseDurationMs int64  `json:"effective_lease_duration_ms"`
+
+	// Input Activity input payload (any valid JSON)
+	Input          interface{}        `json:"input"`
+	LeaseExpiresAt time.Time          `json:"lease_expires_at"`
+	TaskId         openapi_types.UUID `json:"task_id"`
+}
+
 // EngineRepairReason defines model for EngineRepairReason.
 type EngineRepairReason string
 
@@ -1290,6 +1343,30 @@ type GetTraceEventsParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// ClaimRemoteActivityTasksParams defines parameters for ClaimRemoteActivityTasks.
+type ClaimRemoteActivityTasksParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// CompleteRemoteActivityTaskParams defines parameters for CompleteRemoteActivityTask.
+type CompleteRemoteActivityTaskParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// FailRemoteActivityTaskParams defines parameters for FailRemoteActivityTask.
+type FailRemoteActivityTaskParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
+// HeartbeatRemoteActivityTaskParams defines parameters for HeartbeatRemoteActivityTask.
+type HeartbeatRemoteActivityTaskParams struct {
+	// XContinuaEnginePreview Required preview header for mutating engine routes.
+	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+}
+
 // BackfillEngineProjectionsParams defines parameters for BackfillEngineProjections.
 type BackfillEngineProjectionsParams struct {
 	// XContinuaEnginePreview Required preview header for mutating engine routes.
@@ -1360,6 +1437,18 @@ type IngestParams struct {
 	// Any other value is rejected with `400 unsupported_async_version`.
 	XContinuaAsyncVersion *string `json:"X-Continua-Async-Version,omitempty"`
 }
+
+// ClaimRemoteActivityTasksJSONRequestBody defines body for ClaimRemoteActivityTasks for application/json ContentType.
+type ClaimRemoteActivityTasksJSONRequestBody = EngineRemoteActivityClaimRequest
+
+// CompleteRemoteActivityTaskJSONRequestBody defines body for CompleteRemoteActivityTask for application/json ContentType.
+type CompleteRemoteActivityTaskJSONRequestBody = EngineRemoteActivityCompleteRequest
+
+// FailRemoteActivityTaskJSONRequestBody defines body for FailRemoteActivityTask for application/json ContentType.
+type FailRemoteActivityTaskJSONRequestBody = EngineRemoteActivityFailRequest
+
+// HeartbeatRemoteActivityTaskJSONRequestBody defines body for HeartbeatRemoteActivityTask for application/json ContentType.
+type HeartbeatRemoteActivityTaskJSONRequestBody = EngineRemoteActivityHeartbeatRequest
 
 // BackfillEngineProjectionsJSONRequestBody defines body for BackfillEngineProjections for application/json ContentType.
 type BackfillEngineProjectionsJSONRequestBody = EngineProjectionBackfillRequest
@@ -1560,6 +1649,18 @@ type ServerInterface interface {
 	// List spans for a trace
 	// (GET /api/traces/{id}/spans)
 	ListSpansByTrace(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Claim remote engine activity tasks
+	// (POST /v1/engine/activities/claim)
+	ClaimRemoteActivityTasks(w http.ResponseWriter, r *http.Request, params ClaimRemoteActivityTasksParams)
+	// Complete a remote activity task
+	// (POST /v1/engine/activities/{id}/complete)
+	CompleteRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params CompleteRemoteActivityTaskParams)
+	// Fail or retry a remote activity task
+	// (POST /v1/engine/activities/{id}/fail)
+	FailRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params FailRemoteActivityTaskParams)
+	// Renew a remote activity task lease
+	// (POST /v1/engine/activities/{id}/heartbeat)
+	HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params HeartbeatRemoteActivityTaskParams)
 	// Get an engine instance and current run
 	// (GET /v1/engine/instances/{instance_key})
 	GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string)
@@ -1659,6 +1760,30 @@ func (_ Unimplemented) GetTraceEvents(w http.ResponseWriter, r *http.Request, id
 // List spans for a trace
 // (GET /api/traces/{id}/spans)
 func (_ Unimplemented) ListSpansByTrace(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Claim remote engine activity tasks
+// (POST /v1/engine/activities/claim)
+func (_ Unimplemented) ClaimRemoteActivityTasks(w http.ResponseWriter, r *http.Request, params ClaimRemoteActivityTasksParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Complete a remote activity task
+// (POST /v1/engine/activities/{id}/complete)
+func (_ Unimplemented) CompleteRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params CompleteRemoteActivityTaskParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Fail or retry a remote activity task
+// (POST /v1/engine/activities/{id}/fail)
+func (_ Unimplemented) FailRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params FailRemoteActivityTaskParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Renew a remote activity task lease
+// (POST /v1/engine/activities/{id}/heartbeat)
+func (_ Unimplemented) HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params HeartbeatRemoteActivityTaskParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2270,6 +2395,233 @@ func (siw *ServerInterfaceWrapper) ListSpansByTrace(w http.ResponseWriter, r *ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListSpansByTrace(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ClaimRemoteActivityTasks operation middleware
+func (siw *ServerInterfaceWrapper) ClaimRemoteActivityTasks(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ClaimRemoteActivityTasksParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ClaimRemoteActivityTasks(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CompleteRemoteActivityTask operation middleware
+func (siw *ServerInterfaceWrapper) CompleteRemoteActivityTask(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params CompleteRemoteActivityTaskParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CompleteRemoteActivityTask(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// FailRemoteActivityTask operation middleware
+func (siw *ServerInterfaceWrapper) FailRemoteActivityTask(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params FailRemoteActivityTaskParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.FailRemoteActivityTask(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// HeartbeatRemoteActivityTask operation middleware
+func (siw *ServerInterfaceWrapper) HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params HeartbeatRemoteActivityTaskParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
+		var XContinuaEnginePreview string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Continua-Engine-Preview", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
+			return
+		}
+
+		params.XContinuaEnginePreview = XContinuaEnginePreview
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.HeartbeatRemoteActivityTask(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3187,6 +3539,18 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/traces/{id}/spans", wrapper.ListSpansByTrace)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/activities/claim", wrapper.ClaimRemoteActivityTasks)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/activities/{id}/complete", wrapper.CompleteRemoteActivityTask)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/activities/{id}/fail", wrapper.FailRemoteActivityTask)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/engine/activities/{id}/heartbeat", wrapper.HeartbeatRemoteActivityTask)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/instances/{instance_key}", wrapper.GetEngineInstance)

--- a/openspec/changes/add-remote-activities-python-worker/design.md
+++ b/openspec/changes/add-remote-activities-python-worker/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The engine's activity task system currently only supports in-process Go workers. Remote workers need to claim, execute, and complete tasks over REST without direct access to engine DB tables. This proposal adds the remote activity protocol as a preview-gated extension and ships a Python SDK worker implementation.
+
+### Stakeholders
+- Engine runtime: execution target routing, remote claim/complete paths
+- Engine store: new column, updated claim queries
+- Platform API: new REST endpoints for remote workers
+- Python SDK: new worker module
+
+## Goals / Non-Goals
+
+### Goals
+- Remote activity workers that never touch engine DB tables
+- Backward-compatible: existing in-process workers unchanged
+- Lease-based execution with heartbeat renewal
+- Python SDK worker with handler registry and graceful shutdown
+- Non-retryable error support for remote failures
+
+### Non-Goals
+- Task queues or named routing groups (deferred to v2)
+- Long-polling or WebSocket-based claim (v1 is short-poll only)
+- TypeScript/JS SDK worker
+- Python workflow authoring
+- Sticky worker affinity or caching
+- Native async handler execution in the Python worker
+
+## Decisions
+
+### Decision: Short-polling claim, not long-poll
+Claim returns immediately with zero or more tasks. Workers poll on their own interval.
+
+**Why:** Simplest correct implementation. Long-poll adds server-side hold complexity and connection management. Short-poll is sufficient for preview and easy to upgrade later.
+
+**Alternatives considered:** Long-poll (holds connection until task available or timeout). Rejected for v1 complexity; can be added later as a non-breaking enhancement.
+
+### Decision: No task_queue in v1
+Remote routing is `execution_target = 'remote'` plus `activity_types` filter on claim. No named queue routing.
+
+**Why:** Named queues add schema, API, and SDK complexity without clear v1 use cases. Execution target + type filter covers the preview need (route specific activity types to Python workers).
+
+**Alternatives considered:** Adding `task_queue TEXT` column and requiring queue names. Rejected because it front-loads routing complexity that isn't needed until multiple distinct worker pools exist.
+
+### Decision: Lease clamping
+Server clamps lease duration to min 10s, default 60s, max 5m. Python worker heartbeats at half the effective lease.
+
+**Why:** Prevents workers from holding tasks indefinitely (max 5m) or losing them too quickly (min 10s). Half-lease heartbeat is a standard pattern that ensures renewal happens before expiry.
+
+### Decision: Complete/fail conflict matrix, not post-terminal idempotency
+Complete/fail uses a strict ownership rule. A valid call must target a remote activity task that is still claimed by the requesting `worker_id` under an unexpired lease. Calls from stale workers, tasks reclaimed by another worker, local-target tasks, already terminal tasks, queued retry tasks, and terminal calls that conflict with the existing state return explicit conflicts instead of silent success.
+
+**Why:** Current activity completion/failure clears `claimed_by`, so the server cannot later prove that a post-terminal duplicate came from the same worker and represented the same operation. Returning 409 for post-success duplicates is simpler than adding terminal operation fingerprints in v1, and it prevents a Python worker from reporting success when its output or failure did not become the authoritative engine result.
+
+### Decision: Sync Python handlers on a bounded thread pool
+The Python worker v1 supports synchronous handler callables executed on a bounded `ThreadPoolExecutor`, using the SDK's existing sync `httpx.Client` style for REST calls. Async coroutine handlers are out of scope for v1 and should be rejected at registration time with a clear error.
+
+**Why:** The current Python SDK is sync-first and already depends on `httpx`. Supporting both sync and async execution would double the scheduler, heartbeat, shutdown, and cancellation surface before the remote protocol proves itself.
+
+### Decision: Preview gate
+Remote activity endpoints are preview-gated using the existing `X-Continua-Engine-Preview: 1` header, consistent with the mutating `/v1/engine` routes already in the repo.
+
+**Why:** This is a new external surface. Gating allows iteration without stability commitments. Reusing the existing preview header avoids introducing a second gating mechanism.
+
+## Risks / Trade-offs
+
+- **Polling overhead:** Short-poll at scale produces empty claim requests. Acceptable for preview; long-poll or push would reduce this for production.
+- **Lease expiry race:** A worker completing just as its lease expires could race with stale reclaim. The conflict matrix prevents false success from stale workers, but the task may still be double-executed after reclaim. Activity handlers should use the task context's stable identifiers for idempotency when they perform remote side effects.
+- **Python SDK surface:** The worker module is the first Python code that interacts with engine-specific endpoints. SDK structure and error taxonomy set precedent for future polyglot workers.
+
+## Open Questions
+
+None. All clarifications resolved in the proposal phase.

--- a/openspec/changes/add-remote-activities-python-worker/proposal.md
+++ b/openspec/changes/add-remote-activities-python-worker/proposal.md
@@ -1,0 +1,32 @@
+# Change: Add Remote Activities And Python Worker
+
+## Why
+
+Activity execution is currently in-process only. Workflows that need to call Python ML models, external APIs with Python-specific SDKs, or long-running computations must embed that logic in the Go server. Remote activity workers allow external processes to claim, execute, and complete activity tasks over REST, keeping the engine's activity retry and lease semantics intact while enabling polyglot execution.
+
+## What Changes
+
+### Engine Remote Activity Protocol
+- Add `workflow.ActivityOptions.ExecutionTarget` with values `local` (default) and `remote`
+- Add `engine.activity_tasks.execution_target TEXT NOT NULL DEFAULT 'local'`
+- Local claim queries only claim `local` tasks; remote claim is a separate endpoint
+- Add preview-gated REST endpoints: claim, heartbeat/renew lease, complete, and fail
+- Claim returns immediately with zero or more tasks (short-polling, no long-poll in v1)
+- Server clamps lease duration: min 10s, default 60s, max 5m
+- Complete/fail requires matching `worker_id` lease ownership; stale, already-terminal, local-target, or otherwise wrong-state calls return conflicts
+- Failure reuses existing retry logic with non-retryable flag support
+
+### Engine Remote Activity Routing
+- No `task_queue` in v1; routing is execution target plus supported activity types
+- Existing in-process workers continue handling `local` tasks with no migration break
+
+### Python Remote Activity Worker
+- Handler registry for sync Python callables, short-polling loop, configurable concurrency limit
+- Heartbeat loop at half of the effective lease duration returned by claim
+- Graceful shutdown with in-flight task completion
+- Complete/fail calls with typed errors and non-retryable error support
+- No Python workflow authoring; no TS/JS SDK
+
+## Impact
+- Affected specs: engine-remote-activity-protocol (new), engine-remote-activity-routing (new), python-remote-activity-worker (new)
+- Affected code: `engine/pkg/workflow/`, `engine/internal/store/`, `engine/internal/activity/`, `engine/db/`, `contracts/openapi/`, `internal/api/`, `sdks/python/`

--- a/openspec/changes/add-remote-activities-python-worker/specs/engine-remote-activity-protocol/spec.md
+++ b/openspec/changes/add-remote-activities-python-worker/specs/engine-remote-activity-protocol/spec.md
@@ -1,0 +1,166 @@
+## ADDED Requirements
+
+### Requirement: Remote Activity Claim Endpoint
+The engine MUST provide `POST /v1/engine/activities/claim` as an API-key-authenticated, project-scoped, preview-gated endpoint. Requests MUST include `X-Continua-Engine-Preview: 1`. The request MUST include `worker_id` (string) and `activity_types` (non-empty list of strings). The request MAY include `lease_duration` (duration string) and `max_tasks` (integer).
+
+The server MUST trim and validate `worker_id`: it MUST be non-empty after trimming and no longer than 128 characters, otherwise the endpoint MUST return 400 Bad Request. The server MUST reject requests with an empty `activity_types` list, and MUST trim and validate every `activity_types` entry as non-empty and no longer than 256 characters (400 Bad Request).
+
+The server MUST clamp `max_tasks` to minimum 1, default 10, maximum 50. The server MUST clamp `lease_duration` to minimum 10 seconds, default 60 seconds, maximum 5 minutes.
+
+The endpoint MUST return immediately with zero or more claimable tasks matching the requested activity types and `execution_target = 'remote'`. Claimable tasks MUST satisfy the same availability predicate as the local claim path: `(status = 'queued' AND available_at <= now)` OR `(status = 'claimed' AND lease_expires_at IS NOT NULL AND lease_expires_at < now)`. The claim query MUST apply project, `execution_target`, activity type, and availability filters before ordering and applying `max_tasks`. There MUST be no long-polling or connection holding in v1. The response MUST include the effective lease expiry and effective lease duration in milliseconds for each claimed task.
+
+The remote claim transaction MUST atomically set `status = 'claimed'`, `claimed_by`, `claimed_at`, `lease_expires_at`, persist the effective lease duration on each claimed task (as `lease_duration_ms` or equivalent), and increment `attempt_count` by 1. This MUST apply both to queued claims and stale-lease reclaims so retry exhaustion and backoff accounting match the existing local activity claim path.
+
+Stale tasks (where `lease_expires_at` has passed after the last successful claim or heartbeat) MUST be reclaimable by any worker.
+
+#### Scenario: Claim returns available remote tasks
+- **WHEN** a worker calls `POST /v1/engine/activities/claim` with `worker_id: "w1"`, `activity_types: ["send_email", "process_image"]`, `max_tasks: 5`
+- **THEN** the response contains up to 5 tasks with `execution_target = 'remote'` and matching activity types
+- **AND** each task includes task ID, activity key, activity type, input, effective lease expiry, and `effective_lease_duration_ms`
+- **AND** each claimed task has `claimed_by = "w1"` and `attempt_count` incremented by 1
+
+#### Scenario: Claim returns empty when no tasks available
+- **WHEN** a worker calls claim and no remote tasks match the requested activity types
+- **THEN** the response contains an empty task list
+- **AND** the response is returned immediately (no blocking)
+
+#### Scenario: Claim respects retry backoff availability
+- **WHEN** a remote task is queued for retry with `available_at` in the future
+- **THEN** remote claim does not return that task before `available_at <= now`
+- **WHEN** `available_at <= now`
+- **THEN** remote claim may return the task if its activity type and project match
+
+#### Scenario: Claim request validation
+- **WHEN** a worker calls claim with a blank `worker_id`, a too-long `worker_id`, an empty `activity_types` list, a blank activity type, or a too-long activity type
+- **THEN** the response is 400 Bad Request
+
+#### Scenario: Lease duration clamping
+- **WHEN** a worker requests `lease_duration: "3s"`
+- **THEN** the effective lease is clamped to 10 seconds
+- **WHEN** a worker requests `lease_duration: "10m"`
+- **THEN** the effective lease is clamped to 5 minutes
+- **WHEN** a worker omits `lease_duration`
+- **THEN** the effective lease defaults to 60 seconds
+
+#### Scenario: Stale lease reclaim
+- **WHEN** worker "w1" claims a task but its lease expires without heartbeat
+- **THEN** worker "w2" can claim the same task on a subsequent claim call
+- **AND** the reclaim updates `claimed_by`, `claimed_at`, `lease_expires_at`, and `lease_duration_ms`
+- **AND** increments `attempt_count` by 1
+
+### Requirement: Remote Activity Heartbeat Endpoint
+The engine MUST provide `POST /v1/engine/activities/{id}/heartbeat` as an API-key-authenticated, project-scoped, preview-gated endpoint. Requests MUST include `X-Continua-Engine-Preview: 1`. The request MUST include `worker_id`.
+
+The server MUST trim and validate `worker_id`: it MUST be non-empty after trimming and no longer than 128 characters, otherwise the endpoint MUST return 400 Bad Request.
+
+The endpoint MUST validate current remote lease ownership using the same ownership predicate as complete/fail: the task belongs to the authenticated project, `execution_target = 'remote'`, status is `claimed`, `claimed_by` matches `worker_id`, and the lease has not expired. On success, it MUST extend the lease by the stored effective lease duration (persisted at claim time) from now and return the new effective expiry and effective lease duration in milliseconds.
+
+If the task is local-target, queued, terminal, expired, claimed by another worker, or otherwise not currently owned by the requesting remote worker, the endpoint MUST return a 409 Conflict. A missing or cross-project task MUST return 404.
+
+#### Scenario: Heartbeat renews lease
+- **WHEN** worker "w1" owns task T (claimed with effective lease 60s) and calls heartbeat
+- **THEN** the task's `lease_expires_at` is set to now + 60 seconds
+- **AND** the response contains the new effective expiry and `effective_lease_duration_ms`
+
+#### Scenario: Heartbeat from non-owner rejected
+- **WHEN** worker "w2" (not the current owner) calls heartbeat for task T
+- **THEN** the response is 409 Conflict
+
+#### Scenario: Heartbeat only renews owned remote claimed tasks
+- **WHEN** worker "w1" calls heartbeat for a local-target, queued, terminal, expired, or reclaimed task
+- **THEN** the response is 409 Conflict
+- **AND** the task lease is not extended
+
+#### Scenario: Heartbeat missing or cross-project task
+- **WHEN** a worker calls heartbeat for a missing task or a task outside the authenticated project
+- **THEN** the response is 404 Not Found
+
+#### Scenario: Heartbeat request validation
+- **WHEN** a worker calls heartbeat with a blank or too-long `worker_id`
+- **THEN** the response is 400 Bad Request
+
+### Requirement: Remote Activity Complete Endpoint
+The engine MUST provide `POST /v1/engine/activities/{id}/complete` as an API-key-authenticated, project-scoped, preview-gated endpoint. Requests MUST include `X-Continua-Engine-Preview: 1`. The request MUST include `worker_id` and `output` (JSON).
+
+The server MUST trim and validate `worker_id`: it MUST be non-empty after trimming and no longer than 128 characters, otherwise the endpoint MUST return 400 Bad Request.
+
+The endpoint MUST validate that the requesting `worker_id` currently owns the task's lease. On success, it MUST complete the task and wake the waiting workflow run.
+
+Current lease ownership requires all of: the task belongs to the authenticated project, `execution_target = 'remote'`, status is `claimed`, `claimed_by` matches `worker_id`, and the lease has not expired.
+
+The endpoint MUST return 409 Conflict instead of silent success when the task is local-target, queued, claimed by another worker, reclaimed after lease expiry, already completed, already failed, or already cancelled. A missing or cross-project task MUST return 404.
+
+#### Scenario: Complete with valid lease ownership
+- **WHEN** worker "w1" owns task T and calls complete with output `{"result": "ok"}`
+- **THEN** the task transitions to `completed` with the provided output
+- **AND** the waiting workflow run is woken
+
+#### Scenario: Duplicate complete after success is rejected
+- **WHEN** worker "w1" calls complete for task T after an earlier complete call already transitioned T to `completed`
+- **THEN** the response is 409 Conflict
+- **AND** the task's completed output is not changed
+
+#### Scenario: Complete with stale lease is rejected
+- **WHEN** worker "w1" calls complete for task T but worker "w2" has already reclaimed it
+- **THEN** the response is 409 Conflict
+- **AND** the task's state is unchanged
+
+#### Scenario: Complete against wrong terminal state is rejected
+- **WHEN** worker "w1" calls complete for task T but T is already failed or cancelled
+- **THEN** the response is 409 Conflict
+- **AND** the task's terminal state is unchanged
+
+#### Scenario: Complete request validation
+- **WHEN** a worker calls complete with a blank or too-long `worker_id`
+- **THEN** the response is 400 Bad Request
+
+### Requirement: Remote Activity Fail Endpoint
+The engine MUST provide `POST /v1/engine/activities/{id}/fail` as an API-key-authenticated, project-scoped, preview-gated endpoint. Requests MUST include `X-Continua-Engine-Preview: 1`. The request MUST include `worker_id`, `error_code` (string), `error_message` (string), and optionally `non_retryable` (boolean).
+
+The server MUST trim and validate `worker_id`: it MUST be non-empty after trimming and no longer than 128 characters, otherwise the endpoint MUST return 400 Bad Request.
+
+The server MUST validate `error_code` before mutating task state: it MUST be non-empty and no longer than 128 characters, otherwise the endpoint MUST return 400 Bad Request. The server MUST enforce a durable `error_message` maximum of 4096 characters by truncating longer messages before storing retry history, terminal state, or workflow wake errors.
+
+If `non_retryable` is true or the task's retry policy is exhausted, the task MUST transition to `failed` and wake the waiting workflow run with the error. Otherwise, the task MUST be requeued with appropriate backoff using existing retry logic.
+
+Current lease ownership requires all of: the task belongs to the authenticated project, `execution_target = 'remote'`, status is `claimed`, `claimed_by` matches `worker_id`, and the lease has not expired.
+
+The endpoint MUST return 409 Conflict instead of silent success when the task is local-target, queued, claimed by another worker, reclaimed after lease expiry, already completed, already cancelled, or already failed. A missing or cross-project task MUST return 404.
+
+#### Scenario: Retryable failure requeues
+- **WHEN** worker "w1" fails task T with `non_retryable: false` and the task has remaining retry attempts
+- **THEN** the task is requeued with backoff computed from existing retry policy
+- **AND** `activity.retry_scheduled` history event is appended
+
+#### Scenario: Non-retryable failure terminates task
+- **WHEN** worker "w1" fails task T with `non_retryable: true`
+- **THEN** the task transitions to `failed` regardless of remaining retry attempts
+- **AND** the waiting workflow run is woken with the error
+
+#### Scenario: Retry exhaustion terminates task
+- **WHEN** worker "w1" fails task T and no retry attempts remain
+- **THEN** the task transitions to `failed`
+- **AND** the waiting workflow run is woken with the error
+
+#### Scenario: Duplicate fail after retry requeue is rejected
+- **WHEN** worker "w1" calls fail for task T after an earlier fail call already requeued T for retry
+- **THEN** the response is 409 Conflict
+- **AND** the task remains queued for retry
+
+#### Scenario: Fail with stale lease is rejected
+- **WHEN** worker "w1" calls fail for task T but worker "w2" has already reclaimed it
+- **THEN** the response is 409 Conflict
+- **AND** the task's state is unchanged
+
+#### Scenario: Fail error fields are bounded
+- **WHEN** a worker calls fail with a blank or too-long `worker_id`
+- **THEN** the response is 400 Bad Request
+- **WHEN** a worker calls fail with an empty `error_code` or an `error_code` longer than 128 characters
+- **THEN** the response is 400 Bad Request
+- **WHEN** a worker calls fail with an `error_message` longer than 4096 characters
+- **THEN** the stored retry or terminal error message is truncated to 4096 characters
+
+#### Scenario: Fail against completed task is rejected
+- **WHEN** worker "w1" calls fail for task T but T is already completed
+- **THEN** the response is 409 Conflict
+- **AND** the task's completed output is unchanged

--- a/openspec/changes/add-remote-activities-python-worker/specs/engine-remote-activity-routing/spec.md
+++ b/openspec/changes/add-remote-activities-python-worker/specs/engine-remote-activity-routing/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Execution Target Activity Option
+`workflow.ActivityOptions` MUST support an `ExecutionTarget` field with normalized values `local` and `remote`. An empty or unset value MUST default to `local`.
+
+When a workflow schedules an activity with `ExecutionTarget: "remote"`, the created `engine.activity_tasks` row MUST have `execution_target = 'remote'`.
+
+The `execution_target` column MUST have a CHECK constraint: `execution_target IN ('local', 'remote')`. The migration MUST add partial indexes that include `execution_target` to support efficient local and remote claim queries (e.g., `WHERE execution_target = 'local' AND status = 'queued'` and `WHERE execution_target = 'remote' AND status = 'queued' AND activity_type IN (...)`).
+
+#### Scenario: Default execution target is local
+- **WHEN** a workflow calls `Activity("key", "type", input, &out)` without options
+- **THEN** the activity task is created with `execution_target = 'local'`
+
+#### Scenario: Explicit remote execution target
+- **WHEN** a workflow calls `ActivityWithOptions("key", "type", input, &out, ActivityOptions{ExecutionTarget: "remote"})`
+- **THEN** the activity task is created with `execution_target = 'remote'`
+
+#### Scenario: Invalid execution target rejected
+- **WHEN** a workflow provides `ExecutionTarget: "gpu_cluster"`
+- **THEN** the activity options normalization returns an error
+
+### Requirement: Local And Remote Claim Isolation
+In-process (local) activity worker claim queries MUST only claim tasks with `execution_target = 'local'`. Remote claim endpoint queries MUST only claim tasks with `execution_target = 'remote'`.
+
+Existing in-process workers MUST continue handling default local tasks without any migration or configuration change.
+
+#### Scenario: Local worker ignores remote tasks
+- **WHEN** the in-process activity worker claims the next task
+- **AND** there are pending tasks with `execution_target = 'remote'` but none with `local`
+- **THEN** the claim returns no task
+
+#### Scenario: Remote claim ignores local tasks
+- **WHEN** a remote worker calls the claim endpoint
+- **AND** there are pending tasks with `execution_target = 'local'` but none with `remote`
+- **THEN** the claim returns an empty task list
+
+#### Scenario: No migration break for existing workflows
+- **WHEN** the execution_target column migration runs
+- **THEN** all existing activity tasks default to `execution_target = 'local'`
+- **AND** existing in-process workers continue claiming and completing them with no behavior change
+
+### Requirement: No Task Queue In V1
+The engine MUST NOT implement named task queues or queue-based routing in this version. Remote task routing MUST use only `execution_target` filtering combined with `activity_types` filtering on the claim request.
+
+#### Scenario: Routing by execution target and activity type
+- **WHEN** a remote worker claims with `activity_types: ["send_email"]`
+- **THEN** only remote tasks with `activity_type = 'send_email'` are returned
+- **AND** no queue name or queue routing is involved

--- a/openspec/changes/add-remote-activities-python-worker/specs/python-remote-activity-worker/spec.md
+++ b/openspec/changes/add-remote-activities-python-worker/specs/python-remote-activity-worker/spec.md
@@ -1,0 +1,122 @@
+## ADDED Requirements
+
+### Requirement: Activity Worker Handler Registry
+The Python SDK MUST provide an `ActivityWorker` class with a handler registry. Handlers MUST be registered via `worker.register(activity_type, handler_fn)` or a decorator form `@worker.activity("type_name")`.
+
+V1 handlers MUST be synchronous Python callables. Coroutine functions and async handler execution are out of scope for v1 and MUST be rejected at registration time with a clear error.
+
+Each handler MUST receive the task input (deserialized JSON) and return a result (serializable to JSON) or raise an exception. For ergonomics, one-argument handlers MUST be supported. Handlers MAY also accept a second `ActivityTaskContext` argument. `ActivityTaskContext` MUST expose `task_id`, `activity_key`, `activity_type`, and a cancellation/lost-lease indicator that handlers can poll before performing side effects.
+
+#### Scenario: Register handler with method
+- **WHEN** a developer calls `worker.register("send_email", send_email_handler)`
+- **THEN** the worker dispatches `send_email` activity tasks to `send_email_handler`
+
+#### Scenario: Register handler with decorator
+- **WHEN** a developer decorates a function with `@worker.activity("process_image")`
+- **THEN** the worker dispatches `process_image` activity tasks to the decorated function
+
+#### Scenario: Unregistered activity type
+- **WHEN** the worker receives a task with an activity type that has no registered handler
+- **THEN** the worker fails the task with an appropriate error code and message
+
+#### Scenario: Handler receives task context
+- **WHEN** a registered handler accepts `(input, context)`
+- **THEN** the worker passes deserialized input as the first argument
+- **AND** passes an `ActivityTaskContext` containing task ID, activity key, and activity type as the second argument
+
+#### Scenario: Async handler rejected in v1
+- **WHEN** a developer attempts to register an async coroutine handler
+- **THEN** registration fails with a clear error explaining that remote activity worker v1 supports sync handlers only
+
+### Requirement: Polling Loop
+The `ActivityWorker` MUST implement a polling loop that calls the claim endpoint at a configurable interval. The worker MUST pass its registered activity types in the claim request.
+
+The worker MUST have a stable `worker_id` for the worker instance lifetime. `ActivityWorker` MUST accept a configurable `worker_id`; if omitted, it MUST generate one non-empty value no longer than 128 characters once during worker construction or before the first claim, for example `py-<uuid4>`. The same `worker_id` value MUST be used for claim, heartbeat, complete, and fail calls for all tasks claimed by that worker instance. The worker MUST NOT generate `worker_id` per request or per task.
+
+By default, the worker MUST set claim `max_tasks` to the number of currently available execution slots (`concurrency_limit - active_in_flight_task_count`) and MUST skip claim calls when no execution slots are available. The worker MUST NOT keep a local claimed-but-not-running backlog by default; any configurable prefetch/backlog option MUST be explicit, bounded, and documented as starting leases before handler execution.
+
+When tasks are claimed, the worker MUST dispatch them immediately to registered synchronous handlers on a bounded thread pool, up to a configurable concurrency limit. The worker MUST use the effective lease duration returned by the claim response, not local reimplementation of server clamp logic, to schedule default heartbeat intervals.
+
+#### Scenario: Worker polls and executes tasks
+- **WHEN** the worker is started with `worker.run()`
+- **THEN** it repeatedly calls the claim endpoint
+- **AND** uses the same `worker_id` value on claim, heartbeat, complete, and fail calls
+- **AND** sets claim `max_tasks` to the current number of available execution slots
+- **AND** dispatches claimed tasks immediately to registered handlers
+- **AND** calls the complete or fail endpoint based on the handler outcome
+
+#### Scenario: Worker ID generated once
+- **WHEN** an `ActivityWorker` is created without a configured `worker_id`
+- **THEN** the worker generates one non-empty `worker_id` no longer than 128 characters
+- **AND** reuses that same value for all claim, heartbeat, complete, and fail calls during the worker instance lifetime
+
+#### Scenario: Concurrency limit respected
+- **WHEN** the worker has a concurrency limit of 5 and no active in-flight tasks
+- **THEN** the next claim request uses `max_tasks: 5`
+- **WHEN** the worker already has 5 active in-flight tasks
+- **THEN** it skips claiming until a slot opens
+- **AND** at most 5 tasks execute concurrently
+- **AND** execution uses worker threads rather than asyncio tasks
+
+#### Scenario: Backlog disabled by default
+- **WHEN** the worker has a concurrency limit of 5
+- **AND** the server has 10 matching tasks available
+- **THEN** the worker claims at most 5 tasks by default
+- **AND** at most 5 tasks execute concurrently
+- **AND** does not hold the remaining tasks in a local claimed-but-not-running backlog
+
+### Requirement: Heartbeat Loop
+For each in-flight task, the worker MUST send heartbeats at half of the effective lease duration by default. The heartbeat interval MUST be configurable.
+
+If a heartbeat fails with 409 Conflict or 404 Not Found, the worker SHOULD signal cancellation through `ActivityTaskContext` for handlers that accepted a context argument and MUST NOT call complete or fail for that task. The worker MUST treat both responses as no-longer-owned task outcomes and MUST NOT attempt to force-kill a running sync handler thread.
+
+#### Scenario: Heartbeat sent at half lease interval
+- **WHEN** a task is claimed with effective lease of 60 seconds
+- **THEN** the worker sends a heartbeat after 30 seconds
+- **AND** continues heartbeating at 30-second intervals until the task completes
+
+#### Scenario: Lost lease detected via heartbeat
+- **WHEN** a heartbeat returns 409 Conflict
+- **THEN** the worker marks the task context as cancelled/lost-lease if the handler accepted context
+- **AND** does not call complete or fail for that task
+
+#### Scenario: Missing task detected via heartbeat
+- **WHEN** a heartbeat returns 404 Not Found
+- **THEN** the worker marks the task context as cancelled/lost-lease if the handler accepted context
+- **AND** does not call complete or fail for that task
+
+### Requirement: Graceful Shutdown
+The worker MUST support graceful shutdown. On shutdown signal (SIGINT, SIGTERM), the worker MUST:
+1. Stop claiming new tasks
+2. Continue heartbeating still-owned in-flight tasks while waiting for handlers to complete (up to a configurable timeout)
+3. Call complete or fail only for completed handlers whose task lease is still owned and not marked lost-lease
+4. Exit cleanly
+
+#### Scenario: Graceful shutdown completes in-flight work
+- **WHEN** the worker receives SIGINT with 3 tasks in flight
+- **THEN** the worker stops polling for new tasks
+- **AND** continues heartbeating still-owned in-flight tasks while waiting for the 3 in-flight handlers to complete
+- **AND** calls complete or fail only for tasks whose lease remains owned
+- **AND** leaves tasks that timed out or were marked lost-lease for natural reclaim
+- **AND** exits cleanly
+
+#### Scenario: Shutdown timeout exceeded
+- **WHEN** the worker receives SIGINT and in-flight tasks exceed the shutdown timeout
+- **THEN** the worker exits after the timeout
+- **AND** does not call complete or fail for unfinished tasks after the timeout
+- **AND** uncompleted tasks have their leases expire naturally for reclaim
+
+### Requirement: Error Mapping
+The Python SDK MUST provide a `NonRetryableError` exception class. When a handler raises `NonRetryableError`, the worker MUST call the fail endpoint with `non_retryable: true`.
+
+Unhandled exceptions from handlers MUST be mapped to a generic error code with a bounded error message (exception type and message, truncated to 4096 characters) and `non_retryable: false` (retryable by default). The full traceback MAY be logged locally but MUST NOT be sent as the error message, since error messages become durable engine history data.
+
+#### Scenario: NonRetryableError maps correctly
+- **WHEN** a handler raises `NonRetryableError("Invalid input format")`
+- **THEN** the worker calls fail with `error_code: "non_retryable_error"`, `error_message: "Invalid input format"`, `non_retryable: true`
+
+#### Scenario: Unhandled exception is retryable with bounded message
+- **WHEN** a handler raises `ConnectionError("timeout")`
+- **THEN** the worker calls fail with `error_code: "activity_error"`, `error_message: "ConnectionError: timeout"` (truncated to 4096 chars), and `non_retryable: false`
+- **AND** the full traceback is logged locally
+- **AND** the engine retries the task if retry attempts remain

--- a/openspec/changes/add-remote-activities-python-worker/tasks.md
+++ b/openspec/changes/add-remote-activities-python-worker/tasks.md
@@ -1,0 +1,95 @@
+## 0. Prerequisite Gate
+- [x] 0.1 Close prior-phase validation debt: retries, suspend/resume, ContinueAsNew, generated drift, and debugger tests must be green before starting
+
+## 1. Engine Remote Activity Routing
+
+### 1.1 Schema
+- [x] 1.1.1 Create engine migration: add `execution_target TEXT NOT NULL DEFAULT 'local'` with CHECK constraint `execution_target IN ('local', 'remote')`, and `lease_duration_ms BIGINT` to `engine.activity_tasks`; add partial indexes for local and remote claim queries
+- [x] 1.1.2 Update local claim queries to filter `WHERE execution_target = 'local'`
+- [x] 1.1.3 Add remote claim query: filter `WHERE execution_target = 'remote'` with `activity_type IN (...)`, the local availability predicate (`queued` with `available_at <= NOW()` or expired `claimed` lease), and `max_tasks` limit; atomically set claimed_by/claimed_at/lease_expires_at/lease_duration_ms and increment attempt_count for queued claims and stale-lease reclaims
+- [x] 1.1.4 Add sqlc queries for heartbeat/renew lease, remote complete, remote fail, and conflict classification for stale/reclaimed/local-target/wrong-terminal-state calls
+- [x] 1.1.5 Run `make generate`
+
+### 1.2 Activity Options
+- [x] 1.2.1 Add `ExecutionTarget string` to `workflow.ActivityOptions` with normalized values `local` and `remote`
+- [x] 1.2.2 Update `NormalizeActivityOptions` to validate and default `ExecutionTarget`
+- [x] 1.2.3 Pass `execution_target` through to `CreateActivityTask` params
+- [x] 1.2.4 Verify existing in-process activity workers only claim `local` tasks (no behavior change)
+
+## 2. Engine Remote Activity Protocol
+
+### 2.1 REST Endpoints
+- [x] 2.1.1 Add preview-gated OpenAPI paths requiring `X-Continua-Engine-Preview: 1`: `POST /v1/engine/activities/claim`, `POST /v1/engine/activities/{id}/heartbeat`, `POST /v1/engine/activities/{id}/complete`, `POST /v1/engine/activities/{id}/fail`
+- [x] 2.1.2 Define request/response schemas: claim (bounded non-empty worker_id, non-empty bounded activity_types, lease_duration, max_tasks; task responses include lease_expires_at and effective_lease_duration_ms), heartbeat (bounded non-empty worker_id; response includes lease_expires_at and effective_lease_duration_ms), complete (bounded non-empty worker_id, output), fail (bounded non-empty worker_id, bounded error_code, bounded/truncated error_message, non_retryable)
+- [x] 2.1.3 Run `make generate`
+- [x] 2.1.4 Implement claim handler: validate bounded non-empty worker_id and activity_types entries, clamp lease (min 10s, default 60s, max 5m), claim/reclaim only queued tasks whose `available_at <= now` or claimed tasks whose lease expired, update attempt_count atomically, return tasks with effective lease expiry and effective lease duration in milliseconds
+- [x] 2.1.5 Implement heartbeat handler: validate bounded non-empty worker_id and remote lease ownership (`execution_target = 'remote'`, status `claimed`, matching worker, unexpired lease), return 409 for local-target/queued/terminal/expired/reclaimed/non-owned tasks, return 404 for missing/cross-project tasks, renew lease, return effective expiry and effective lease duration in milliseconds
+- [x] 2.1.6 Implement complete handler: validate bounded non-empty worker_id ownership, complete task, wake waiting run, and return 409 for stale/reclaimed/local-target/already-terminal/wrong-state calls, including duplicate complete calls after a successful response
+- [x] 2.1.7 Implement fail handler: validate bounded non-empty worker_id ownership, bound `error_code`, truncate `error_message`, fail or retry task based on retry policy and non_retryable flag, and return 409 for stale/reclaimed/local-target/already-terminal/wrong-state calls, including duplicate fail calls after retry requeue or terminal failure
+
+### 2.2 Auth And Scoping
+- [x] 2.2.1 Remote activity endpoints MUST be API-key authenticated and project-scoped (same middleware as existing engine endpoints)
+- [x] 2.2.2 Claim, heartbeat, complete, and fail operations MUST only access tasks belonging to the authenticated project
+
+## 3. Python Remote Activity Worker
+
+### 3.1 Worker Module
+- [x] 3.1.1 Create `sdks/python/src/continua/worker.py` with `ActivityWorker` class and configurable `worker_id` (generated once per worker instance when omitted)
+- [x] 3.1.2 Implement handler registry for synchronous callables: `worker.register(activity_type, handler_fn)` and decorator form `@worker.activity(type_name)`; reject coroutine handlers in v1
+- [x] 3.1.3 Implement polling loop: configurable poll interval, calls claim endpoint with `max_tasks` set to available execution slots, skips claiming when no slots are available, dispatches claimed tasks immediately to registered handlers
+- [x] 3.1.4 Implement concurrency limit with a bounded thread pool: cap on concurrent sync task executions and avoid a local claimed-but-not-running backlog by default
+- [x] 3.1.5 Implement heartbeat loop: heartbeat at half of `effective_lease_duration_ms` for each in-flight task; treat heartbeat 409 and 404 as lost/no-longer-owned and signal the task context
+- [x] 3.1.6 Implement complete/fail calls: serialize output or map errors, call complete/fail endpoints with the same worker-instance `worker_id`, and suppress terminal calls for tasks marked lost/no-longer-owned
+- [x] 3.1.7 Implement graceful shutdown: stop claiming, continue heartbeating still-owned in-flight tasks while waiting, complete/fail only still-owned completed tasks, and leave timeout/lost-lease tasks for reclaim
+- [x] 3.1.8 Implement non-retryable error support: `NonRetryableError` exception class, mapped to `non_retryable: true` on fail
+- [x] 3.1.9 Implement optional `ActivityTaskContext` second handler argument with task_id, activity_key, activity_type, and lost-lease/cancellation indicator
+
+### 3.2 Error Taxonomy
+- [x] 3.2.1 Map Python exceptions to error codes and messages
+- [x] 3.2.2 `NonRetryableError` maps to `non_retryable: true`
+- [x] 3.2.3 Unhandled exceptions map to a generic error code with bounded exception type/message; full traceback is logged locally only and is not sent as the durable error message
+
+## 4. Tests
+
+### 4.1 Engine Routing Tests
+- [x] 4.1.1 Test: local activity claim only returns `local` tasks
+- [x] 4.1.2 Test: remote activity claim only returns `remote` tasks
+- [x] 4.1.3 Test: claim with empty response (no available tasks) returns immediately
+- [x] 4.1.4 Test: remote type filtering (claim only returns tasks matching requested activity_types)
+
+### 4.2 Protocol Tests
+- [x] 4.2.1 Test: lease clamping (below min clamped to 10s, above max clamped to 5m)
+- [x] 4.2.2 Test: heartbeat renewal extends lease expiry only for owned remote claimed tasks; local-target/queued/terminal/expired/reclaimed/non-owned tasks return 409 without extending the lease
+- [x] 4.2.3 Test: stale lease reclaim (task reclaimed after lease expiry)
+- [x] 4.2.4 Test: complete with matching worker_id succeeds
+- [x] 4.2.5 Test: duplicate complete after successful response returns 409 and does not mutate completed output
+- [x] 4.2.6 Test: complete with stale/reclaimed worker_id returns 409 and does not mutate task state
+- [x] 4.2.7 Test: complete/fail against local-target or wrong terminal state returns 409 and does not mutate task state
+- [x] 4.2.8 Test: duplicate fail after retry requeue or terminal failure returns 409 and does not mutate task state
+- [x] 4.2.9 Test: fail with retryable error requeues task with backoff
+- [x] 4.2.10 Test: fail with non-retryable error or exhausted retry policy terminates task immediately
+- [x] 4.2.11 Test: auth, preview gating, and project scoping (router-level auth/preview coverage plus cross-project claim returns nothing)
+- [x] 4.2.12 Test: heartbeat for missing/cross-project tasks returns 404 without leaking task existence
+- [x] 4.2.13 Test: fail rejects invalid or too-long `error_code` and truncates too-long `error_message`
+- [x] 4.2.14 Test: remote claim increments attempt_count and persists claimed_by/claimed_at/lease_expires_at/lease_duration_ms for queued claims and stale-lease reclaims
+- [x] 4.2.15 Test: all remote endpoints reject blank or too-long worker_id, and claim rejects blank, too-long, or too many activity_types entries
+- [x] 4.2.16 Test: remote claim respects `available_at` retry backoff and does not claim queued retry tasks before they become available
+- [x] 4.2.17 Test: complete and fail return 404 for missing/cross-project task IDs without leaking task existence
+
+### 4.3 Python Worker Tests
+- [x] 4.3.1 Test: handler registration and dispatch
+- [x] 4.3.2 Test: polling loop claims and executes tasks
+- [x] 4.3.3 Test: concurrency limit respected with sync thread-pool execution, slot-based `max_tasks`, and no default local claimed-but-not-running backlog
+- [x] 4.3.4 Test: heartbeat sent at half of claim response `effective_lease_duration_ms`
+- [x] 4.3.5 Test: graceful shutdown heartbeats still-owned tasks, completes/fails only still-owned finished tasks, and leaves timeout/lost-lease tasks for reclaim
+- [x] 4.3.6 Test: NonRetryableError mapped correctly
+- [x] 4.3.7 Test: unhandled exception mapped to generic error
+- [x] 4.3.8 Test: optional `ActivityTaskContext` second argument receives task metadata and lost-lease cancellation signal
+- [x] 4.3.9 Test: coroutine handlers are rejected in v1
+- [x] 4.3.10 Test: worker_id is stable for the worker instance lifetime and reused across claim, heartbeat, complete, and fail
+- [x] 4.3.11 Test: heartbeat 404/409 marks the task lost/no-longer-owned, signals context cancellation, and suppresses complete/fail
+
+### 4.4 Validation
+- [x] 4.4.1 Run `make generate` and verify no drift
+- [x] 4.4.2 Run targeted Go tests for engine/store/API changes
+- [x] 4.4.3 Run `cd sdks/python && uv run pytest`

--- a/sdks/python/src/continua/__init__.py
+++ b/sdks/python/src/continua/__init__.py
@@ -37,6 +37,7 @@ from .exceptions import (
 from .session import SessionContext, get_current_session, session
 from .span import SpanContext, get_current_span, span
 from .trace import TraceContext, get_current_trace, trace
+from .worker import ActivityTaskContext, ActivityWorker, NonRetryableError
 
 __all__ = [
     # Core client
@@ -50,6 +51,8 @@ __all__ = [
     "TraceContext",
     "SpanContext",
     "SessionContext",
+    "ActivityTaskContext",
+    "ActivityWorker",
     # Context getters
     "get_current_trace",
     "get_current_span",
@@ -61,6 +64,7 @@ __all__ = [
     "EngineRunNotFoundError",
     "EngineRunNotTerminalError",
     "EngineRunWaitTimeoutError",
+    "NonRetryableError",
     "RateLimitError",
     "ValidationError",
     "NetworkError",

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
 
 
 class Error(BaseModel):
@@ -99,6 +99,54 @@ class EnginePendingActivityItem(BaseModel):
     status: str
     available_at: AwareDatetime
     attempt_count: int
+
+
+class ActivityType(RootModel[str]):
+    root: str = Field(..., max_length=256, min_length=1)
+
+
+class EngineRemoteActivityClaimRequest(BaseModel):
+    worker_id: str = Field(..., max_length=128, min_length=1)
+    activity_types: list[ActivityType] = Field(..., max_length=50, min_length=1)
+    lease_duration: str | None = Field(
+        None,
+        description="Requested lease duration, e.g. 60s or 5m. The server clamps the effective value.",
+    )
+    max_tasks: int | None = Field(None, ge=1, le=50)
+
+
+class EngineRemoteActivityTask(BaseModel):
+    task_id: UUID
+    activity_key: str
+    activity_type: str
+    input: Any = Field(..., description="Activity input payload (any valid JSON)")
+    lease_expires_at: AwareDatetime
+    effective_lease_duration_ms: int
+
+
+class EngineRemoteActivityClaimResponse(BaseModel):
+    tasks: list[EngineRemoteActivityTask]
+
+
+class EngineRemoteActivityHeartbeatRequest(BaseModel):
+    worker_id: str = Field(..., max_length=128, min_length=1)
+
+
+class EngineRemoteActivityHeartbeatResponse(BaseModel):
+    lease_expires_at: AwareDatetime
+    effective_lease_duration_ms: int
+
+
+class EngineRemoteActivityCompleteRequest(BaseModel):
+    worker_id: str = Field(..., max_length=128, min_length=1)
+    output: Any = Field(..., description="Activity output payload (any valid JSON)")
+
+
+class EngineRemoteActivityFailRequest(BaseModel):
+    worker_id: str = Field(..., max_length=128, min_length=1)
+    error_code: str = Field(..., max_length=128, min_length=1)
+    error_message: str = Field(..., max_length=4096)
+    non_retryable: bool | None = False
 
 
 class EnginePendingTimerItem(BaseModel):

--- a/sdks/python/src/continua/worker.py
+++ b/sdks/python/src/continua/worker.py
@@ -1,0 +1,468 @@
+"""Remote activity worker for Continua engine activity tasks."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import signal
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from .exceptions import AuthenticationError, NetworkError, ValidationError
+
+_PREVIEW_HEADERS = {"X-Continua-Engine-Preview": "1"}
+_DEFAULT_ENDPOINT = "http://localhost:8080"
+_DEFAULT_POLL_INTERVAL = 1.0
+_DEFAULT_CONCURRENCY_LIMIT = 5
+_DEFAULT_LEASE_DURATION = "60s"
+_DEFAULT_SHUTDOWN_TIMEOUT = 30.0
+_MAX_ERROR_MESSAGE_LENGTH = 4096
+
+ActivityHandler = Callable[..., Any]
+
+
+class NonRetryableError(Exception):
+    """Raised by handlers to fail an activity without retrying it."""
+
+
+@dataclass(frozen=True)
+class _HandlerRegistration:
+    handler: ActivityHandler
+    accepts_context: bool
+
+
+@dataclass(frozen=True)
+class _TaskOutcome:
+    output: Any | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    non_retryable: bool = False
+
+    @property
+    def succeeded(self) -> bool:
+        return self.error_code is None
+
+
+class ActivityTaskContext:
+    """Context passed to remote activity handlers that accept a second argument."""
+
+    def __init__(self, *, task_id: str, activity_key: str, activity_type: str) -> None:
+        self.task_id = task_id
+        self.activity_key = activity_key
+        self.activity_type = activity_type
+        self._lost = threading.Event()
+
+    @property
+    def lost_lease(self) -> bool:
+        return self._lost.is_set()
+
+    @property
+    def cancelled(self) -> bool:
+        return self._lost.is_set()
+
+    def is_cancelled(self) -> bool:
+        return self._lost.is_set()
+
+    def _mark_lost(self) -> None:
+        self._lost.set()
+
+
+@dataclass
+class _InFlightTask:
+    task: dict[str, Any]
+    context: ActivityTaskContext
+    future: Future[_TaskOutcome]
+    heartbeat_interval: float
+    next_heartbeat_at: float
+
+
+class ActivityWorker:
+    """Short-polling remote activity worker for synchronous Python handlers."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        endpoint: str = _DEFAULT_ENDPOINT,
+        worker_id: str | None = None,
+        poll_interval: float = _DEFAULT_POLL_INTERVAL,
+        concurrency_limit: int = _DEFAULT_CONCURRENCY_LIMIT,
+        lease_duration: str = _DEFAULT_LEASE_DURATION,
+        heartbeat_interval: float | None = None,
+        shutdown_timeout: float = _DEFAULT_SHUTDOWN_TIMEOUT,
+        client: httpx.Client | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        if concurrency_limit < 1:
+            raise ValueError("concurrency_limit must be at least 1")
+        if poll_interval <= 0:
+            raise ValueError("poll_interval must be positive")
+        if heartbeat_interval is not None and heartbeat_interval <= 0:
+            raise ValueError("heartbeat_interval must be positive when provided")
+        if shutdown_timeout < 0:
+            raise ValueError("shutdown_timeout must be non-negative")
+
+        generated_worker_id = worker_id or f"py-{uuid.uuid4()}"
+        if not generated_worker_id.strip() or len(generated_worker_id) > 128:
+            raise ValueError("worker_id must be non-empty and at most 128 characters")
+
+        self.api_key = api_key
+        self.endpoint = endpoint.rstrip("/")
+        self.worker_id = generated_worker_id
+        self.poll_interval = poll_interval
+        self.concurrency_limit = concurrency_limit
+        self.lease_duration = lease_duration
+        self.heartbeat_interval = heartbeat_interval
+        self.shutdown_timeout = shutdown_timeout
+        self._logger = logger or logging.getLogger(__name__)
+        self._handlers: dict[str, _HandlerRegistration] = {}
+        self._in_flight: dict[str, _InFlightTask] = {}
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._executor = ThreadPoolExecutor(max_workers=concurrency_limit)
+        self._owns_client = client is None
+        self._client = client or httpx.Client(
+            base_url=self.endpoint,
+            headers={"X-API-Key": api_key},
+            timeout=30.0,
+        )
+
+    def register(self, activity_type: str, handler_fn: ActivityHandler) -> ActivityHandler:
+        """Register a synchronous handler for an activity type."""
+        activity_type = activity_type.strip()
+        if not activity_type:
+            raise ValueError("activity_type must be non-empty")
+        if inspect.iscoroutinefunction(handler_fn):
+            raise TypeError("remote activity worker v1 supports sync handlers only")
+        accepts_context = _handler_accepts_context(handler_fn)
+        self._handlers[activity_type] = _HandlerRegistration(
+            handler=handler_fn,
+            accepts_context=accepts_context,
+        )
+        return handler_fn
+
+    def activity(self, activity_type: str) -> Callable[[ActivityHandler], ActivityHandler]:
+        """Decorator form for registering an activity handler."""
+
+        def decorator(handler_fn: ActivityHandler) -> ActivityHandler:
+            return self.register(activity_type, handler_fn)
+
+        return decorator
+
+    def stop(self) -> None:
+        """Request a graceful shutdown."""
+        self._stop_event.set()
+
+    def close(self) -> None:
+        """Close worker resources."""
+        self._executor.shutdown(wait=False, cancel_futures=True)
+        if self._owns_client:
+            self._client.close()
+
+    def run(self) -> None:
+        """Run the blocking polling loop until stopped or signalled."""
+        previous_handlers = self._install_signal_handlers()
+        try:
+            while not self._stop_event.is_set():
+                self.poll_once()
+                time.sleep(self.poll_interval)
+            self.wait_for_idle(timeout=self.shutdown_timeout)
+        finally:
+            self._restore_signal_handlers(previous_handlers)
+            self.close()
+
+    def poll_once(self) -> int:
+        """Run one poll/dispatch/heartbeat/drain iteration.
+
+        Returns the number of tasks claimed in this iteration.
+        """
+        self._tick_heartbeats()
+        self._drain_finished()
+        if self._stop_event.is_set():
+            return 0
+
+        activity_types = sorted(self._handlers.keys())
+        if not activity_types:
+            return 0
+
+        available_slots = self._available_slots()
+        if available_slots <= 0:
+            return 0
+
+        response = self._request(
+            "POST",
+            "/v1/engine/activities/claim",
+            json={
+                "worker_id": self.worker_id,
+                "activity_types": activity_types,
+                "lease_duration": self.lease_duration,
+                "max_tasks": available_slots,
+            },
+        )
+        payload = response.json()
+        tasks = payload.get("tasks", [])
+        for task in tasks[:available_slots]:
+            self._dispatch_task(task)
+        return len(tasks[:available_slots])
+
+    def wait_for_idle(self, *, timeout: float | None = None) -> bool:
+        """Wait for in-flight handlers to finish while continuing heartbeats."""
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            self._tick_heartbeats()
+            self._drain_finished()
+            if self._in_flight_count() == 0:
+                return True
+            if deadline is not None and time.monotonic() >= deadline:
+                self._mark_all_in_flight_lost()
+                return False
+            time.sleep(min(self.poll_interval, 0.05))
+
+    def _dispatch_task(self, task: dict[str, Any]) -> None:
+        task_id = str(task["task_id"])
+        context = ActivityTaskContext(
+            task_id=task_id,
+            activity_key=str(task["activity_key"]),
+            activity_type=str(task["activity_type"]),
+        )
+        heartbeat_interval = self._heartbeat_interval_for_task(task)
+        future = self._executor.submit(self._execute_task, task, context)
+        with self._lock:
+            self._in_flight[task_id] = _InFlightTask(
+                task=task,
+                context=context,
+                future=future,
+                heartbeat_interval=heartbeat_interval,
+                next_heartbeat_at=time.monotonic() + heartbeat_interval,
+            )
+
+    def _execute_task(
+        self,
+        task: dict[str, Any],
+        context: ActivityTaskContext,
+    ) -> _TaskOutcome:
+        registration = self._handlers.get(str(task["activity_type"]))
+        if registration is None:
+            return _TaskOutcome(
+                error_code="activity_not_registered",
+                error_message=f"no handler registered for activity type {task['activity_type']}",
+                non_retryable=True,
+            )
+
+        try:
+            if registration.accepts_context:
+                output = registration.handler(task.get("input"), context)
+            else:
+                output = registration.handler(task.get("input"))
+            return _TaskOutcome(output=output)
+        except NonRetryableError as exc:
+            return _TaskOutcome(
+                error_code="non_retryable_error",
+                error_message=_truncate(str(exc), _MAX_ERROR_MESSAGE_LENGTH),
+                non_retryable=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - handler exceptions are reported to the engine.
+            self._logger.exception("Remote activity handler failed")
+            return _TaskOutcome(
+                error_code="activity_error",
+                error_message=_truncate(f"{type(exc).__name__}: {exc}", _MAX_ERROR_MESSAGE_LENGTH),
+                non_retryable=False,
+            )
+
+    def _tick_heartbeats(self) -> None:
+        now = time.monotonic()
+        with self._lock:
+            due = [
+                item
+                for item in self._in_flight.values()
+                if not item.future.done()
+                and not item.context.lost_lease
+                and now >= item.next_heartbeat_at
+            ]
+
+        for item in due:
+            response = self._request(
+                "POST",
+                f"/v1/engine/activities/{item.context.task_id}/heartbeat",
+                json={"worker_id": self.worker_id},
+                raise_for_status=False,
+            )
+            if response.status_code in {404, 409}:
+                item.context._mark_lost()
+                continue
+            self._raise_for_response(response)
+            payload = response.json()
+            item.heartbeat_interval = self._heartbeat_interval_from_ms(
+                payload.get("effective_lease_duration_ms")
+            )
+            item.next_heartbeat_at = time.monotonic() + item.heartbeat_interval
+
+    def _drain_finished(self) -> None:
+        with self._lock:
+            finished = [
+                (task_id, item)
+                for task_id, item in self._in_flight.items()
+                if item.future.done()
+            ]
+            for task_id, _ in finished:
+                self._in_flight.pop(task_id, None)
+
+        for _, item in finished:
+            if item.context.lost_lease:
+                continue
+            outcome = item.future.result()
+            if outcome.succeeded:
+                self._complete_task(item, outcome.output)
+            else:
+                self._fail_task(item, outcome)
+
+    def _complete_task(self, item: _InFlightTask, output: Any) -> None:
+        response = self._request(
+            "POST",
+            f"/v1/engine/activities/{item.context.task_id}/complete",
+            json={"worker_id": self.worker_id, "output": output},
+            raise_for_status=False,
+        )
+        if response.status_code in {404, 409}:
+            item.context._mark_lost()
+            return
+        self._raise_for_response(response)
+
+    def _fail_task(self, item: _InFlightTask, outcome: _TaskOutcome) -> None:
+        response = self._request(
+            "POST",
+            f"/v1/engine/activities/{item.context.task_id}/fail",
+            json={
+                "worker_id": self.worker_id,
+                "error_code": outcome.error_code,
+                "error_message": outcome.error_message,
+                "non_retryable": outcome.non_retryable,
+            },
+            raise_for_status=False,
+        )
+        if response.status_code in {404, 409}:
+            item.context._mark_lost()
+            return
+        self._raise_for_response(response)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        raise_for_status: bool = True,
+    ) -> httpx.Response:
+        try:
+            response = self._client.request(
+                method,
+                path,
+                json=json,
+                headers=_PREVIEW_HEADERS,
+            )
+        except httpx.RequestError as exc:
+            raise NetworkError("Network request failed", cause=exc) from exc
+
+        if raise_for_status:
+            self._raise_for_response(response)
+        return response
+
+    def _raise_for_response(self, response: httpx.Response) -> None:
+        if 200 <= response.status_code < 300:
+            return
+
+        payload: dict[str, Any] = {}
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+
+        message = str(payload.get("message") or response.text or "Request failed")
+        if response.status_code == 401:
+            raise AuthenticationError(message)
+        if response.status_code == 400:
+            raise ValidationError("Validation error", message)
+        raise NetworkError(
+            f"Remote activity worker request failed with status {response.status_code}"
+        )
+
+    def _available_slots(self) -> int:
+        return self.concurrency_limit - self._in_flight_count()
+
+    def _in_flight_count(self) -> int:
+        with self._lock:
+            return len(self._in_flight)
+
+    def _mark_all_in_flight_lost(self) -> None:
+        with self._lock:
+            for item in self._in_flight.values():
+                item.context._mark_lost()
+
+    def _heartbeat_interval_for_task(self, task: dict[str, Any]) -> float:
+        if self.heartbeat_interval is not None:
+            return self.heartbeat_interval
+        return self._heartbeat_interval_from_ms(task.get("effective_lease_duration_ms"))
+
+    @staticmethod
+    def _heartbeat_interval_from_ms(effective_lease_duration_ms: object) -> float:
+        if not isinstance(effective_lease_duration_ms, int) or effective_lease_duration_ms <= 0:
+            return _DEFAULT_POLL_INTERVAL
+        return max(effective_lease_duration_ms / 2000.0, 0.001)
+
+    def _install_signal_handlers(
+        self,
+    ) -> dict[signal.Signals, signal.Handlers] | None:
+        if threading.current_thread() is not threading.main_thread():
+            return None
+
+        previous: dict[signal.Signals, signal.Handlers] = {}
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            previous[sig] = signal.getsignal(sig)
+
+            def handler(_signum: int, _frame: object) -> None:
+                self.stop()
+
+            signal.signal(sig, handler)
+        return previous
+
+    @staticmethod
+    def _restore_signal_handlers(
+        previous_handlers: dict[signal.Signals, signal.Handlers] | None,
+    ) -> None:
+        if previous_handlers is None:
+            return
+        for sig, handler in previous_handlers.items():
+            signal.signal(sig, handler)
+
+
+def _handler_accepts_context(handler_fn: ActivityHandler) -> bool:
+    signature = inspect.signature(handler_fn)
+    parameters = list(signature.parameters.values())
+    if any(param.kind == inspect.Parameter.VAR_POSITIONAL for param in parameters):
+        return True
+
+    positional = [
+        param
+        for param in parameters
+        if param.kind
+        in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        }
+    ]
+    if len(positional) < 1:
+        raise TypeError("activity handlers must accept at least the input argument")
+    return len(positional) >= 2
+
+
+def _truncate(value: str, max_length: int) -> str:
+    if len(value) <= max_length:
+        return value
+    return value[:max_length]

--- a/sdks/python/tests/test_worker.py
+++ b/sdks/python/tests/test_worker.py
@@ -1,0 +1,353 @@
+"""Tests for the remote activity worker."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from continua import ActivityTaskContext, ActivityWorker, NonRetryableError
+
+
+class StubResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = ""
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class RecordingClient:
+    def __init__(
+        self,
+        *,
+        claims: list[list[dict[str, Any]]] | None = None,
+        heartbeat_statuses: list[int] | None = None,
+    ) -> None:
+        self.claims = claims or []
+        self.heartbeat_statuses = heartbeat_statuses or []
+        self.requests: list[dict[str, Any]] = []
+        self.closed = False
+        self._lock = threading.Lock()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> StubResponse:
+        with self._lock:
+            self.requests.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "json": json,
+                    "headers": headers,
+                }
+            )
+
+            if path == "/v1/engine/activities/claim":
+                tasks = self.claims.pop(0) if self.claims else []
+                return StubResponse(200, {"tasks": tasks})
+
+            if path.endswith("/heartbeat"):
+                status = self.heartbeat_statuses.pop(0) if self.heartbeat_statuses else 200
+                return StubResponse(
+                    status,
+                    {
+                        "lease_expires_at": "2026-04-13T12:00:00Z",
+                        "effective_lease_duration_ms": 20,
+                    },
+                )
+
+            if path.endswith("/complete") or path.endswith("/fail"):
+                return StubResponse(204)
+
+        return StubResponse(500, {"message": "unexpected request"})
+
+    def close(self) -> None:
+        self.closed = True
+
+    def paths(self) -> list[str]:
+        return [request["path"] for request in self.requests]
+
+    def payloads_for(self, suffix: str) -> list[dict[str, Any]]:
+        return [
+            request["json"]
+            for request in self.requests
+            if request["path"].endswith(suffix)
+        ]
+
+
+def task(
+    task_id: str,
+    activity_type: str,
+    *,
+    input_value: dict[str, Any] | None = None,
+    effective_lease_duration_ms: int = 1000,
+) -> dict[str, Any]:
+    return {
+        "task_id": task_id,
+        "activity_key": task_id + "-key",
+        "activity_type": activity_type,
+        "input": input_value or {"value": task_id},
+        "lease_expires_at": "2026-04-13T12:00:00Z",
+        "effective_lease_duration_ms": effective_lease_duration_ms,
+    }
+
+
+def test_handler_registration_decorator_dispatch_and_context() -> None:
+    client = RecordingClient(
+        claims=[[task("task-1", "process_image", input_value={"value": 41})]]
+    )
+    worker = ActivityWorker(api_key="test-key", worker_id="worker-1", client=client)
+    seen_contexts: list[ActivityTaskContext] = []
+
+    @worker.activity("process_image")
+    def process_image(payload: dict[str, Any], context: ActivityTaskContext) -> dict[str, Any]:
+        seen_contexts.append(context)
+        return {"value": payload["value"] + 1}
+
+    try:
+        assert worker.poll_once() == 1
+        assert worker.wait_for_idle(timeout=1.0)
+    finally:
+        worker.close()
+
+    assert seen_contexts[0].task_id == "task-1"
+    complete_payload = client.payloads_for("/complete")[0]
+    assert complete_payload == {"worker_id": "worker-1", "output": {"value": 42}}
+
+
+def test_concurrency_limit_sets_slot_based_max_tasks_and_avoids_backlog() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    client = RecordingClient(
+        claims=[
+            [
+                task("task-1", "slow"),
+                task("task-2", "slow"),
+            ]
+        ]
+    )
+    worker = ActivityWorker(
+        api_key="test-key",
+        worker_id="worker-1",
+        client=client,
+        concurrency_limit=1,
+        poll_interval=0.01,
+    )
+
+    def slow(payload: dict[str, Any]) -> dict[str, Any]:
+        started.set()
+        release.wait(timeout=1.0)
+        return payload
+
+    worker.register("slow", slow)
+    try:
+        assert worker.poll_once() == 1
+        assert started.wait(timeout=1.0)
+        assert worker.poll_once() == 0
+        claim_payloads = client.payloads_for("/claim")
+        assert len(claim_payloads) == 1
+        assert claim_payloads[0]["max_tasks"] == 1
+
+        release.set()
+        assert worker.wait_for_idle(timeout=1.0)
+    finally:
+        worker.close()
+
+    assert len(client.payloads_for("/complete")) == 1
+
+
+def test_heartbeat_uses_half_effective_lease_and_successfully_renews() -> None:
+    release = threading.Event()
+    client = RecordingClient(
+        claims=[[task("task-1", "slow", effective_lease_duration_ms=20)]],
+        heartbeat_statuses=[200],
+    )
+    worker = ActivityWorker(
+        api_key="test-key",
+        worker_id="worker-1",
+        client=client,
+        concurrency_limit=1,
+        poll_interval=0.01,
+    )
+
+    def slow(payload: dict[str, Any]) -> dict[str, Any]:
+        release.wait(timeout=1.0)
+        return payload
+
+    worker.register("slow", slow)
+    try:
+        assert worker.poll_once() == 1
+        time.sleep(0.02)
+        assert worker.poll_once() == 0
+        release.set()
+        assert worker.wait_for_idle(timeout=1.0)
+    finally:
+        worker.close()
+
+    heartbeat_payload = client.payloads_for("/heartbeat")[0]
+    assert heartbeat_payload == {"worker_id": "worker-1"}
+
+
+@pytest.mark.parametrize("heartbeat_status", [404, 409])
+def test_heartbeat_lost_lease_status_marks_context_lost_and_suppresses_terminal_call(
+    heartbeat_status: int,
+) -> None:
+    client = RecordingClient(
+        claims=[[task("task-1", "lost", effective_lease_duration_ms=20)]],
+        heartbeat_statuses=[heartbeat_status],
+    )
+    worker = ActivityWorker(
+        api_key="test-key",
+        worker_id="worker-1",
+        client=client,
+        concurrency_limit=1,
+        poll_interval=0.01,
+    )
+    observed_lost = threading.Event()
+
+    def lost(payload: dict[str, Any], context: ActivityTaskContext) -> dict[str, Any]:
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if context.lost_lease:
+                observed_lost.set()
+                return payload
+            time.sleep(0.005)
+        return payload
+
+    worker.register("lost", lost)
+    try:
+        assert worker.poll_once() == 1
+        time.sleep(0.02)
+        assert worker.poll_once() == 0
+        assert observed_lost.wait(timeout=1.0)
+        assert worker.wait_for_idle(timeout=1.0)
+    finally:
+        worker.close()
+
+    assert client.payloads_for("/heartbeat")
+    assert not client.payloads_for("/complete")
+    assert not client.payloads_for("/fail")
+
+
+def test_error_mapping_for_non_retryable_and_unhandled_exceptions() -> None:
+    client = RecordingClient(
+        claims=[
+            [
+                task("task-1", "bad_input"),
+                task("task-2", "flaky"),
+                task("task-3", "unknown"),
+            ]
+        ]
+    )
+    worker = ActivityWorker(
+        api_key="test-key",
+        worker_id="stable-worker",
+        client=client,
+        concurrency_limit=3,
+    )
+
+    def bad_input(_payload: dict[str, Any]) -> None:
+        raise NonRetryableError("invalid input")
+
+    def flaky(_payload: dict[str, Any]) -> None:
+        raise ConnectionError("timeout")
+
+    worker.register("bad_input", bad_input)
+    worker.register("flaky", flaky)
+    try:
+        assert worker.poll_once() == 3
+        assert worker.wait_for_idle(timeout=1.0)
+    finally:
+        worker.close()
+
+    fail_payloads = sorted(client.payloads_for("/fail"), key=lambda payload: payload["error_code"])
+    assert {
+        (payload["error_code"], payload["error_message"], payload["non_retryable"])
+        for payload in fail_payloads
+    } == {
+        ("activity_error", "ConnectionError: timeout", False),
+        (
+            "activity_not_registered",
+            "no handler registered for activity type unknown",
+            True,
+        ),
+        ("non_retryable_error", "invalid input", True),
+    }
+    worker_ids = {request["json"]["worker_id"] for request in client.requests if request["json"]}
+    assert worker_ids == {"stable-worker"}
+
+
+def test_graceful_shutdown_waits_or_marks_unfinished_tasks_lost() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    client = RecordingClient(claims=[[task("task-1", "slow")]])
+    worker = ActivityWorker(
+        api_key="test-key",
+        worker_id="worker-1",
+        client=client,
+        concurrency_limit=1,
+        poll_interval=0.01,
+    )
+
+    def slow(payload: dict[str, Any], context: ActivityTaskContext) -> dict[str, Any]:
+        started.set()
+        release.wait(timeout=1.0)
+        return {"lost": context.lost_lease, "payload": payload}
+
+    worker.register("slow", slow)
+    try:
+        assert worker.poll_once() == 1
+        assert started.wait(timeout=1.0)
+        assert not worker.wait_for_idle(timeout=0.01)
+        release.set()
+        time.sleep(0.02)
+        assert worker.wait_for_idle(timeout=1.0)
+    finally:
+        worker.close()
+
+    assert not client.payloads_for("/complete")
+    assert not client.payloads_for("/fail")
+
+
+def test_coroutine_handlers_are_rejected() -> None:
+    worker = ActivityWorker(api_key="test-key", worker_id="worker-1", client=RecordingClient())
+
+    async def async_handler(_payload: dict[str, Any]) -> None:
+        return None
+
+    try:
+        with pytest.raises(TypeError, match="sync handlers only"):
+            worker.register("async", async_handler)
+    finally:
+        worker.close()
+
+
+def test_worker_id_generated_once_and_reused() -> None:
+    client = RecordingClient(claims=[[task("task-1", "echo")]])
+    worker = ActivityWorker(api_key="test-key", client=client)
+
+    def echo(payload: dict[str, Any]) -> dict[str, Any]:
+        return payload
+
+    worker.register("echo", echo)
+    try:
+        generated_worker_id = worker.worker_id
+        assert generated_worker_id.startswith("py-")
+        assert len(generated_worker_id) <= 128
+        assert worker.poll_once() == 1
+        assert worker.wait_for_idle(timeout=1.0)
+    finally:
+        worker.close()
+
+    worker_ids = {request["json"]["worker_id"] for request in client.requests if request["json"]}
+    assert worker_ids == {generated_worker_id}

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -352,9 +352,9 @@ describe('TraceDetailPage', () => {
       await screen.findByRole('heading', { name: 'Drive the engine run from the debugger' })
     ).toBeInTheDocument();
     expect(screen.getByText('Engine wait state and queued work')).toBeInTheDocument();
-    expect(screen.getByText('payments.charge · charge-card')).toBeInTheDocument();
-    expect(screen.getByText('approval-timeout')).toBeInTheDocument();
-    expect(screen.getByText('manual_override')).toBeInTheDocument();
+    expect(await screen.findByText('payments.charge · charge-card')).toBeInTheDocument();
+    expect(await screen.findByText('approval-timeout')).toBeInTheDocument();
+    expect(await screen.findByText('manual_override')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Signal' })).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Suspend' })).toBeEnabled();


### PR DESCRIPTION
## What changed
- add the OpenSpec package for `add-remote-activities-python-worker`
- add engine-side remote activity routing, lease ownership checks, claim/heartbeat/complete/fail APIs, and the supporting migration/sqlc/OpenAPI regeneration
- add the sync Python remote activity worker, packaging export, and worker coverage

## Why
This implements the approved OpenSpec change for preview-gated remote activity execution with strict lease ownership semantics and a first Python worker that can execute remote activities over REST.

## Impact
- workflows can target activities to `remote` while preserving existing local worker behavior
- authenticated remote workers can claim and manage activity execution through the engine API
- Python SDK users can run sync activity handlers with bounded concurrency, heartbeats, and lost-lease suppression

## Validation
- `openspec validate add-remote-activities-python-worker --strict`
- `go test -v ./internal/api -run RemoteActivity`
- `cd engine && go test -v ./internal/store -run 'Remote|Lease|ExecutionTarget'`
- `go test -v -race ./internal/api/... ./internal/ingest/... ./internal/store/... ./internal/jobs/...`
- `cd engine && go test -v -race ./...`
- `make lint`
- `cd sdks/python && uv run pytest tests/test_worker.py`
- `cd sdks/python && uv run ruff check src/continua/worker.py tests/test_worker.py`

## Notes
- unrelated local worktree changes were intentionally left unstaged and are not part of this PR
- PR is opened as draft by default


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote activity execution: preview-gated API to claim, heartbeat, complete, and fail remote tasks (requires preview header).
  * Activities gain execution target (local or remote) enabling distributed workers.
  * Python SDK: new ActivityWorker, ActivityTaskContext, and NonRetryableError for synchronous remote workers.

* **Documentation**
  * Added design, protocol, routing, and Python worker specs detailing lease/heartbeat, ownership, and retry semantics.

* **Chores**
  * Minor .gitignore correction for repo-root path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->