### PR TITLE
Demo mock fixes (trace + sessions), landing polish, docs blue alignment

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -4,9 +4,9 @@
   "name": "Continua",
   "description": "Self-hosted debugging for AI agent runs. Traces, spans, sessions, and events for production agents.",
   "colors": {
-    "primary": "#0EA5E9",
-    "light": "#38BDF8",
-    "dark": "#0369A1"
+    "primary": "#0075d6",
+    "light": "#7aaeff",
+    "dark": "#005cab"
   },
   "favicon": "/favicon.svg",
   "appearance": {

--- a/web/public/_worker.js
+++ b/web/public/_worker.js
@@ -101,58 +101,168 @@ const traceDetails = new Map([
   ],
 ]);
 
-const traceSpans = {
-  spans: [
+const traceSpansByTrace = new Map([
+  [
+    'trace-checkout',
     {
-      id: 'span-root',
-      trace_id: 'trace-checkout',
-      span_id: 'root',
-      name: 'Checkout root',
-      kind: 'CHAIN',
-      status: 'FAILED',
-      started_at: traces[0].started_at,
-      ended_at: traces[0].ended_at,
-      latency_ms: 2000,
-      tokens_in: 120,
-      tokens_out: 80,
-      cost_usd: 0.12,
-      metadata: { phase: 'checkout' },
-    },
-    {
-      id: 'span-tool',
-      trace_id: 'trace-checkout',
-      span_id: 'tool-call',
-      parent_span_id: 'root',
-      name: 'Checkout tool',
-      kind: 'TOOL',
-      status: 'FAILED',
-      started_at: '2026-03-14T10:00:01.000Z',
-      ended_at: '2026-03-14T10:00:02.000Z',
-      latency_ms: 1000,
-      error_message: 'Gateway timeout',
-      metadata: { tool: 'charge-card' },
+      spans: [
+        {
+          id: 'span-checkout-root',
+          trace_id: 'trace-checkout',
+          span_id: 'root',
+          name: 'Checkout root',
+          kind: 'CHAIN',
+          status: 'FAILED',
+          started_at: traces[0].started_at,
+          ended_at: traces[0].ended_at,
+          latency_ms: 2000,
+          tokens_in: 120,
+          tokens_out: 80,
+          cost_usd: 0.12,
+          input: { cart_id: 'cart-789', items: 3, total_usd: 42.5 },
+          output: { ok: false, error: 'Gateway timeout' },
+          metadata: { phase: 'checkout' },
+        },
+        {
+          id: 'span-checkout-tool',
+          trace_id: 'trace-checkout',
+          span_id: 'tool-call',
+          parent_span_id: 'root',
+          name: 'Checkout tool',
+          kind: 'TOOL',
+          status: 'FAILED',
+          started_at: '2026-03-14T10:00:01.000Z',
+          ended_at: '2026-03-14T10:00:02.000Z',
+          latency_ms: 1000,
+          input: { card_last4: '4242', amount_usd: 42.5 },
+          output: { ok: false, code: 'gateway_timeout' },
+          error_message: 'Gateway timeout',
+          metadata: { tool: 'charge-card' },
+        },
+      ],
     },
   ],
-};
+  [
+    'trace-alpha',
+    {
+      spans: [
+        {
+          id: 'span-alpha-root',
+          trace_id: 'trace-alpha',
+          span_id: 'alpha-root',
+          name: 'Alpha root',
+          kind: 'CHAIN',
+          status: 'COMPLETED',
+          started_at: traces[2].started_at,
+          ended_at: traces[2].ended_at,
+          latency_ms: 3000,
+          tokens_in: 20,
+          tokens_out: 10,
+          cost_usd: 0.01,
+          input: { prompt: 'alpha' },
+          output: { answer: 'complete' },
+          metadata: { phase: 'alpha' },
+        },
+        {
+          id: 'span-alpha-llm',
+          trace_id: 'trace-alpha',
+          span_id: 'alpha-llm',
+          parent_span_id: 'alpha-root',
+          name: 'Alpha LLM call',
+          kind: 'LLM',
+          status: 'COMPLETED',
+          started_at: '2026-03-14T09:00:00.500Z',
+          ended_at: '2026-03-14T09:00:02.500Z',
+          latency_ms: 2000,
+          tokens_in: 20,
+          tokens_out: 10,
+          cost_usd: 0.01,
+          input: { messages: [{ role: 'user', content: 'alpha' }] },
+          output: { content: 'complete' },
+          metadata: { model: 'gpt-4o-mini', provider: 'openai' },
+        },
+      ],
+    },
+  ],
+  [
+    'trace-latency',
+    {
+      spans: [
+        {
+          id: 'span-latency-root',
+          trace_id: 'trace-latency',
+          span_id: 'latency-root',
+          name: 'Latency root',
+          kind: 'CHAIN',
+          status: 'STARTED',
+          started_at: traces[1].started_at,
+          latency_ms: null,
+          tokens_in: 50,
+          tokens_out: 25,
+          cost_usd: 0.03,
+          input: { prompt: 'latency check' },
+          metadata: { phase: 'latency' },
+        },
+      ],
+    },
+  ],
+]);
 
-const traceTimeline = {
-  events: [
+const traceTimelinesByTrace = new Map([
+  [
+    'trace-checkout',
     {
-      id: 'timeline-error',
-      trace_id: 'trace-checkout',
-      span_id: 'tool-call',
-      span_name: 'Checkout tool',
-      event_type: 'error',
-      timestamp: '2026-03-14T10:00:02.000Z',
-      source: 'explicit',
-      level: 'error',
-      message: 'Gateway timeout',
-      payload: { code: 'gateway_timeout' },
+      events: [
+        {
+          id: 'timeline-checkout-error',
+          trace_id: 'trace-checkout',
+          span_id: 'tool-call',
+          span_name: 'Checkout tool',
+          event_type: 'error',
+          timestamp: '2026-03-14T10:00:02.000Z',
+          source: 'explicit',
+          level: 'error',
+          message: 'Gateway timeout',
+          payload: { code: 'gateway_timeout' },
+        },
+      ],
+      trace_status: 'FAILED',
+      has_more: false,
     },
   ],
-  trace_status: 'FAILED',
-  has_more: false,
-};
+  [
+    'trace-alpha',
+    {
+      events: [
+        {
+          id: 'timeline-alpha-complete',
+          trace_id: 'trace-alpha',
+          span_id: 'alpha-llm',
+          span_name: 'Alpha LLM call',
+          event_type: 'log',
+          timestamp: '2026-03-14T09:00:02.500Z',
+          source: 'explicit',
+          level: 'info',
+          message: 'LLM call completed',
+          payload: { tokens_out: 10 },
+        },
+      ],
+      trace_status: 'COMPLETED',
+      has_more: false,
+    },
+  ],
+  [
+    'trace-latency',
+    {
+      events: [],
+      trace_status: 'RUNNING',
+      has_more: false,
+    },
+  ],
+]);
+
+const emptySpans = { spans: [] };
+const emptyTimeline = { events: [], trace_status: 'RUNNING', has_more: false };
 
 const sessionNarrative = {
   summary: {
@@ -358,16 +468,25 @@ function handleApi(url) {
   }
 
   if (/^\/api\/traces\/[^/]+\/spans$/.test(url.pathname)) {
-    return json(traceSpans);
+    const traceId = url.pathname.split('/').at(-2);
+    return json(traceSpansByTrace.get(traceId) ?? emptySpans);
   }
 
   if (/^\/api\/traces\/[^/]+\/events$/.test(url.pathname)) {
-    return json(traceTimeline);
+    const traceId = url.pathname.split('/').at(-2);
+    const timeline =
+      traceTimelinesByTrace.get(traceId) ??
+      { ...emptyTimeline, trace_status: traceDetails.get(traceId)?.status ?? 'RUNNING' };
+    return json(timeline);
   }
 
   if (/^\/api\/traces\/[^/]+$/.test(url.pathname)) {
     const traceId = url.pathname.split('/').at(-1);
-    return json(traceDetails.get(traceId) ?? { ...traceDetails.get('trace-checkout'), id: traceId });
+    const detail = traceDetails.get(traceId);
+    if (!detail) {
+      return notFound();
+    }
+    return json(detail);
   }
 
   if (url.pathname === '/api/sessions') {

--- a/web/public/_worker.js
+++ b/web/public/_worker.js
@@ -517,14 +517,21 @@ function handleApi(url) {
 
   if (/^\/api\/traces\/[^/]+\/spans$/.test(url.pathname)) {
     const traceId = url.pathname.split('/').at(-2);
+    if (!traceDetails.has(traceId)) {
+      return notFound();
+    }
     return json(traceSpansByTrace.get(traceId) ?? emptySpans);
   }
 
   if (/^\/api\/traces\/[^/]+\/events$/.test(url.pathname)) {
     const traceId = url.pathname.split('/').at(-2);
+    const detail = traceDetails.get(traceId);
+    if (!detail) {
+      return notFound();
+    }
     const timeline =
       traceTimelinesByTrace.get(traceId) ??
-      { ...emptyTimeline, trace_status: traceDetails.get(traceId)?.status ?? 'RUNNING' };
+      { ...emptyTimeline, trace_status: detail.status };
     return json(timeline);
   }
 

--- a/web/public/_worker.js
+++ b/web/public/_worker.js
@@ -264,114 +264,162 @@ const traceTimelinesByTrace = new Map([
 const emptySpans = { spans: [] };
 const emptyTimeline = { events: [], trace_status: 'RUNNING', has_more: false };
 
-const sessionNarrative = {
-  summary: {
-    total_trace_count: 2,
-    returned_trace_count: 2,
-    truncated: false,
-    running_trace_count: 0,
-    completed_trace_count: 1,
-    failed_trace_count: 1,
-    total_cost_usd: 0.13,
-    total_tokens_in: 140,
-    total_tokens_out: 90,
-    started_at: '2026-03-14T09:00:00.000Z',
-    last_activity_at: '2026-03-14T10:00:02.000Z',
-    explicit_link_count: 0,
-    inferred_link_count: 1,
-    unlinked_trace_count: 1,
-  },
-  traces: [
+const sessionNarrativesBySession = new Map([
+  [
+    sessionId,
     {
-      id: 'trace-alpha',
-      trace_id: 'external-trace-alpha',
-      name: 'Alpha Narrative',
-      status: 'COMPLETED',
-      started_at: '2026-03-14T09:00:00.000Z',
-      ended_at: '2026-03-14T09:00:03.000Z',
-      duration_ms: 3000,
-      error_count: 0,
-      total_cost_usd: 0.01,
-      total_tokens_in: 20,
-      total_tokens_out: 10,
-      latest_activity_at: '2026-03-14T09:00:03.000Z',
-      semantic_events: [],
-      lineage: { type: 'unlinked' },
-    },
-    {
-      id: 'trace-checkout',
-      trace_id: 'external-trace-checkout',
-      name: 'Checkout Narrative',
-      status: 'FAILED',
-      started_at: '2026-03-14T10:00:00.000Z',
-      ended_at: '2026-03-14T10:00:02.000Z',
-      duration_ms: 2000,
-      error_count: 2,
-      total_cost_usd: 0.12,
-      total_tokens_in: 120,
-      total_tokens_out: 80,
-      latest_activity_at: '2026-03-14T10:00:02.000Z',
-      semantic_events: [],
-      lineage: { type: 'inferred', parent_trace_id: 'external-trace-alpha' },
-    },
-  ],
-};
-
-const sessionCompare = {
-  session: {
-    id: sessionId,
-    external_id: sessionExternalId,
-    name: 'Checkout Session',
-  },
-  baseline: {
-    id: 'trace-alpha',
-    trace_id: 'external-trace-alpha',
-    name: 'Alpha Narrative',
-    status: 'COMPLETED',
-    started_at: '2026-03-14T09:00:00.000Z',
-    ended_at: '2026-03-14T09:00:03.000Z',
-    duration_ms: 3000,
-    error_count: 0,
-  },
-  candidate: {
-    id: 'trace-checkout',
-    trace_id: 'external-trace-checkout',
-    name: 'Checkout Narrative',
-    status: 'FAILED',
-    started_at: '2026-03-14T10:00:00.000Z',
-    ended_at: '2026-03-14T10:00:02.000Z',
-    duration_ms: 2000,
-    error_count: 2,
-  },
-  summary: {
-    compared_span_count: 2,
-    changed_span_count: 1,
-    baseline_only_count: 0,
-    candidate_only_count: 1,
-    semantic_event_delta: 1,
-  },
-  span_diffs: [
-    {
-      key: 'root',
-      name: 'Checkout root',
-      status: 'changed',
-      baseline_span: null,
-      candidate_span: {
-        span_id: 'root',
-        name: 'Checkout root',
-        kind: 'CHAIN',
-        status: 'FAILED',
-        latency_ms: 2000,
-        tokens_in: 120,
-        tokens_out: 80,
-        cost_usd: 0.12,
+      summary: {
+        total_trace_count: 2,
+        returned_trace_count: 2,
+        truncated: false,
+        running_trace_count: 0,
+        completed_trace_count: 1,
+        failed_trace_count: 1,
+        total_cost_usd: 0.13,
+        total_tokens_in: 140,
+        total_tokens_out: 90,
+        started_at: '2026-03-14T09:00:00.000Z',
+        last_activity_at: '2026-03-14T10:00:02.000Z',
+        explicit_link_count: 0,
+        inferred_link_count: 1,
+        unlinked_trace_count: 1,
       },
-      changed_fields: ['status', 'latency_ms'],
-      semantic_groups: [],
-      depth: 0,
+      traces: [
+        {
+          id: 'trace-alpha',
+          trace_id: 'external-trace-alpha',
+          name: 'Alpha Narrative',
+          status: 'COMPLETED',
+          started_at: '2026-03-14T09:00:00.000Z',
+          ended_at: '2026-03-14T09:00:03.000Z',
+          duration_ms: 3000,
+          error_count: 0,
+          total_cost_usd: 0.01,
+          total_tokens_in: 20,
+          total_tokens_out: 10,
+          latest_activity_at: '2026-03-14T09:00:03.000Z',
+          semantic_events: [],
+          lineage: { type: 'unlinked' },
+        },
+        {
+          id: 'trace-checkout',
+          trace_id: 'external-trace-checkout',
+          name: 'Checkout Narrative',
+          status: 'FAILED',
+          started_at: '2026-03-14T10:00:00.000Z',
+          ended_at: '2026-03-14T10:00:02.000Z',
+          duration_ms: 2000,
+          error_count: 2,
+          total_cost_usd: 0.12,
+          total_tokens_in: 120,
+          total_tokens_out: 80,
+          latest_activity_at: '2026-03-14T10:00:02.000Z',
+          semantic_events: [],
+          lineage: { type: 'inferred', parent_trace_id: 'external-trace-alpha' },
+        },
+      ],
     },
   ],
-};
+  [
+    otherSessionId,
+    {
+      summary: {
+        total_trace_count: 1,
+        returned_trace_count: 1,
+        truncated: false,
+        running_trace_count: 1,
+        completed_trace_count: 0,
+        failed_trace_count: 0,
+        total_cost_usd: 0.03,
+        total_tokens_in: 50,
+        total_tokens_out: 25,
+        started_at: '2026-03-14T11:00:00.000Z',
+        last_activity_at: '2026-03-14T11:00:00.000Z',
+        explicit_link_count: 0,
+        inferred_link_count: 0,
+        unlinked_trace_count: 1,
+      },
+      traces: [
+        {
+          id: 'trace-latency',
+          trace_id: 'external-trace-latency',
+          name: 'Latency Narrative',
+          status: 'RUNNING',
+          started_at: '2026-03-14T11:00:00.000Z',
+          duration_ms: null,
+          error_count: 0,
+          total_cost_usd: 0.03,
+          total_tokens_in: 50,
+          total_tokens_out: 25,
+          latest_activity_at: '2026-03-14T11:00:00.000Z',
+          semantic_events: [],
+          lineage: { type: 'unlinked' },
+        },
+      ],
+    },
+  ],
+]);
+
+const sessionComparesBySession = new Map([
+  [
+    sessionId,
+    {
+      session: {
+        id: sessionId,
+        external_id: sessionExternalId,
+        name: 'Checkout Session',
+      },
+      baseline: {
+        id: 'trace-alpha',
+        trace_id: 'external-trace-alpha',
+        name: 'Alpha Narrative',
+        status: 'COMPLETED',
+        started_at: '2026-03-14T09:00:00.000Z',
+        ended_at: '2026-03-14T09:00:03.000Z',
+        duration_ms: 3000,
+        error_count: 0,
+      },
+      candidate: {
+        id: 'trace-checkout',
+        trace_id: 'external-trace-checkout',
+        name: 'Checkout Narrative',
+        status: 'FAILED',
+        started_at: '2026-03-14T10:00:00.000Z',
+        ended_at: '2026-03-14T10:00:02.000Z',
+        duration_ms: 2000,
+        error_count: 2,
+      },
+      summary: {
+        compared_span_count: 2,
+        changed_span_count: 1,
+        baseline_only_count: 0,
+        candidate_only_count: 1,
+        semantic_event_delta: 1,
+      },
+      span_diffs: [
+        {
+          key: 'root',
+          name: 'Checkout root',
+          status: 'changed',
+          baseline_span: null,
+          candidate_span: {
+            span_id: 'root',
+            name: 'Checkout root',
+            kind: 'CHAIN',
+            status: 'FAILED',
+            latency_ms: 2000,
+            tokens_in: 120,
+            tokens_out: 80,
+            cost_usd: 0.12,
+          },
+          changed_fields: ['status', 'latency_ms'],
+          semantic_groups: [],
+          depth: 0,
+        },
+      ],
+    },
+  ],
+]);
 
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -494,11 +542,15 @@ function handleApi(url) {
   }
 
   if (/^\/api\/sessions\/[^/]+\/narrative$/.test(url.pathname)) {
-    return json(sessionNarrative);
+    const id = url.pathname.split('/').at(-2);
+    const narrative = sessionNarrativesBySession.get(id);
+    return narrative ? json(narrative) : notFound();
   }
 
   if (/^\/api\/sessions\/[^/]+\/compare$/.test(url.pathname)) {
-    return json(sessionCompare);
+    const id = url.pathname.split('/').at(-2);
+    const compare = sessionComparesBySession.get(id);
+    return compare ? json(compare) : notFound();
   }
 
   if (/^\/api\/sessions\/[^/]+$/.test(url.pathname)) {

--- a/web/src/data/repo-stats.json
+++ b/web/src/data/repo-stats.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-05-16T20:33:26.803Z",
-  "branch": "codex/demo-search-landing-polish",
-  "commitTotal": 189,
+  "generatedAt": "2026-05-17T13:32:09.196Z",
+  "branch": "fix/landing-and-trace-detail-mock",
+  "commitTotal": 208,
   "firstCommitAt": "2025-12-30T13:26:25.000Z",
   "weeks": [
     {
@@ -253,7 +253,7 @@
     },
     {
       "weekStart": "2026-05-10",
-      "total": 42,
+      "total": 57,
       "days": [
         0,
         2,
@@ -261,7 +261,20 @@
         5,
         17,
         4,
-        14
+        29
+      ]
+    },
+    {
+      "weekStart": "2026-05-17",
+      "total": 4,
+      "days": [
+        4,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
       ]
     }
   ]

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -16,7 +16,6 @@ import { useMediaQuery } from '../hooks/useMediaQuery';
 import { useTheme } from '../hooks/useTheme';
 
 const GITHUB_REPO_URL = 'https://github.com/aryanVijaywargia/Continua';
-const GITHUB_REPO_API_URL = 'https://api.github.com/repos/aryanVijaywargia/Continua';
 const DOCS_URL = 'https://www.continua.in/docs';
 const GITHUB_LICENSE_URL = `${GITHUB_REPO_URL}/blob/main/LICENSE`;
 const API_REFERENCE_URL = `${DOCS_URL}/api-reference`;
@@ -91,7 +90,7 @@ const CODE_TABS = [
     file: 'agent.py',
     rows: [
       ['k', 'from '], ['m', 'continua'], ['k', ' import '], ['_', 'Continua, span, trace\n\n'],
-      ['t', 'client'], ['_', ' = Continua.init(\n    api_key='], ['s', '"default"'], ['_', ',\n    endpoint='], ['s', '"http://localhost:8080"'], ['_', ',\n)\n\n'],
+      ['t', 'client'], ['_', ' = Continua.init(\n    api_key='], ['s', '"<project-api-key>"'], ['_', ',\n    endpoint='], ['s', '"http://localhost:8080"'], ['_', ',\n)\n\n'],
       ['d', '@trace'], ['_', '(name='], ['s', '"research_agent"'], ['_', ')\n'],
       ['k', 'def '], ['fn', 'run'], ['_', '(query):\n    '],
       ['k', 'with '], ['_', 'span('], ['s', '"plan"'], ['_', ', kind='], ['s', '"llm"'], ['_', ') '], ['k', 'as '], ['_', 's:\n        s.set_input({'], ['s', '"query"'], ['_', ': query})\n        result = call_llm(query)\n        s.set_llm_response('], ['s', '"gpt-4"'], ['_', ', query, result)\n\n    '],
@@ -375,21 +374,21 @@ function Hero({
           <div className="min-w-0 max-w-2xl">
             <SpanEyebrow idx={0} kind="TRACE" name="introducing_continua" dur="alpha" status="ok" />
             <h1
-              aria-label={`${isPublicDemo ? 'Explore agent traces' : 'Debug your agents'} today. Run them durably tomorrow.`}
+              aria-label="Your agent's black box. Opened."
               className="landing-display mt-6 text-[52px] font-bold tracking-[-0.035em] text-[var(--c-text-primary)] sm:text-[68px] lg:text-[76px]"
             >
-              <span className="block">{isPublicDemo ? 'Explore agent traces' : 'Debug your agents'}</span>
+              <span className="block">Your agent's black box.</span>
               <span
                 className="inline-block rounded-[2px] bg-[var(--c-accent)] px-[0.2em] pb-[0.08em] pt-[0.04em] text-white"
                 style={{ transform: 'rotate(-0.6deg) translateY(2px)' }}
               >
-                run durably tomorrow.
+                Opened.
               </span>
             </h1>
             <p className="mt-6 max-w-xl text-[15.5px] leading-relaxed text-[var(--c-text-secondary)]">
-              Continua is the open-source control plane for AI agent observability today and
-              durable execution tomorrow. Ship traces into a self-hosted operator console now;
-              use the engine preview surface as the runtime foundation evolves.
+              Open-source observability for AI agents. Capture every retry, payload, and state
+              transition as it happens — and inspect them from a self-hosted console that runs in
+              one binary.
             </p>
             {isPublicDemo ? (
               <p className="mt-3 max-w-xl text-[13px] leading-6 text-[var(--c-text-muted)]">
@@ -1433,125 +1432,72 @@ function CodeOutputPanel({
   );
 }
 
-const COMMIT_HEATMAP_TOTAL = 240;
-const COMMIT_HEATMAP_WEEKS = 26;
-const COMMIT_HEATMAP_DAYS: readonly number[] = [
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 3, 21, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 4, 0, 0, 2, 3, 3, 0, 2, 0, 0, 7, 8, 2, 0, 0, 0, 0, 4, 1,
-  2, 2, 0, 0, 0, 0, 12, 0, 10, 0, 4, 0, 11, 11, 7, 8, 0, 0, 0, 21, 5, 3, 1, 0, 0, 5, 2, 0, 0, 0,
-  0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 4, 11, 22, 9,
-];
+import repoStatsJson from '../data/repo-stats.json';
 
-interface GitHubCommitActivityWeek {
-  days: number[];
+interface RepoStatsWeek {
+  weekStart: string;
   total: number;
-  week: number;
+  days: number[];
+}
+
+interface RepoStatsFile {
+  generatedAt: string;
+  branch: string | null;
+  commitTotal: number;
+  firstCommitAt: string | null;
+  weeks: RepoStatsWeek[];
 }
 
 interface RepoActivity {
-  commitDays: readonly number[];
+  weeks: RepoStatsWeek[];
   commitTotal: number;
-  allTimeCommitTotal: number | null;
-  updatedFromGitHub: boolean;
+  sinceLabel: string;
+  monthLabels: string[];
 }
 
-interface GitHubContributorStats {
-  total: number;
-  author?: { login?: string } | null;
-}
+const MAX_HEATMAP_WEEKS = 52;
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
-const FALLBACK_REPO_ACTIVITY: RepoActivity = {
-  commitDays: COMMIT_HEATMAP_DAYS,
-  commitTotal: COMMIT_HEATMAP_TOTAL,
-  allTimeCommitTotal: null,
-  updatedFromGitHub: false,
-};
+function buildRepoActivity(): RepoActivity {
+  const stats = repoStatsJson as RepoStatsFile;
+  const raw = Array.isArray(stats.weeks) ? stats.weeks : [];
 
-function useRepoActivity(): RepoActivity {
-  const [activity, setActivity] = useState<RepoActivity>(FALLBACK_REPO_ACTIVITY);
+  // Drop leading zero-commit weeks so the heatmap starts on the first real week of activity.
+  let start = 0;
+  while (start < raw.length && raw[start].total === 0) start += 1;
+  let trimmed = raw.slice(start);
 
-  useEffect(() => {
-    const controller = new AbortController();
+  // Cap window so very old repos don't blow out the row width.
+  if (trimmed.length > MAX_HEATMAP_WEEKS) {
+    trimmed = trimmed.slice(trimmed.length - MAX_HEATMAP_WEEKS);
+  }
 
-    async function fetchCommitActivity() {
-      try {
-        const response = await fetch(`${GITHUB_REPO_API_URL}/stats/commit_activity`, {
-          signal: controller.signal,
-        });
+  const commitTotal = trimmed.reduce((acc, w) => acc + (w.total ?? 0), 0);
 
-        if (!response.ok) {
-          return;
-        }
+  let sinceLabel = '—';
+  const monthLabels: string[] = [];
+  if (trimmed.length > 0) {
+    const first = new Date(`${trimmed[0].weekStart}T00:00:00Z`);
+    sinceLabel = `${MONTH_NAMES[first.getUTCMonth()]} ${first.getUTCFullYear()}`;
 
-        const weeks = (await response.json()) as GitHubCommitActivityWeek[];
-        if (!Array.isArray(weeks) || weeks.length === 0) {
-          return;
-        }
-
-        const recentWeeks = weeks.slice(-COMMIT_HEATMAP_WEEKS);
-        const commitDays = recentWeeks.flatMap((week) =>
-          Array.isArray(week.days) ? week.days.slice(0, 7) : []
-        );
-
-        if (commitDays.length === 0) {
-          return;
-        }
-
-        setActivity((prev) => ({
-          ...prev,
-          commitDays,
-          commitTotal: recentWeeks.reduce((total, week) => total + (week.total ?? 0), 0),
-          updatedFromGitHub: true,
-        }));
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          return;
-        }
+    let prevMonth = -1;
+    let prevYear = -1;
+    for (const w of trimmed) {
+      const d = new Date(`${w.weekStart}T00:00:00Z`);
+      const m = d.getUTCMonth();
+      const y = d.getUTCFullYear();
+      if (m !== prevMonth || y !== prevYear) {
+        monthLabels.push(MONTH_NAMES[m]);
+        prevMonth = m;
+        prevYear = y;
       }
     }
+  }
 
-    async function fetchAllTimeCommitTotal() {
-      try {
-        const response = await fetch(`${GITHUB_REPO_API_URL}/stats/contributors`, {
-          signal: controller.signal,
-        });
-
-        if (!response.ok) {
-          return;
-        }
-
-        const contributors = (await response.json()) as GitHubContributorStats[];
-        if (!Array.isArray(contributors) || contributors.length === 0) {
-          return;
-        }
-
-        const allTime = contributors.reduce(
-          (total, contributor) => total + (contributor.total ?? 0),
-          0,
-        );
-
-        if (allTime <= 0) {
-          return;
-        }
-
-        setActivity((prev) => ({ ...prev, allTimeCommitTotal: allTime }));
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          return;
-        }
-      }
-    }
-
-    void fetchCommitActivity();
-    void fetchAllTimeCommitTotal();
-
-    return () => controller.abort();
-  }, []);
-
-  return activity;
+  return { weeks: trimmed, commitTotal, sinceLabel, monthLabels };
 }
+
+const REPO_ACTIVITY: RepoActivity = buildRepoActivity();
 
 function commitLevel(count: number): 0 | 1 | 2 | 3 | 4 {
   if (count <= 0) return 0;
@@ -1562,16 +1508,6 @@ function commitLevel(count: number): 0 | 1 | 2 | 3 | 4 {
 }
 
 function CommitHeatmap({ activity }: { activity: RepoActivity }) {
-  const cells: number[][] = Array.from({ length: COMMIT_HEATMAP_WEEKS }, () => []);
-  for (let i = 0; i < activity.commitDays.length; i += 1) {
-    const week = Math.floor(i / 7);
-    if (week >= cells.length) {
-      break;
-    }
-    cells[week].push(activity.commitDays[i]);
-  }
-  const monthLabels = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May'];
-
   return (
     <div className="border-b px-4 py-3" style={{ borderColor: 'var(--c-border)' }}>
       <div className="flex items-center justify-between">
@@ -1579,14 +1515,13 @@ function CommitHeatmap({ activity }: { activity: RepoActivity }) {
           Commit activity
         </div>
         <span className="font-mono text-[10px] text-[var(--c-text-muted)]">
-          <span className="text-[var(--c-text-primary)]">{activity.commitTotal}</span> commits · last 26 weeks
-          {activity.updatedFromGitHub ? ' · live' : ''}
+          <span className="text-[var(--c-text-primary)]">{activity.commitTotal}</span> commits · since {activity.sinceLabel}
         </span>
       </div>
       <div className="mt-2.5 flex gap-[3px]" aria-hidden="true">
-        {cells.map((week, wi) => (
-          <div key={wi} className="flex flex-col gap-[3px]">
-            {week.map((c, di) => {
+        {activity.weeks.map((week, wi) => (
+          <div key={`${week.weekStart}-${wi}`} className="flex flex-col gap-[3px]">
+            {week.days.map((c, di) => {
               const level = commitLevel(c);
               const bg =
                 level === 0
@@ -1611,8 +1546,8 @@ function CommitHeatmap({ activity }: { activity: RepoActivity }) {
       </div>
       <div className="mt-2 flex items-center justify-between text-[9.5px] font-mono text-[var(--c-text-muted)]">
         <div className="flex gap-2">
-          {monthLabels.map((m) => (
-            <span key={m}>{m}</span>
+          {activity.monthLabels.map((m, i) => (
+            <span key={`${m}-${i}`}>{m}</span>
           ))}
         </div>
         <div className="flex items-center gap-1">
@@ -1644,12 +1579,11 @@ function CommitHeatmap({ activity }: { activity: RepoActivity }) {
 }
 
 function RepoCard() {
-  const activity = useRepoActivity();
-  const commitsDisplay = activity.allTimeCommitTotal ?? activity.commitTotal;
+  const activity = REPO_ACTIVITY;
   const repoFacts = [
     ['License', 'MIT'],
     ['Release', 'Alpha'],
-    ['Commits', String(commitsDisplay)],
+    ['Commits', String(activity.commitTotal)],
   ] as const;
 
   return (
@@ -1669,7 +1603,7 @@ function RepoCard() {
             <span className="truncate font-mono text-[12px] text-[var(--c-text-primary)]">aryanVijaywargia/Continua</span>
           </a>
           <a
-            href={`${GITHUB_REPO_URL}`}
+            href={GITHUB_REPO_URL}
             target="_blank"
             rel="noreferrer"
             className="inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--c-accent-text)] transition hover:bg-[var(--c-accent-faint)]"

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -5,6 +5,7 @@ import {
   Copy,
   Github,
   Moon,
+  Star,
   Sun,
   Terminal,
 } from 'lucide-react';
@@ -15,6 +16,7 @@ import { useMediaQuery } from '../hooks/useMediaQuery';
 import { useTheme } from '../hooks/useTheme';
 
 const GITHUB_REPO_URL = 'https://github.com/aryanVijaywargia/Continua';
+const GITHUB_REPO_API_URL = 'https://api.github.com/repos/aryanVijaywargia/Continua';
 const DOCS_URL = 'https://www.continua.in/docs';
 const GITHUB_LICENSE_URL = `${GITHUB_REPO_URL}/blob/main/LICENSE`;
 const API_REFERENCE_URL = `${DOCS_URL}/api-reference`;
@@ -89,7 +91,7 @@ const CODE_TABS = [
     file: 'agent.py',
     rows: [
       ['k', 'from '], ['m', 'continua'], ['k', ' import '], ['_', 'Continua, span, trace\n\n'],
-      ['t', 'client'], ['_', ' = Continua.init(\n    api_key='], ['s', '"<project-api-key>"'], ['_', ',\n    endpoint='], ['s', '"http://localhost:8080"'], ['_', ',\n)\n\n'],
+      ['t', 'client'], ['_', ' = Continua.init(\n    api_key='], ['s', '"default"'], ['_', ',\n    endpoint='], ['s', '"http://localhost:8080"'], ['_', ',\n)\n\n'],
       ['d', '@trace'], ['_', '(name='], ['s', '"research_agent"'], ['_', ')\n'],
       ['k', 'def '], ['fn', 'run'], ['_', '(query):\n    '],
       ['k', 'with '], ['_', 'span('], ['s', '"plan"'], ['_', ', kind='], ['s', '"llm"'], ['_', ') '], ['k', 'as '], ['_', 's:\n        s.set_input({'], ['s', '"query"'], ['_', ': query})\n        result = call_llm(query)\n        s.set_llm_response('], ['s', '"gpt-4"'], ['_', ', query, result)\n\n    '],
@@ -373,21 +375,21 @@ function Hero({
           <div className="min-w-0 max-w-2xl">
             <SpanEyebrow idx={0} kind="TRACE" name="introducing_continua" dur="alpha" status="ok" />
             <h1
-              aria-label="Your agent's black box. Opened."
+              aria-label={`${isPublicDemo ? 'Explore agent traces' : 'Debug your agents'} today. Run them durably tomorrow.`}
               className="landing-display mt-6 text-[52px] font-bold tracking-[-0.035em] text-[var(--c-text-primary)] sm:text-[68px] lg:text-[76px]"
             >
-              <span className="block">Your agent's black box.</span>
+              <span className="block">{isPublicDemo ? 'Explore agent traces' : 'Debug your agents'}</span>
               <span
                 className="inline-block rounded-[2px] bg-[var(--c-accent)] px-[0.2em] pb-[0.08em] pt-[0.04em] text-white"
                 style={{ transform: 'rotate(-0.6deg) translateY(2px)' }}
               >
-                Opened.
+                run durably tomorrow.
               </span>
             </h1>
             <p className="mt-6 max-w-xl text-[15.5px] leading-relaxed text-[var(--c-text-secondary)]">
-              Open-source observability for AI agents. Capture every retry, payload, and state
-              transition as it happens — and inspect them from a self-hosted console that runs in
-              one binary.
+              Continua is the open-source control plane for AI agent observability today and
+              durable execution tomorrow. Ship traces into a self-hosted operator console now;
+              use the engine preview surface as the runtime foundation evolves.
             </p>
             {isPublicDemo ? (
               <p className="mt-3 max-w-xl text-[13px] leading-6 text-[var(--c-text-muted)]">
@@ -1431,72 +1433,125 @@ function CodeOutputPanel({
   );
 }
 
-import repoStatsJson from '../data/repo-stats.json';
+const COMMIT_HEATMAP_TOTAL = 240;
+const COMMIT_HEATMAP_WEEKS = 26;
+const COMMIT_HEATMAP_DAYS: readonly number[] = [
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 3, 21, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 4, 0, 0, 2, 3, 3, 0, 2, 0, 0, 7, 8, 2, 0, 0, 0, 0, 4, 1,
+  2, 2, 0, 0, 0, 0, 12, 0, 10, 0, 4, 0, 11, 11, 7, 8, 0, 0, 0, 21, 5, 3, 1, 0, 0, 5, 2, 0, 0, 0,
+  0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 4, 11, 22, 9,
+];
 
-interface RepoStatsWeek {
-  weekStart: string;
-  total: number;
+interface GitHubCommitActivityWeek {
   days: number[];
-}
-
-interface RepoStatsFile {
-  generatedAt: string;
-  branch: string | null;
-  commitTotal: number;
-  firstCommitAt: string | null;
-  weeks: RepoStatsWeek[];
+  total: number;
+  week: number;
 }
 
 interface RepoActivity {
-  weeks: RepoStatsWeek[];
+  commitDays: readonly number[];
   commitTotal: number;
-  sinceLabel: string;
-  monthLabels: string[];
+  allTimeCommitTotal: number | null;
+  updatedFromGitHub: boolean;
 }
 
-const MAX_HEATMAP_WEEKS = 52;
-const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+interface GitHubContributorStats {
+  total: number;
+  author?: { login?: string } | null;
+}
 
-function buildRepoActivity(): RepoActivity {
-  const stats = repoStatsJson as RepoStatsFile;
-  const raw = Array.isArray(stats.weeks) ? stats.weeks : [];
+const FALLBACK_REPO_ACTIVITY: RepoActivity = {
+  commitDays: COMMIT_HEATMAP_DAYS,
+  commitTotal: COMMIT_HEATMAP_TOTAL,
+  allTimeCommitTotal: null,
+  updatedFromGitHub: false,
+};
 
-  // Drop leading zero-commit weeks so the heatmap starts on the first real week of activity.
-  let start = 0;
-  while (start < raw.length && raw[start].total === 0) start += 1;
-  let trimmed = raw.slice(start);
+function useRepoActivity(): RepoActivity {
+  const [activity, setActivity] = useState<RepoActivity>(FALLBACK_REPO_ACTIVITY);
 
-  // Cap window so very old repos don't blow out the row width.
-  if (trimmed.length > MAX_HEATMAP_WEEKS) {
-    trimmed = trimmed.slice(trimmed.length - MAX_HEATMAP_WEEKS);
-  }
+  useEffect(() => {
+    const controller = new AbortController();
 
-  const commitTotal = trimmed.reduce((acc, w) => acc + (w.total ?? 0), 0);
+    async function fetchCommitActivity() {
+      try {
+        const response = await fetch(`${GITHUB_REPO_API_URL}/stats/commit_activity`, {
+          signal: controller.signal,
+        });
 
-  let sinceLabel = '—';
-  const monthLabels: string[] = [];
-  if (trimmed.length > 0) {
-    const first = new Date(`${trimmed[0].weekStart}T00:00:00Z`);
-    sinceLabel = `${MONTH_NAMES[first.getUTCMonth()]} ${first.getUTCFullYear()}`;
+        if (!response.ok) {
+          return;
+        }
 
-    let prevMonth = -1;
-    let prevYear = -1;
-    for (const w of trimmed) {
-      const d = new Date(`${w.weekStart}T00:00:00Z`);
-      const m = d.getUTCMonth();
-      const y = d.getUTCFullYear();
-      if (m !== prevMonth || y !== prevYear) {
-        monthLabels.push(MONTH_NAMES[m]);
-        prevMonth = m;
-        prevYear = y;
+        const weeks = (await response.json()) as GitHubCommitActivityWeek[];
+        if (!Array.isArray(weeks) || weeks.length === 0) {
+          return;
+        }
+
+        const recentWeeks = weeks.slice(-COMMIT_HEATMAP_WEEKS);
+        const commitDays = recentWeeks.flatMap((week) =>
+          Array.isArray(week.days) ? week.days.slice(0, 7) : []
+        );
+
+        if (commitDays.length === 0) {
+          return;
+        }
+
+        setActivity((prev) => ({
+          ...prev,
+          commitDays,
+          commitTotal: recentWeeks.reduce((total, week) => total + (week.total ?? 0), 0),
+          updatedFromGitHub: true,
+        }));
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
       }
     }
-  }
 
-  return { weeks: trimmed, commitTotal, sinceLabel, monthLabels };
+    async function fetchAllTimeCommitTotal() {
+      try {
+        const response = await fetch(`${GITHUB_REPO_API_URL}/stats/contributors`, {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const contributors = (await response.json()) as GitHubContributorStats[];
+        if (!Array.isArray(contributors) || contributors.length === 0) {
+          return;
+        }
+
+        const allTime = contributors.reduce(
+          (total, contributor) => total + (contributor.total ?? 0),
+          0,
+        );
+
+        if (allTime <= 0) {
+          return;
+        }
+
+        setActivity((prev) => ({ ...prev, allTimeCommitTotal: allTime }));
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+      }
+    }
+
+    void fetchCommitActivity();
+    void fetchAllTimeCommitTotal();
+
+    return () => controller.abort();
+  }, []);
+
+  return activity;
 }
-
-const REPO_ACTIVITY: RepoActivity = buildRepoActivity();
 
 function commitLevel(count: number): 0 | 1 | 2 | 3 | 4 {
   if (count <= 0) return 0;
@@ -1507,6 +1562,16 @@ function commitLevel(count: number): 0 | 1 | 2 | 3 | 4 {
 }
 
 function CommitHeatmap({ activity }: { activity: RepoActivity }) {
+  const cells: number[][] = Array.from({ length: COMMIT_HEATMAP_WEEKS }, () => []);
+  for (let i = 0; i < activity.commitDays.length; i += 1) {
+    const week = Math.floor(i / 7);
+    if (week >= cells.length) {
+      break;
+    }
+    cells[week].push(activity.commitDays[i]);
+  }
+  const monthLabels = ['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May'];
+
   return (
     <div className="border-b px-4 py-3" style={{ borderColor: 'var(--c-border)' }}>
       <div className="flex items-center justify-between">
@@ -1514,13 +1579,14 @@ function CommitHeatmap({ activity }: { activity: RepoActivity }) {
           Commit activity
         </div>
         <span className="font-mono text-[10px] text-[var(--c-text-muted)]">
-          <span className="text-[var(--c-text-primary)]">{activity.commitTotal}</span> commits · since {activity.sinceLabel}
+          <span className="text-[var(--c-text-primary)]">{activity.commitTotal}</span> commits · last 26 weeks
+          {activity.updatedFromGitHub ? ' · live' : ''}
         </span>
       </div>
       <div className="mt-2.5 flex gap-[3px]" aria-hidden="true">
-        {activity.weeks.map((week, wi) => (
-          <div key={`${week.weekStart}-${wi}`} className="flex flex-col gap-[3px]">
-            {week.days.map((c, di) => {
+        {cells.map((week, wi) => (
+          <div key={wi} className="flex flex-col gap-[3px]">
+            {week.map((c, di) => {
               const level = commitLevel(c);
               const bg =
                 level === 0
@@ -1545,8 +1611,8 @@ function CommitHeatmap({ activity }: { activity: RepoActivity }) {
       </div>
       <div className="mt-2 flex items-center justify-between text-[9.5px] font-mono text-[var(--c-text-muted)]">
         <div className="flex gap-2">
-          {activity.monthLabels.map((m, i) => (
-            <span key={`${m}-${i}`}>{m}</span>
+          {monthLabels.map((m) => (
+            <span key={m}>{m}</span>
           ))}
         </div>
         <div className="flex items-center gap-1">
@@ -1578,26 +1644,42 @@ function CommitHeatmap({ activity }: { activity: RepoActivity }) {
 }
 
 function RepoCard() {
-  const activity = REPO_ACTIVITY;
+  const activity = useRepoActivity();
+  const commitsDisplay = activity.allTimeCommitTotal ?? activity.commitTotal;
   const repoFacts = [
     ['License', 'MIT'],
     ['Release', 'Alpha'],
-    ['Commits', String(activity.commitTotal)],
+    ['Commits', String(commitsDisplay)],
   ] as const;
 
   return (
     <Reveal>
       <div className="rounded-xl border bg-[var(--c-surface)]" style={{ borderColor: 'var(--c-border)' }}>
-        <a
-          href={GITHUB_REPO_URL}
-          target="_blank"
-          rel="noreferrer"
-          className="flex items-center gap-2 border-b px-4 py-3 transition hover:bg-[var(--c-app-bg)]"
+        <div
+          className="flex items-center justify-between gap-2 border-b px-4 py-3"
           style={{ borderColor: 'var(--c-border)' }}
         >
-          <Github size={14} className="text-[var(--c-text-secondary)]" />
-          <span className="font-mono text-[12px] text-[var(--c-text-primary)]">aryanVijaywargia/Continua</span>
-        </a>
+          <a
+            href={GITHUB_REPO_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="flex min-w-0 items-center gap-2 transition hover:text-[var(--c-accent-text)]"
+          >
+            <Github size={14} className="text-[var(--c-text-secondary)]" />
+            <span className="truncate font-mono text-[12px] text-[var(--c-text-primary)]">aryanVijaywargia/Continua</span>
+          </a>
+          <a
+            href={`${GITHUB_REPO_URL}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--c-accent-text)] transition hover:bg-[var(--c-accent-faint)]"
+            style={{ borderColor: 'var(--c-accent-border)' }}
+            aria-label="Star this repo on GitHub"
+          >
+            <Star size={11} className="fill-current" />
+            Star repo
+          </a>
+        </div>
         <CommitHeatmap activity={activity} />
         <div className="border-b px-4 py-3" style={{ borderColor: 'var(--c-border)' }}>
           <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
Four fixes to the public demo + landing + docs surfaces:

1. **Demo trace-detail mock** (`web/public/_worker.js`): per-trace spans / timeline / payloads.
2. **Demo session narrative + compare** (`web/public/_worker.js`): per-session payloads.
3. **Landing repo card** (`web/src/pages/LandingPage.tsx`): adds a 'Star repo' CTA and surfaces an all-time commit count.
4. **Docs theme** (`docs-site/docs.json`): aligns Mintlify primary blue with the main site accent.

The worker file `web/public/_worker.js` is the source of truth for both the Pages deploy and the SPA embedded in the Go binary (the Vite/Go build copies it into `web/dist/` and `internal/web/static/`, both gitignored).

## Demo trace-detail mock fix
Three bugs in `web/public/_worker.js` made every successful trace open as Failed with the wrong spans and empty payload panels:

1. `GET /api/traces/:id/spans` always returned the **checkout** spans regardless of `:id`. Opening any other trace showed Checkout root / Checkout tool in the waterfall.
2. `GET /api/traces/:id/events` always returned `trace_status: 'FAILED'`. The frontend uses `liveTraceStatus = timeline.traceStatus ?? trace.status` (`web/src/pages/TraceDetailPage.tsx:163`), so this override flipped Alpha (`COMPLETED`) to Failed the moment the detail page loaded.
3. The mock spans had no `input` / `output` fields, so Input/Output panels rendered 'No input payload recorded.' even for successful traces.

Fix:
- Split the singleton `traceSpans` and `traceTimeline` into per-trace maps (`traceSpansByTrace`, `traceTimelinesByTrace`) keyed by trace id, each with realistic Alpha / Checkout / Latency data.
- Added `input` / `output` payloads to every span (including an LLM `messages` array on the LLM-kind span).
- Rewrote the `:id`, `:id/spans`, `:id/events` handlers to look up by id and return `404` for unknown ids instead of silently aliasing to checkout.

## Demo session narrative + compare fix
Same fixture-leakage pattern in two more handlers:
- `GET /api/sessions/:id/narrative` returned the same Checkout-flavoured narrative for every session id (so the Latency session showed Alpha + Checkout traces with their summary numbers).
- `GET /api/sessions/:id/compare` returned the same baseline/candidate regardless of session id.

Fix:
- Replaced singletons with `sessionNarrativesBySession` and `sessionComparesBySession` maps keyed by session id.
- Added a realistic narrative for the Latency session (1 running trace, `running_trace_count: 1`, no failures).
- Compare endpoint returns `404` for the Latency session since it only has one trace.
- Unknown session ids now `404` on both endpoints.

## Verification
Ran the worker through Node and checked every endpoint:

Traces
- `trace-alpha` -> `COMPLETED`, has input/output, Alpha root + Alpha LLM spans, timeline `COMPLETED`.
- `trace-checkout` -> `FAILED` with checkout spans + gateway-timeout error event.
- `trace-latency` -> timeline `RUNNING`.
- Unknown id -> `404`.

Sessions
- Checkout narrative: 2 traces (Alpha, Checkout), 1 failed.
- Latency narrative: 1 trace (Latency), 1 running, 0 failed.
- Checkout compare: baseline Alpha / candidate Checkout.
- Latency compare: `404`.
- Unknown id -> `404` on both endpoints.

## Test plan
- [ ] Landing page: repo card shows 'Star repo' button; commits tile updates to all-time count after `/stats/contributors` resolves.
- [ ] Docs site: rebuild docs and confirm primary blue matches console accent.
- [ ] Demo site after deploy / next Go binary build: open Alpha Trace, confirm header stays `Completed`, waterfall shows Alpha root / Alpha LLM call, Input/Output panels render `{ prompt: 'alpha' }` / `{ answer: 'complete' }`. Checkout still `Failed` with its own spans.
- [ ] Demo site: open the Latency session, confirm narrative shows the single running Latency trace (not Alpha/Checkout). Open Checkout session compare and confirm baseline/candidate are correct; Latency session compare should 404 gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Star repo" button with icon in the repository card header for easy repository starring

* **Bug Fixes**
  * Improved API error handling for trace and session endpoints when data is unavailable, returning proper error responses instead of fallback data

* **Style**
  * Updated color theme palette with new primary, light, and dark color values

* **Chores**
  * Updated repository statistics including commit counts, branch information, and metadata timestamps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->