### PR TITLE
Fix engine tests after project seed removal

### DIFF
--- a/engine/internal/testutil/testdb.go
+++ b/engine/internal/testutil/testdb.go
@@ -110,6 +110,8 @@ func NewTestDatabase(t *testing.T) *TestDatabase {
 		adminPool.Close()
 	})
 
+	EnsurePlatformProject(t, pool, DefaultPlatformProjectID)
+
 	return &TestDatabase{
 		Pool:        pool,
 		DatabaseURL: databaseURL,


### PR DESCRIPTION
## Summary
- provision the explicit engine test platform project in the shared engine test database helper
- keeps the production default project seed removed while restoring engine tests that project trace/session shells into the platform schema

## Validation
- go test -race ./engine/internal/workflow

## Context
PR #92 was merged after all checks except the engine Go test were green. This follow-up carries the remaining CI fix against main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test database initialization to ensure proper platform schema configuration during engine test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->