### PR TITLE
fix landing repo stats on shallow deploy checkouts

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/web/scripts/gen-repo-stats.mjs
+++ b/web/scripts/gen-repo-stats.mjs
@@ -15,7 +15,7 @@
 //   }
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -58,12 +58,43 @@ function writeFallback(reason) {
   console.warn(`[gen-repo-stats] git unavailable, wrote empty stats: ${reason}`);
 }
 
+function readExistingStats() {
+  if (!existsSync(outPath)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(outPath, 'utf8'));
+    if (
+      typeof parsed?.commitTotal === 'number' &&
+      Array.isArray(parsed?.weeks) &&
+      parsed.weeks.length > 0
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Fall through: malformed cached data should not block regeneration.
+  }
+
+  return null;
+}
+
 if (!tryGit(['rev-parse', '--show-toplevel'])) {
   writeFallback('not a git checkout');
   process.exit(0);
 }
 
 const branch = tryGit(['rev-parse', '--abbrev-ref', 'HEAD']) || 'HEAD';
+const isShallowRepository = tryGit(['rev-parse', '--is-shallow-repository']) === 'true';
+const existingStats = readExistingStats();
+
+if (isShallowRepository && existingStats) {
+  console.warn(
+    `[gen-repo-stats] shallow git checkout detected; keeping bundled stats with ${existingStats.commitTotal} commits`
+  );
+  process.exit(0);
+}
+
 const log = tryGit(['log', '--no-merges', '--pretty=format:%at']);
 if (!log) {
   writeFallback('git log returned no commits');


### PR DESCRIPTION
## What changed
- preserve bundled repo stats when the generator detects a shallow git checkout
- fetch full git history in the Cloudflare Pages deploy workflow before rebuilding landing stats

## Why
The landing page moved from the GitHub API to build-time stats so it would keep working while the repository was private. The deploy workflow still used GitHub Actions' default shallow checkout, so `git log` only saw the checked-out commit and regenerated the landing card as `1 commit · since May 2026`.

## Impact
The repo card now keeps accurate history in constrained checkouts and refreshes correctly on each deployed commit to `main`.

## Validation
- synthetic shallow-clone repro: generator keeps the existing bundled stats instead of overwriting them with one commit
- `pnpm --filter web exec vitest run src/pages/LandingPage.test.tsx --pool=forks --no-file-parallelism`
- `pnpm --filter web type-check`
- `pnpm --filter web build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to fetch complete git history during builds for improved consistency.
  * Improved repository statistics generation script to cache and reuse statistics when working with shallow repositories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->