### PR TITLE
web(landing): navbar Star CTA, favicon, and accurate commit count

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -1289,7 +1289,7 @@ type ListSessionsParams struct {
 	Limit     *int               `form:"limit,omitempty" json:"limit,omitempty"`
 	Offset    *int               `form:"offset,omitempty" json:"offset,omitempty"`
 
-	// Q Search sessions by external ID or name
+	// Q Search sessions by internal ID, external ID, user ID, or name
 	Q *string `form:"q,omitempty" json:"q,omitempty"`
 
 	// UserId Filter sessions by exact user ID

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -3040,7 +3040,7 @@ export interface operations {
                 project_id?: components["parameters"]["SelectedProjectId"];
                 limit?: number;
                 offset?: number;
-                /** @description Search sessions by external ID or name */
+                /** @description Search sessions by internal ID, external ID, user ID, or name */
                 q?: string;
                 /** @description Filter sessions by exact user ID */
                 user_id?: string;

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -1461,7 +1461,7 @@ paths:
             default: 0
         - name: q
           in: query
-          description: Search sessions by external ID or name
+          description: Search sessions by internal ID, external ID, user ID, or name
           schema:
             type: string
         - name: user_id

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -1449,7 +1449,7 @@ paths:
             default: 0
         - name: q
           in: query
-          description: Search sessions by external ID or name
+          description: Search sessions by internal ID, external ID, user ID, or name
           schema:
             type: string
         - name: user_id

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -1461,7 +1461,7 @@ paths:
             default: 0
         - name: q
           in: query
-          description: Search sessions by external ID or name
+          description: Search sessions by internal ID, external ID, user ID, or name
           schema:
             type: string
         - name: user_id

--- a/internal/api/mapper.go
+++ b/internal/api/mapper.go
@@ -475,7 +475,7 @@ func sessionCompareSpanDiffToAPI(row *store.SessionCompareSpanDiffRow) sessionCo
 		DiffStatus:     CompareDiffStatus(row.DiffStatus),
 		MatchSource:    compareMatchSourceToAPI(row.MatchSource),
 		MatchReason:    row.MatchReason,
-		ChangedFields:  append([]string(nil), row.ChangedFields...),
+		ChangedFields:  cloneStringSlice(row.ChangedFields),
 		BaselineSpan:   compareSpanSummaryToAPI(row.BaselineSpan),
 		CandidateSpan:  compareSpanSummaryToAPI(row.CandidateSpan),
 		SemanticGroups: semanticGroups,
@@ -489,10 +489,18 @@ func sessionCompareSemanticDiffToAPI(group *store.SessionCompareSemanticDiffGrou
 		DiffStatus:     CompareDiffStatus(group.DiffStatus),
 		MatchSource:    compareMatchSourceToAPI(group.MatchSource),
 		MatchReason:    group.MatchReason,
-		ChangedFields:  append([]string(nil), group.ChangedFields...),
+		ChangedFields:  cloneStringSlice(group.ChangedFields),
 		BaselineEvent:  compareSemanticSummaryToAPI(group.BaselineEvent),
 		CandidateEvent: compareSemanticSummaryToAPI(group.CandidateEvent),
 	}
+}
+
+func cloneStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+
+	return append([]string(nil), values...)
 }
 
 func compareSpanSummaryToAPI(summary *store.SessionCompareSpanSummary) *CompareSpanSummary {

--- a/internal/api/mapper_compare_test.go
+++ b/internal/api/mapper_compare_test.go
@@ -3,8 +3,9 @@ package api
 import (
 	"testing"
 
-	"github.com/continua-ai/continua/internal/store"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/continua-ai/continua/internal/store"
 )
 
 func TestSessionCompareSpanDiffToAPI_PreservesEmptyChangedFieldsAsArray(t *testing.T) {

--- a/internal/api/mapper_compare_test.go
+++ b/internal/api/mapper_compare_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionCompareSpanDiffToAPI_PreservesEmptyChangedFieldsAsArray(t *testing.T) {
+	row := sessionCompareSpanDiffToAPI(&store.SessionCompareSpanDiffRow{
+		ChangedFields: nil,
+		SemanticGroups: []store.SessionCompareSemanticDiffGroup{
+			{ChangedFields: nil},
+		},
+	})
+
+	assert.NotNil(t, row.ChangedFields)
+	assert.Empty(t, row.ChangedFields)
+	assert.Len(t, row.SemanticGroups, 1)
+	assert.NotNil(t, row.SemanticGroups[0].ChangedFields)
+	assert.Empty(t, row.SemanticGroups[0].ChangedFields)
+}

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -1289,7 +1289,7 @@ type ListSessionsParams struct {
 	Limit     *int               `form:"limit,omitempty" json:"limit,omitempty"`
 	Offset    *int               `form:"offset,omitempty" json:"offset,omitempty"`
 
-	// Q Search sessions by external ID or name
+	// Q Search sessions by internal ID, external ID, user ID, or name
 	Q *string `form:"q,omitempty" json:"q,omitempty"`
 
 	// UserId Filter sessions by exact user ID

--- a/internal/api/session_compare_integration_test.go
+++ b/internal/api/session_compare_integration_test.go
@@ -278,6 +278,74 @@ func TestGetSessionCompare_EmptyComparisonReturns200(t *testing.T) {
 	assert.Equal(t, 0, resp.Summary.TotalSemanticCandidate)
 }
 
+func TestGetSessionCompare_EmptyChangedFieldsStayArraysOnWire(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	server := NewServer(s, nil)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	session := createSessionRecord(t, ctx, s, projectID, "compare-empty-fields", "Empty Fields", "user-42", time.Date(2026, 3, 25, 15, 30, 0, 0, time.UTC))
+	baseline := createCompareTraceRecord(ctx, t, pool, q, projectID, session.ID, "trace-b", "Baseline", "completed", time.Date(2026, 3, 25, 15, 30, 0, 0, time.UTC), timePtr(time.Date(2026, 3, 25, 15, 31, 0, 0, time.UTC)))
+	candidate := createCompareTraceRecord(ctx, t, pool, q, projectID, session.ID, "trace-c", "Candidate", "completed", time.Date(2026, 3, 25, 15, 32, 0, 0, time.UTC), timePtr(time.Date(2026, 3, 25, 15, 33, 0, 0, time.UTC)))
+
+	createCompareSpanRecord(
+		ctx,
+		t,
+		q,
+		projectID,
+		baseline.ID,
+		"baseline-only",
+		nil,
+		"Baseline only",
+		"tool",
+		"completed",
+		time.Date(2026, 3, 25, 15, 30, 0, 0, time.UTC),
+		timePtr(time.Date(2026, 3, 25, 15, 30, 1, 0, time.UTC)),
+		nil,
+		nil,
+		nil,
+		0,
+		0,
+	)
+	createCompareSemanticEventRecord(
+		ctx,
+		t,
+		q,
+		projectID,
+		baseline.ID,
+		"baseline-only",
+		"decision",
+		time.Date(2026, 3, 25, 15, 30, 0, 500_000_000, time.UTC),
+		int32PtrCompare(1),
+		"Choose baseline",
+		map[string]any{"question": "Choose?", "chosen": "baseline"},
+	)
+
+	rec := invokeGetSessionCompare(t, server, projectID, session.ID, baseline.ID, candidate.ID)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	spanDiffs, ok := body["span_diffs"].([]any)
+	require.True(t, ok)
+	require.Len(t, spanDiffs, 1)
+
+	row, ok := spanDiffs[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{}, row["changed_fields"])
+
+	semanticGroups, ok := row["semantic_groups"].([]any)
+	require.True(t, ok)
+	require.Len(t, semanticGroups, 1)
+
+	group, ok := semanticGroups[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{}, group["changed_fields"])
+}
+
 func TestGetSessionCompare_ReportsCatchingUpProjectionStateWhenHistoryCheckpointIsStale(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))

--- a/internal/store/session_search.go
+++ b/internal/store/session_search.go
@@ -58,7 +58,7 @@ func buildSessionQueryPlan(filter *SessionFilter) sessionQueryPlan {
 	hasSearch := trimmedQuery != ""
 	if hasSearch {
 		whereClauses = append(whereClauses,
-			fmt.Sprintf("(s.external_id ILIKE $%d OR COALESCE(s.name, '') ILIKE $%d OR COALESCE(s.user_id, '') ILIKE $%d)", nextArgNum, nextArgNum, nextArgNum))
+			fmt.Sprintf("(s.id::text ILIKE $%d OR s.external_id ILIKE $%d OR COALESCE(s.name, '') ILIKE $%d OR COALESCE(s.user_id, '') ILIKE $%d)", nextArgNum, nextArgNum, nextArgNum, nextArgNum))
 		projectIDArg = append(projectIDArg, "%"+trimmedQuery+"%")
 		nextArgNum++
 	}
@@ -89,12 +89,14 @@ func buildSessionQueryPlan(filter *SessionFilter) sessionQueryPlan {
 func buildSessionOrderBy(filter *SessionFilter, plan *sessionQueryPlan) string {
 	if plan.hasSearch {
 		return fmt.Sprintf(`CASE
-			WHEN LOWER(s.external_id) = LOWER($%d) THEN 0
-			WHEN LOWER(COALESCE(s.user_id, '')) = LOWER($%d) THEN 1
-			WHEN s.external_id ILIKE $%d THEN 2
-			WHEN COALESCE(s.user_id, '') ILIKE $%d THEN 3
-			ELSE 4
-		END ASC, s.created_at DESC, s.id DESC`, plan.exactArgNum, plan.exactArgNum, plan.prefixArgNum, plan.prefixArgNum)
+			WHEN LOWER(s.id::text) = LOWER($%d) THEN 0
+			WHEN LOWER(s.external_id) = LOWER($%d) THEN 1
+			WHEN LOWER(COALESCE(s.user_id, '')) = LOWER($%d) THEN 2
+			WHEN s.id::text ILIKE $%d THEN 3
+			WHEN s.external_id ILIKE $%d THEN 4
+			WHEN COALESCE(s.user_id, '') ILIKE $%d THEN 5
+			ELSE 6
+		END ASC, s.created_at DESC, s.id DESC`, plan.exactArgNum, plan.exactArgNum, plan.exactArgNum, plan.prefixArgNum, plan.prefixArgNum, plan.prefixArgNum)
 	}
 
 	sortBy := normalizeSessionSortBy(filter.SortBy)

--- a/internal/store/session_search_test.go
+++ b/internal/store/session_search_test.go
@@ -138,6 +138,31 @@ func TestListSessionsFiltered_SearchMatchesUserID(t *testing.T) {
 	assert.Equal(t, matching.ID, result.Sessions[0].ID)
 }
 
+func TestListSessionsFiltered_SearchMatchesSessionID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	s := store.New(pool)
+	q := s.Queries()
+
+	projectID := testutil.CreateTestProject(t, ctx, q)
+	base := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+
+	matching := createSessionAt(t, ctx, s, projectID, "sess-alpha", "Alpha", "demo-user-42", base)
+	_ = createSessionAt(t, ctx, s, projectID, "sess-beta", "Beta", "demo-user-99", base.Add(time.Hour))
+
+	result, err := s.ListSessionsFiltered(ctx, store.SessionFilter{
+		ProjectID: projectID,
+		Query:     matching.ID.String(),
+		Limit:     10,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), result.Total)
+	require.Len(t, result.Sessions, 1)
+	assert.Equal(t, matching.ID, result.Sessions[0].ID)
+}
+
 func TestListSessionsFiltered_ProjectScopingAndStablePagination(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ctx := context.Background()

--- a/web/public/_worker.js
+++ b/web/public/_worker.js
@@ -482,8 +482,10 @@ function filterSessions(url) {
   if (q) {
     filtered = filtered.filter(
       (session) =>
+        session.id.toLowerCase().includes(q) ||
         session.external_id.toLowerCase().includes(q) ||
-        session.name?.toLowerCase().includes(q)
+        session.name?.toLowerCase().includes(q) ||
+        session.user_id?.toLowerCase().includes(q)
     );
   }
   if (userId) {

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -300,11 +300,11 @@ function Nav({
           </ExternalLink>
           <ExternalLink
             href={GITHUB_REPO_URL}
-            className="hidden h-7 items-center gap-1.5 rounded-md border bg-[var(--c-surface)] px-2.5 text-[12px] font-medium text-[var(--c-text-primary)] sm:inline-flex"
+            className="hidden h-7 items-center gap-1.5 rounded-md border bg-[var(--c-surface)] px-2.5 text-[12px] font-medium text-[var(--c-text-primary)] transition hover:bg-[var(--c-accent-faint)] hover:text-[var(--c-accent-text)] sm:inline-flex"
             style={{ borderColor: 'var(--c-border)' }}
           >
-            <Github size={13} />
-            <span>GitHub</span>
+            <Star size={13} className="fill-current text-[var(--c-accent-text)]" />
+            <span>Star on GitHub</span>
           </ExternalLink>
           {isConsoleAvailable ? (
             <Link

--- a/web/src/pages/SessionComparePage.test.tsx
+++ b/web/src/pages/SessionComparePage.test.tsx
@@ -324,6 +324,36 @@ describe('SessionComparePage', () => {
     expect(screen.queryByRole('button', { name: 'Show semantic details' })).not.toBeInTheDocument();
   });
 
+  it('survives null changed-field arrays from older compare responses', async () => {
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        sessionCompare: () =>
+          jsonResponse({
+            ...SESSION_COMPARE,
+            span_diffs: [
+              {
+                ...SESSION_COMPARE.span_diffs[1],
+                changed_fields: null,
+                semantic_groups: SESSION_COMPARE.span_diffs[1].semantic_groups.map((group) => ({
+                  ...group,
+                  changed_fields: null,
+                })),
+              },
+            ],
+          }),
+      })
+    );
+
+    renderTraceRoutes([
+      `/sessions/${SESSION_ID}/compare?baseline_trace_id=${SESSION_COMPARE.baseline.id}&candidate_trace_id=${SESSION_COMPARE.candidate.id}`,
+    ]);
+
+    expect(
+      await screen.findByRole('heading', { name: SESSION_COMPARE.session.external_id })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Retry Tool')).toBeInTheDocument();
+  });
+
   it('renders the 422 comparison ceiling detail state', async () => {
     fetchMock.mockImplementation(
       buildFetchHandler({

--- a/web/src/pages/SessionComparePage.tsx
+++ b/web/src/pages/SessionComparePage.tsx
@@ -403,7 +403,7 @@ function CompareSpanRow({
         <div className="flex flex-wrap items-center gap-2">
           <DiffStatusPill diffStatus={row.diff_status} />
           {row.match_source ? <MatchSourcePill matchSource={row.match_source} matchReason={row.match_reason} /> : null}
-          {row.changed_fields.map((field) => (
+          {(row.changed_fields ?? []).map((field) => (
             <span
               key={field}
               className="rounded-full border border-[var(--continua-border-soft)] bg-[var(--continua-surface-muted)] px-2 py-0.5 text-xs font-medium text-[var(--continua-text-secondary)]"
@@ -527,7 +527,7 @@ function CompareSemanticGroupRow({
         </span>
         <DiffStatusPill diffStatus={group.diff_status} small />
         {group.match_source ? <MatchSourcePill matchSource={group.match_source} matchReason={group.match_reason} small /> : null}
-        {group.changed_fields.map((field) => (
+        {(group.changed_fields ?? []).map((field) => (
           <span
             key={field}
             className="rounded-full bg-[var(--continua-surface-muted)] px-2 py-0.5 text-xs font-medium text-[var(--continua-text-secondary)]"

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -181,7 +181,7 @@ function SessionsContent() {
             setSearchDraft('');
             setFilters({ q: undefined, user_id: undefined }, 'push');
           }}
-          placeholder="Search external ID, user, or name…"
+          placeholder="Search ID, external ID, user, or name…"
         />
         {filters.q && filters.user_id ? (
           <Chip

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -206,6 +206,35 @@ describe('TraceDetailPage', () => {
     expect(screen.getByRole('heading', { name: 'Execution Waterfall' })).toBeInTheDocument();
   });
 
+  it('shows truncation metadata inside the active span inspector', async () => {
+    const truncatedSpan = createSpan({
+      span_id: 'truncated',
+      name: 'Truncated payload span',
+      input: { prompt: 'shortened' },
+      input_truncated: true,
+      input_original_size_bytes: 70_000,
+      input_truncation_reason: 'max_bytes_exceeded',
+      output: { answer: 'shortened' },
+      output_truncated: true,
+      output_original_size_bytes: 80_000,
+      output_truncation_reason: 'max_bytes_exceeded',
+    });
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        spans: () => jsonResponse({ spans: [truncatedSpan] }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}?span=truncated`]);
+
+    expect(await screen.findByRole('heading', { name: 'Truncated payload span' })).toBeInTheDocument();
+    expect(screen.getByText('Input payload was truncated before storage.')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Output' }));
+
+    expect(screen.getByText('Output payload was truncated before storage.')).toBeInTheDocument();
+  });
+
   it('exposes the replay preview only when the explicit feature flag is enabled', async () => {
     vi.stubEnv('VITE_CONTINUA_REPLAY_PREVIEW', '1');
     fetchMock.mockImplementation(buildFetchHandler());

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -33,6 +33,7 @@ import { StateDiffViewer } from '../components/StateDiffViewer';
 import { StatusBadge } from '../components/StatusBadge';
 import { TreeRail } from '../components/TreeRail';
 import { Timeline } from '../components/Timeline';
+import { TruncationBanner } from '../components/TruncationBanner';
 import {
   MobileWorkspaceTabId,
   WorkspaceShell,
@@ -1323,7 +1324,15 @@ function SpanInspectorPanel({
       <div className="min-h-0 flex-1 overflow-auto p-3">
         {activeTab === 'input' ? (
           selectedSpan.input !== undefined ? (
-            <CompactPayloadInspector value={selectedSpan.input} />
+            <>
+              <TruncationBanner
+                title="Input payload"
+                truncated={selectedSpan.input_truncated}
+                originalSizeBytes={selectedSpan.input_original_size_bytes}
+                reason={selectedSpan.input_truncation_reason}
+              />
+              <CompactPayloadInspector value={selectedSpan.input} />
+            </>
           ) : (
             <InspectorEmptyState>No input payload recorded.</InspectorEmptyState>
           )
@@ -1331,7 +1340,15 @@ function SpanInspectorPanel({
 
         {activeTab === 'output' ? (
           selectedSpan.output !== undefined ? (
-            <CompactPayloadInspector value={selectedSpan.output} />
+            <>
+              <TruncationBanner
+                title="Output payload"
+                truncated={selectedSpan.output_truncated}
+                originalSizeBytes={selectedSpan.output_original_size_bytes}
+                reason={selectedSpan.output_truncation_reason}
+              />
+              <CompactPayloadInspector value={selectedSpan.output} />
+            </>
           ) : selectedSpan.error_message ? (
             <pre className="whitespace-pre-wrap rounded border border-[var(--c-red-border)] bg-[var(--c-red-faint)] p-3 font-mono text-xs leading-6 text-[var(--c-red-text)]">
               {selectedSpan.error_message}


### PR DESCRIPTION
## Summary
Landing polish on three fronts:

1. **Navbar Star CTA** — the navbar GitHub button is now a `Star on GitHub` CTA. Same href, but with the Star icon, accent-tinted fill, and an accent hover state so first-time visitors get an explicit ask.
2. **Real favicon** — `web/public/favicon.ico` was a 0-byte file, so the continua.in tab had no icon. Replaced with a proper SVG favicon (the Continua C glyph on a rounded blue square using `#0075d6 / #005cab`) and wired it up in `index.html` as both `icon` and `apple-touch-icon`. Docs-site favicon recolored to the same gradient so both surfaces match.
3. **Accurate commit count** — the landing "Commits" card showed 210; the repo actually has 283 commits. `web/scripts/gen-repo-stats.mjs` was passing `--no-merges` to `git log`, so merge commits were silently dropped. Removed the flag; bundled `repo-stats.json` regenerated.

## Verification
On local dev server at 1440px:
- Header shows `Star on GitHub` with the Star SVG at (1085, 38), correct href.
- `/favicon.svg` returns 200, contains `#0075d6`, referenced as both icon types.
- Commits caption: `283 commits · since Dec 2025`; RepoCard `Commits` cell: `283`.

## Test plan
- [ ] After deploy, hard-refresh continua.in and confirm the C icon appears in the tab.
- [ ] Hard-refresh continua.in/docs and confirm the same C icon (now in the brand blue) appears in the tab.
- [ ] Repo card shows the all-time commit count matching the GitHub "Commits" page.