### PR TITLE
docs(readme): premium visual pass with banner, 16:9 diagrams, status matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,459 @@
-# Continua
+<p align="center">
+  <img src="./assets/banner.svg" alt="Continua — self-hosted debugging for AI agent runs" />
+</p>
 
-> **Status: Current**
-> This README is the repo-verified entrypoint for the current checkout. For the short architecture handoff, use [docs/DEBUGGER_PLATFORM_BASELINE.md](./docs/DEBUGGER_PLATFORM_BASELINE.md). For the doc map and status convention, use [docs/README.md](./docs/README.md).
+<div align="center">
 
-AI agent observability debugger and operator console.
+  # Continua
 
-## Hosted Demo Vs Local Self-Host
+  **Self-hosted debugging for AI agent runs.**
 
-Continua now supports two distinct deployment modes:
+  <p>
+    <a href="#quickstart"><b>Quickstart</b></a> ·
+    <a href="#why-continua"><b>Why</b></a> ·
+    <a href="#features"><b>Features</b></a> ·
+    <a href="#architecture"><b>Architecture</b></a> ·
+    <a href="#python-sdk"><b>Python SDK</b></a> ·
+    <a href="#rest-api-surface"><b>REST API</b></a> ·
+    <a href="./docs/setup.md"><b>Docs</b></a>
+  </p>
 
-- **Public portfolio demo**: public landing page plus a read-only seeded debugger demo
-- **Private operator console**: authenticated debugger for real traces and sessions
+  <p>
+    <a href="./docs/setup.md">Setup guide</a> ·
+    <a href="./docs/DEBUGGER_PLATFORM_BASELINE.md">Baseline</a> ·
+    <a href="./docs/architecture/overview.md">Architecture overview</a> ·
+    <a href="./docs/event-conventions.md">Event conventions</a> ·
+    <a href="./openspec">OpenSpec</a> ·
+    <a href="https://github.com/continua-ai/continua/issues">Issues</a>
+  </p>
 
-The hosted portfolio site is intentionally sample-data only. For real usage with your own traces, run Continua locally or deploy a separate private environment.
+  <p>
+    <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-0EA5E9?style=flat-square"></a>
+    <img alt="Go 1.24+" src="https://img.shields.io/badge/go-1.24%2B-00ADD8?style=flat-square&logo=go&logoColor=white">
+    <img alt="Node 20+" src="https://img.shields.io/badge/node-20%2B-339933?style=flat-square&logo=node.js&logoColor=white">
+    <img alt="pnpm 9+" src="https://img.shields.io/badge/pnpm-9%2B-F69220?style=flat-square&logo=pnpm&logoColor=white">
+    <img alt="Python 3.10+" src="https://img.shields.io/badge/python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white">
+    <img alt="Postgres 16+" src="https://img.shields.io/badge/postgres-16%2B-4169E1?style=flat-square&logo=postgresql&logoColor=white">
+    <img alt="OpenAPI 3" src="https://img.shields.io/badge/openapi-3-6BA539?style=flat-square&logo=openapiinitiative&logoColor=white">
+    <img alt="Docker demo" src="https://img.shields.io/badge/demo-Docker%20Compose-2496ED?style=flat-square&logo=docker&logoColor=white">
+    <img alt="Status: alpha" src="https://img.shields.io/badge/status-alpha-F59E0B?style=flat-square">
+  </p>
 
-## Current Product Surface
+  <p>
+    <a href="https://github.com/continua-ai/continua/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/continua-ai/continua?style=flat-square&color=2DD4BF"></a>
+    <a href="https://github.com/continua-ai/continua/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/continua-ai/continua?style=flat-square&color=8B5CF6"></a>
+    <a href="https://github.com/continua-ai/continua/issues"><img alt="Open issues" src="https://img.shields.io/github/issues/continua-ai/continua?style=flat-square&color=F43F5E"></a>
+  </p>
 
-Continua's implemented product path today is:
+</div>
 
-```text
-Python SDK / custom client
-  -> authenticated REST ingest
-  -> Postgres persistence
-  -> River background jobs
-  -> REST read APIs
-  -> embedded React debugger operator console
-```
+---
 
-The current web surface includes:
-- `/` landing page
-- `/dashboard` overview built from existing trace and session endpoints
-- `/traces` and `/traces/:id` for trace triage and investigation
-- `/sessions`, `/sessions/:id`, and `/sessions/:id/compare` for workflow-level investigation
-- `/settings` for operator session and theme controls
+Continua is a **local operator console for debugging AI agent executions**. It accepts traces over an authenticated REST ingest API, persists them in Postgres, processes async work with River, and serves a React debugger from the Go backend — in a single binary, on your own infrastructure.
 
-## Quick Start
+The current product is intentionally concrete: trace runs, inspect spans and payloads, compare session attempts, and keep enough durable state to understand why an agent failed, stalled, retried, or behaved differently than expected.
+
+> [!NOTE]
+> Public demo mode uses seeded sample traces only. Use the private local console path when you want to ingest and inspect your own traces.
+
+## At a glance
+
+| Shipped today | Scaffolded / future-facing |
+| --- | --- |
+| Authenticated REST ingest (`POST /v1/ingest`) | Live WebSocket runtime (`internal/ws`) |
+| Idempotent batches, sync + durable async paths | Proxy capture (`internal/proxy`) |
+| Postgres persistence (sqlc-backed store) | Replay execution runtime (`internal/replay`) |
+| River workers: ingest, rollups, payload cleanup | Feature-complete TypeScript SDK (`sdks/typescript`) |
+| Trace, session, timeline, and compare read APIs | Durable engine workflow execution (`engine/`) |
+| Embedded React debugger (failure-first) | Score/eval APIs, alerts, telemetry |
+| Python SDK (traces, spans, sessions, batching, async polling) | |
+| Engine schema/store/CLI **foundation only** | |
+
+Source of truth for this boundary: [`docs/DEBUGGER_PLATFORM_BASELINE.md`](./docs/DEBUGGER_PLATFORM_BASELINE.md).
+
+## Quickstart
+
+The recommended first run is Docker Compose. It does not require local Go, Node, pnpm, Python, or uv.
 
 ```bash
-# Setup
-./scripts/setup.sh
-
-# Start development
-make dev           # Start Postgres via docker compose
-make dev-server    # Start the Go server
-make dev-web       # Start the Vite web app
-make seed-demo     # Rebuild the seeded public demo project through ingest
-
-# Read the local run guide
-# docs/guides/run-locally.md
+git clone https://github.com/continua-ai/continua.git
+cd continua
+make demo
 ```
+
+Open:
+
+```text
+http://localhost:8080
+```
+
+Check the server:
+
+```bash
+curl http://localhost:8080/api/health
+```
+
+Useful demo commands:
+
+```bash
+make docker-logs      # follow service logs
+make reset-demo       # reset demo data and reseed
+make docker-down      # stop the Docker stack
+```
+
+`make demo` builds the Continua image, starts Postgres, runs migrations, starts the Go server with the embedded web UI, and seeds deterministic sample traces and sessions.
+
+## Why Continua
+
+Agent failures are rarely a single log line. The useful context is usually spread across model calls, tool calls, retries, state changes, branch decisions, and session-level attempts. Continua gives that context a durable home and a debugger built for investigation, not just dashboards.
+
+Use it when you need to answer:
+
+| Question | Where Continua helps |
+| --- | --- |
+| What failed first? | Failure-first trace detail, span tree, waterfall, and timeline |
+| What changed during the run? | State diff and semantic event surfaces |
+| Why did this branch happen? | `decision` event inspection with reasoning |
+| How did two attempts differ? | Session detail and trace comparison (`/sessions/:id/compare`) |
+| Was ingest processed yet? | Sync ingest, async batch status, and polling helpers |
+
+## Features
+
+![Continua features at a glance](./assets/diagrams/feature-strip.svg)
+
+- **Trace debugger** — span tree, execution waterfall, selected spans, payload inspection, breadcrumbs, truncation banners, and merged timeline events.
+- **Session workflows** — browse sessions, open session detail, and compare baseline vs. candidate traces from the same workflow.
+- **Durable ingest path** — project-scoped API key auth, idempotent batches via `batch_key`, sync ingest, opt-in async ingest (`X-Continua-Async-Version: 2`), and batch polling.
+- **Background processing** — River workers handle async ingest, trace rollups, and payload cleanup.
+- **Embedded operator console** — the Vite React app is built into `internal/web/static/` and served by the Go binary.
+- **Python SDK** — `trace`, `span`, `session`, `event`, batching, retries, async polling, and engine-control helpers live under `sdks/python`.
+
+Current debugger routes (sourced from [`web/src/App.tsx`](./web/src/App.tsx)):
+
+| Route | Purpose |
+| --- | --- |
+| `/` | Landing page |
+| `/dashboard` | Overview built from trace and session APIs |
+| `/traces` | Trace search, filters, sorting, and pagination |
+| `/traces/:id` | Failure-first trace investigation |
+| `/sessions` | Session list |
+| `/sessions/:id` | Session detail and trace drill-down |
+| `/sessions/:id/compare` | Baseline vs. candidate trace comparison |
+| `/settings` | API key, operator session, and theme controls |
 
 ## Architecture
 
-- **Backend**: Go 1.22+, Chi router, Fx wiring
-- **Frontend**: Vite + React + TypeScript SPA embedded into the Go binary for production
-- **Database**: PostgreSQL is the real runtime database
-- **Queueing**: River workers run inside the platform server
-- **SDKs**: Python is real; TypeScript is still a stub package
+![Continua runtime architecture](./assets/diagrams/runtime-architecture.svg)
 
-Important runtime boundaries:
-- `db/platform/migrations/sqlite/` is bootstrap-only scaffolding, not a peer runtime target
-- runtime config is env-only via `internal/config/config.go`
-- WebSocket runtime, proxy capture, replay runtime, and durable engine execution are not implemented product features today
+```mermaid
+flowchart LR
+  client["Python SDK or custom client"]
+  ingest["Authenticated REST ingest"]
+  postgres[("Postgres")]
+  jobs["River background jobs"]
+  readapi["REST read APIs"]
+  ui["Embedded React debugger"]
 
-## Commands
+  client --> ingest --> postgres
+  postgres --> jobs --> postgres
+  postgres --> readapi --> ui
+```
+
+| Layer | Current implementation |
+| --- | --- |
+| Backend | Go 1.24+, Chi router, Fx wiring, OpenAPI-backed handlers |
+| Database | PostgreSQL 16+, sqlc-backed store wrappers |
+| Background jobs | River workers for async ingest, rollups, and retention cleanup |
+| Contracts | OpenAPI 3, plus generated Go, TypeScript, and Python types |
+| Frontend | Vite, React, TypeScript, TanStack Query |
+| SDKs | Python active; TypeScript stub only |
+
+Source-of-truth files:
+
+- REST contract: [`contracts/openapi/openapi.yaml`](./contracts/openapi/openapi.yaml)
+- WebSocket schema contract: [`contracts/websocket/events.ts`](./contracts/websocket/events.ts)
+- Platform schema and queries: [`db/platform/migrations/postgres`](./db/platform/migrations/postgres/) and [`db/platform/queries`](./db/platform/queries/)
+- Runtime behavior: [`cmd/continua`](./cmd/continua/), [`internal`](./internal/), [`web`](./web/), and [`sdks/python`](./sdks/python/)
+
+## How it works
+
+![Continua ingest flow](./assets/diagrams/ingest-flow.svg)
+
+```mermaid
+flowchart LR
+  client["SDK / REST client"]
+  auth["API key auth"]
+  validate["Validate payload"]
+  batch["Claim idempotent batch"]
+  sync["Sync write path"]
+  async["Async accepted batch"]
+  jobs["River ingest worker"]
+  store[("Postgres traces, spans, events")]
+  poll["Batch polling"]
+  debugger["Debugger read APIs"]
+
+  client --> auth --> validate --> batch
+  batch --> sync --> store
+  batch --> async --> jobs --> store
+  async --> poll
+  store --> debugger
+```
+
+1. A Python SDK or custom client posts trace data to `POST /v1/ingest`.
+2. API key auth resolves the project scope before any protected write.
+3. Validation and idempotent batch handling choose the sync path or async acceptance path.
+4. Postgres stores projects, batches, sessions, traces, spans, and span events.
+5. River workers process async batches, compute trace rollups, and run cleanup jobs.
+6. The debugger reads traces, sessions, spans, timelines, and comparisons through REST APIs.
+
+Trace detail uses REST polling against `GET /api/traces/{id}/events` today. There is no live WebSocket runtime in the current checkout.
+
+## Data model
+
+![Continua data model](./assets/diagrams/data-model.svg)
+
+```mermaid
+erDiagram
+  projects ||--o{ ingest_batches : owns
+  projects ||--o{ sessions : owns
+  projects ||--o{ traces : owns
+  sessions ||--o{ traces : groups
+  traces   ||--o{ spans : contains
+  spans    ||--o{ span_events : emits
+```
+
+External identifiers (`external_id`, `trace_id`, `span_id`, `parent_span_id`) are the IDs SDKs send and the debugger surfaces in URLs. Timeline responses merge stored explicit events with synthetic lifecycle markers derived from spans. See [`docs/architecture/overview.md`](./docs/architecture/overview.md) for the full storage model.
+
+## Event semantics
+
+![Implemented event types](./assets/diagrams/event-types.svg)
+
+Continua events are **debugger-facing observability signals**, not replay primitives. The debugger renders eleven implemented event types — `log`, `error`, `exception`, `message`, `metric`, `custom`, `state_change`, `decision`, `effect`, `wait`, and `snapshot_marker` — each with a documented payload shape. See [`docs/event-conventions.md`](./docs/event-conventions.md) for when to use each type and the expected payload fields.
+
+## Python SDK
+
+Install:
 
 ```bash
-make generate                  # Contracts, sqlc, copied server types, Python SDK types
-make build                     # Go server + web UI
-make test                      # Go + JS tests
-make lint                      # Go + JS lint
-pnpm --filter web test         # Frontend Vitest suites
-pnpm --filter web test:e2e     # Playwright UI smoke coverage
-make seed-demo                 # Reset and repopulate the public demo dataset
-make help                      # Show all make targets
+pip install continua
 ```
 
-## Project Structure
+Create a trace:
+
+```python
+from continua import Continua
+
+client = Continua(
+    api_key="default",
+    endpoint="http://localhost:8080",
+    ingest_mode="server_default",  # or "sync", "async_v2"
+)
+
+with client.trace(name="agent-run") as trace:
+    with trace.span(name="plan") as span:
+        span.set_input({"goal": "summarize doc"})
+        span.set_output({"plan": ["read", "summarize"]})
+```
+
+> [!IMPORTANT]
+> True async ingest is not read-after-write. If your code reads ingested data immediately after writing it, use `ingest_mode="sync"` or call `client.wait_for_batch(batch_id)` before reading.
+
+See [`sdks/python/README.md`](./sdks/python/README.md) for SDK-specific usage and development commands.
+
+## REST API surface
+
+The full REST contract lives in [`contracts/openapi/openapi.yaml`](./contracts/openapi/openapi.yaml). Current operations:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/v1/ingest` | Batch ingest traces, spans, and events (sync or async) |
+| `GET` | `/v1/ingest/batches/{id}` | Poll the processing status of an ingest batch |
+| `GET` | `/api/traces` | List traces with filters, sort, and pagination |
+| `GET` | `/api/traces/{id}` | Get a single trace |
+| `GET` | `/api/traces/{id}/spans` | List spans for a trace |
+| `GET` | `/api/traces/{id}/events` | Get the merged timeline for a trace |
+| `GET` | `/api/sessions` | List sessions |
+| `GET` | `/api/sessions/{id}` | Get a single session |
+| `GET` | `/api/sessions/{id}/compare` | Compare baseline vs. candidate traces in a session |
+| `GET` | `/api/health` | Health check (routed directly, not in OpenAPI) |
+
+All protected routes require a project-scoped API key. The 5 MB request-body cap applies to `/v1/ingest`.
+
+## Engine foundation
+
+[`engine/`](./engine/) is an isolated Go module shipping the durable-execution **foundation only**:
+
+- a dedicated Postgres `engine` schema with reversible migrations
+- sqlc-backed query generation
+- an engine-local store with its own pgx pool
+- a `continua-engine` CLI with `version`, `migrate up`, and `migrate down <steps>`
+
+What this does **not** include yet: workflow execution, history replay, activity workers, public execution APIs, or a debugger UI for engine state. Treat the `engine/` schema as plumbing, not product surface. See [`engine/README.md`](./engine/README.md) for details.
+
+## Project structure
 
 ```text
-continua/
-├── cmd/continua/           # Go server binary and CLI
-├── contracts/              # OpenAPI and WebSocket contract sources
-├── db/platform/            # Postgres migrations and sqlc inputs
-├── docs/                   # Current and historical documentation
-├── engine/                 # Future durable execution module
-├── internal/               # Active platform runtime
-├── sdks/python/            # Primary usable SDK
-├── sdks/typescript/        # Stub SDK package
-├── web/                    # Vite React debugger app
-├── Makefile                # Build/test/dev entrypoints
-└── pnpm-workspace.yaml     # JS workspace
+cmd/continua                     Cobra entrypoint for serve, migrate, and version
+internal/api                     OpenAPI-backed handlers, router, auth, and mappers
+internal/ingest                  Ingest DTOs, validation, orchestration, and write path
+internal/jobs                    River workers for async ingest, rollups, and cleanup
+internal/store                   sqlc-backed store wrappers and focused handwritten SQL
+internal/config                  Env-only runtime configuration
+internal/web                     Embedded React app handler and static assets
+contracts                        OpenAPI, WebSocket schema, and generated contract types
+db/platform                      Postgres migrations, sqlc queries, and generated DB code
+web                              Vite React debugger UI
+sdks/python                      Active Python SDK
+sdks/typescript                  Early TypeScript SDK stub
+engine                           Isolated engine schema/store/CLI foundation
+docs                             Current docs, historical context, diagrams, and setup guides
+openspec                         Active and implemented change proposals
 ```
 
-## Architecture Rules
+## Configuration
 
-See [docs/architecture/RULES.md](./docs/architecture/RULES.md) for the current anti-drift rules.
+The platform server is configured with environment variables in [`internal/config/config.go`](./internal/config/config.go).
+
+Required:
+
+| Variable | Purpose |
+| --- | --- |
+| `DATABASE_URL` | Postgres connection string |
+
+Common optional variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `HOST`, `PORT` | Server bind address, defaulting to `0.0.0.0:8080` |
+| `PUBLIC_DEMO_ENABLED` | Enables the read-only seeded demo workspace |
+| `PUBLIC_DEMO_PROJECT_ID` | Project shown in public demo mode |
+| `PUBLIC_DEMO_LABEL` | Demo workspace label in the UI |
+| `INGEST_TRUE_ASYNC_DEFAULT` | Server default async ingest behavior |
+| `INGEST_DEPENDENCY_RETRY_WINDOW` | Retry window for dependency-sensitive ingest |
+| `INGEST_FAILED_PAYLOAD_RETENTION` | Retention for failed ingest payloads |
+| `RIVER_QUEUE_*` | River worker pool sizing |
+
+> [!WARNING]
+> `config.example.yaml` is not the runtime contract for the current server. The live config source is environment variables read by `internal/config/config.go`.
+
+## Native development
+
+Use the native path when changing Go, React, contracts, database queries, or SDK code.
+
+Prerequisites:
+
+- Go 1.24+
+- Node.js 20+
+- pnpm 9+
+- Docker with Docker Compose v2
+- Python 3.10+
+- uv
+
+Start the native stack:
+
+```bash
+./scripts/setup.sh
+make dev
+
+export DATABASE_URL="postgres://continua:continua@localhost:5432/continua?sslmode=disable"
+make migrate
+make dev-server
+```
+
+In another terminal:
+
+```bash
+make dev-web
+```
+
+Open:
+
+```text
+http://localhost:3000/dashboard
+```
+
+For a fresh local database, use API key `default` when the UI asks for a project API key.
+
+Regenerate code after changing contracts, sqlc queries, or migrations that affect generated types:
+
+```bash
+make generate
+```
+
+## Testing
+
+Targeted checks:
+
+```bash
+go test ./internal/api/...
+go test ./internal/ingest/...
+go test ./internal/store/...
+go test ./internal/jobs/...
+pnpm --filter web test
+pnpm --filter web test:e2e
+cd sdks/python && uv run pytest
+```
+
+Full local validation:
+
+```bash
+make generate
+make lint
+make test
+```
+
+## Current boundary and roadmap signals
+
+Implemented and active:
+
+- Authenticated REST ingest
+- Postgres persistence
+- River-backed background jobs
+- Trace, session, timeline, and compare read APIs
+- Embedded React debugger operator console
+- Python SDK
+- Engine schema/store/CLI foundation
+
+Scaffolded or future-facing in this checkout:
+
+- Live WebSocket runtime
+- Proxy capture
+- Replay execution runtime
+- Feature-complete TypeScript SDK
+- Durable engine workflow execution and public debugger runtime
+
+These roadmap signals come from the current baseline docs, source tree, and TODOs — they are not described here as shipped product behavior.
+
+## Documentation
+
+- [`docs/setup.md`](./docs/setup.md) — canonical setup guide for humans and agents
+- [`docs/DEBUGGER_PLATFORM_BASELINE.md`](./docs/DEBUGGER_PLATFORM_BASELINE.md) — repo-verified current platform baseline
+- [`docs/architecture/overview.md`](./docs/architecture/overview.md) — runtime architecture overview
+- [`docs/architecture/RULES.md`](./docs/architecture/RULES.md) — anti-drift architecture rules
+- [`docs/event-conventions.md`](./docs/event-conventions.md) — debugger-facing event semantics
+- [`docs/README.md`](./docs/README.md) — documentation map and status convention
+- [`openspec/`](./openspec/) — active and implemented change proposals
+
+## Contributing
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md). The short version:
+
+```bash
+make generate
+make lint
+make test
+```
+
+Documentation follows the status convention in [`docs/README.md`](./docs/README.md): current docs are authoritative for the checkout, while historical phase docs are context only.
+
+<a href="https://github.com/continua-ai/continua/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=continua-ai/continua" alt="Continua contributors" />
+</a>
 
 ## License
 
-MIT
+Continua is released under the [MIT License](./LICENSE).
+
+---
+
+<sub>Made with Go · Chi · Fx · Postgres · River · sqlc · React · Vite · TanStack Query · OpenAPI.</sub>

--- a/README.old.md
+++ b/README.old.md
@@ -1,0 +1,171 @@
+<div align="center">
+
+<img src="web/public/logo.svg" alt="Continua" width="96" height="96" />
+
+# Continua
+
+**Self-hosted debugging for AI agent runs.**
+
+[Quick Start](#quick-start) | [What You Get](#what-you-get) | [Python SDK](#python-sdk) | [Architecture](#architecture) | [Setup Guide](./docs/setup.md)
+
+</div>
+
+Continua gives agent builders a local operator console for the moments when a run fails, stalls, retries, or behaves differently than expected. Send traces from your agent, keep them durably in Postgres, and inspect the execution with a React debugger served by the Go backend.
+
+It is meant to be easy to clone and run. The recommended first path is Docker Compose: one command starts Postgres, applies migrations, boots the embedded web UI, and seeds a safe demo workspace.
+
+> [!NOTE]
+> The public/demo mode uses seeded sample traces only. Use the private local console path when you want to inspect your own traces.
+
+## Quick Start
+
+```bash
+git clone https://github.com/continua-ai/continua.git
+cd continua
+make demo
+```
+
+Open <http://localhost:8080>.
+
+`make demo` does the full first-run path:
+
+- builds the Continua Docker image with the embedded React UI
+- starts Postgres
+- runs database migrations
+- starts the Go server
+- seeds deterministic sample traces and sessions
+
+Useful follow-up commands:
+
+```bash
+curl http://localhost:8080/api/health
+make docker-logs
+make reset-demo
+make docker-down
+```
+
+For a deterministic agent-readable runbook, point your coding agent at [docs/setup.md](./docs/setup.md).
+
+## What You Get
+
+- **Failure-first trace debugger**: trace tree, execution waterfall, inspector tabs, payload inspection, state diff, and breadcrumbs.
+- **Session investigation**: list sessions, open session detail, and compare two traces from the same workflow.
+- **Durable ingest**: authenticated REST ingest, idempotent batches, async processing, and batch polling.
+- **Local operator console**: project-scoped API key mode for private local usage.
+- **Single server artifact**: the Vite React app is embedded into the Go binary for production-style runs.
+- **Python SDK**: helpers for traces, spans, sessions, events, batching, retries, and async ingest polling.
+
+The main app routes are:
+
+| Route | Purpose |
+| --- | --- |
+| `/` | Landing page |
+| `/dashboard` | Overview built from trace and session APIs |
+| `/traces`, `/traces/:id` | Trace list and failure investigation |
+| `/sessions`, `/sessions/:id` | Session list and workflow detail |
+| `/sessions/:id/compare` | Baseline vs. candidate trace comparison |
+| `/settings` | Local API key, operator session, and theme controls |
+
+## Python SDK
+
+```bash
+pip install continua
+```
+
+```python
+from continua import Continua
+
+client = Continua(
+    api_key="default",
+    endpoint="http://localhost:8080",
+    ingest_mode="server_default",  # or "sync", "async_v2"
+)
+
+with client.trace(name="agent-run") as trace:
+    with trace.span(name="plan") as span:
+        span.set_input({"goal": "summarize doc"})
+        span.set_output({"plan": ["read", "summarize"]})
+```
+
+> [!IMPORTANT]
+> True async ingest is not read-after-write. If your code reads ingested data immediately after writing it, use `ingest_mode="sync"` or call `client.wait_for_batch(batch_id)` before reading.
+
+See [sdks/python/README.md](./sdks/python/README.md) for full SDK usage.
+
+## Native Development
+
+Use the native path when you are changing Go, React, contracts, or the Python SDK.
+
+```bash
+./scripts/setup.sh
+make dev
+
+export DATABASE_URL="postgres://continua:continua@localhost:5432/continua?sslmode=disable"
+make migrate
+make dev-server
+```
+
+In another terminal:
+
+```bash
+make dev-web
+```
+
+Open <http://localhost:3000>. The backend stays on <http://localhost:8080>.
+
+`./scripts/setup.sh` verifies that Go, Node.js, pnpm, Docker, Python, and uv are already installed, then installs repo dependencies and local Go developer tools.
+
+## Architecture
+
+```text
+Python SDK / custom client
+  -> authenticated REST ingest
+  -> Postgres persistence
+  -> River background jobs
+  -> REST read APIs
+  -> embedded React debugger operator console
+```
+
+| Layer | Stack |
+| --- | --- |
+| Backend | Go 1.24+, Chi router, Fx wiring, River workers |
+| Database | PostgreSQL, sqlc-backed store |
+| Contracts | OpenAPI 3 plus generated Go, TypeScript, and Python types |
+| Frontend | Vite, React, TypeScript, TanStack Query |
+| SDKs | Python active; TypeScript currently stubbed |
+
+Source-of-truth files:
+
+- REST contract: `contracts/openapi/openapi.yaml`
+- WebSocket schema contract: `contracts/websocket/events.ts`
+- Platform schema and queries: `db/platform/migrations/postgres/`, `db/platform/queries/`
+- Current runtime behavior: `cmd/continua`, `internal/`, `web/`, `sdks/python/`
+
+Run `make generate` after changing contracts, sqlc queries, or migrations that affect generated types.
+
+> [!WARNING]
+> WebSocket runtime, proxy capture, replay runtime, durable engine execution, and TypeScript SDK parity are scaffolded or future-facing in this checkout. Treat the React debugger and Python SDK as the active product surface.
+
+## Common Commands
+
+```bash
+make demo                      # Docker-first demo: build, migrate, serve, seed
+make reset-demo                # Remove Docker demo volume and reseed
+make docker-logs               # Follow Docker service logs
+make docker-down               # Stop Docker services
+make setup                     # Install native repo dependencies
+make generate                  # Regenerate contracts, sqlc, server types
+make build                     # Build Go server and embedded web UI
+make test                      # Run Go and JS tests
+make lint                      # Run Go and JS linters
+pnpm --filter web test         # Frontend Vitest suites
+cd sdks/python && uv run pytest
+```
+
+## Documentation
+
+- [docs/setup.md](./docs/setup.md): canonical setup guide for humans and agents
+- [docs/README.md](./docs/README.md): documentation map and status convention
+- [docs/DEBUGGER_PLATFORM_BASELINE.md](./docs/DEBUGGER_PLATFORM_BASELINE.md): current implemented-vs-scaffolded baseline
+- [docs/architecture/RULES.md](./docs/architecture/RULES.md): anti-drift architecture rules
+- [openspec/](./openspec): active and implemented change proposals

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,0 +1,155 @@
+<svg width="2400" height="600" viewBox="0 0 2400 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="bannerTitle bannerDesc">
+  <title id="bannerTitle">Continua — self-hosted debugging for AI agent runs</title>
+  <desc id="bannerDesc">Continua banner showing the wordmark, tagline, and an abstract span-waterfall motif representing the trace debugger.</desc>
+
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="2400" y2="600" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1020"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <linearGradient id="logoGrad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38BDF8"/>
+      <stop offset="1" stop-color="#6366F1"/>
+    </linearGradient>
+    <linearGradient id="barTeal" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#2DD4BF"/>
+      <stop offset="1" stop-color="#22D3EE"/>
+    </linearGradient>
+    <linearGradient id="barViolet" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8B5CF6"/>
+      <stop offset="1" stop-color="#A78BFA"/>
+    </linearGradient>
+    <linearGradient id="barAmber" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#F59E0B"/>
+      <stop offset="1" stop-color="#FBBF24"/>
+    </linearGradient>
+    <linearGradient id="barRose" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#F43F5E"/>
+      <stop offset="1" stop-color="#FB7185"/>
+    </linearGradient>
+    <linearGradient id="barSlate" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#475569"/>
+      <stop offset="1" stop-color="#64748B"/>
+    </linearGradient>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M48 0H0V48" stroke="#FFFFFF" stroke-opacity="0.035"/>
+    </pattern>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="22" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect width="2400" height="600" fill="url(#bgGrad)"/>
+  <rect width="2400" height="600" fill="url(#grid)"/>
+
+  <!-- ambient glows -->
+  <circle cx="120" cy="540" r="320" fill="#6366F1" opacity="0.14"/>
+  <circle cx="2240" cy="80" r="320" fill="#2DD4BF" opacity="0.12"/>
+
+  <!-- logo glyph (scaled from web/public/logo.svg, neutral colors) -->
+  <g transform="translate(140 130) scale(1.5)">
+    <circle cx="32" cy="32" r="28" stroke="url(#logoGrad)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32" fill="none"/>
+    <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#logoGrad)" stroke-width="4.5" stroke-linecap="round" fill="none"/>
+    <circle cx="46" cy="18" r="3.25" fill="url(#logoGrad)"/>
+    <circle cx="46" cy="46" r="3.25" fill="url(#logoGrad)"/>
+  </g>
+
+  <!-- wordmark -->
+  <text x="270" y="200" fill="#F8FAFC" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="128" font-weight="800" letter-spacing="-3">Continua</text>
+
+  <!-- tagline -->
+  <text x="142" y="290" fill="#CBD5E1" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="40" font-weight="500">Self-hosted debugging for AI agent runs.</text>
+
+  <!-- subtag -->
+  <text x="142" y="346" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="26">Trace, inspect, and compare executions — from ingest to UI, on your own infrastructure.</text>
+
+  <!-- pill chips -->
+  <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="22" font-weight="600">
+    <g transform="translate(142 400)">
+      <rect width="178" height="50" rx="25" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="26" cy="25" r="6" fill="#2DD4BF"/>
+      <text x="46" y="33" fill="#E2E8F0">Self-hosted</text>
+    </g>
+    <g transform="translate(338 400)">
+      <rect width="178" height="50" rx="25" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="26" cy="25" r="6" fill="#A78BFA"/>
+      <text x="46" y="33" fill="#E2E8F0">Open source</text>
+    </g>
+    <g transform="translate(534 400)">
+      <rect width="120" height="50" rx="25" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="26" cy="25" r="6" fill="#F59E0B"/>
+      <text x="46" y="33" fill="#E2E8F0">MIT</text>
+    </g>
+    <g transform="translate(672 400)">
+      <rect width="252" height="50" rx="25" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="26" cy="25" r="6" fill="#60A5FA"/>
+      <text x="46" y="33" fill="#E2E8F0">Go · Postgres · React</text>
+    </g>
+  </g>
+
+  <!-- ingest -> store -> process -> inspect mini-strip -->
+  <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="20" font-weight="600" fill="#94A3B8">
+    <text x="142" y="528">INGEST</text>
+    <text x="320" y="528">PERSIST</text>
+    <text x="510" y="528">PROCESS</text>
+    <text x="710" y="528">INSPECT</text>
+  </g>
+  <g stroke="#334155" stroke-width="2" stroke-linecap="round" stroke-dasharray="1 6">
+    <path d="M236 521 L308 521"/>
+    <path d="M420 521 L498 521"/>
+    <path d="M614 521 L698 521"/>
+  </g>
+
+  <!-- right-side waterfall motif: stylized trace span bars inside a "window" -->
+  <g transform="translate(1340 100)">
+    <rect width="920" height="400" rx="20" fill="#0B1220" stroke="#1E293B"/>
+    <!-- title bar -->
+    <rect width="920" height="56" rx="20" fill="#0F172A"/>
+    <circle cx="32" cy="28" r="7" fill="#F87171"/>
+    <circle cx="56" cy="28" r="7" fill="#FBBF24"/>
+    <circle cx="80" cy="28" r="7" fill="#34D399"/>
+    <text x="120" y="35" fill="#94A3B8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">trace · agent-run · 2.4s</text>
+    <!-- waterfall ruler -->
+    <g stroke="#1E293B" stroke-width="1">
+      <line x1="40" y1="92" x2="880" y2="92"/>
+      <line x1="40" y1="92" x2="40" y2="368"/>
+    </g>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12" fill="#475569">
+      <text x="40" y="84">0s</text>
+      <text x="250" y="84">0.6s</text>
+      <text x="460" y="84">1.2s</text>
+      <text x="670" y="84">1.8s</text>
+      <text x="850" y="84">2.4s</text>
+    </g>
+    <!-- span rows -->
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14" fill="#CBD5E1">
+      <!-- root -->
+      <rect x="60" y="110" width="800" height="18" rx="4" fill="url(#barSlate)"/>
+      <text x="68" y="124" fill="#0B1220" font-weight="700">agent.run</text>
+      <!-- plan -->
+      <rect x="80" y="146" width="180" height="18" rx="4" fill="url(#barTeal)"/>
+      <text x="88" y="160" fill="#0B1220" font-weight="700">plan</text>
+      <!-- retrieve -->
+      <rect x="270" y="182" width="240" height="18" rx="4" fill="url(#barViolet)"/>
+      <text x="278" y="196" fill="#0B1220" font-weight="700">retrieve.docs</text>
+      <!-- model call -->
+      <rect x="520" y="218" width="200" height="18" rx="4" fill="url(#barAmber)"/>
+      <text x="528" y="232" fill="#0B1220" font-weight="700">model.invoke</text>
+      <!-- tool call -->
+      <rect x="730" y="254" width="100" height="18" rx="4" fill="url(#barTeal)"/>
+      <text x="738" y="268" fill="#0B1220" font-weight="700">tool.search</text>
+      <!-- retry / failure -->
+      <rect x="520" y="290" width="260" height="18" rx="4" fill="url(#barRose)"/>
+      <text x="528" y="304" fill="#0B1220" font-weight="700">model.invoke · retry</text>
+      <!-- decision -->
+      <rect x="780" y="326" width="80" height="18" rx="4" fill="url(#barAmber)"/>
+      <text x="788" y="340" fill="#0B1220" font-weight="700">decide</text>
+    </g>
+  </g>
+</svg>
+</content>
+</invoke>

--- a/assets/diagrams/data-model.svg
+++ b/assets/diagrams/data-model.svg
@@ -1,0 +1,150 @@
+<svg width="2400" height="1200" viewBox="0 0 2400 1200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="dataTitle dataDesc">
+  <title id="dataTitle">Continua data model</title>
+  <desc id="dataDesc">Entity-relationship diagram showing projects, ingest_batches, sessions, traces, spans, and span_events with key columns and external identifiers.</desc>
+
+  <defs>
+    <linearGradient id="dmBg" x1="0" y1="0" x2="2400" y2="1200" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1020"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <pattern id="dmGrid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M48 0H0V48" stroke="#FFFFFF" stroke-opacity="0.03"/>
+    </pattern>
+    <marker id="dmDot" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6">
+      <circle cx="5" cy="5" r="4" fill="#64748B"/>
+    </marker>
+  </defs>
+
+  <rect width="2400" height="1200" fill="url(#dmBg)"/>
+  <rect width="2400" height="1200" fill="url(#dmGrid)"/>
+
+  <text x="120" y="140" fill="#F8FAFC" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="64" font-weight="800" letter-spacing="-1.5">Data model</text>
+  <text x="120" y="200" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="30">Project-scoped, with internal UUIDs and stable external identifiers.</text>
+
+  <!-- Entity helper styles via reused groups -->
+  <!-- projects -->
+  <g transform="translate(120 320)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="380" height="220" rx="20" fill="#0B1220" stroke="#1E293B"/>
+    <rect width="380" height="56" rx="20" fill="#0F172A"/>
+    <text x="24" y="38" fill="#2DD4BF" font-size="22" font-weight="700">projects</text>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#94A3B8">
+      <text x="24" y="98">id  (uuid, pk)</text>
+      <text x="24" y="130">name</text>
+      <text x="24" y="162">api_key  (project scope)</text>
+      <text x="24" y="194">created_at</text>
+    </g>
+  </g>
+
+  <!-- ingest_batches -->
+  <g transform="translate(120 620)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="380" height="260" rx="20" fill="#0B1220" stroke="#1E293B"/>
+    <rect width="380" height="56" rx="20" fill="#0F172A"/>
+    <text x="24" y="38" fill="#A78BFA" font-size="22" font-weight="700">ingest_batches</text>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#94A3B8">
+      <text x="24" y="98">id  (uuid, pk)</text>
+      <text x="24" y="130">project_id  → projects.id</text>
+      <text x="24" y="162">batch_key  (idempotent)</text>
+      <text x="24" y="194">status  (queued/succeeded)</text>
+      <text x="24" y="226">trace_count · span_count</text>
+    </g>
+  </g>
+
+  <!-- sessions -->
+  <g transform="translate(660 320)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="380" height="220" rx="20" fill="#0B1220" stroke="#1E293B"/>
+    <rect width="380" height="56" rx="20" fill="#0F172A"/>
+    <text x="24" y="38" fill="#60A5FA" font-size="22" font-weight="700">sessions</text>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#94A3B8">
+      <text x="24" y="98">id  (uuid, pk)</text>
+      <text x="24" y="130">project_id  → projects.id</text>
+      <text x="24" y="162">external_id  (user-facing)</text>
+      <text x="24" y="194">created_at</text>
+    </g>
+  </g>
+
+  <!-- traces -->
+  <g transform="translate(1200 320)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="420" height="260" rx="20" fill="#0B1220" stroke="#1E293B"/>
+    <rect width="420" height="56" rx="20" fill="#0F172A"/>
+    <text x="24" y="38" fill="#F59E0B" font-size="22" font-weight="700">traces</text>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#94A3B8">
+      <text x="24" y="98">id  (uuid, pk)</text>
+      <text x="24" y="130">project_id  → projects.id</text>
+      <text x="24" y="162">session_id  → sessions.id</text>
+      <text x="24" y="194">trace_id  (external)</text>
+      <text x="24" y="226">status · started_at · ended_at</text>
+    </g>
+  </g>
+
+  <!-- spans -->
+  <g transform="translate(1780 320)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="480" height="260" rx="20" fill="#0B1220" stroke="#1E293B"/>
+    <rect width="480" height="56" rx="20" fill="#0F172A"/>
+    <text x="24" y="38" fill="#22D3EE" font-size="22" font-weight="700">spans</text>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#94A3B8">
+      <text x="24" y="98">id  (uuid, pk)</text>
+      <text x="24" y="130">trace_id  → traces.id</text>
+      <text x="24" y="162">span_id  (external)</text>
+      <text x="24" y="194">parent_span_id  (external)</text>
+      <text x="24" y="226">name · kind · input · output</text>
+    </g>
+  </g>
+
+  <!-- span_events -->
+  <g transform="translate(1780 660)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="480" height="220" rx="20" fill="#0B1220" stroke="#1E293B"/>
+    <rect width="480" height="56" rx="20" fill="#0F172A"/>
+    <text x="24" y="38" fill="#FB7185" font-size="22" font-weight="700">span_events</text>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#94A3B8">
+      <text x="24" y="98">id  (uuid, pk)</text>
+      <text x="24" y="130">span_id  → spans.id</text>
+      <text x="24" y="162">type  (log/error/decision/...)</text>
+      <text x="24" y="194">payload · occurred_at</text>
+    </g>
+  </g>
+
+  <!-- engine schema (foundation only) -->
+  <g transform="translate(660 660)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="960" height="220" rx="20" fill="#0B1220" stroke="#1E293B" stroke-dasharray="6 4"/>
+    <rect width="960" height="56" rx="20" fill="#0F172A"/>
+    <text x="24" y="38" fill="#A78BFA" font-size="22" font-weight="700">engine schema  ·  foundation only</text>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#94A3B8">
+      <text x="24" y="98">engine.instances · engine.runs · engine.history</text>
+      <text x="24" y="130">engine.inbox · engine.activity_tasks</text>
+      <text x="24" y="162">engine.request_dedupe · engine.projection_checkpoints</text>
+      <text x="24" y="194" fill="#64748B" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">No public execution API or debugger runtime yet.</text>
+    </g>
+  </g>
+
+  <!-- relationships -->
+  <g stroke="#64748B" stroke-width="3" fill="none" stroke-linecap="round">
+    <!-- projects -> ingest_batches -->
+    <path d="M310 540 L 310 620" stroke-dasharray="0"/>
+    <!-- projects -> sessions -->
+    <path d="M500 430 L 660 430"/>
+    <!-- sessions -> traces -->
+    <path d="M1040 430 L 1200 430"/>
+    <!-- traces -> spans -->
+    <path d="M1620 430 L 1780 430"/>
+    <!-- spans -> span_events -->
+    <path d="M2020 580 L 2020 660"/>
+    <!-- ingest_batches -> traces (writes) -->
+    <path d="M500 700 C 800 700 900 470 1200 470" stroke-dasharray="6 6"/>
+  </g>
+
+  <!-- legend -->
+  <g transform="translate(120 990)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="2160" height="120" rx="20" fill="#0B1220" stroke="#1E293B"/>
+    <g font-size="20" fill="#CBD5E1">
+      <circle cx="36" cy="40" r="8" fill="#2DD4BF"/><text x="56" y="46">project scope</text>
+      <circle cx="220" cy="40" r="8" fill="#60A5FA"/><text x="240" y="46">workflow</text>
+      <circle cx="380" cy="40" r="8" fill="#F59E0B"/><text x="400" y="46">run</text>
+      <circle cx="500" cy="40" r="8" fill="#22D3EE"/><text x="520" y="46">tree</text>
+      <circle cx="620" cy="40" r="8" fill="#FB7185"/><text x="640" y="46">timeline</text>
+      <circle cx="800" cy="40" r="8" fill="#A78BFA"/><text x="820" y="46">durable batch / engine foundation</text>
+    </g>
+    <text x="36" y="90" fill="#94A3B8" font-size="20">External identifiers (external_id, trace_id, span_id, parent_span_id) are the IDs SDKs send and the debugger surfaces in URLs.</text>
+  </g>
+</svg>
+</content>
+</invoke>

--- a/assets/diagrams/event-types.svg
+++ b/assets/diagrams/event-types.svg
@@ -1,0 +1,114 @@
+<svg width="2400" height="1000" viewBox="0 0 2400 1000" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="evTitle evDesc">
+  <title id="evTitle">Continua event semantics</title>
+  <desc id="evDesc">The eleven implemented event types the debugger renders: log, error, exception, message, metric, custom, state_change, decision, effect, wait, and snapshot_marker.</desc>
+
+  <defs>
+    <linearGradient id="evBg" x1="0" y1="0" x2="2400" y2="1000" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1020"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <pattern id="evGrid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M48 0H0V48" stroke="#FFFFFF" stroke-opacity="0.03"/>
+    </pattern>
+  </defs>
+
+  <rect width="2400" height="1000" fill="url(#evBg)"/>
+  <rect width="2400" height="1000" fill="url(#evGrid)"/>
+
+  <text x="120" y="120" fill="#F8FAFC" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="56" font-weight="800" letter-spacing="-1.5">Event semantics</text>
+  <text x="120" y="172" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="26">Debugger-facing signals — not replay primitives. See docs/event-conventions.md.</text>
+
+  <!-- 4 columns x 3 rows = 12 slots, only 11 used; last slot blank for breathing room -->
+  <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <!-- Row 1 -->
+    <g transform="translate(120 240)">
+      <rect width="540" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#60A5FA"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">log</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Operational log line tied to a span.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">default level: info</text>
+    </g>
+    <g transform="translate(700 240)">
+      <rect width="540" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#FB7185"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">error</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Explicit failure signal without exception details.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">default level: error</text>
+    </g>
+    <g transform="translate(1280 240)">
+      <rect width="540" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#F87171"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">exception</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Captured exception with structured metadata.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">exception_type · message · traceback</text>
+    </g>
+    <g transform="translate(1860 240)">
+      <rect width="420" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#A78BFA"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">message</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Lightweight narrative milestone.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">default level: info</text>
+    </g>
+
+    <!-- Row 2 -->
+    <g transform="translate(120 460)">
+      <rect width="540" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#22D3EE"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">metric</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Numeric measurement attached to a span.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">metric_name · metric_value · unit</text>
+    </g>
+    <g transform="translate(700 460)">
+      <rect width="540" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#64748B"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">custom</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Domain-specific event that does not fit another type.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">ad-hoc payload</text>
+    </g>
+    <g transform="translate(1280 460)">
+      <rect width="540" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#2DD4BF"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">state_change</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Observable state transition for the State view.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">key · namespace · old_value · new_value</text>
+    </g>
+    <g transform="translate(1860 460)">
+      <rect width="420" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#F59E0B"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">decision</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Branch point with a chosen outcome.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">question · chosen · reasoning</text>
+    </g>
+
+    <!-- Row 3 -->
+    <g transform="translate(120 680)">
+      <rect width="540" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#8B5CF6"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">effect</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">External side effect, tool call, or model invocation.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">effect_kind · idempotent · idempotency_key</text>
+    </g>
+    <g transform="translate(700 680)">
+      <rect width="540" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#FBBF24"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">wait</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Blocked or deferred progress awaiting resolution.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">wait_kind · phase · resolution</text>
+    </g>
+    <g transform="translate(1280 680)">
+      <rect width="540" height="190" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <circle cx="46" cy="46" r="10" fill="#34D399"/>
+      <text x="80" y="56" fill="#F8FAFC" font-size="32" font-weight="700">snapshot_marker</text>
+      <text x="40" y="110" fill="#94A3B8" font-size="20">Debugger milestone with a compact label.</text>
+      <text x="40" y="146" fill="#64748B" font-size="18" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">marker_kind · label</text>
+    </g>
+    <g transform="translate(1860 680)">
+      <rect width="420" height="190" rx="20" fill="#0B1220" stroke="#1E293B" stroke-dasharray="6 6"/>
+      <text x="40" y="56" fill="#475569" font-size="22" font-weight="700" letter-spacing="3">11 TYPES</text>
+      <text x="40" y="110" fill="#64748B" font-size="20">Use the type that best fits the signal.</text>
+      <text x="40" y="146" fill="#475569" font-size="18">See event conventions →</text>
+    </g>
+  </g>
+</svg>
+</content>
+</invoke>

--- a/assets/diagrams/feature-strip.svg
+++ b/assets/diagrams/feature-strip.svg
@@ -1,0 +1,139 @@
+<svg width="2400" height="1350" viewBox="0 0 2400 1350" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="featTitle featDesc">
+  <title id="featTitle">Continua features at a glance</title>
+  <desc id="featDesc">Four feature tiles illustrating the implemented surfaces: Ingest, Persist, Inspect, and Compare. Illustrations are abstract, not screenshots of the running app.</desc>
+
+  <defs>
+    <linearGradient id="featBg" x1="0" y1="0" x2="2400" y2="1350" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1020"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <pattern id="featGrid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M48 0H0V48" stroke="#FFFFFF" stroke-opacity="0.03"/>
+    </pattern>
+  </defs>
+
+  <rect width="2400" height="1350" fill="url(#featBg)"/>
+  <rect width="2400" height="1350" fill="url(#featGrid)"/>
+
+  <text x="120" y="140" fill="#F8FAFC" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="64" font-weight="800" letter-spacing="-1.5">Built for agent debugging</text>
+  <text x="120" y="200" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="30">Four surfaces. One Go binary. Postgres-backed. Local-first.</text>
+
+  <!-- Tile 1: INGEST -->
+  <g transform="translate(120 300)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="1080" height="460" rx="28" fill="#0B1220" stroke="#1E293B"/>
+    <text x="40" y="76" fill="#2DD4BF" font-size="22" font-weight="700" letter-spacing="3">01 · INGEST</text>
+    <text x="40" y="136" fill="#F8FAFC" font-size="44" font-weight="800">Authenticated REST batches</text>
+    <text x="40" y="180" fill="#94A3B8" font-size="22">Idempotent batch_key, sync or durable async, project-scoped API key.</text>
+
+    <!-- code preview -->
+    <g transform="translate(40 220)">
+      <rect width="1000" height="220" rx="16" fill="#06121F" stroke="#1E293B"/>
+      <rect width="1000" height="36" rx="16" fill="#0F172A"/>
+      <circle cx="22" cy="18" r="5" fill="#F87171"/>
+      <circle cx="40" cy="18" r="5" fill="#FBBF24"/>
+      <circle cx="58" cy="18" r="5" fill="#34D399"/>
+      <text x="80" y="22" fill="#64748B" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">POST /v1/ingest</text>
+      <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">
+        <text x="20" y="76" fill="#94A3B8">curl -X POST http://localhost:8080/v1/ingest \</text>
+        <text x="20" y="106" fill="#94A3B8">  -H "Authorization: Bearer $API_KEY" \</text>
+        <text x="20" y="136" fill="#94A3B8">  -H "X-Continua-Async-Version: 2" \</text>
+        <text x="20" y="166" fill="#94A3B8">  -d '{ "traces": [ ... ], "spans": [ ... ] }'</text>
+        <text x="20" y="196" fill="#A78BFA">← 202 Accepted { batch_id, status: "queued" }</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- Tile 2: PERSIST -->
+  <g transform="translate(1240 300)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="1040" height="460" rx="28" fill="#0B1220" stroke="#1E293B"/>
+    <text x="40" y="76" fill="#60A5FA" font-size="22" font-weight="700" letter-spacing="3">02 · PERSIST</text>
+    <text x="40" y="136" fill="#F8FAFC" font-size="44" font-weight="800">Postgres + River jobs</text>
+    <text x="40" y="180" fill="#94A3B8" font-size="22">Projects, sessions, traces, spans, span_events — plus rollups and cleanup.</text>
+
+    <!-- entity stack -->
+    <g transform="translate(40 220)">
+      <rect width="960" height="60" rx="14" fill="#0F172A" stroke="#1E293B"/>
+      <text x="24" y="38" fill="#E2E8F0" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20">projects</text>
+      <text x="900" y="38" fill="#475569" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="16">root</text>
+
+      <rect y="76" width="960" height="60" rx="14" fill="#0F172A" stroke="#1E293B"/>
+      <text x="24" y="114" fill="#E2E8F0" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20">sessions</text>
+      <text x="880" y="114" fill="#475569" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="16">workflow</text>
+
+      <rect y="152" width="960" height="60" rx="14" fill="#0F172A" stroke="#1E293B"/>
+      <text x="24" y="190" fill="#E2E8F0" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20">traces</text>
+      <text x="884" y="190" fill="#475569" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="16">run</text>
+
+      <rect y="228" width="960" height="60" rx="14" fill="#0F172A" stroke="#1E293B"/>
+      <text x="24" y="266" fill="#E2E8F0" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20">spans · span_events</text>
+      <text x="864" y="266" fill="#475569" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="16">timeline</text>
+    </g>
+  </g>
+
+  <!-- Tile 3: INSPECT -->
+  <g transform="translate(120 800)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="1080" height="460" rx="28" fill="#0B1220" stroke="#1E293B"/>
+    <text x="40" y="76" fill="#F59E0B" font-size="22" font-weight="700" letter-spacing="3">03 · INSPECT</text>
+    <text x="40" y="136" fill="#F8FAFC" font-size="44" font-weight="800">Failure-first trace debugger</text>
+    <text x="40" y="180" fill="#94A3B8" font-size="22">Span tree, execution waterfall, payload inspector, merged polling timeline.</text>
+
+    <!-- waterfall preview -->
+    <g transform="translate(40 220)">
+      <rect width="1000" height="220" rx="16" fill="#06121F" stroke="#1E293B"/>
+      <rect width="1000" height="36" rx="16" fill="#0F172A"/>
+      <text x="20" y="22" fill="#64748B" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">execution waterfall · /traces/:id</text>
+      <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13" fill="#0B1220">
+        <rect x="20" y="60" width="940" height="20" rx="4" fill="#475569"/><text x="28" y="74" font-weight="700">agent.run</text>
+        <rect x="40" y="92" width="220" height="20" rx="4" fill="#2DD4BF"/><text x="48" y="106" font-weight="700">plan</text>
+        <rect x="270" y="92" width="300" height="20" rx="4" fill="#A78BFA"/><text x="278" y="106" font-weight="700">retrieve.docs</text>
+        <rect x="580" y="92" width="240" height="20" rx="4" fill="#F59E0B"/><text x="588" y="106" font-weight="700">model.invoke</text>
+        <rect x="830" y="92" width="120" height="20" rx="4" fill="#22D3EE"/><text x="838" y="106" font-weight="700">tool.search</text>
+        <rect x="40" y="124" width="380" height="20" rx="4" fill="#FB7185"/><text x="48" y="138" font-weight="700">model.invoke · retry</text>
+        <rect x="430" y="124" width="160" height="20" rx="4" fill="#F59E0B"/><text x="438" y="138" font-weight="700">decide</text>
+        <rect x="600" y="124" width="280" height="20" rx="4" fill="#A78BFA"/><text x="608" y="138" font-weight="700">tool.write</text>
+        <rect x="40" y="156" width="640" height="20" rx="4" fill="#475569"/><text x="48" y="170" fill="#CBD5E1" font-weight="700">timeline · merged events</text>
+        <rect x="690" y="156" width="270" height="20" rx="4" fill="#FB7185"/><text x="698" y="170" font-weight="700">error · context_lost</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- Tile 4: COMPARE -->
+  <g transform="translate(1240 800)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect width="1040" height="460" rx="28" fill="#0B1220" stroke="#1E293B"/>
+    <text x="40" y="76" fill="#A78BFA" font-size="22" font-weight="700" letter-spacing="3">04 · COMPARE</text>
+    <text x="40" y="136" fill="#F8FAFC" font-size="44" font-weight="800">Baseline vs candidate</text>
+    <text x="40" y="180" fill="#94A3B8" font-size="22">Diff two terminal traces from the same session — spans, timing, decisions.</text>
+
+    <!-- two columns -->
+    <g transform="translate(40 220)">
+      <g>
+        <rect width="460" height="220" rx="16" fill="#06121F" stroke="#1E293B"/>
+        <rect width="460" height="36" rx="16" fill="#0F172A"/>
+        <text x="20" y="22" fill="#2DD4BF" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">baseline_trace_id</text>
+        <g>
+          <rect x="20" y="60" width="420" height="20" rx="4" fill="#475569"/>
+          <rect x="40" y="92" width="160" height="20" rx="4" fill="#2DD4BF"/>
+          <rect x="210" y="92" width="200" height="20" rx="4" fill="#A78BFA"/>
+          <rect x="40" y="124" width="260" height="20" rx="4" fill="#F59E0B"/>
+          <rect x="40" y="156" width="380" height="20" rx="4" fill="#22D3EE"/>
+          <rect x="40" y="188" width="140" height="20" rx="4" fill="#475569"/>
+        </g>
+      </g>
+      <g transform="translate(500 0)">
+        <rect width="460" height="220" rx="16" fill="#06121F" stroke="#1E293B"/>
+        <rect width="460" height="36" rx="16" fill="#0F172A"/>
+        <text x="20" y="22" fill="#FB7185" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">candidate_trace_id</text>
+        <g>
+          <rect x="20" y="60" width="420" height="20" rx="4" fill="#475569"/>
+          <rect x="40" y="92" width="180" height="20" rx="4" fill="#2DD4BF"/>
+          <rect x="230" y="92" width="160" height="20" rx="4" fill="#FB7185"/>
+          <rect x="40" y="124" width="220" height="20" rx="4" fill="#FB7185"/>
+          <rect x="40" y="156" width="320" height="20" rx="4" fill="#22D3EE"/>
+          <rect x="40" y="188" width="240" height="20" rx="4" fill="#A78BFA"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>
+</content>
+</invoke>

--- a/assets/diagrams/ingest-flow.svg
+++ b/assets/diagrams/ingest-flow.svg
@@ -1,0 +1,143 @@
+<svg width="2400" height="1350" viewBox="0 0 2400 1350" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ingestTitle ingestDesc">
+  <title id="ingestTitle">Continua ingest flow</title>
+  <desc id="ingestDesc">From SDK request through API key auth, validation, idempotent batch claim, sync or async write paths, River workers, durable storage, batch polling, and debugger reads.</desc>
+
+  <defs>
+    <linearGradient id="ingBg" x1="0" y1="0" x2="2400" y2="1350" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1020"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <pattern id="ingGrid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M48 0H0V48" stroke="#FFFFFF" stroke-opacity="0.03"/>
+    </pattern>
+    <marker id="ingArrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748B"/>
+    </marker>
+  </defs>
+
+  <rect width="2400" height="1350" fill="url(#ingBg)"/>
+  <rect width="2400" height="1350" fill="url(#ingGrid)"/>
+
+  <text x="120" y="140" fill="#F8FAFC" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="64" font-weight="800" letter-spacing="-1.5">Ingest flow</text>
+  <text x="120" y="200" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="30">Authenticated, idempotent batches with both sync and durable async paths.</text>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <g transform="translate(120 320)">
+      <rect width="320" height="200" rx="22" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="320" height="56" rx="22" fill="#0F172A"/>
+      <text x="24" y="38" fill="#94A3B8" font-size="20" font-weight="700">01 · CLIENT</text>
+      <text x="24" y="98" fill="#F8FAFC" font-size="28" font-weight="700">SDK request</text>
+      <text x="24" y="138" fill="#94A3B8" font-size="20">POST /v1/ingest</text>
+      <text x="24" y="168" fill="#64748B" font-size="18">JSON body, 5MB cap</text>
+    </g>
+    <g transform="translate(500 320)">
+      <rect width="320" height="200" rx="22" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="320" height="56" rx="22" fill="#0F172A"/>
+      <text x="24" y="38" fill="#94A3B8" font-size="20" font-weight="700">02 · AUTH</text>
+      <text x="24" y="98" fill="#F8FAFC" font-size="28" font-weight="700">API key</text>
+      <text x="24" y="138" fill="#94A3B8" font-size="20">resolves project_id</text>
+      <text x="24" y="168" fill="#64748B" font-size="18">scoped to request ctx</text>
+    </g>
+    <g transform="translate(880 320)">
+      <rect width="320" height="200" rx="22" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="320" height="56" rx="22" fill="#0F172A"/>
+      <text x="24" y="38" fill="#94A3B8" font-size="20" font-weight="700">03 · VALIDATE</text>
+      <text x="24" y="98" fill="#F8FAFC" font-size="28" font-weight="700">Payload check</text>
+      <text x="24" y="138" fill="#94A3B8" font-size="20">DTO normalization</text>
+      <text x="24" y="168" fill="#64748B" font-size="18">shared processor path</text>
+    </g>
+    <g transform="translate(1260 320)">
+      <rect width="320" height="200" rx="22" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="320" height="56" rx="22" fill="#0F172A"/>
+      <text x="24" y="38" fill="#94A3B8" font-size="20" font-weight="700">04 · BATCH</text>
+      <text x="24" y="98" fill="#F8FAFC" font-size="28" font-weight="700">Idempotent claim</text>
+      <text x="24" y="138" fill="#94A3B8" font-size="20">batch_key dedupe</text>
+      <text x="24" y="168" fill="#64748B" font-size="18">ingest_batches row</text>
+    </g>
+    <g transform="translate(1640 320)">
+      <rect width="320" height="200" rx="22" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="320" height="56" rx="22" fill="#0F172A"/>
+      <text x="24" y="38" fill="#94A3B8" font-size="20" font-weight="700">05 · ROUTE</text>
+      <text x="24" y="98" fill="#F8FAFC" font-size="28" font-weight="700">Sync or async</text>
+      <text x="24" y="138" fill="#94A3B8" font-size="20">sync=true → inline</text>
+      <text x="24" y="168" fill="#64748B" font-size="18">async v2 → durable</text>
+    </g>
+    <g transform="translate(2020 320)">
+      <rect width="320" height="200" rx="22" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="320" height="56" rx="22" fill="#0F172A"/>
+      <text x="24" y="38" fill="#94A3B8" font-size="20" font-weight="700">06 · STORE</text>
+      <text x="24" y="98" fill="#F8FAFC" font-size="28" font-weight="700">Postgres write</text>
+      <text x="24" y="138" fill="#94A3B8" font-size="20">traces · spans · events</text>
+      <text x="24" y="168" fill="#64748B" font-size="18">rollups follow async</text>
+    </g>
+  </g>
+
+  <g stroke="#475569" stroke-width="3" fill="none" stroke-linecap="round" marker-end="url(#ingArrow)">
+    <line x1="440" y1="420" x2="498" y2="420"/>
+    <line x1="820" y1="420" x2="878" y2="420"/>
+    <line x1="1200" y1="420" x2="1258" y2="420"/>
+    <line x1="1580" y1="420" x2="1638" y2="420"/>
+    <line x1="1960" y1="420" x2="2018" y2="420"/>
+  </g>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <g transform="translate(120 620)">
+      <rect width="2220" height="220" rx="24" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="10" height="220" rx="5" fill="#2DD4BF"/>
+      <text x="40" y="60" fill="#2DD4BF" font-size="24" font-weight="700">SYNC PATH</text>
+      <text x="40" y="100" fill="#F8FAFC" font-size="30" font-weight="700">Inline write before response</text>
+      <text x="40" y="138" fill="#94A3B8" font-size="22">200 OK · batch.status = succeeded · read-after-write safe</text>
+      <text x="40" y="174" fill="#64748B" font-size="20">Choose when integration code reads ingested data immediately afterwards.</text>
+
+      <g transform="translate(1280 50)" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#CBD5E1">
+        <rect width="900" height="130" rx="14" fill="#06121F" stroke="#1E293B"/>
+        <text x="20" y="36" fill="#94A3B8">POST /v1/ingest?sync=true</text>
+        <text x="20" y="68" fill="#2DD4BF">→ validate → batch claim → inline write</text>
+        <text x="20" y="100" fill="#22D3EE">← 200 OK { batch_id, status: "succeeded" }</text>
+      </g>
+    </g>
+
+    <g transform="translate(120 880)">
+      <rect width="2220" height="280" rx="24" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="10" height="280" rx="5" fill="#A78BFA"/>
+      <text x="40" y="60" fill="#A78BFA" font-size="24" font-weight="700">ASYNC PATH</text>
+      <text x="40" y="100" fill="#F8FAFC" font-size="30" font-weight="700">202 accepted · River workers complete the write</text>
+      <text x="40" y="138" fill="#94A3B8" font-size="22">Durable batch row · X-Continua-Async-Version: 2 · poll /v1/ingest/batches/&#123;id&#125;</text>
+      <text x="40" y="174" fill="#FB7185" font-size="20">Not read-after-write. Use sync, or wait_for_batch() before reading.</text>
+
+      <g transform="translate(40 200)" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="18" fill="#E2E8F0">
+        <g>
+          <rect width="240" height="48" rx="24" fill="#0F172A" stroke="#1E293B"/>
+          <circle cx="24" cy="24" r="6" fill="#A78BFA"/>
+          <text x="44" y="32">ingest worker</text>
+        </g>
+        <g transform="translate(260 0)">
+          <rect width="240" height="48" rx="24" fill="#0F172A" stroke="#1E293B"/>
+          <circle cx="24" cy="24" r="6" fill="#60A5FA"/>
+          <text x="44" y="32">rollup worker</text>
+        </g>
+        <g transform="translate(520 0)">
+          <rect width="240" height="48" rx="24" fill="#0F172A" stroke="#1E293B"/>
+          <circle cx="24" cy="24" r="6" fill="#F59E0B"/>
+          <text x="44" y="32">cleanup worker</text>
+        </g>
+      </g>
+
+      <g transform="translate(1280 50)" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#CBD5E1">
+        <rect width="900" height="180" rx="14" fill="#06121F" stroke="#1E293B"/>
+        <text x="20" y="36" fill="#94A3B8">POST /v1/ingest  (X-Continua-Async-Version: 2)</text>
+        <text x="20" y="68" fill="#A78BFA">← 202 Accepted { batch_id, status: "queued" }</text>
+        <text x="20" y="100" fill="#94A3B8">GET /v1/ingest/batches/&#123;id&#125;   (poll)</text>
+        <text x="20" y="132" fill="#22D3EE">← 200 OK { status: "succeeded", trace_count, span_count }</text>
+        <text x="20" y="164" fill="#64748B">client.wait_for_batch(batch_id) does this in the Python SDK</text>
+      </g>
+    </g>
+  </g>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect x="120" y="1220" width="2220" height="64" rx="18" fill="#0B1220" stroke="#1E293B"/>
+    <text x="152" y="1262" fill="#CBD5E1" font-size="22">client  →  auth  →  validate  →  batch claim  →  sync write or async accept  →  Postgres  →  debugger read APIs</text>
+  </g>
+</svg>
+</content>
+</invoke>

--- a/assets/diagrams/runtime-architecture.svg
+++ b/assets/diagrams/runtime-architecture.svg
@@ -1,0 +1,179 @@
+<svg width="2400" height="1350" viewBox="0 0 2400 1350" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="archTitle archDesc">
+  <title id="archTitle">Continua runtime architecture</title>
+  <desc id="archDesc">SDK clients send authenticated REST ingest to a single Go server, which persists in Postgres, processes work with River background jobs, exposes REST read APIs, and serves an embedded React debugger.</desc>
+
+  <defs>
+    <linearGradient id="archBg" x1="0" y1="0" x2="2400" y2="1350" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1020"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <pattern id="archGrid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M48 0H0V48" stroke="#FFFFFF" stroke-opacity="0.03"/>
+    </pattern>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748B"/>
+    </marker>
+  </defs>
+
+  <rect width="2400" height="1350" fill="url(#archBg)"/>
+  <rect width="2400" height="1350" fill="url(#archGrid)"/>
+
+  <!-- title block -->
+  <text x="120" y="140" fill="#F8FAFC" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="64" font-weight="800" letter-spacing="-1.5">Runtime architecture</text>
+  <text x="120" y="200" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="30">A single Go server, an embedded React debugger, and a Postgres-backed observability core.</text>
+
+  <!-- Tier label: clients -->
+  <text x="160" y="340" fill="#64748B" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="22" font-weight="700" letter-spacing="3">CLIENTS</text>
+
+  <!-- Client cards -->
+  <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <g transform="translate(160 380)">
+      <rect width="360" height="160" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="6" height="160" rx="3" fill="#2DD4BF"/>
+      <text x="36" y="60" fill="#F8FAFC" font-size="30" font-weight="700">Python SDK</text>
+      <text x="36" y="100" fill="#94A3B8" font-size="22">continua.Continua(...)</text>
+      <text x="36" y="132" fill="#64748B" font-size="20">batching · retries · async polling</text>
+    </g>
+    <g transform="translate(160 580)">
+      <rect width="360" height="160" rx="20" fill="#0B1220" stroke="#1E293B"/>
+      <rect x="0" y="0" width="6" height="160" rx="3" fill="#A78BFA"/>
+      <text x="36" y="60" fill="#F8FAFC" font-size="30" font-weight="700">Custom REST</text>
+      <text x="36" y="100" fill="#94A3B8" font-size="22">POST /v1/ingest</text>
+      <text x="36" y="132" fill="#64748B" font-size="20">project-scoped API key</text>
+    </g>
+  </g>
+
+  <!-- Big platform server panel -->
+  <g transform="translate(640 320)">
+    <rect width="1240" height="900" rx="28" fill="#0B1220" stroke="#1E293B"/>
+    <text x="40" y="70" fill="#E2E8F0" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="30" font-weight="700">Platform server · cmd/continua</text>
+    <text x="40" y="108" fill="#64748B" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="22">Go · Chi router · Fx · embedded React debugger</text>
+
+    <!-- internal modules row 1 -->
+    <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+      <g transform="translate(40 160)">
+        <rect width="360" height="160" rx="18" fill="#0F172A" stroke="#1E293B"/>
+        <text x="24" y="50" fill="#2DD4BF" font-size="22" font-weight="700">internal/api</text>
+        <text x="24" y="90" fill="#E2E8F0" font-size="24">Auth · routing · mappers</text>
+        <text x="24" y="124" fill="#64748B" font-size="18">/v1/ingest · /api/traces · /api/sessions</text>
+      </g>
+      <g transform="translate(440 160)">
+        <rect width="360" height="160" rx="18" fill="#0F172A" stroke="#1E293B"/>
+        <text x="24" y="50" fill="#60A5FA" font-size="22" font-weight="700">internal/ingest</text>
+        <text x="24" y="90" fill="#E2E8F0" font-size="24">Validate · batch · write</text>
+        <text x="24" y="124" fill="#64748B" font-size="18">sync path · async acceptance</text>
+      </g>
+      <g transform="translate(840 160)">
+        <rect width="360" height="160" rx="18" fill="#0F172A" stroke="#1E293B"/>
+        <text x="24" y="50" fill="#A78BFA" font-size="22" font-weight="700">internal/jobs</text>
+        <text x="24" y="90" fill="#E2E8F0" font-size="24">River workers</text>
+        <text x="24" y="124" fill="#64748B" font-size="18">ingest · rollups · cleanup</text>
+      </g>
+
+      <g transform="translate(40 360)">
+        <rect width="360" height="160" rx="18" fill="#0F172A" stroke="#1E293B"/>
+        <text x="24" y="50" fill="#F59E0B" font-size="22" font-weight="700">internal/store</text>
+        <text x="24" y="90" fill="#E2E8F0" font-size="24">sqlc wrappers</text>
+        <text x="24" y="124" fill="#64748B" font-size="18">+ dynamic trace search</text>
+      </g>
+      <g transform="translate(440 360)">
+        <rect width="360" height="160" rx="18" fill="#0F172A" stroke="#1E293B"/>
+        <text x="24" y="50" fill="#22D3EE" font-size="22" font-weight="700">internal/config</text>
+        <text x="24" y="90" fill="#E2E8F0" font-size="24">Env-only runtime</text>
+        <text x="24" y="124" fill="#64748B" font-size="18">DATABASE_URL · INGEST_*</text>
+      </g>
+      <g transform="translate(840 360)">
+        <rect width="360" height="160" rx="18" fill="#0F172A" stroke="#1E293B"/>
+        <text x="24" y="50" fill="#FB7185" font-size="22" font-weight="700">internal/web</text>
+        <text x="24" y="90" fill="#E2E8F0" font-size="24">Embedded UI</text>
+        <text x="24" y="124" fill="#64748B" font-size="18">Vite bundle in Go binary</text>
+      </g>
+
+      <!-- Debugger UI window inside the server panel -->
+      <g transform="translate(40 560)">
+        <rect width="1160" height="300" rx="20" fill="#06121F" stroke="#1E293B"/>
+        <rect width="1160" height="44" rx="20" fill="#0F172A"/>
+        <circle cx="24" cy="22" r="6" fill="#F87171"/>
+        <circle cx="44" cy="22" r="6" fill="#FBBF24"/>
+        <circle cx="64" cy="22" r="6" fill="#34D399"/>
+        <text x="100" y="28" fill="#94A3B8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16">react debugger · /dashboard · /traces · /sessions</text>
+
+        <!-- sidebar -->
+        <rect x="24" y="68" width="200" height="212" rx="12" fill="#0B1220" stroke="#1E293B"/>
+        <text x="40" y="98" fill="#E2E8F0" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="16" font-weight="700">Overview</text>
+        <text x="40" y="130" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="16">Traces</text>
+        <text x="40" y="162" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="16">Sessions</text>
+        <text x="40" y="194" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="16">Compare</text>
+        <text x="40" y="226" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="16">Settings</text>
+
+        <!-- main rail -->
+        <g transform="translate(248 80)">
+          <rect width="888" height="22" rx="4" fill="#475569"/>
+          <rect x="20" y="38" width="280" height="18" rx="4" fill="#2DD4BF"/>
+          <rect x="320" y="38" width="220" height="18" rx="4" fill="#A78BFA"/>
+          <rect x="560" y="38" width="180" height="18" rx="4" fill="#F59E0B"/>
+          <rect x="20" y="72" width="180" height="18" rx="4" fill="#22D3EE"/>
+          <rect x="220" y="72" width="320" height="18" rx="4" fill="#FB7185"/>
+          <rect x="560" y="72" width="160" height="18" rx="4" fill="#A78BFA"/>
+          <rect x="20" y="106" width="220" height="18" rx="4" fill="#2DD4BF"/>
+          <rect x="260" y="106" width="160" height="18" rx="4" fill="#F59E0B"/>
+          <rect x="440" y="106" width="200" height="18" rx="4" fill="#22D3EE"/>
+          <rect x="20" y="140" width="380" height="18" rx="4" fill="#475569"/>
+          <rect x="420" y="140" width="200" height="18" rx="4" fill="#FB7185"/>
+          <rect x="20" y="174" width="600" height="18" rx="4" fill="#A78BFA"/>
+        </g>
+      </g>
+    </g>
+  </g>
+
+  <!-- Postgres -->
+  <g transform="translate(1980 460)">
+    <rect width="280" height="180" rx="20" fill="#0B1220" stroke="#1E293B"/>
+    <rect x="0" y="0" width="280" height="60" rx="20" fill="#0F172A"/>
+    <text x="24" y="40" fill="#60A5FA" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="22" font-weight="700">Postgres</text>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#94A3B8">
+      <text x="24" y="92">projects</text>
+      <text x="24" y="116">ingest_batches</text>
+      <text x="24" y="140">sessions · traces</text>
+      <text x="24" y="164">spans · span_events</text>
+    </g>
+  </g>
+
+  <!-- Engine schema (foundation only, labeled) -->
+  <g transform="translate(1980 700)">
+    <rect width="280" height="180" rx="20" fill="#0B1220" stroke="#1E293B" stroke-dasharray="6 4"/>
+    <rect x="0" y="0" width="280" height="60" rx="20" fill="#0F172A"/>
+    <text x="24" y="40" fill="#A78BFA" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="22" font-weight="700">engine schema</text>
+    <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="14" fill="#475569">
+      <text x="24" y="76">foundation only</text>
+    </g>
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#94A3B8">
+      <text x="24" y="106">engine.runs</text>
+      <text x="24" y="130">engine.history</text>
+      <text x="24" y="154">engine.inbox · tasks</text>
+    </g>
+  </g>
+
+  <!-- arrows: SDK -> api -->
+  <g stroke="#64748B" stroke-width="3" fill="none" stroke-linecap="round" marker-end="url(#arrow)">
+    <path d="M520 460 L 678 460"/>
+    <path d="M520 660 L 678 460"/>
+    <!-- api -> ingest internal arrow (within panel, drawn subtly) -->
+    <path d="M1020 480 L 1080 480" stroke-width="2"/>
+    <path d="M1420 480 L 1480 480" stroke-width="2"/>
+    <!-- store -> Postgres -->
+    <path d="M1040 540 L 1040 590 L 1980 550" stroke-width="3"/>
+    <!-- jobs -> Postgres -->
+    <path d="M1880 540 L 1980 555" stroke-width="3"/>
+    <!-- Postgres -> api (read) -->
+    <path d="M2120 640 L 2120 740"/>
+  </g>
+
+  <!-- footer caption -->
+  <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif">
+    <rect x="160" y="1240" width="2080" height="64" rx="18" fill="#0B1220" stroke="#1E293B"/>
+    <text x="192" y="1282" fill="#CBD5E1" font-size="22">Python SDK or custom client  →  authenticated REST ingest  →  Postgres  →  River background jobs  →  REST read APIs  →  embedded React debugger</text>
+  </g>
+</svg>
+</content>
+</invoke>

--- a/assets/readme-hero.svg
+++ b/assets/readme-hero.svg
@@ -1,0 +1,51 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Continua operator console overview</title>
+  <desc id="desc">A premium README hero graphic showing the Continua ingest, persistence, jobs, API, and debugger console path.</desc>
+  <rect width="1600" height="900" rx="0" fill="#0B1020"/>
+  <path d="M0 0H1600V900H0V0Z" fill="url(#grid)"/>
+  <circle cx="1360" cy="160" r="280" fill="#2DD4BF" opacity="0.12"/>
+  <circle cx="250" cy="760" r="340" fill="#8B5CF6" opacity="0.11"/>
+  <rect x="96" y="96" width="1408" height="708" rx="32" fill="#111827" stroke="#263244"/>
+  <rect x="96" y="96" width="1408" height="84" rx="32" fill="#0F172A"/>
+  <circle cx="142" cy="138" r="10" fill="#F87171"/>
+  <circle cx="174" cy="138" r="10" fill="#FBBF24"/>
+  <circle cx="206" cy="138" r="10" fill="#34D399"/>
+  <text x="252" y="147" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="24">continua local operator console</text>
+
+  <text x="156" y="274" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="74" font-weight="800">Debug AI agent runs</text>
+  <text x="156" y="340" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="34">Trace, inspect, and compare executions from ingest to UI.</text>
+
+  <g transform="translate(156 420)">
+    <rect width="250" height="134" rx="20" fill="#101827" stroke="#2DD4BF"/>
+    <text x="28" y="46" fill="#2DD4BF" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">01 Ingest</text>
+    <text x="28" y="86" fill="#E2E8F0" font-family="Inter, Arial, sans-serif" font-size="24">REST batches</text>
+  </g>
+  <g transform="translate(452 420)">
+    <rect width="250" height="134" rx="20" fill="#101827" stroke="#60A5FA"/>
+    <text x="28" y="46" fill="#60A5FA" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">02 Store</text>
+    <text x="28" y="86" fill="#E2E8F0" font-family="Inter, Arial, sans-serif" font-size="24">Postgres</text>
+  </g>
+  <g transform="translate(748 420)">
+    <rect width="250" height="134" rx="20" fill="#101827" stroke="#A78BFA"/>
+    <text x="28" y="46" fill="#A78BFA" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">03 Process</text>
+    <text x="28" y="86" fill="#E2E8F0" font-family="Inter, Arial, sans-serif" font-size="24">River jobs</text>
+  </g>
+  <g transform="translate(1044 420)">
+    <rect width="250" height="134" rx="20" fill="#101827" stroke="#F59E0B"/>
+    <text x="28" y="46" fill="#F59E0B" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">04 Inspect</text>
+    <text x="28" y="86" fill="#E2E8F0" font-family="Inter, Arial, sans-serif" font-size="24">React debugger</text>
+  </g>
+
+  <path d="M410 487H444" stroke="#475569" stroke-width="4" stroke-linecap="round"/>
+  <path d="M706 487H740" stroke="#475569" stroke-width="4" stroke-linecap="round"/>
+  <path d="M1002 487H1036" stroke="#475569" stroke-width="4" stroke-linecap="round"/>
+
+  <rect x="156" y="642" width="1138" height="76" rx="18" fill="#0B1220" stroke="#223047"/>
+  <text x="188" y="690" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="25">Python SDK or custom client -> authenticated ingest -> durable storage -> debugger read APIs</text>
+
+  <defs>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M48 0H0V48" stroke="#FFFFFF" stroke-opacity="0.035"/>
+    </pattern>
+  </defs>
+</svg>

--- a/docs/diagrams/data-model.mmd
+++ b/docs/diagrams/data-model.mmd
@@ -1,0 +1,54 @@
+erDiagram
+  projects ||--o{ ingest_batches : "owns"
+  projects ||--o{ sessions : "owns"
+  projects ||--o{ traces : "owns"
+  sessions ||--o{ traces : "groups"
+  traces ||--o{ spans : "contains"
+  spans ||--o{ span_events : "emits"
+
+  projects {
+    uuid id PK
+    string name
+    string api_key
+    timestamptz created_at
+  }
+  ingest_batches {
+    uuid id PK
+    uuid project_id FK
+    string batch_key
+    string status
+    int trace_count
+    int span_count
+  }
+  sessions {
+    uuid id PK
+    uuid project_id FK
+    string external_id
+    timestamptz created_at
+  }
+  traces {
+    uuid id PK
+    uuid project_id FK
+    uuid session_id FK
+    string trace_id
+    string status
+    timestamptz started_at
+    timestamptz ended_at
+  }
+  spans {
+    uuid id PK
+    uuid trace_id FK
+    string span_id
+    string parent_span_id
+    string name
+    string kind
+    jsonb input
+    jsonb output
+  }
+  span_events {
+    uuid id PK
+    uuid span_id FK
+    string type
+    jsonb payload
+    timestamptz occurred_at
+  }

--- a/docs/diagrams/event-types.mmd
+++ b/docs/diagrams/event-types.mmd
@@ -1,0 +1,38 @@
+flowchart LR
+  classDef operational fill:#0B1220,stroke:#60A5FA,color:#E2E8F0;
+  classDef failure fill:#0B1220,stroke:#FB7185,color:#E2E8F0;
+  classDef semantic fill:#0B1220,stroke:#2DD4BF,color:#E2E8F0;
+  classDef milestone fill:#0B1220,stroke:#34D399,color:#E2E8F0;
+  classDef domain fill:#0B1220,stroke:#A78BFA,color:#E2E8F0;
+
+  subgraph Operational
+    log
+    metric
+  end
+
+  subgraph Failure
+    error
+    exception
+  end
+
+  subgraph Semantic
+    state_change
+    decision
+    effect
+    wait
+  end
+
+  subgraph Milestone
+    message
+    snapshot_marker
+  end
+
+  subgraph Domain
+    custom
+  end
+
+  class log,metric operational;
+  class error,exception failure;
+  class state_change,decision,effect,wait semantic;
+  class message,snapshot_marker milestone;
+  class custom domain;

--- a/docs/diagrams/ingest-flow.mmd
+++ b/docs/diagrams/ingest-flow.mmd
@@ -1,0 +1,17 @@
+flowchart LR
+  client["SDK / REST client"]
+  auth["API key auth"]
+  validate["Validate payload"]
+  batch["Claim idempotent batch"]
+  sync["Sync write path"]
+  async["Async accepted batch"]
+  jobs["River ingest worker"]
+  store[("Postgres traces, spans, events")]
+  poll["Batch polling"]
+  debugger["Debugger read APIs"]
+
+  client --> auth --> validate --> batch
+  batch --> sync --> store
+  batch --> async --> jobs --> store
+  async --> poll
+  store --> debugger

--- a/docs/diagrams/runtime-architecture.mmd
+++ b/docs/diagrams/runtime-architecture.mmd
@@ -1,0 +1,11 @@
+flowchart LR
+  client["Python SDK or custom client"]
+  ingest["Authenticated REST ingest"]
+  postgres[("Postgres")]
+  jobs["River background jobs"]
+  readapi["REST read APIs"]
+  ui["Embedded React debugger"]
+
+  client --> ingest --> postgres
+  postgres --> jobs --> postgres
+  postgres --> readapi --> ui

--- a/docs/readme-improvement-changelog.md
+++ b/docs/readme-improvement-changelog.md
@@ -1,0 +1,139 @@
+# README Improvement Changelog
+
+Status: Current
+
+## Summary
+
+Iterative refinement of the root `README.md`. Each entry documents what changed, which skills were used or skipped, and what assets were produced.
+
+---
+
+## 2026-05-12 — Premium visual pass
+
+### Goal
+
+Take the (already accurate) refreshed README and make it visibly stunning, drawing design cues from Langfuse, Trigger.dev, and Temporal — without introducing any new claims about replay, live WebSocket runtime, proxy capture, TypeScript SDK parity, or durable engine execution.
+
+### Skills used
+
+- `readme-generator-glincker` — repo-aware structure, prerequisites, commands, project tree, license accuracy.
+- `readme-generator-visual` — full-bleed banner, 16:9 feature/architecture/ingest strips, badge stack, GitHub description and topic suggestions.
+- `mermaid-tools` — Mermaid sources for runtime architecture, ingest flow, data model, and event types, alongside static SVG exports for GitHub rendering and offline viewers.
+
+### Skills skipped
+
+- `cli-demo-generator` — skipped because generating a terminal GIF requires VHS or similar global tooling not already required by the repo (the brief disallows global installs and root-level dependency churn). The README continues to rely on copy-paste-clean `make demo` commands.
+- `walkthrough` — skipped for the README refresh because the root README already links to [`docs/setup.md`](./setup.md), [`docs/DEBUGGER_PLATFORM_BASELINE.md`](./DEBUGGER_PLATFORM_BASELINE.md), and [`docs/architecture/overview.md`](./architecture/overview.md). A separate interactive walkthrough page would duplicate those without new insight.
+
+### README changes
+
+- **New full-bleed banner** at the top of the README (`assets/banner.svg`, 2400×600), Langfuse/Trigger.dev style, replacing the smaller hero treatment.
+- **Two-row centered nav** under the title: primary CTAs (Quickstart · Why · Features · Architecture · Python SDK · REST API · Docs) plus a secondary doc-row (Setup guide · Baseline · Architecture overview · Event conventions · OpenSpec · Issues).
+- **Tighter badge stack** with logo-style shields for License, Go 1.24+, Node 20+, pnpm 9+, Python 3.10+, Postgres 16+, OpenAPI 3, Docker demo, and status: alpha — plus GitHub-state shields (stars, last commit, open issues). No badges that imply community surfaces we do not have (no Discord, Twitter, npm/PyPI downloads, or Docker Hub pulls).
+- **"At a glance" status matrix** placed near the top to make the implemented-vs-scaffolded boundary visible above the fold.
+- **Wide 16:9 feature strip** under `Features` (`assets/diagrams/feature-strip.svg`) illustrating the Ingest · Persist · Inspect · Compare surfaces as abstract tiles. Explicitly not labeled as screenshots.
+- **Refreshed 16:9 architecture image** (`assets/diagrams/runtime-architecture.svg`) and **16:9 ingest flow image** (`assets/diagrams/ingest-flow.svg`) — both paired with Mermaid blocks for GitHub-native rendering.
+- **New data model section** with `assets/diagrams/data-model.svg`, an `erDiagram` Mermaid block, and `docs/diagrams/data-model.mmd` as the reviewable source.
+- **New event semantics section** with `assets/diagrams/event-types.svg`, `docs/diagrams/event-types.mmd`, and a one-paragraph pointer to `docs/event-conventions.md`. Lists the eleven implemented event types only.
+- **REST API surface table** sourced from `contracts/openapi/openapi.yaml` (`POST /v1/ingest`, `GET /v1/ingest/batches/{id}`, `GET /api/traces`, `GET /api/traces/{id}`, `GET /api/traces/{id}/spans`, `GET /api/traces/{id}/events`, `GET /api/sessions`, `GET /api/sessions/{id}`, `GET /api/sessions/{id}/compare`, plus the directly routed `GET /api/health`).
+- **Explicit "Engine foundation" section** clarifying that only schema/store/CLI exist today; workflow execution, history replay, activity workers, public exec APIs, and the engine debugger UI are not implemented.
+- **GitHub callouts** used consistently (`> [!NOTE]`, `> [!IMPORTANT]`, `> [!WARNING]`).
+- **Contributors mosaic** via `contrib.rocks` and a single-line "Made with…" stack credit at the bottom.
+
+### Assets added or refreshed
+
+- `assets/banner.svg` — **new** full-bleed banner.
+- `assets/diagrams/feature-strip.svg` — **new** four-tile 16:9 feature image.
+- `assets/diagrams/runtime-architecture.svg` — refreshed to 16:9, dark theme.
+- `assets/diagrams/ingest-flow.svg` — refreshed to 16:9, dark theme.
+- `assets/diagrams/data-model.svg` — **new** entity-relationship illustration.
+- `assets/diagrams/event-types.svg` — **new** 11-cell event type grid.
+- `docs/diagrams/data-model.mmd` — **new** Mermaid source.
+- `docs/diagrams/event-types.mmd` — **new** Mermaid source.
+
+`assets/readme-hero.svg` is retained as a smaller alternate, but is no longer referenced from the root README.
+
+### Accuracy guardrails
+
+- Only endpoints currently in `contracts/openapi/openapi.yaml` are listed.
+- Engine section is explicitly labeled "foundation only".
+- Trace detail timeline described as **polling** based on `GET /api/traces/{id}/events`, never WebSocket.
+- TypeScript SDK described as a stub package.
+- `config.example.yaml` continues to be flagged as not the runtime contract.
+- No screenshots of the live UI. The illustrations are abstract operator-console motifs.
+- No fake metrics, testimonials, or community badges.
+
+### Suggested GitHub metadata
+
+For repository `description`:
+
+> Self-hosted debugging for AI agent runs — authenticated REST ingest, Postgres persistence, React debugger, Python SDK.
+
+For repository `topics`:
+
+`ai-agents`, `agent-observability`, `agent-debugging`, `llm-tracing`, `observability`, `tracing`, `self-hosted`, `go`, `postgres`, `react`, `python-sdk`, `openapi`, `river-jobs`, `sqlc`, `tanstack-query`, `chi-router`.
+
+### Accuracy sources
+
+- `README.old.md`
+- `docs/setup.md`
+- `docs/DEBUGGER_PLATFORM_BASELINE.md`
+- `docs/architecture/overview.md`
+- `docs/event-conventions.md`
+- `Makefile`
+- `package.json`
+- `go.mod`
+- `web/src/App.tsx`
+- `contracts/openapi/openapi.yaml`
+- `sdks/python/README.md`
+- `engine/README.md`
+
+---
+
+## 2026-05-11 — Initial refresh
+
+### Summary
+
+Updated the root `README.md` into a more polished GitHub landing page while keeping claims grounded in the current repository implementation.
+
+### Skills used
+
+- `readme-generator-glincker`: repo-aware README structure, prerequisites, commands, testing, project structure, and license coverage.
+- `readme-generator-visual`: visual hierarchy and static README asset direction. Playwright was not installed because SVG assets and GitHub-native Mermaid blocks were sufficient.
+- `mermaid-tools`: architecture and ingest/data-flow Mermaid source structure.
+
+### Skills skipped
+
+- `cli-demo-generator`: skipped because generating a terminal GIF would require VHS or similar local recording dependencies not already required by the repo.
+- `walkthrough`: skipped for the README refresh because the root README benefits more from concise diagrams and links to current docs than a separate interactive walkthrough page.
+
+### README changes
+
+- Added a centered hero section with badges and a static SVG visual.
+- Reframed the product description around the implemented self-hosted AI agent debugger path.
+- Added clearer Quickstart, Why Continua, Features, Demo, Python SDK, Architecture, How it Works, Project Structure, Configuration, Development, Testing, Roadmap Signals, Documentation, Contributing, and License sections.
+- Added Mermaid diagrams for runtime architecture and ingest/investigation flow.
+- Preserved an explicit implemented-vs-scaffolded boundary for WebSockets, proxy capture, replay, TypeScript SDK parity, and durable engine runtime.
+
+### Assets added
+
+- `assets/readme-hero.svg`
+- `assets/diagrams/runtime-architecture.svg`
+- `assets/diagrams/ingest-flow.svg`
+- `docs/diagrams/runtime-architecture.mmd`
+- `docs/diagrams/ingest-flow.mmd`
+
+### Accuracy sources
+
+- `README.old.md`
+- `docs/setup.md`
+- `docs/DEBUGGER_PLATFORM_BASELINE.md`
+- `docs/architecture/overview.md`
+- `docs/event-conventions.md`
+- `Makefile`
+- `package.json`
+- `go.mod`
+- `web/src/App.tsx`
+- `contracts/openapi/openapi.yaml`
+- `sdks/python/README.md`
+- `engine/README.md`

--- a/docs/readme-skill-setup-notes.md
+++ b/docs/readme-skill-setup-notes.md
@@ -1,0 +1,25 @@
+# README Skill Setup Notes
+
+Status: Current
+
+## Local Skill Layout
+
+The README refresh skills were installed locally for both Claude Code and Codex-style discovery:
+
+- `.claude/skills/readme-generator-glincker`
+- `.claude/skills/readme-generator-visual`
+- `.claude/skills/mermaid-tools`
+- `.claude/skills/cli-demo-generator`
+- `.claude/skills/walkthrough`
+
+The matching `.agents/skills/<skill-name>` entries are relative symlinks to `../../.claude/skills/<skill-name>`.
+
+`.agents/skills` itself is a real directory, not a symlink.
+
+## Notes
+
+- Symlinks are supported in this environment and were used.
+- No fallback copies were required.
+- No Playwright or Chromium install was needed for Phase 1 or the README refresh.
+- `readme-generator-visual` includes a `package.json` dependency on Playwright, but the refresh used static SVG assets and Mermaid source instead of running screenshot generation.
+- The `walkthrough` source used lowercase `skill.md`; it was normalized to `SKILL.md` for case-sensitive checkout compatibility.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,200 @@
+# Continua Setup Guide
+
+> **Status: Current**
+> This is the canonical setup guide for humans and coding agents. Prefer this over older phase docs when bringing up the repo.
+
+## Recommended Path: Docker Demo
+
+Use this path for first contact, demos, and agent-driven setup. It does not require a local Go, Node, pnpm, Python, or uv installation.
+
+Prerequisites:
+
+- Git
+- Docker with Docker Compose v2
+- A free local port `8080`
+
+Run:
+
+```bash
+git clone https://github.com/continua-ai/continua.git
+cd continua
+make demo
+```
+
+Expected result:
+
+- Postgres is running in Docker.
+- Continua has applied platform migrations.
+- The Go server is running on `http://localhost:8080`.
+- The embedded React UI is served by the Go server.
+- Demo traces and sessions are visible in the public demo workspace.
+
+Open:
+
+```text
+http://localhost:8080
+```
+
+Health check:
+
+```bash
+curl http://localhost:8080/api/health
+```
+
+Useful Docker commands:
+
+```bash
+make docker-logs      # follow service logs
+make docker-down      # stop the demo stack
+make reset-demo       # delete Docker data volume, rebuild, migrate, and reseed
+```
+
+## What `make demo` Does
+
+`make demo` runs `scripts/demo.sh`, which performs the complete first-run flow:
+
+1. Builds the Docker image from `deploy/docker/Dockerfile`.
+2. Starts `postgres` and `continua` from `deploy/docker-compose/docker-compose.yml`.
+3. Runs `continua migrate up` before the server starts.
+4. Starts `continua serve` with public demo mode enabled.
+5. Runs the `demo-seed` service, which resets a deterministic demo project and emits sample traces through the ingest API.
+
+Demo project defaults:
+
+| Setting | Value |
+| --- | --- |
+| Project ID | `11111111-1111-4111-8111-111111111111` |
+| Demo API key used by seeding | `continua-demo-local` |
+| App URL | `http://localhost:8080` |
+| Postgres URL inside Docker | `postgres://continua:continua@postgres:5432/continua?sslmode=disable` |
+
+The public demo UI is read-only and uses seeded sample traces. It is safe to explore without entering an API key.
+
+## Private Local Console
+
+Use this path when you want to ingest and inspect your own local traces. This path uses the native dev server and Vite for fast frontend iteration.
+
+Prerequisites:
+
+- Go 1.24+
+- Node.js 20+
+- pnpm 9+
+- Docker
+- Python 3.10+
+- uv
+
+Run:
+
+```bash
+./scripts/setup.sh
+make dev
+
+export DATABASE_URL="postgres://continua:continua@localhost:5432/continua?sslmode=disable"
+make migrate
+make dev-server
+```
+
+In another terminal:
+
+```bash
+make dev-web
+```
+
+Open:
+
+```text
+http://localhost:3000/dashboard
+```
+
+For a fresh local database, use API key `default` when the UI asks for a project API key.
+
+Emit sample private traces:
+
+```bash
+cd sdks/python
+CONTINUA_API_URL="http://localhost:8080" \
+CONTINUA_API_KEY="default" \
+uv run python examples/e2e_demo.py
+```
+
+## Ports
+
+| Port | Used by | Path |
+| --- | --- | --- |
+| `8080` | Go server and embedded UI in Docker demo | `make demo` |
+| `5432` | Postgres | Docker demo and native `make dev` |
+| `3000` | Vite dev server | native `make dev-web` |
+
+## Runtime Configuration
+
+The server uses environment variables through `internal/config/config.go`.
+
+Required:
+
+| Variable | Purpose |
+| --- | --- |
+| `DATABASE_URL` | Postgres connection string |
+
+Common optional variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `HOST`, `PORT` | Server bind address, defaults to `0.0.0.0:8080` |
+| `PUBLIC_DEMO_ENABLED` | Enables read-only seeded demo mode |
+| `PUBLIC_DEMO_PROJECT_ID` | Project shown in public demo mode |
+| `PUBLIC_DEMO_LABEL` | Demo workspace label in the UI |
+| `INGEST_TRUE_ASYNC_DEFAULT` | Server default async ingest behavior |
+| `RIVER_QUEUE_*` | River worker pool sizes |
+
+Do not use `config.example.yaml` as the runtime contract. It is forward-looking and not the active config source.
+
+## Troubleshooting
+
+Port `8080` is already in use:
+
+```bash
+lsof -nP -iTCP:8080
+make docker-down
+```
+
+Docker data looks stale:
+
+```bash
+make reset-demo
+```
+
+The app is up but no traces appear:
+
+```bash
+make docker-logs
+docker compose -f deploy/docker-compose/docker-compose.yml --profile seed run --rm demo-seed
+```
+
+Native server fails with `DATABASE_URL environment variable is required`:
+
+```bash
+export DATABASE_URL="postgres://continua:continua@localhost:5432/continua?sslmode=disable"
+make migrate
+make dev-server
+```
+
+Native UI cannot load data:
+
+- Confirm the backend is running on `http://localhost:8080`.
+- Confirm Vite is running on `http://localhost:3000`.
+- Confirm the UI has API key `default` in `/settings`.
+
+## Current Product Boundary
+
+Implemented setup path:
+
+```text
+Python SDK / custom client
+  -> authenticated REST ingest
+  -> Postgres persistence
+  -> River background jobs
+  -> REST read APIs
+  -> embedded React debugger operator console
+```
+
+The TypeScript SDK, live WebSocket runtime, proxy capture, replay runtime, and durable engine execution are not the main local setup path today.


### PR DESCRIPTION
## Summary

- Recreates the root README into a premium GitHub landing page using design cues from Langfuse, Trigger.dev, and Temporal — full-bleed banner, two-row centered nav, dense badge stack, and 16:9 section visuals.
- Adds an **"At a glance"** status matrix near the top so the implemented-vs-scaffolded boundary is visible above the fold, plus dedicated sections for **REST API surface**, **data model**, **event semantics**, and the **engine foundation**.
- Keeps every claim grounded against the current implementation. No new claims about replay, live WebSocket runtime, proxy capture, TypeScript SDK parity, or durable engine execution.

## What's in the PR

- New `assets/banner.svg` (2400×600 full-bleed hero) and four new 16:9 diagram strips: `feature-strip.svg`, `data-model.svg`, `event-types.svg`, plus refreshed `runtime-architecture.svg` and `ingest-flow.svg`.
- New Mermaid sources alongside each SVG: `docs/diagrams/data-model.mmd`, `docs/diagrams/event-types.mmd` (plus the existing `runtime-architecture.mmd` and `ingest-flow.mmd`).
- Updated `docs/readme-improvement-changelog.md` documenting this visual pass — which README skills were used (\`readme-generator-glincker\`, \`readme-generator-visual\`, \`mermaid-tools\`) and which were skipped (\`cli-demo-generator\`, \`walkthrough\`) and why.
- Includes the previously-untracked `docs/setup.md`, `docs/readme-skill-setup-notes.md`, and `README.old.md` so the README's primary doc links and history all resolve on this branch.

## Accuracy guardrails

- Only endpoints in `contracts/openapi/openapi.yaml` are listed in the REST API surface table.
- Engine section is explicitly labeled "foundation only".
- Trace detail timeline described as **polling** (\`GET /api/traces/{id}/events\`), never WebSocket.
- TypeScript SDK is called out as a stub package.
- \`config.example.yaml\` flagged as not the runtime contract.
- No fake screenshots, no fake metrics, no community badges we cannot back (no Discord, Twitter, npm/PyPI downloads, or Docker Hub pulls).

## Notes for reviewers

- The README references \`make demo\`, \`make reset-demo\`, and \`scripts/demo.sh\`, which exist on parallel branches but are not on \`main\` yet. If those Makefile targets land separately, the quickstart will work end-to-end on \`main\`. Otherwise, consider landing the demo plumbing alongside (or after) this PR.

## Test plan

- [ ] Open the README on the PR diff and confirm the banner, four section images, Mermaid blocks, and callouts render in GitHub's web preview.
- [ ] Spot-check each command in the README against the \`Makefile\` and confirm Docker quickstart works locally.
- [ ] Verify every relative link in the README resolves: \`docs/setup.md\`, \`docs/DEBUGGER_PLATFORM_BASELINE.md\`, \`docs/architecture/overview.md\`, \`docs/event-conventions.md\`, \`contracts/openapi/openapi.yaml\`, \`sdks/python/README.md\`, \`engine/README.md\`, \`CONTRIBUTING.md\`, \`LICENSE\`.
- [ ] Run \`make generate && make lint && make test\` to confirm no docs changes break tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Substantially restructured README with expanded quickstart, features, and architecture sections
  * Added new diagrams documenting data model, event types, ingest flow, and runtime architecture
  * Added comprehensive setup guide for Docker and native development paths
  * Included Python SDK walkthrough and REST API surface reference
  * Added event semantics and data model documentation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/68)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->