### PR TITLE
sync landing and docs theme preference

### DIFF
--- a/web/src/hooks/ThemeProvider.tsx
+++ b/web/src/hooks/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
+  LEGACY_THEME_STORAGE_KEY,
   ThemeContext,
   THEME_STORAGE_KEY,
   type ResolvedTheme,
@@ -14,12 +15,27 @@ function readInitialMode(): ThemeMode {
     return 'system';
   }
 
-  const storedMode = window.localStorage.getItem(THEME_STORAGE_KEY);
-  if (storedMode === 'light' || storedMode === 'dark' || storedMode === 'system') {
-    return storedMode;
+  const storedMode =
+    window.localStorage.getItem(THEME_STORAGE_KEY) ??
+    window.localStorage.getItem(LEGACY_THEME_STORAGE_KEY);
+  const normalizedMode = normalizeStoredMode(storedMode);
+  if (normalizedMode) {
+    return normalizedMode;
   }
 
   return 'system';
+}
+
+function normalizeStoredMode(mode: string | null): ThemeMode | null {
+  if (mode === 'true') {
+    return 'dark';
+  }
+
+  if (mode === 'false') {
+    return 'light';
+  }
+
+  return mode === 'light' || mode === 'dark' || mode === 'system' ? mode : null;
 }
 
 function resolveTheme(mode: ThemeMode, prefersDark: boolean): ResolvedTheme {
@@ -41,6 +57,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }
 
     window.localStorage.setItem(THEME_STORAGE_KEY, mode);
+    window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, mode);
   }, [mode]);
 
   useEffect(() => {

--- a/web/src/hooks/themeContext.ts
+++ b/web/src/hooks/themeContext.ts
@@ -3,7 +3,8 @@ import { createContext } from 'react';
 export type ThemeMode = 'system' | 'light' | 'dark';
 export type ResolvedTheme = 'light' | 'dark';
 
-export const THEME_STORAGE_KEY = 'continua_theme_mode';
+export const THEME_STORAGE_KEY = 'isDarkMode';
+export const LEGACY_THEME_STORAGE_KEY = 'continua_theme_mode';
 
 export interface ThemeContextValue {
   mode: ThemeMode;

--- a/web/src/hooks/useTheme.test.tsx
+++ b/web/src/hooks/useTheme.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { setMatchMediaMatches } from '../test/matchMedia';
 import { ThemeProvider } from './ThemeProvider';
 import { THEME_STORAGE_KEY, useTheme } from './useTheme';
+import { LEGACY_THEME_STORAGE_KEY } from './themeContext';
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return <ThemeProvider>{children}</ThemeProvider>;
@@ -48,5 +49,28 @@ describe('useTheme', () => {
     expect(result.current.resolvedTheme).toBe('dark');
     expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('migrates the legacy landing-page theme key into the shared docs theme key', () => {
+    setMatchMediaMatches(false);
+    localStorage.setItem(LEGACY_THEME_STORAGE_KEY, 'dark');
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    expect(result.current.mode).toBe('dark');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(localStorage.getItem(LEGACY_THEME_STORAGE_KEY)).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('normalizes legacy docs boolean theme values from the shared key', () => {
+    setMatchMediaMatches(false);
+    localStorage.setItem(THEME_STORAGE_KEY, 'true');
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    expect(result.current.mode).toBe('dark');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(localStorage.getItem(LEGACY_THEME_STORAGE_KEY)).toBe('dark');
   });
 });


### PR DESCRIPTION
## Summary
- use Mintlify's `isDarkMode` storage key as the shared theme preference between the landing page and docs
- migrate the prior landing-page key forward so existing visitors keep their chosen mode
- normalize older boolean-like docs values and add regression coverage for both migration paths

## Why
The landing page stored theme selection under `continua_theme_mode`, while the Mintlify docs runtime reads `isDarkMode`. Crossing from the landing page into `/docs` therefore lost the user's explicit light/dark choice and let the docs fall back to their own preference.

## Impact
Users who switch theme on the landing page should now see the same theme when they open the docs, with existing stored preferences preserved.

## Validation
- `pnpm --filter web test` ✅ (399 tests passed)
- `pnpm --filter web test -- src/hooks/useTheme.test.tsx` ✅ (3 tests passed)
- Attempted to re-run the focused test inside the clean publish worktree, but that worktree had no installed `node_modules`; no branch files were left changed by that attempt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->