### PR TITLE
feat(worker): proxy /docs/* to Mintlify when MINTLIFY_HOST env is set

### DIFF
--- a/web/public/_worker.js
+++ b/web/public/_worker.js
@@ -395,6 +395,18 @@ export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
+    // Proxy /docs/* to the Mintlify-hosted docs site when MINTLIFY_HOST is configured.
+    // Set MINTLIFY_HOST (e.g. "continua.mintlify.dev") in Cloudflare Pages env vars to activate.
+    const mintlifyHost = env?.MINTLIFY_HOST;
+    if (mintlifyHost && (url.pathname === '/docs' || url.pathname.startsWith('/docs/'))) {
+      const proxyUrl = new URL(url.pathname + url.search, `https://${mintlifyHost}`);
+      const proxyRequest = new Request(proxyUrl, request);
+      proxyRequest.headers.set('Host', mintlifyHost);
+      proxyRequest.headers.set('X-Forwarded-Host', url.host);
+      proxyRequest.headers.set('X-Forwarded-Proto', 'https');
+      return fetch(proxyRequest);
+    }
+
     if (url.pathname.startsWith('/api/')) {
       return handleApi(url);
     }


### PR DESCRIPTION
## Summary

Follow-up to #80. The Worker proxy change that lets \`continua.in/docs\` serve the Mintlify-hosted docs site landed on the PR branch _after_ #80 was merged, so it didn't make it into main. This PR resubmits exactly that one commit.

## What this adds

A guarded block at the top of \`web/public/_worker.js\`'s \`fetch\` handler:

\`\`\`js
const mintlifyHost = env?.MINTLIFY_HOST;
if (mintlifyHost && (url.pathname === '/docs' || url.pathname.startsWith('/docs/'))) {
  const proxyUrl = new URL(url.pathname + url.search, \`https://\${mintlifyHost}\`);
  const proxyRequest = new Request(proxyUrl, request);
  proxyRequest.headers.set('Host', mintlifyHost);
  proxyRequest.headers.set('X-Forwarded-Host', url.host);
  proxyRequest.headers.set('X-Forwarded-Proto', 'https');
  return fetch(proxyRequest);
}
\`\`\`

Standard Mintlify Cloudflare-subpath pattern — preserves \`Host\` / \`X-Forwarded-Host\` / \`X-Forwarded-Proto\` for correct canonical URLs and SEO metadata.

## Properties

- **No-op when \`MINTLIFY_HOST\` is unset** → safe to merge now, no behavior change until the env var is configured
- **Flipped on by env var** → after Mintlify connects, set \`MINTLIFY_HOST=<subdomain>.mintlify.dev\` in CF Pages and the route activates on the next auto-redeploy
- **Reversible** → unset the env var to roll back instantly, no code rollback needed

## Activation steps after merge

1. Go to [mintlify.com/dashboard](https://mintlify.com/dashboard) → New Documentation → connect this repo, point at \`docs-site/\`. Mintlify gives you a URL like \`continua.mintlify.dev\`.
2. In Cloudflare Pages → Settings → Environment variables → Production → add \`MINTLIFY_HOST=continua.mintlify.dev\` (or whatever subdomain Mintlify assigned).
3. Save. CF Pages auto-redeploys in ~30 sec.
4. Open \`https://continua.in/docs\` — should serve the Mintlify site under the apex domain.

## Test plan

- [ ] Without \`MINTLIFY_HOST\` set: \`/docs\` falls through to current SPA behavior (no regression)
- [ ] With \`MINTLIFY_HOST\` set: \`/docs\` and \`/docs/guides/quickstart\` serve Mintlify content under \`continua.in\`
- [ ] \`/traces\`, \`/sessions\`, \`/api/*\` paths unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for routing documentation requests to external Mintlify hosts when configured with an environment variable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/81)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->