### PR TITLE
Point README Docs links to the hosted Mintlify site

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <a href="#features"><b>Features</b></a> ·
     <a href="#architecture"><b>Architecture</b></a> ·
     <a href="#python-sdk"><b>Python SDK</b></a> ·
-    <a href="./docs-site/"><b>Docs</b></a> ·
+    <a href="https://www.continua.in/docs"><b>Docs</b></a> ·
     <a href="https://github.com/aryanVijaywargia/Continua/issues"><b>Issues</b></a>
   </p>
 
@@ -22,7 +22,7 @@
     <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-0EA5E9?style=flat-square"></a>
     <img alt="Docker demo" src="https://img.shields.io/badge/demo-Docker%20Compose-2496ED?style=flat-square&logo=docker&logoColor=white">
     <img alt="Status: alpha" src="https://img.shields.io/badge/status-alpha-F59E0B?style=flat-square">
-    <a href="./docs-site/"><img alt="Docs" src="https://img.shields.io/badge/docs-Mintlify-22D3EE?style=flat-square"></a>
+    <a href="https://www.continua.in/docs"><img alt="Docs" src="https://img.shields.io/badge/docs-Mintlify-22D3EE?style=flat-square"></a>
   </p>
 
 </div>


### PR DESCRIPTION
## Summary

The two prominent **Docs** entries in `README.md` — the top-nav link and the Mintlify badge — both pointed to `./docs-site/`, which on github.com just renders as a folder listing. Visitors clicking "Docs" expect to land on the actual hosted documentation.

Both now link to `https://www.continua.in/docs` so the GitHub repo's Docs CTAs open the live Mintlify site.

## What's NOT changed

- Inline references like `[events concept guide](./docs-site/concepts/events.mdx)` are intentionally left alone. They render as readable markdown on GitHub, help code readers jump from README into source, and aren't affected if the hosted URL ever changes.
- The repo's About-sidebar website URL (`https://continua.in`) is unchanged — that points to the marketing root which already surfaces docs via its own nav.

## Test plan

- [x] Two-line diff scoped strictly to the nav row and badge row
- [x] `HEAD https://www.continua.in/docs` returns 200 (verified)
- [ ] Skim the rendered README on the PR page to confirm both Docs links resolve correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to point to the official documentation website.
  * Adjusted documentation badge placement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->