### PR TITLE
Fix engine loop cancellation race

### DIFF
--- a/engine/internal/worker/loop.go
+++ b/engine/internal/worker/loop.go
@@ -11,6 +11,9 @@ type IterationFunc func(context.Context, string) error
 
 func RunLoop(ctx context.Context, pollInterval time.Duration, prefix string, fn IterationFunc) error {
 	if err := fn(ctx, workerID(prefix)); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
 		return err
 	}
 
@@ -23,6 +26,9 @@ func RunLoop(ctx context.Context, pollInterval time.Duration, prefix string, fn 
 			return nil
 		case <-ticker.C:
 			if err := fn(ctx, workerID(prefix)); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
 				return err
 			}
 		}

--- a/engine/internal/worker/loop_test.go
+++ b/engine/internal/worker/loop_test.go
@@ -1,0 +1,32 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRunLoopSuppressesIterationErrorAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	iterationErr := errors.New("write failed after cancellation")
+
+	err := RunLoop(ctx, time.Hour, "test", func(context.Context, string) error {
+		cancel()
+		return iterationErr
+	})
+	if err != nil {
+		t.Fatalf("RunLoop() error = %v, want nil", err)
+	}
+}
+
+func TestRunLoopReturnsIterationErrorBeforeCancellation(t *testing.T) {
+	iterationErr := errors.New("poll failed")
+
+	err := RunLoop(context.Background(), time.Hour, "test", func(context.Context, string) error {
+		return iterationErr
+	})
+	if !errors.Is(err, iterationErr) {
+		t.Fatalf("RunLoop() error = %v, want %v", err, iterationErr)
+	}
+}


### PR DESCRIPTION
## Summary
- suppress engine worker loop iteration errors that arrive after the loop context has already been canceled
- add direct unit coverage for cancellation-vs-poll-error behavior

## Root cause
The failing GitHub Actions job reached the expected runtime state, then failed while shutting down `continua-engine serve`. A poll iteration was still in-flight when the test canceled the serve context, and a Postgres write surfaced as `write failed: ... i/o timeout`. Since shutdown had already been requested, the loop should treat that cancellation race as normal termination instead of propagating it as a test failure.

## Validation
- `go test -count=1 ./internal/worker`
- `go test -race -count=1 -run TestEngineRuntimeActivityPickupAfterRestart ./cmd/continua-engine`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error handling during loop execution to suppress errors when context cancellation occurs, applying to both initial and subsequent loop iterations.

* **Tests**
  * Added tests to validate error suppression behavior following cancellation and to confirm errors are properly returned when they occur prior to cancellation being triggered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/79)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->