### PR TITLE
Landing/docs polish: theme sync, branded favicon, commit heatmap, same-tab docs nav

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -9,10 +9,13 @@
     "dark": "#0369A1"
   },
   "favicon": "/favicon.svg",
+  "appearance": {
+    "default": "system"
+  },
   "logo": {
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg",
-    "href": "https://github.com/aryanVijaywargia/Continua"
+    "href": "https://www.continua.in"
   },
   "navigation": {
     "tabs": [

--- a/docs-site/favicon.svg
+++ b/docs-site/favicon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-grad-favicon" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0075D6"/>
-      <stop offset="1" stop-color="#005CAB"/>
+      <stop offset="0" stop-color="#0EA5E9"/>
+      <stop offset="1" stop-color="#0369A1"/>
     </linearGradient>
   </defs>
-  <circle cx="32" cy="32" r="28" stroke="url(#cont-grad-favicon)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>
-  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad-favicon)" stroke-width="4.5" stroke-linecap="round"/>
-  <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad-favicon)"/>
-  <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad-favicon)"/>
+  <rect width="64" height="64" rx="14" fill="url(#cont-grad-favicon)"/>
+  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="#ffffff" stroke-width="6" stroke-linecap="round" fill="none"/>
+  <circle cx="46" cy="18" r="4" fill="#ffffff"/>
+  <circle cx="46" cy="46" r="4" fill="#ffffff"/>
 </svg>

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -1378,20 +1378,124 @@ function CodeOutputPanel({
   );
 }
 
+const COMMIT_HEATMAP_TOTAL = 240;
+const COMMIT_HEATMAP_WEEKS = 26;
+const COMMIT_HEATMAP_DAYS: readonly number[] = [
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 3, 21, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 4, 0, 0, 2, 3, 3, 0, 2, 0, 0, 7, 8, 2, 0, 0, 0, 0, 4, 1,
+  2, 2, 0, 0, 0, 0, 12, 0, 10, 0, 4, 0, 11, 11, 7, 8, 0, 0, 0, 21, 5, 3, 1, 0, 0, 5, 2, 0, 0, 0,
+  0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 4, 11, 22, 9,
+];
+
+function commitLevel(count: number): 0 | 1 | 2 | 3 | 4 {
+  if (count <= 0) return 0;
+  if (count <= 2) return 1;
+  if (count <= 5) return 2;
+  if (count <= 10) return 3;
+  return 4;
+}
+
+function CommitHeatmap() {
+  const cells: number[][] = Array.from({ length: COMMIT_HEATMAP_WEEKS }, () => []);
+  for (let i = 0; i < COMMIT_HEATMAP_DAYS.length; i += 1) {
+    const week = Math.floor(i / 7);
+    cells[week].push(COMMIT_HEATMAP_DAYS[i]);
+  }
+  const monthLabels = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May'];
+
+  return (
+    <div className="border-b px-4 py-3" style={{ borderColor: 'var(--c-border)' }}>
+      <div className="flex items-center justify-between">
+        <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--c-text-muted)]">
+          Commit activity
+        </div>
+        <span className="font-mono text-[10px] text-[var(--c-text-muted)]">
+          <span className="text-[var(--c-text-primary)]">{COMMIT_HEATMAP_TOTAL}</span> commits · last 26 weeks
+        </span>
+      </div>
+      <div className="mt-2.5 flex gap-[3px]" aria-hidden="true">
+        {cells.map((week, wi) => (
+          <div key={wi} className="flex flex-col gap-[3px]">
+            {week.map((c, di) => {
+              const level = commitLevel(c);
+              const bg =
+                level === 0
+                  ? 'var(--c-app-bg)'
+                  : level === 1
+                    ? 'color-mix(in srgb, var(--c-accent) 25%, transparent)'
+                    : level === 2
+                      ? 'color-mix(in srgb, var(--c-accent) 50%, transparent)'
+                      : level === 3
+                        ? 'color-mix(in srgb, var(--c-accent) 75%, transparent)'
+                        : 'var(--c-accent)';
+              return (
+                <div
+                  key={di}
+                  className="h-[9px] w-[9px] rounded-[2px] border"
+                  style={{ background: bg, borderColor: 'var(--c-border)' }}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 flex items-center justify-between text-[9.5px] font-mono text-[var(--c-text-muted)]">
+        <div className="flex gap-2">
+          {monthLabels.map((m) => (
+            <span key={m}>{m}</span>
+          ))}
+        </div>
+        <div className="flex items-center gap-1">
+          <span>less</span>
+          {[0, 1, 2, 3, 4].map((lvl) => (
+            <span
+              key={lvl}
+              className="inline-block h-[8px] w-[8px] rounded-[2px] border"
+              style={{
+                borderColor: 'var(--c-border)',
+                background:
+                  lvl === 0
+                    ? 'var(--c-app-bg)'
+                    : lvl === 1
+                      ? 'color-mix(in srgb, var(--c-accent) 25%, transparent)'
+                      : lvl === 2
+                        ? 'color-mix(in srgb, var(--c-accent) 50%, transparent)'
+                        : lvl === 3
+                          ? 'color-mix(in srgb, var(--c-accent) 75%, transparent)'
+                          : 'var(--c-accent)',
+              }}
+            />
+          ))}
+          <span>more</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function RepoCard() {
   const repoFacts = [
     ['License', 'MIT'],
     ['Docs', 'continua.in/docs'],
-    ['Engine', 'preview'],
+    ['Commits', String(COMMIT_HEATMAP_TOTAL)],
   ] as const;
 
   return (
     <Reveal>
       <div className="rounded-xl border bg-[var(--c-surface)]" style={{ borderColor: 'var(--c-border)' }}>
-        <div className="flex items-center gap-2 border-b px-4 py-3" style={{ borderColor: 'var(--c-border)' }}>
+        <a
+          href={GITHUB_REPO_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center gap-2 border-b px-4 py-3 transition hover:bg-[var(--c-app-bg)]"
+          style={{ borderColor: 'var(--c-border)' }}
+        >
           <Github size={14} className="text-[var(--c-text-secondary)]" />
           <span className="font-mono text-[12px] text-[var(--c-text-primary)]">aryanVijaywargia/Continua</span>
-        </div>
+        </a>
+        <CommitHeatmap />
         <div className="border-b px-4 py-3" style={{ borderColor: 'var(--c-border)' }}>
           <div className="flex items-center justify-between">
             <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--c-text-muted)]">Current surface</div>

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -1545,6 +1545,16 @@ function RepoCard() {
   );
 }
 
+function isSameOriginHref(href: string): boolean {
+  if (typeof window === 'undefined') return false;
+  if (href.startsWith('/') || href.startsWith('#')) return true;
+  try {
+    return new URL(href, window.location.href).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
 function ExternalLink({
   href,
   children,
@@ -1556,8 +1566,14 @@ function ExternalLink({
   className?: string;
   style?: CSSProperties;
 }) {
+  const sameOrigin = isSameOriginHref(href);
   return (
-    <a href={href} target="_blank" rel="noreferrer" className={className} style={style}>
+    <a
+      href={href}
+      {...(sameOrigin ? {} : { target: '_blank', rel: 'noreferrer' })}
+      className={className}
+      style={style}
+    >
       {children}
     </a>
   );


### PR DESCRIPTION
## Summary

Four small but visible fixes to the landing page and Mintlify docs site.

- **Docs logo + theme default** — Mintlify's `logo.href` previously pointed at the GitHub repo; it now opens the landing page so the Continua brand consistently routes home. Added `appearance.default: "system"` so the docs follows the OS theme, matching the landing default and keeping the two visually aligned.
- **Bolder favicon** — Rebuilt `favicon.svg` as a filled, gradient-backed Continua mark so the icon reads correctly at the small sizes Mintlify uses for the favicon, the Ask AI source chip, and the search-result thumbnail.
- **Repo card heatmap + commit count** — Restored a GitHub-style activity heatmap on the landing repo card (26 weeks of real commit data, baked from `git rev-list`) and replaced the `Engine preview` bottom-tile with `Commits 240` so the card surfaces repo activity instead of restating engine status that already lives in the current-surface section. The repo header is now a real GitHub link.
- **Same-tab docs nav** — `ExternalLink` was unconditionally adding `target="_blank"`. For docs URLs on `continua.in` this caused a blank new-tab flash before the Cloudflare worker proxied to Mintlify. Same-origin hrefs now stay in the current tab; cross-origin links (GitHub, license, changelog) still open in a new tab.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run src/pages/LandingPage.test.tsx` — all 4 tests pass
- [ ] Manual: load landing, confirm heatmap renders and `Commits 240` tile shows
- [ ] Manual: click a docs link from landing → no blank-tab flash, URL transitions in-place to `/docs`
- [ ] Manual: click Continua logo on docs (Mintlify) → routes to landing, not GitHub
- [ ] Manual: confirm Mintlify search/Ask-AI chip shows the new favicon

## Caveats

- `COMMIT_HEATMAP_TOTAL` and the day array are static (baked today). They'll drift unless we add a build-time script or a runtime GitHub fetch — happy to follow up if you want either.
- Cross-domain theme is system-default-aligned, not live-toggle-synced. Mintlify (hosted) doesn't expose a documented `?theme=` URL parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub commit activity heatmap visualization to repository cards with weekly view and legend
  * Enabled system appearance configuration for device-based theme selection
  * Made repository headers clickable for improved navigation
  * Updated repository information to display commit count metrics

* **Bug Fixes**
  * Fixed external link behavior to prevent same-origin URLs from opening in new tabs

* **Other**
  * Updated website logo link to continua.in

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->