### PR TITLE
Fix mobile trace detail layout theming

### DIFF
--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -72,7 +72,7 @@ export function CopyButton({
     <button
       {...buttonProps}
       type={type}
-      className={`inline-flex items-center justify-center rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-2.5 py-1 text-xs font-medium text-[var(--continua-text-secondary)] transition hover:bg-[var(--continua-surface-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] disabled:cursor-not-allowed disabled:opacity-60 ${className}`.trim()}
+      className={`inline-flex items-center justify-center rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-2.5 py-1 text-xs font-medium text-[var(--c-text-secondary)] transition hover:border-[var(--c-border-strong)] hover:text-[var(--c-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)] disabled:cursor-not-allowed disabled:opacity-60 ${className}`.trim()}
       data-copy-status={status}
       onClick={handleClick}
     >

--- a/web/src/components/DecisionValuePill.tsx
+++ b/web/src/components/DecisionValuePill.tsx
@@ -13,8 +13,8 @@ export function DecisionValuePill({
     <span
       className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
         tone === 'accent'
-          ? 'border-[var(--continua-accent)] bg-[var(--continua-accent-faint)] text-[var(--continua-accent)]'
-          : 'border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] text-[var(--continua-text-secondary)]'
+          ? 'border-[var(--c-accent-border)] bg-[var(--c-accent-faint)] text-[var(--c-accent-text)]'
+          : 'border-[var(--c-border)] bg-[var(--c-surface)] text-[var(--c-text-secondary)]'
       }`}
     >
       {children}

--- a/web/src/components/ExecutionWaterfall.tsx
+++ b/web/src/components/ExecutionWaterfall.tsx
@@ -125,11 +125,17 @@ export function ExecutionWaterfall({
         </div>
         <div className="relative border-l border-[var(--c-border)] px-4 py-2">
           <div className="relative flex h-full items-start justify-between gap-2 text-[10.5px] font-medium uppercase tracking-[0.04em] text-[var(--c-text-muted)]">
-            {ticks.map((tick) => (
+            {ticks.filter((tick) => tick.leftPercent < 100).map((tick) => (
               <span
                 key={tick.leftPercent}
-                className="translate-x-[-50%] whitespace-nowrap"
-                style={{ marginLeft: `${tick.leftPercent}%` }}
+                className="hidden whitespace-nowrap sm:inline"
+                style={{
+                  marginLeft: `${tick.leftPercent}%`,
+                  transform:
+                    tick.leftPercent === 0
+                      ? 'translateX(0)'
+                      : 'translateX(-50%)',
+                }}
               >
                 +{tick.label}
               </span>

--- a/web/src/components/PayloadInspector.tsx
+++ b/web/src/components/PayloadInspector.tsx
@@ -171,8 +171,8 @@ export function PayloadInspector({
 
   if (tree === null) {
     return (
-        <div
-        className={`rounded-lg border border-dashed border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-4 py-6 text-sm text-[var(--continua-text-muted)] ${className}`.trim()}
+      <div
+        className={`rounded-md border border-dashed border-[var(--c-border)] bg-[var(--c-surface-muted)] px-4 py-6 text-sm text-[var(--c-text-muted)] ${className}`.trim()}
       >
         No data
       </div>
@@ -187,9 +187,9 @@ export function PayloadInspector({
 
   return (
     <section
-      className={`flex min-h-0 flex-col rounded-lg border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] ${className}`.trim()}
+      className={`flex min-h-0 flex-col overflow-hidden rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] ${className}`.trim()}
     >
-      <div className="flex flex-wrap items-center gap-2 border-b border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] p-3">
+      <div className="flex flex-wrap items-center gap-2 border-b border-[var(--c-border)] bg-[var(--c-surface-muted)] p-3">
         <label className="sr-only" htmlFor={searchInputId}>
           Search payload
         </label>
@@ -200,11 +200,11 @@ export function PayloadInspector({
           onChange={(event) => setSearchQuery(event.target.value)}
           placeholder="Search payload"
           aria-label="Search payload"
-          className="min-w-0 flex-1 rounded-lg border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-3 py-2 text-sm text-[var(--continua-text-primary)] shadow-sm transition focus:border-[var(--continua-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
+          className="min-w-[11rem] flex-1 rounded-md border border-[var(--c-border)] bg-[var(--c-app-bg)] px-3 py-2 text-sm text-[var(--c-text-primary)] transition placeholder:text-[var(--c-text-muted)] focus:border-[var(--c-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)]"
         />
         <button
           type="button"
-          className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-3 py-1.5 text-xs font-medium text-[var(--continua-text-secondary)] transition hover:bg-[var(--continua-surface-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 py-1.5 text-xs font-medium text-[var(--c-text-secondary)] transition hover:border-[var(--c-border-strong)] hover:text-[var(--c-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)] disabled:cursor-not-allowed disabled:opacity-60"
           disabled={matchCount === 0}
           onClick={() =>
             setActiveMatchIndex((index) =>
@@ -216,7 +216,7 @@ export function PayloadInspector({
         </button>
         <button
           type="button"
-          className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-3 py-1.5 text-xs font-medium text-[var(--continua-text-secondary)] transition hover:bg-[var(--continua-surface-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 py-1.5 text-xs font-medium text-[var(--c-text-secondary)] transition hover:border-[var(--c-border-strong)] hover:text-[var(--c-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)] disabled:cursor-not-allowed disabled:opacity-60"
           disabled={matchCount === 0}
           onClick={() =>
             setActiveMatchIndex((index) =>
@@ -228,7 +228,7 @@ export function PayloadInspector({
         </button>
         <button
           type="button"
-          className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-3 py-1.5 text-xs font-medium text-[var(--continua-text-secondary)] transition hover:bg-[var(--continua-surface-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 py-1.5 text-xs font-medium text-[var(--c-text-secondary)] transition hover:border-[var(--c-border-strong)] hover:text-[var(--c-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)] disabled:cursor-not-allowed disabled:opacity-60"
           title={
             expandAllDisabled
               ? 'Expand all is disabled for payloads with more than 5,000 nodes.'
@@ -241,7 +241,7 @@ export function PayloadInspector({
         </button>
         <button
           type="button"
-          className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-3 py-1.5 text-xs font-medium text-[var(--continua-text-secondary)] transition hover:bg-[var(--continua-surface-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
+          className="rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 py-1.5 text-xs font-medium text-[var(--c-text-secondary)] transition hover:border-[var(--c-border-strong)] hover:text-[var(--c-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)]"
           onClick={handleCollapseAll}
         >
           Collapse all
@@ -252,11 +252,11 @@ export function PayloadInspector({
           idleLabel="Copy full JSON"
           successLabel="Copied JSON"
         />
-        <span className="ml-auto text-xs text-[var(--continua-text-muted)]">{matchSummary}</span>
+        <span className="ml-auto text-xs text-[var(--c-text-muted)]">{matchSummary}</span>
       </div>
 
       <div className="min-h-0 overflow-auto p-3">
-        <div className="font-mono text-xs leading-6 text-[var(--continua-text-primary)]">
+        <div className="font-mono text-xs leading-6 text-[var(--c-text-primary)]">
           <PayloadNodeRow
             node={tree}
             activeMatchId={activeMatch?.id ?? null}
@@ -304,13 +304,13 @@ function PayloadNodeRow({
           <button
             type="button"
             aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${describeNode(node)}`}
-            className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--continua-text-muted)] transition hover:bg-[var(--continua-surface-muted)] hover:text-[var(--continua-text-secondary)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
+            className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--c-text-muted)] transition hover:bg-[var(--c-row-hover-bg)] hover:text-[var(--c-text-secondary)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)]"
             onClick={() => onToggleExpanded(node.path)}
           >
             {isExpanded ? '-' : '+'}
           </button>
         ) : (
-          <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-[var(--continua-border-soft)]">
+          <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-[var(--c-text-muted)]">
             -
           </span>
         )}
@@ -321,14 +321,14 @@ function PayloadNodeRow({
               <>
                 <HighlightableText
                   activeMatchId={activeMatchId}
-                  className="break-all text-[var(--continua-accent)]"
+                  className="break-all text-[var(--c-accent-text)]"
                   isMatch={keyMatch}
                   matchId={keyMatchId}
                   registerMatchElement={registerMatchElement}
                 >
                   {String(node.key)}
                 </HighlightableText>
-                <span className="text-[var(--continua-text-muted)]">:</span>
+                <span className="text-[var(--c-text-muted)]">:</span>
               </>
             )}
 
@@ -339,8 +339,8 @@ function PayloadNodeRow({
                 activeMatchId={activeMatchId}
                 className={
                   typeof node.value === 'string'
-                    ? 'max-h-36 overflow-auto whitespace-pre-wrap break-words text-emerald-700 dark:text-emerald-300'
-                    : 'break-all text-[var(--continua-text-primary)]'
+                    ? 'max-h-36 overflow-auto whitespace-pre-wrap break-words text-[var(--c-green-text)]'
+                    : 'break-all text-[var(--c-text-primary)]'
                 }
                 isMatch={valueMatch}
                 matchId={valueMatchId}
@@ -395,8 +395,8 @@ function CollectionSummary({ node }: { node: TreeNode }) {
 
   return (
     <span className="inline-flex flex-wrap items-center gap-2">
-      <span className="text-[var(--continua-text-muted)]">{node.type === 'object' ? '{}' : '[]'}</span>
-      <span className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2 py-0.5 text-[11px] font-medium text-[var(--continua-text-secondary)]">
+      <span className="text-[var(--c-text-muted)]">{node.type === 'object' ? '{}' : '[]'}</span>
+      <span className="rounded-md border border-[var(--c-border)] bg-[var(--c-surface-muted)] px-2 py-0.5 text-[11px] font-medium text-[var(--c-text-secondary)]">
         {describeCollection(node)}
       </span>
     </span>
@@ -426,8 +426,8 @@ function HighlightableText({
       className={`${className} ${
         isMatch
           ? activeMatchId === matchId
-            ? 'rounded bg-amber-200 px-1 dark:bg-amber-400/40'
-            : 'rounded bg-yellow-100 px-1 dark:bg-yellow-400/20'
+            ? 'rounded bg-[var(--c-amber-faint)] px-1 text-[var(--c-amber-text)] ring-1 ring-[var(--c-amber-border)]'
+            : 'rounded bg-[var(--c-amber-faint)] px-1 text-[var(--c-amber-text)]'
           : ''
       }`.trim()}
       data-match-state={

--- a/web/src/components/ReasoningTab.tsx
+++ b/web/src/components/ReasoningTab.tsx
@@ -10,22 +10,22 @@ interface ReasoningTabProps {
 
 export function ReasoningTab({ entries, onSelectSpan }: ReasoningTabProps) {
   return (
-    <section className="overflow-hidden rounded-xl border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] shadow-sm">
-      <div className="border-b border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-4 py-3">
-        <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-[var(--continua-text-secondary)]">
+    <section className="overflow-hidden rounded-md border border-[var(--c-border)] bg-[var(--c-surface)]">
+      <div className="border-b border-[var(--c-border)] bg-[var(--c-surface-muted)] px-4 py-3">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--c-text-muted)]">
           Reasoning
         </h2>
-        <p className="mt-1 text-sm text-[var(--continua-text-muted)]">
+        <p className="mt-1 text-sm text-[var(--c-text-muted)]">
           Chronological decision events across the full trace.
         </p>
       </div>
 
       {entries.length === 0 ? (
-        <div className="px-4 py-12 text-center text-sm text-[var(--continua-text-muted)]">
+        <div className="px-4 py-12 text-center text-sm text-[var(--c-text-muted)]">
           No reasoning decisions recorded for this trace.
         </div>
       ) : (
-        <div className="divide-y divide-[var(--continua-border-soft)]">
+        <div className="divide-y divide-[var(--c-border-subtle)]">
           {entries.map((entry) => {
             const isNavigable = Boolean(entry.spanId);
 
@@ -36,7 +36,7 @@ export function ReasoningTab({ entries, onSelectSpan }: ReasoningTabProps) {
                 disabled={!isNavigable}
                 className={`flex w-full gap-4 p-4 text-left transition ${
                   isNavigable
-                    ? 'hover:bg-[var(--continua-surface-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent)]'
+                    ? 'hover:bg-[var(--c-row-hover-bg)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)]'
                     : 'cursor-default opacity-80'
                 }`}
                 onClick={() => {
@@ -58,30 +58,30 @@ export function ReasoningTab({ entries, onSelectSpan }: ReasoningTabProps) {
                   onSelectSpan(entry.spanId);
                 }}
               >
-                <div className="min-w-28 rounded-xl bg-[var(--continua-text-primary)] px-3 py-2 text-xs font-medium uppercase tracking-[0.18em] text-[var(--continua-surface-elevated)]">
+                <div className="min-w-28 rounded-md border border-[var(--c-border)] bg-[var(--c-table-head-bg)] px-3 py-2 text-xs font-medium uppercase tracking-[0.08em] text-[var(--c-text-secondary)]">
                   <div>{formatTimelineTime(entry.event.timestamp)}</div>
-                  <div className="mt-1 text-[10px] tracking-[0.25em] opacity-50">
+                  <div className="mt-1 truncate text-[10px] text-[var(--c-text-muted)]">
                     {entry.spanName}
                   </div>
                 </div>
 
                 <div className="min-w-0 flex-1">
-                  <div className="text-sm font-semibold leading-6 text-[var(--continua-text-primary)]">
+                  <div className="text-sm font-semibold leading-6 text-[var(--c-text-primary)]">
                     {entry.question}
                   </div>
-                  <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-[var(--continua-text-secondary)]">
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-[var(--c-text-secondary)]">
                     <span>Chosen</span>
                     <DecisionValuePill tone="accent">
                       {formatInlineSemanticValue(entry.chosen)}
                     </DecisionValuePill>
                   </div>
                   {entry.reasoning ? (
-                    <p className="mt-2 text-sm text-[var(--continua-text-secondary)]">
+                    <p className="mt-2 text-sm text-[var(--c-text-secondary)]">
                       {entry.reasoning}
                     </p>
                   ) : null}
                   {entry.alternatives && entry.alternatives.length > 0 ? (
-                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--continua-text-muted)]">
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--c-text-muted)]">
                       <span>Alternatives</span>
                       {entry.alternatives.map((alternative, index) => (
                         <DecisionValuePill

--- a/web/src/components/SpanBreadcrumb.tsx
+++ b/web/src/components/SpanBreadcrumb.tsx
@@ -24,7 +24,7 @@ export function SpanBreadcrumb({
       aria-label={ariaLabel}
       className={`overflow-x-auto ${className}`.trim()}
     >
-      <ol className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-[var(--continua-text-muted)]">
+      <ol className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-[var(--c-text-muted)]">
         {path.map((segment, index) => {
           const isCurrent = index === lastIndex;
           const isInteractive = !isCurrent && Boolean(onSelectSpan);
@@ -34,7 +34,7 @@ export function SpanBreadcrumb({
               {isInteractive ? (
                 <button
                   type="button"
-                  className="truncate rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-2.5 py-1 font-medium text-[var(--continua-text-secondary)] transition hover:bg-[var(--continua-surface-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
+                  className="truncate rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-2.5 py-1 font-medium text-[var(--c-text-secondary)] transition hover:border-[var(--c-border-strong)] hover:text-[var(--c-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)]"
                   aria-label={`Select ancestor span ${segment.name}`}
                   onClick={() => onSelectSpan?.(segment.spanId)}
                 >
@@ -44,8 +44,8 @@ export function SpanBreadcrumb({
                 <span
                   className={`truncate rounded-full px-2.5 py-1 ${
                     isCurrent
-                      ? 'bg-[var(--continua-text-primary)] text-[var(--continua-surface-elevated)]'
-                      : 'bg-[var(--continua-surface-muted)] font-medium text-[var(--continua-text-secondary)]'
+                      ? 'bg-[var(--c-accent-faint)] text-[var(--c-accent-text)] ring-1 ring-[var(--c-accent-border)]'
+                      : 'bg-[var(--c-surface-muted)] font-medium text-[var(--c-text-secondary)]'
                   }`}
                   aria-current={isCurrent ? 'page' : undefined}
                 >

--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -46,7 +46,7 @@ export function SpanDetail({
 }: SpanDetailProps) {
   if (!span) {
     return (
-      <div className="flex h-full items-center justify-center text-[var(--continua-text-muted)]">
+      <div className="flex h-full items-center justify-center text-[var(--c-text-muted)]">
         Select a span to view details
       </div>
     );
@@ -69,7 +69,7 @@ export function SpanDetail({
   });
 
   return (
-    <div className="h-full overflow-y-auto p-4">
+    <div className="h-full overflow-y-auto bg-[var(--c-app-bg)] p-4">
       {/* Header */}
       <div className="mb-4">
         <SpanBreadcrumb
@@ -77,11 +77,11 @@ export function SpanDetail({
           onSelectSpan={onSelectSpan}
           className="mb-3"
         />
-        <h2 className="text-xl font-semibold tracking-[-0.03em] text-[var(--continua-text-primary)]">
+        <h2 className="text-lg font-semibold text-[var(--c-text-primary)]">
           {span.name}
         </h2>
         <div className="mt-2 flex items-center gap-2">
-          <span className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--continua-text-secondary)]">
+          <span className="rounded border border-[var(--c-border)] bg-[var(--c-surface)] px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--c-text-secondary)]">
             {span.kind}
           </span>
           <StatusBadge status={span.status} />
@@ -89,7 +89,7 @@ export function SpanDetail({
       </div>
 
       {/* Metrics */}
-      <div className="grid grid-cols-3 gap-4 mb-6">
+      <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
         <MetricCard label="Duration" value={formatDuration(span.latency_ms)} />
         <MetricCard label="Tokens" value={formatTokens(totalTokens)} />
         <MetricCard label="Cost" value={formatCost(span.cost_usd)} />
@@ -98,14 +98,14 @@ export function SpanDetail({
       {/* Token breakdown */}
       {(span.tokens_in || span.tokens_out) && (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Token Breakdown</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--c-text-secondary)]">Token Breakdown</h3>
           <div className="app-surface-muted p-3 text-sm">
             <div className="flex justify-between">
-              <span className="text-[var(--continua-text-secondary)]">Input tokens:</span>
+              <span className="text-[var(--c-text-secondary)]">Input tokens:</span>
               <span className="font-mono">{span.tokens_in ?? 0}</span>
             </div>
             <div className="flex justify-between mt-1">
-              <span className="text-[var(--continua-text-secondary)]">Output tokens:</span>
+              <span className="text-[var(--c-text-secondary)]">Output tokens:</span>
               <span className="font-mono">{span.tokens_out ?? 0}</span>
             </div>
           </div>
@@ -115,8 +115,8 @@ export function SpanDetail({
       {/* Error message */}
       {span.error_message && (
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-red-700 mb-2">Error</h3>
-          <div className="rounded border border-red-300/40 bg-red-50/80 p-3 font-mono text-sm text-red-800 whitespace-pre-wrap dark:border-red-400/25 dark:bg-red-400/10 dark:text-red-100">
+          <h3 className="mb-2 text-sm font-medium text-[var(--c-red-text)]">Error</h3>
+          <div className="whitespace-pre-wrap rounded border border-[var(--c-red-border)] bg-[var(--c-red-faint)] p-3 font-mono text-sm text-[var(--c-red-text)]">
             {span.error_message}
           </div>
         </div>
@@ -125,7 +125,7 @@ export function SpanDetail({
       {/* LLM context */}
       {showLLMContext && (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">LLM Context</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--c-text-secondary)]">LLM Context</h3>
           <div className="app-surface-muted p-3 text-sm">
             <DetailRow label="Model" value={span.model} />
             <DetailRow label="Provider" value={span.provider} className="mt-1" />
@@ -136,7 +136,7 @@ export function SpanDetail({
       {/* Input */}
       {span.input !== undefined && (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Input</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--c-text-secondary)]">Input</h3>
           <TruncationBanner
             title="Input payload"
             truncated={span.input_truncated}
@@ -150,7 +150,7 @@ export function SpanDetail({
       {/* Output */}
       {span.output !== undefined && (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Output</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--c-text-secondary)]">Output</h3>
           <TruncationBanner
             title="Output payload"
             truncated={span.output_truncated}
@@ -164,34 +164,34 @@ export function SpanDetail({
       {/* Metadata */}
       {span.metadata && Object.keys(span.metadata).length > 0 && (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Metadata</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--c-text-secondary)]">Metadata</h3>
           <JsonViewer data={span.metadata} />
         </div>
       )}
 
       {decisions.length > 0 && (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Decisions</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--c-text-secondary)]">Decisions</h3>
           <div className="space-y-3">
             {decisions.map((decision) => (
               <div
                 key={decision.event.id}
-                className="rounded-xl border border-[var(--continua-border-strong)] bg-[var(--continua-surface-muted)] p-3"
+                className="rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] p-3"
               >
-                <div className="text-sm font-semibold text-[var(--continua-text-primary)]">
+                <div className="text-sm font-semibold text-[var(--c-text-primary)]">
                   {decision.question}
                 </div>
-                <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-[var(--continua-text-secondary)]">
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-[var(--c-text-secondary)]">
                   <span>Chosen</span>
                   <DecisionValuePill tone="accent">
                     {formatInlineSemanticValue(decision.chosen)}
                   </DecisionValuePill>
                 </div>
                 {decision.reasoning ? (
-                  <p className="mt-2 text-sm text-[var(--continua-text-secondary)]">{decision.reasoning}</p>
+                  <p className="mt-2 text-sm text-[var(--c-text-secondary)]">{decision.reasoning}</p>
                 ) : null}
                 {decision.alternatives && decision.alternatives.length > 0 ? (
-                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--continua-text-muted)]">
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--c-text-muted)]">
                     <span>Alternatives</span>
                     {decision.alternatives.map((alternative, index) => (
                       <DecisionValuePill
@@ -210,7 +210,7 @@ export function SpanDetail({
 
       {span.status === 'FAILED' && retrySafety ? (
         <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">
+          <h3 className="mb-2 text-sm font-medium text-[var(--c-text-secondary)]">
             Retry Safety
           </h3>
           <div className="app-surface-muted p-4">
@@ -220,18 +220,18 @@ export function SpanDetail({
                 variant="full"
                 aria-label={getAccessibleSummary(retrySafety.classification)}
               />
-              <span className="text-sm text-[var(--continua-text-secondary)]">
+              <span className="text-sm text-[var(--c-text-secondary)]">
                 Advisory only. Retry safety is inferred from recorded effect metadata.
               </span>
             </div>
-            <p className="mt-3 text-sm text-[var(--continua-text-secondary)]">
+            <p className="mt-3 text-sm text-[var(--c-text-secondary)]">
               {getReasonExplanation(retrySafety.reason)}
             </p>
             {(retrySafety.effectKind !== undefined ||
               retrySafety.hasExternalSideEffect !== undefined ||
               retrySafety.idempotent !== undefined ||
               retrySafety.idempotencyKey !== undefined) ? (
-              <div className="mt-4 rounded-xl border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] p-3 text-sm">
+              <div className="mt-4 rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] p-3 text-sm">
                 <DetailRow label="effect_kind" value={retrySafety.effectKind} mono />
                 {retrySafety.hasExternalSideEffect !== undefined ? (
                   <DetailRow
@@ -265,7 +265,7 @@ export function SpanDetail({
 
       {/* IDs */}
       <div className="mb-6">
-          <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Identifiers</h3>
+          <h3 className="mb-2 text-sm font-medium text-[var(--c-text-secondary)]">Identifiers</h3>
           <div className="app-surface-muted p-3 text-sm">
           <DetailRow label="Span UUID" value={span.id} mono />
           <DetailRow
@@ -289,7 +289,7 @@ export function SpanDetail({
                   <button
                     type="button"
                     aria-label={`Select parent span ${span.parent_span_id}`}
-                    className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-elevated)] px-2.5 py-1 text-xs font-medium text-[var(--continua-text-secondary)] transition hover:border-[var(--continua-border-strong)] hover:text-[var(--continua-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)]"
+                    className="rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-2.5 py-1 text-xs font-medium text-[var(--c-text-secondary)] transition hover:border-[var(--c-border-strong)] hover:text-[var(--c-accent-text)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)]"
                     onClick={() => onSelectSpan(parentSpan.span_id)}
                   >
                     {span.parent_span_id}
@@ -313,8 +313,8 @@ export function SpanDetail({
 
       {/* Timestamps */}
       <div>
-        <h3 className="mb-2 text-sm font-medium text-[var(--continua-text-secondary)]">Timestamps</h3>
-        <div className="app-surface-muted p-3 text-sm">
+        <h3 className="mb-2 text-sm font-medium text-[var(--c-text-secondary)]">Timestamps</h3>
+        <div className="app-surface-muted p-3 text-sm text-[var(--c-text-primary)]">
           <DetailRow
             label="Started"
             value={formatTimestamp(span.started_at)}
@@ -342,8 +342,8 @@ interface MetricCardProps {
 function MetricCard({ label, value }: MetricCardProps) {
   return (
     <div className="app-surface-muted p-3 text-center">
-      <div className="text-xl font-semibold text-[var(--continua-text-primary)]">{value}</div>
-      <div className="mt-1 text-xs text-[var(--continua-text-muted)]">{label}</div>
+      <div className="text-lg font-semibold text-[var(--c-text-primary)]">{value}</div>
+      <div className="mt-1 text-xs text-[var(--c-text-muted)]">{label}</div>
     </div>
   );
 }
@@ -367,16 +367,16 @@ function DetailRow({
 
   return (
     <div className={`flex justify-between gap-4 ${className}`.trim()}>
-      <span className="text-[var(--continua-text-secondary)]">{label}:</span>
+      <span className="text-[var(--c-text-secondary)]">{label}:</span>
       {hasValue ? (
         <span className="flex min-w-0 items-center justify-end gap-2">
-          <span className={mono ? 'font-mono text-xs text-right' : 'text-right'}>
+          <span className={mono ? 'text-right font-mono text-xs text-[var(--c-text-primary)]' : 'text-right text-[var(--c-text-primary)]'}>
             {value}
           </span>
           {action}
         </span>
       ) : (
-        <span className="text-[var(--continua-text-muted)]">-</span>
+        <span className="text-[var(--c-text-muted)]">-</span>
       )}
     </div>
   );

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -8,15 +8,15 @@ interface StatusBadgeProps {
 export function StatusBadge({ status }: StatusBadgeProps) {
   const colors = {
     RUNNING:
-      'border border-sky-300/60 bg-sky-100/80 text-sky-900 dark:border-sky-400/25 dark:bg-sky-400/10 dark:text-sky-100',
+      'border border-[var(--c-blue-border)] bg-[var(--c-blue-faint)] text-[var(--c-blue-text)]',
     STARTED:
-      'border border-sky-300/60 bg-sky-100/80 text-sky-900 dark:border-sky-400/25 dark:bg-sky-400/10 dark:text-sky-100',
+      'border border-[var(--c-blue-border)] bg-[var(--c-blue-faint)] text-[var(--c-blue-text)]',
     COMPLETED:
-      'border border-emerald-300/60 bg-emerald-100/80 text-emerald-900 dark:border-emerald-400/20 dark:bg-emerald-400/10 dark:text-emerald-100',
+      'border border-[var(--c-green-border)] bg-[var(--c-green-faint)] text-[var(--c-green-text)]',
     FAILED:
-      'border border-red-300/60 bg-red-100/80 text-red-900 dark:border-red-400/25 dark:bg-red-400/10 dark:text-red-100',
+      'border border-[var(--c-red-border)] bg-[var(--c-red-faint)] text-[var(--c-red-text)]',
     SCHEDULED:
-      'border border-[var(--continua-border-strong)] bg-[var(--continua-surface-muted)] text-[var(--continua-text-secondary)]',
+      'border border-[var(--c-border)] bg-[var(--c-surface-muted)] text-[var(--c-text-secondary)]',
   };
 
   return (

--- a/web/src/components/WorkspaceShell.tsx
+++ b/web/src/components/WorkspaceShell.tsx
@@ -45,17 +45,17 @@ export function WorkspaceShell({
   }
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col overflow-hidden border border-[var(--c-border)] bg-[var(--c-surface)]">
-      <div className="border-b border-[var(--c-border)] bg-[var(--c-surface-muted)] px-3 py-3">
-        <div className="flex flex-wrap items-center gap-2">
+    <section className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[var(--c-app-bg)]">
+      <div className="border-b border-[var(--c-border)] bg-[var(--c-app-bg)] px-4">
+        <div className="flex overflow-x-auto">
           {MOBILE_TABS.map((tab) => (
             <button
               key={tab.id}
               type="button"
-              className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] ${
+              className={`-mb-px shrink-0 border-b-2 px-3.5 py-2 text-[13px] font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)] ${
                 activeMobileTab === tab.id
-                  ? 'border border-[var(--c-accent-border)] bg-[var(--c-accent-faint)] text-[var(--c-accent-text)]'
-                  : 'border border-[var(--c-border)] bg-[var(--c-surface)] text-[var(--c-text-secondary)] hover:border-[var(--c-border-strong)] hover:text-[var(--c-text-primary)]'
+                  ? 'border-[var(--c-accent)] text-[var(--c-text-primary)]'
+                  : 'border-transparent text-[var(--c-text-secondary)] hover:text-[var(--c-text-primary)]'
               }`}
               aria-pressed={activeMobileTab === tab.id}
               onClick={() => onMobileTabChange(tab.id)}
@@ -107,19 +107,19 @@ function MobileExecutionPane({
   const [mode, setMode] = useState<'waterfall' | 'tree'>('waterfall');
 
   return (
-    <div className="h-full" style={{ display: active ? 'block' : 'none' }}>
-      <div className="border-b border-[var(--c-border)] bg-[var(--c-surface-muted)] px-3 py-2">
-        <div className="flex flex-wrap items-center gap-2">
+    <div className="h-full flex-col" style={{ display: active ? 'flex' : 'none' }}>
+      <div className="border-b border-[var(--c-border)] bg-[var(--c-app-bg)] px-4">
+        <div className="flex overflow-x-auto">
           {(['waterfall', 'tree'] as const).map((nextMode) => (
             <button
               key={nextMode}
               type="button"
               aria-pressed={mode === nextMode}
               onClick={() => setMode(nextMode)}
-              className={`rounded-full px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--continua-accent-faint)] ${
+              className={`-mb-px shrink-0 border-b-2 px-3.5 py-2 text-xs font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)] ${
                 mode === nextMode
-                  ? 'border border-[var(--c-accent-border)] bg-[var(--c-accent-faint)] text-[var(--c-accent-text)]'
-                  : 'border border-[var(--c-border)] bg-[var(--c-surface)] text-[var(--c-text-secondary)]'
+                  ? 'border-[var(--c-accent)] text-[var(--c-text-primary)]'
+                  : 'border-transparent text-[var(--c-text-secondary)] hover:text-[var(--c-text-primary)]'
               }`}
             >
               {nextMode === 'waterfall' ? 'Waterfall' : 'Tree'}
@@ -128,7 +128,7 @@ function MobileExecutionPane({
         </div>
       </div>
 
-      <div className="h-[calc(100%-3.5rem)]">
+      <div className="min-h-0 flex-1">
         <div className="h-full" style={{ display: mode === 'waterfall' ? 'block' : 'none' }}>
           {waterfall}
         </div>

--- a/web/src/utils/waterfallTime.test.ts
+++ b/web/src/utils/waterfallTime.test.ts
@@ -5,6 +5,7 @@ import {
   resetTestEntityCounter,
 } from '../test/traceFixtures';
 import {
+  buildWaterfallTicks,
   deriveWaterfallWindow,
   getWaterfallBarLayout,
 } from './waterfallTime';
@@ -105,5 +106,18 @@ describe('waterfallTime', () => {
     expect(layout.isRunning).toBe(true);
     expect(layout.durationMs).toBe(3000);
     expect(layout.widthPercent).toBe(60);
+  });
+
+  it('deduplicates short-window tick labels so instant traces do not crowd the axis', () => {
+    const ticks = buildWaterfallTicks({
+      startMs: 0,
+      endMs: 1,
+      durationMs: 1,
+    });
+
+    expect(ticks).toEqual([
+      { label: '0ms', leftPercent: 0 },
+      { label: '1ms', leftPercent: 100 },
+    ]);
   });
 });

--- a/web/src/utils/waterfallTime.ts
+++ b/web/src/utils/waterfallTime.ts
@@ -125,7 +125,7 @@ export function buildWaterfallTicks(
     ];
   }
 
-  return Array.from({ length: tickCount }, (_, index) => {
+  const ticks = Array.from({ length: tickCount }, (_, index) => {
     const leftPercent = (index / (tickCount - 1)) * 100;
     const offsetMs = window.durationMs * (leftPercent / 100);
 
@@ -134,6 +134,16 @@ export function buildWaterfallTicks(
       leftPercent,
     };
   });
+
+  const dedupedTicks = new Map<string, WaterfallTick>();
+  const lastTickLabel = ticks[ticks.length - 1]?.label;
+  for (const tick of ticks) {
+    if (!dedupedTicks.has(tick.label) || tick.label === lastTickLabel) {
+      dedupedTicks.set(tick.label, tick);
+    }
+  }
+
+  return Array.from(dedupedTicks.values());
 }
 
 function parseTimestamp(value: string | undefined | null) {


### PR DESCRIPTION
## Summary
- align the mobile trace detail workspace with the desktop debugger theme
- restyle span detail, payload inspector, and related badges to use the shared debugger tokens
- prevent waterfall axis label collisions on short-duration traces

## Verification
- pnpm --filter web lint
- pnpm --filter web type-check
- pnpm --filter web build
- pnpm --filter web exec vitest run src/utils/waterfallTime.test.ts src/components/ExecutionWaterfall.test.tsx src/pages/TraceDetailPage.test.tsx src/components/PayloadInspector.test.tsx src/components/SpanDetail.test.tsx src/components/ReasoningTab.test.tsx --pool=forks --no-file-parallelism

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated color and typography design tokens across multiple UI components throughout the application
  * Enhanced mobile layout and tab navigation with improved responsive behavior and spacing

* **Bug Fixes**
  * Fixed waterfall timeline to prevent duplicate tick labels when viewing very short trace windows

* **Tests**
  * Added test coverage for waterfall time label deduplication scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->