### PR TITLE
Add engine runs console

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -788,10 +788,15 @@ type EngineTraceInfo struct {
 	ChildKey          *string               `json:"child_key,omitempty"`
 	DefinitionName    string                `json:"definition_name"`
 	DefinitionVersion string                `json:"definition_version"`
+	InstanceKey       *string               `json:"instance_key,omitempty"`
 	ParentRunId       *openapi_types.UUID   `json:"parent_run_id,omitempty"`
+	PendingWork       *EnginePendingWork    `json:"pending_work,omitempty"`
 	ProjectionState   EngineProjectionState `json:"projection_state"`
 	RootRunId         *openapi_types.UUID   `json:"root_run_id,omitempty"`
 	RunId             openapi_types.UUID    `json:"run_id"`
+	Status            *EngineRunStatus      `json:"status,omitempty"`
+	UpdatedAt         *time.Time            `json:"updated_at,omitempty"`
+	WaitState         *EngineWaitState      `json:"wait_state,omitempty"`
 }
 
 // EngineWaitState defines model for EngineWaitState.
@@ -1386,6 +1391,9 @@ type ListTracesParams struct {
 
 	// EngineProjectionState Filter by engine projection state
 	EngineProjectionState *EngineProjectionState `form:"engine_projection_state,omitempty" json:"engine_projection_state,omitempty"`
+
+	// EngineOnly When true, return only traces backed by an engine run.
+	EngineOnly *bool `form:"engine_only,omitempty" json:"engine_only,omitempty"`
 
 	// HasErrors Filter traces with errors (error_count > 0)
 	HasErrors *bool `form:"has_errors,omitempty" json:"has_errors,omitempty"`
@@ -2625,6 +2633,14 @@ func (siw *ServerInterfaceWrapper) ListTraces(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// ------------- Optional query parameter "engine_only" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_only", r.URL.Query(), &params.EngineOnly)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_only", Err: err})
+		return
+	}
+
 	// ------------- Optional query parameter "has_errors" -------------
 
 	err = runtime.BindQueryParameter("form", true, false, "has_errors", r.URL.Query(), &params.HasErrors)
@@ -3043,6 +3059,8 @@ func (siw *ServerInterfaceWrapper) GetEngineInstance(w http.ResponseWriter, r *h
 
 	ctx := r.Context()
 
+	ctx = context.WithValue(ctx, Auth0BearerScopes, []string{})
+
 	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
 
 	r = r.WithContext(ctx)
@@ -3064,6 +3082,8 @@ func (siw *ServerInterfaceWrapper) BackfillEngineProjections(w http.ResponseWrit
 	var err error
 
 	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, Auth0BearerScopes, []string{})
 
 	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
 
@@ -3114,6 +3134,8 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 	var err error
 
 	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, Auth0BearerScopes, []string{})
 
 	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
 

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -1533,7 +1533,7 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description Unauthorized - missing or invalid credentials */
+            /** @description Unauthorized - missing or invalid API key */
             401: {
                 headers: {
                     [name: string]: unknown;

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -691,6 +691,12 @@ export interface components {
             definition_name: string;
             definition_version: string;
             projection_state: components["schemas"]["EngineProjectionState"];
+            instance_key?: string;
+            status?: components["schemas"]["EngineRunStatus"];
+            wait_state?: components["schemas"]["EngineWaitState"];
+            pending_work?: components["schemas"]["EnginePendingWork"];
+            /** Format: date-time */
+            updated_at?: string;
             /** Format: uuid */
             parent_run_id?: string;
             /** Format: uuid */
@@ -1621,7 +1627,7 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description Unauthorized - missing or invalid API key */
+            /** @description Unauthorized - missing or invalid credentials */
             401: {
                 headers: {
                     [name: string]: unknown;
@@ -1906,7 +1912,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineInstanceResponse"];
                 };
             };
-            /** @description Unauthorized - missing or invalid API key */
+            /** @description Unauthorized - missing or invalid credentials */
             401: {
                 headers: {
                     [name: string]: unknown;
@@ -2860,6 +2866,8 @@ export interface operations {
                 engine_child_depth?: number;
                 /** @description Filter by engine projection state */
                 engine_projection_state?: components["schemas"]["EngineProjectionState"];
+                /** @description When true, return only traces backed by an engine run. */
+                engine_only?: boolean;
                 /** @description Filter traces with errors (error_count > 0) */
                 has_errors?: boolean;
                 /** @description Filter traces with duration >= this value in milliseconds */

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -2255,7 +2255,7 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description Unauthorized - missing or invalid API key */
+            /** @description Unauthorized - missing or invalid credentials */
             401: {
                 headers: {
                     [name: string]: unknown;

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -1533,7 +1533,7 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description Unauthorized - missing or invalid API key */
+            /** @description Unauthorized - missing or invalid credentials */
             401: {
                 headers: {
                     [name: string]: unknown;

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -698,7 +698,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -66,7 +66,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid credentials
+          description: Unauthorized - missing or invalid API key
           content:
             application/json:
               schema:

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -118,8 +118,6 @@ paths:
       summary: Start an engine workflow run
       tags:
         - Engine
-      security:
-        - apiKey: []
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
@@ -147,7 +145,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:
@@ -376,8 +374,6 @@ paths:
       summary: Get an engine instance and current run
       tags:
         - Engine
-      security:
-        - apiKey: []
       parameters:
         - name: instance_key
           in: path
@@ -392,7 +388,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineInstanceResponse'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:
@@ -675,8 +671,6 @@ paths:
         are not valid backfill targets.
       tags:
         - Engine
-      security:
-        - apiKey: []
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
@@ -1299,6 +1293,12 @@ paths:
           description: Filter by engine projection state
           schema:
             $ref: '#/components/schemas/EngineProjectionState'
+        - name: engine_only
+          in: query
+          description: When true, return only traces backed by an engine run.
+          schema:
+            type: boolean
+            default: false
         - name: has_errors
           in: query
           description: Filter traces with errors (error_count > 0)
@@ -1810,6 +1810,17 @@ components:
           type: string
         projection_state:
           $ref: '#/components/schemas/EngineProjectionState'
+        instance_key:
+          type: string
+        status:
+          $ref: '#/components/schemas/EngineRunStatus'
+        wait_state:
+          $ref: '#/components/schemas/EngineWaitState'
+        pending_work:
+          $ref: '#/components/schemas/EnginePendingWork'
+        updated_at:
+          type: string
+          format: date-time
         parent_run_id:
           type: string
           format: uuid

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -66,7 +66,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -71,7 +71,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid credentials
+          description: Unauthorized - missing or invalid API key
           content:
             application/json:
               schema:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -703,7 +703,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -123,8 +123,6 @@ paths:
       operationId: startEngineRun
       summary: Start an engine workflow run
       tags: [Engine]
-      security:
-        - apiKey: []
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
@@ -152,7 +150,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:
@@ -381,8 +379,6 @@ paths:
       operationId: getEngineInstance
       summary: Get an engine instance and current run
       tags: [Engine]
-      security:
-        - apiKey: []
       parameters:
         - name: instance_key
           in: path
@@ -397,7 +393,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineInstanceResponse'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:
@@ -680,8 +676,6 @@ paths:
         `journal_expired` filters return zero eligible rows because those states
         are not valid backfill targets.
       tags: [Engine]
-      security:
-        - apiKey: []
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
@@ -1287,6 +1281,12 @@ paths:
           description: Filter by engine projection state
           schema:
             $ref: '#/components/schemas/EngineProjectionState'
+        - name: engine_only
+          in: query
+          description: When true, return only traces backed by an engine run.
+          schema:
+            type: boolean
+            default: false
         - name: has_errors
           in: query
           description: Filter traces with errors (error_count > 0)
@@ -1771,6 +1771,17 @@ components:
           type: string
         projection_state:
           $ref: '#/components/schemas/EngineProjectionState'
+        instance_key:
+          type: string
+        status:
+          $ref: '#/components/schemas/EngineRunStatus'
+        wait_state:
+          $ref: '#/components/schemas/EngineWaitState'
+        pending_work:
+          $ref: '#/components/schemas/EnginePendingWork'
+        updated_at:
+          type: string
+          format: date-time
         parent_run_id:
           type: string
           format: uuid

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -71,7 +71,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -698,7 +698,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -66,7 +66,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid credentials
+          description: Unauthorized - missing or invalid API key
           content:
             application/json:
               schema:

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -118,8 +118,6 @@ paths:
       summary: Start an engine workflow run
       tags:
         - Engine
-      security:
-        - apiKey: []
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
@@ -147,7 +145,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:
@@ -376,8 +374,6 @@ paths:
       summary: Get an engine instance and current run
       tags:
         - Engine
-      security:
-        - apiKey: []
       parameters:
         - name: instance_key
           in: path
@@ -392,7 +388,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineInstanceResponse'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:
@@ -675,8 +671,6 @@ paths:
         are not valid backfill targets.
       tags:
         - Engine
-      security:
-        - apiKey: []
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
@@ -1299,6 +1293,12 @@ paths:
           description: Filter by engine projection state
           schema:
             $ref: '#/components/schemas/EngineProjectionState'
+        - name: engine_only
+          in: query
+          description: When true, return only traces backed by an engine run.
+          schema:
+            type: boolean
+            default: false
         - name: has_errors
           in: query
           description: Filter traces with errors (error_count > 0)
@@ -1810,6 +1810,17 @@ components:
           type: string
         projection_state:
           $ref: '#/components/schemas/EngineProjectionState'
+        instance_key:
+          type: string
+        status:
+          $ref: '#/components/schemas/EngineRunStatus'
+        wait_state:
+          $ref: '#/components/schemas/EngineWaitState'
+        pending_work:
+          $ref: '#/components/schemas/EnginePendingWork'
+        updated_at:
+          type: string
+          format: date-time
         parent_run_id:
           type: string
           format: uuid

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -66,7 +66,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized - missing or invalid API key
+          description: Unauthorized - missing or invalid credentials
           content:
             application/json:
               schema:

--- a/internal/api/engine_mapper.go
+++ b/internal/api/engine_mapper.go
@@ -345,7 +345,7 @@ func projectedEngineRunStatusFromTrace(trace *store.TraceRead) EngineRunStatus {
 }
 
 func engineTraceInfoFromTrace(trace *store.TraceRead) *EngineTraceInfo {
-	return engineTraceInfoFromParts(
+	info := engineTraceInfoFromParts(
 		pgUUIDPtr(trace.EngineRunID),
 		trace.EngineDefinitionName,
 		trace.EngineDefinitionVersion,
@@ -355,6 +355,21 @@ func engineTraceInfoFromTrace(trace *store.TraceRead) *EngineTraceInfo {
 		trace.EngineChildKey,
 		trace.EngineChildDepth,
 	)
+	if info == nil {
+		return nil
+	}
+
+	instanceKey := projectedEngineInstanceKey(trace)
+	info.InstanceKey = &instanceKey
+	status := projectedEngineRunStatusFromTrace(trace)
+	info.Status = &status
+	info.PendingWork = &EnginePendingWork{
+		PendingActivityTasks: derefInt64(trace.EnginePendingActivityTasks),
+		PendingInboxItems:    derefInt64(trace.EnginePendingInboxItems),
+	}
+	info.UpdatedAt = &trace.UpdatedAt
+	info.WaitState = parseOptionalWaitState(cloneTraceJSON(trace.EngineWaitState))
+	return info
 }
 
 func engineTraceInfoFromCompareHeader(header *store.SessionCompareTraceHeader) *EngineTraceInfo {

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -260,6 +260,8 @@ func classifyRouteProtection(path string) routeProtection {
 		return routeProtectionAPIKeyOnly
 	case isEngineAPIKeyOnlyRoute(path):
 		return routeProtectionAPIKeyOnly
+	case isEngineConsoleRoute(path):
+		return routeProtectionComposite
 	case strings.HasPrefix(path, "/api/"), isEngineRunScopedRoute(path):
 		return routeProtectionComposite
 	default:
@@ -276,15 +278,15 @@ func isEngineAPIKeyOnlyRoute(path string) bool {
 			strings.HasSuffix(path, "/complete") ||
 			strings.HasSuffix(path, "/fail")):
 		return true
-	case path == "/v1/engine/runs":
-		return true
-	case path == "/v1/engine/projections/backfill":
-		return true
-	case strings.HasPrefix(path, "/v1/engine/instances/"):
-		return true
 	default:
 		return false
 	}
+}
+
+func isEngineConsoleRoute(path string) bool {
+	return path == "/v1/engine/runs" ||
+		strings.HasPrefix(path, "/v1/engine/instances/") ||
+		path == "/v1/engine/projections/backfill"
 }
 
 func isEngineRunScopedRoute(path string) bool {
@@ -316,6 +318,16 @@ func isPublicDemoReadRequest(method, path string) bool {
 	case matchesPathPattern(path, "/api/sessions/{id}/narrative"):
 		return true
 	case matchesPathPattern(path, "/api/sessions/{id}/compare"):
+		return true
+	case matchesPathPattern(path, "/v1/engine/instances/{instance_key}"):
+		return true
+	case matchesPathPattern(path, "/v1/engine/runs/{run_id}"):
+		return true
+	case matchesPathPattern(path, "/v1/engine/runs/{run_id}/pending-work"):
+		return true
+	case matchesPathPattern(path, "/v1/engine/runs/{run_id}/history"):
+		return true
+	case matchesPathPattern(path, "/v1/engine/runs/{run_id}/result"):
 		return true
 	default:
 		return false

--- a/internal/api/middleware/composite_auth_test.go
+++ b/internal/api/middleware/composite_auth_test.go
@@ -23,9 +23,9 @@ func TestClassifyRouteProtection_MatchesOperatorAuthPlan(t *testing.T) {
 	assert.Equal(t, routeProtectionAPIKeyOnly, classifyRouteProtection("/v1/ingest"))
 	assert.Equal(t, routeProtectionComposite, classifyRouteProtection("/api/traces"))
 	assert.Equal(t, routeProtectionComposite, classifyRouteProtection("/api/projects"))
-	assert.Equal(t, routeProtectionAPIKeyOnly, classifyRouteProtection("/v1/engine/runs"))
-	assert.Equal(t, routeProtectionAPIKeyOnly, classifyRouteProtection("/v1/engine/instances/customer-123"))
-	assert.Equal(t, routeProtectionAPIKeyOnly, classifyRouteProtection("/v1/engine/projections/backfill"))
+	assert.Equal(t, routeProtectionComposite, classifyRouteProtection("/v1/engine/runs"))
+	assert.Equal(t, routeProtectionComposite, classifyRouteProtection("/v1/engine/instances/customer-123"))
+	assert.Equal(t, routeProtectionComposite, classifyRouteProtection("/v1/engine/projections/backfill"))
 	assert.Equal(t, routeProtectionComposite, classifyRouteProtection("/v1/engine/runs/11111111-1111-1111-1111-111111111111"))
 	assert.Equal(
 		t,
@@ -49,9 +49,17 @@ func TestPublicDemoReadRequest_OnlyMatchesDebuggerReadRoutes(t *testing.T) {
 	assert.True(t, isPublicDemoReadRequest(http.MethodGet, "/api/sessions/session-123"))
 	assert.True(t, isPublicDemoReadRequest(http.MethodGet, "/api/sessions/session-123/narrative"))
 	assert.True(t, isPublicDemoReadRequest(http.MethodGet, "/api/sessions/session-123/compare"))
+	assert.True(t, isPublicDemoReadRequest(http.MethodGet, "/v1/engine/instances/customer-123"))
+	assert.True(t, isPublicDemoReadRequest(http.MethodGet, "/v1/engine/runs/run-123"))
+	assert.True(t, isPublicDemoReadRequest(http.MethodGet, "/v1/engine/runs/run-123/pending-work"))
+	assert.True(t, isPublicDemoReadRequest(http.MethodGet, "/v1/engine/runs/run-123/history"))
+	assert.True(t, isPublicDemoReadRequest(http.MethodGet, "/v1/engine/runs/run-123/result"))
 	assert.False(t, isPublicDemoReadRequest(http.MethodGet, "/api/traces/trace-123/export"))
 	assert.False(t, isPublicDemoReadRequest(http.MethodGet, "/api/sessions/session-123/admin"))
 	assert.False(t, isPublicDemoReadRequest(http.MethodPost, "/api/traces"))
+	assert.False(t, isPublicDemoReadRequest(http.MethodPost, "/v1/engine/runs"))
+	assert.False(t, isPublicDemoReadRequest(http.MethodPost, "/v1/engine/runs/run-123/signal"))
+	assert.False(t, isPublicDemoReadRequest(http.MethodPost, "/v1/engine/projections/backfill"))
 	assert.False(t, isPublicDemoReadRequest(http.MethodGet, "/api/projects"))
 	assert.False(t, isPublicDemoReadRequest(http.MethodGet, "/v1/ingest"))
 }
@@ -155,6 +163,71 @@ func TestCompositeAuthAcceptsAllowlistedOperatorBearerOnDebuggerRoutes(t *testin
 	assert.Equal(t, "google-oauth2|operator", receivedSubject)
 }
 
+func TestCompositeAuthAcceptsAllowlistedOperatorBearerOnEngineProjectionBackfill(t *testing.T) {
+	authenticator := &Authenticator{
+		auth0: &auth0Authenticator{
+			validateToken: func(context.Context, string) (any, error) {
+				return validatedAuth0Claims("Operator@Example.com", time.Now().Add(time.Hour)), nil
+			},
+			allowedEmails: map[string]struct{}{"operator@example.com": {}},
+		},
+	}
+
+	var receivedMode AuthMode
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
+		receivedMode, ok = GetAuthMode(r.Context())
+		require.True(t, ok)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/projections/backfill", nil)
+	req.Header.Set("Authorization", "Bearer header.payload.signature")
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, AuthModeOperator, receivedMode)
+}
+
+func TestCompositeAuthAcceptsAllowlistedOperatorBearerOnEngineConsoleRoutes(t *testing.T) {
+	authenticator := &Authenticator{
+		auth0: &auth0Authenticator{
+			validateToken: func(context.Context, string) (any, error) {
+				return validatedAuth0Claims("Operator@Example.com", time.Now().Add(time.Hour)), nil
+			},
+			allowedEmails: map[string]struct{}{"operator@example.com": {}},
+		},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "start run", method: http.MethodPost, path: "/v1/engine/runs"},
+		{name: "instance lookup", method: http.MethodGet, path: "/v1/engine/instances/customer-123"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var receivedMode AuthMode
+			protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var ok bool
+				receivedMode, ok = GetAuthMode(r.Context())
+				require.True(t, ok)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer header.payload.signature")
+			rec := httptest.NewRecorder()
+
+			protectedHandler.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusNoContent, rec.Code)
+			assert.Equal(t, AuthModeOperator, receivedMode)
+		})
+	}
+}
+
 func TestCompositeAuthAcceptsLegacyAPIKeyBearerFallbackOnDebuggerRoutes(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ctx := context.Background()
@@ -183,6 +256,77 @@ func TestCompositeAuthAcceptsLegacyAPIKeyBearerFallbackOnDebuggerRoutes(t *testi
 	require.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Equal(t, AuthModeAPIKey, receivedMode)
 	assert.Equal(t, project.ID, receivedProjectID)
+}
+
+func TestCompositeAuthAcceptsAPIKeyOnEngineProjectionBackfill(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	platformStore := store.New(pool)
+
+	apiKey := "projection-backfill-key-" + uuid.NewString()
+	project := createCompositeAuthProject(ctx, t, platformStore, apiKey)
+	authenticator := &Authenticator{store: platformStore}
+
+	var receivedMode AuthMode
+	var receivedProjectID uuid.UUID
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
+		receivedMode, ok = GetAuthMode(r.Context())
+		require.True(t, ok)
+		receivedProjectID, ok = GetProjectID(r.Context())
+		require.True(t, ok)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/projections/backfill", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, AuthModeAPIKey, receivedMode)
+	assert.Equal(t, project.ID, receivedProjectID)
+}
+
+func TestCompositeAuthAcceptsAPIKeyOnEngineConsoleRoutes(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	platformStore := store.New(pool)
+
+	apiKey := "engine-console-key-" + uuid.NewString()
+	project := createCompositeAuthProject(ctx, t, platformStore, apiKey)
+	authenticator := &Authenticator{store: platformStore}
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "start run", method: http.MethodPost, path: "/v1/engine/runs"},
+		{name: "instance lookup", method: http.MethodGet, path: "/v1/engine/instances/customer-123"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var receivedMode AuthMode
+			var receivedProjectID uuid.UUID
+			protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var ok bool
+				receivedMode, ok = GetAuthMode(r.Context())
+				require.True(t, ok)
+				receivedProjectID, ok = GetProjectID(r.Context())
+				require.True(t, ok)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("X-API-Key", apiKey)
+			rec := httptest.NewRecorder()
+
+			protectedHandler.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusNoContent, rec.Code)
+			assert.Equal(t, AuthModeAPIKey, receivedMode)
+			assert.Equal(t, project.ID, receivedProjectID)
+		})
+	}
 }
 
 func TestCompositeAuthAllowsPublicDemoReadWithoutCredentials(t *testing.T) {

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -788,10 +788,15 @@ type EngineTraceInfo struct {
 	ChildKey          *string               `json:"child_key,omitempty"`
 	DefinitionName    string                `json:"definition_name"`
 	DefinitionVersion string                `json:"definition_version"`
+	InstanceKey       *string               `json:"instance_key,omitempty"`
 	ParentRunId       *openapi_types.UUID   `json:"parent_run_id,omitempty"`
+	PendingWork       *EnginePendingWork    `json:"pending_work,omitempty"`
 	ProjectionState   EngineProjectionState `json:"projection_state"`
 	RootRunId         *openapi_types.UUID   `json:"root_run_id,omitempty"`
 	RunId             openapi_types.UUID    `json:"run_id"`
+	Status            *EngineRunStatus      `json:"status,omitempty"`
+	UpdatedAt         *time.Time            `json:"updated_at,omitempty"`
+	WaitState         *EngineWaitState      `json:"wait_state,omitempty"`
 }
 
 // EngineWaitState defines model for EngineWaitState.
@@ -1386,6 +1391,9 @@ type ListTracesParams struct {
 
 	// EngineProjectionState Filter by engine projection state
 	EngineProjectionState *EngineProjectionState `form:"engine_projection_state,omitempty" json:"engine_projection_state,omitempty"`
+
+	// EngineOnly When true, return only traces backed by an engine run.
+	EngineOnly *bool `form:"engine_only,omitempty" json:"engine_only,omitempty"`
 
 	// HasErrors Filter traces with errors (error_count > 0)
 	HasErrors *bool `form:"has_errors,omitempty" json:"has_errors,omitempty"`
@@ -2625,6 +2633,14 @@ func (siw *ServerInterfaceWrapper) ListTraces(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// ------------- Optional query parameter "engine_only" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "engine_only", r.URL.Query(), &params.EngineOnly)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "engine_only", Err: err})
+		return
+	}
+
 	// ------------- Optional query parameter "has_errors" -------------
 
 	err = runtime.BindQueryParameter("form", true, false, "has_errors", r.URL.Query(), &params.HasErrors)
@@ -3043,6 +3059,8 @@ func (siw *ServerInterfaceWrapper) GetEngineInstance(w http.ResponseWriter, r *h
 
 	ctx := r.Context()
 
+	ctx = context.WithValue(ctx, Auth0BearerScopes, []string{})
+
 	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
 
 	r = r.WithContext(ctx)
@@ -3064,6 +3082,8 @@ func (siw *ServerInterfaceWrapper) BackfillEngineProjections(w http.ResponseWrit
 	var err error
 
 	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, Auth0BearerScopes, []string{})
 
 	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
 
@@ -3114,6 +3134,8 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 	var err error
 
 	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, Auth0BearerScopes, []string{})
 
 	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
 

--- a/internal/api/server_helpers.go
+++ b/internal/api/server_helpers.go
@@ -263,6 +263,9 @@ func traceFilterFromParams(projectID uuid.UUID, params *ListTracesParams, limit,
 	if params.EngineProjectionState != nil {
 		filter.EngineProjectionState = string(*params.EngineProjectionState)
 	}
+	if params.EngineOnly != nil {
+		filter.EngineOnly = *params.EngineOnly
+	}
 	if params.SessionId != nil {
 		id := *params.SessionId
 		filter.SessionID = &id
@@ -297,6 +300,7 @@ func traceNeedsDynamicQuery(filter *store.TraceFilter) bool {
 		filter.EngineChildKey != "" ||
 		filter.EngineChildDepth != nil ||
 		filter.EngineProjectionState != "" ||
+		filter.EngineOnly ||
 		filter.HasErrors != nil ||
 		filter.MinDurationMs != nil
 }

--- a/internal/api/server_helpers_test.go
+++ b/internal/api/server_helpers_test.go
@@ -1,6 +1,10 @@
 package api
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
 
 func TestNormalizePagination_Defaults(t *testing.T) {
 	limit, offset := normalizePagination(nil, nil)
@@ -39,5 +43,35 @@ func TestNormalizePagination_ClampsNonPositiveLimit(t *testing.T) {
 	limitNeg, _ := normalizePagination(&neg, nil)
 	if limitNeg != 1 {
 		t.Fatalf("expected limit 1 for negative input, got %d", limitNeg)
+	}
+}
+
+func TestTraceFilterFromParams_EngineOnlyUsesDynamicQuery(t *testing.T) {
+	engineOnly := true
+
+	filter := traceFilterFromParams(uuid.New(), &ListTracesParams{
+		EngineOnly: &engineOnly,
+	}, 50, 0)
+
+	if !filter.EngineOnly {
+		t.Fatal("expected engine_only to map into the store filter")
+	}
+	if !traceNeedsDynamicQuery(&filter) {
+		t.Fatal("expected engine_only=true to use the dynamic trace query")
+	}
+}
+
+func TestTraceFilterFromParams_EngineOnlyFalseIsDefaultPath(t *testing.T) {
+	engineOnly := false
+
+	filter := traceFilterFromParams(uuid.New(), &ListTracesParams{
+		EngineOnly: &engineOnly,
+	}, 50, 0)
+
+	if filter.EngineOnly {
+		t.Fatal("expected engine_only=false to leave the store filter disabled")
+	}
+	if traceNeedsDynamicQuery(&filter) {
+		t.Fatal("expected engine_only=false alone to preserve the default trace query path")
 	}
 }

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -28,6 +28,7 @@ type TraceFilter struct {
 	EngineChildKey          string     // Filter by engine_child_key
 	EngineChildDepth        *int32     // Filter by engine_child_depth
 	EngineProjectionState   string     // Filter by engine_projection_state
+	EngineOnly              bool       // Filter to engine-backed traces
 	HasErrors               *bool      // Filter by error_count > 0
 	MinDurationMs           *int64     // Filter by duration in milliseconds
 	SortDir                 SortDirection
@@ -202,6 +203,10 @@ func (s *Store) ListTracesFiltered(ctx context.Context, filter TraceFilter) (Tra
 		whereClauses = append(whereClauses, fmt.Sprintf("t.engine_projection_state = $%d", argNum))
 		args = append(args, strings.TrimSpace(filter.EngineProjectionState))
 		argNum++
+	}
+
+	if filter.EngineOnly {
+		whereClauses = append(whereClauses, "t.engine_run_id IS NOT NULL")
 	}
 
 	// Session ID filter

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -1000,12 +1000,46 @@ func TestSearch_FilterByEngineMetadata(t *testing.T) {
 	require.Len(t, combined.Traces, 1)
 	assert.Equal(t, engineTrace.ID, combined.Traces[0].ID)
 
+	engineOnly, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:  projectID,
+		EngineOnly: true,
+		Limit:      2,
+	})
+	require.NoError(t, err)
+	assert.Len(t, engineOnly.Traces, 2)
+	assert.Equal(t, int64(3), engineOnly.Total)
+	for _, trace := range engineOnly.Traces {
+		assert.True(t, trace.EngineRunID.Valid)
+		assert.NotEqual(t, nonEngineTrace.ID, trace.ID)
+	}
+
+	engineOnlyWaiting, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:       projectID,
+		EngineOnly:      true,
+		EngineRunStatus: "waiting",
+		Limit:           10,
+	})
+	require.NoError(t, err)
+	require.Len(t, engineOnlyWaiting.Traces, 1)
+	assert.Equal(t, int64(1), engineOnlyWaiting.Total)
+	assert.Equal(t, engineTrace.ID, engineOnlyWaiting.Traces[0].ID)
+
 	allTraces, err := s.ListTracesFiltered(ctx, store.TraceFilter{
 		ProjectID: projectID,
 		Limit:     10,
 	})
 	require.NoError(t, err)
 	assert.Len(t, allTraces.Traces, 4)
+	assert.Equal(t, int64(4), allTraces.Total)
+
+	engineOnlyFalse, err := s.ListTracesFiltered(ctx, store.TraceFilter{
+		ProjectID:  projectID,
+		EngineOnly: false,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, engineOnlyFalse.Traces, 4)
+	assert.Equal(t, int64(4), engineOnlyFalse.Total)
 
 	engineFilteredIDs := []uuid.UUID{byInstance.Traces[0].ID, combined.Traces[0].ID}
 	assert.NotContains(t, engineFilteredIDs, nonEngineTrace.ID)

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -122,17 +122,6 @@ class EngineRunStatus(Enum):
     CONTINUED_AS_NEW = "CONTINUED_AS_NEW"
 
 
-class EngineTraceInfo(BaseModel):
-    run_id: UUID
-    definition_name: str
-    definition_version: str
-    projection_state: EngineProjectionState
-    parent_run_id: UUID | None = None
-    root_run_id: UUID | None = None
-    child_key: str | None = None
-    child_depth: int | None = None
-
-
 class EngineWaitState(BaseModel):
     model_config = ConfigDict(
         extra="allow",
@@ -273,60 +262,10 @@ class EngineFailureSummary(BaseModel):
     status: str
 
 
-class EngineRunSummary(EngineTraceInfo):
-    status: EngineRunStatus
-    instance_key: str
-    continued_from_run_id: UUID | None = None
-    continued_to_run_id: UUID | None = None
-    continued_from_trace_id: str | None = None
-    continued_to_trace_id: str | None = None
-    custom_status: dict[str, Any] | None = None
-    wait_state: EngineWaitState | None = None
-    pending_work: EnginePendingWork
-    result: Any | None = Field(
-        None, description="Terminal workflow result payload when available."
-    )
-    failure: EngineFailureSummary | None = None
-    created_at: AwareDatetime
-    updated_at: AwareDatetime
-    completed_at: AwareDatetime | None = None
-
-
 class Status(Enum):
     RUNNING = "RUNNING"
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
-
-
-class Trace(BaseModel):
-    id: UUID
-    session_id: UUID | None = None
-    session_external_id: str | None = None
-    name: str
-    status: Status
-    started_at: AwareDatetime
-    ended_at: AwareDatetime | None = None
-    total_tokens_in: int | None = None
-    total_tokens_out: int | None = None
-    total_cost_usd: float | None = None
-    error_count: int | None = Field(
-        None, description="Count of failed spans in this trace"
-    )
-    metadata: dict[str, Any] | None = None
-    engine: EngineTraceInfo | None = None
-
-
-class TraceDetail(Trace):
-    trace_id: str | None = None
-    user_id: str | None = None
-    tags: list[str] | None = None
-    environment: str | None = None
-    release: str | None = None
-    input: Any | None = Field(None, description="Trace input payload (any valid JSON)")
-    output: Any | None = Field(
-        None, description="Trace output payload (any valid JSON)"
-    )
-    engine: EngineRunSummary | None = None
 
 
 class EngineStartSession(BaseModel):
@@ -360,25 +299,6 @@ class EngineStartRunResponse(BaseModel):
     run_id: UUID
     instance_key: str
     trace_id: str
-
-
-class EngineInstanceResponse(BaseModel):
-    instance_id: UUID
-    instance_key: str
-    definition_name: str
-    status: str
-    current_run: EngineRunSummary
-
-
-class EngineRunResponse(EngineRunSummary):
-    """
-    Engine run detail. Clients can identify `definition_version_mismatch`
-    from the existing `definition_name`, `definition_version`, and
-    `failure.error_code` fields without a dedicated mismatch endpoint.
-
-    """
-
-    instance_id: UUID
 
 
 class EngineRunResultResponse(BaseModel):
@@ -444,11 +364,6 @@ class EngineControlResponse(BaseModel):
     instance_key: str
     accepted: bool
     wake_applied: bool
-
-
-class TraceList(BaseModel):
-    traces: list[Trace]
-    total: int
 
 
 class Kind(Enum):
@@ -597,22 +512,6 @@ class CompareSessionHeader(BaseModel):
     id: UUID
     external_id: str
     name: str | None = None
-
-
-class CompareTraceHeader(BaseModel):
-    id: UUID
-    trace_id: str
-    name: str
-    status: Status2
-    user_id: str | None = None
-    started_at: AwareDatetime
-    ended_at: AwareDatetime | None = None
-    duration_ms: int | None = None
-    error_count: int | None = None
-    total_cost_usd: float | None = None
-    total_tokens_in: int | None = None
-    total_tokens_out: int | None = None
-    engine: EngineTraceInfo | None = None
 
 
 class CompareSummary(BaseModel):
@@ -932,6 +831,96 @@ class BatchStatusResponse(BaseModel):
     last_error_message: str | None = None
 
 
+class EngineTraceInfo(BaseModel):
+    run_id: UUID
+    definition_name: str
+    definition_version: str
+    projection_state: EngineProjectionState
+    instance_key: str | None = None
+    status: EngineRunStatus | None = None
+    wait_state: EngineWaitState | None = None
+    pending_work: EnginePendingWork | None = None
+    updated_at: AwareDatetime | None = None
+    parent_run_id: UUID | None = None
+    root_run_id: UUID | None = None
+    child_key: str | None = None
+    child_depth: int | None = None
+
+
+class EngineRunSummary(EngineTraceInfo):
+    status: EngineRunStatus
+    instance_key: str
+    continued_from_run_id: UUID | None = None
+    continued_to_run_id: UUID | None = None
+    continued_from_trace_id: str | None = None
+    continued_to_trace_id: str | None = None
+    custom_status: dict[str, Any] | None = None
+    wait_state: EngineWaitState | None = None
+    pending_work: EnginePendingWork
+    result: Any | None = Field(
+        None, description="Terminal workflow result payload when available."
+    )
+    failure: EngineFailureSummary | None = None
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+    completed_at: AwareDatetime | None = None
+
+
+class Trace(BaseModel):
+    id: UUID
+    session_id: UUID | None = None
+    session_external_id: str | None = None
+    name: str
+    status: Status
+    started_at: AwareDatetime
+    ended_at: AwareDatetime | None = None
+    total_tokens_in: int | None = None
+    total_tokens_out: int | None = None
+    total_cost_usd: float | None = None
+    error_count: int | None = Field(
+        None, description="Count of failed spans in this trace"
+    )
+    metadata: dict[str, Any] | None = None
+    engine: EngineTraceInfo | None = None
+
+
+class TraceDetail(Trace):
+    trace_id: str | None = None
+    user_id: str | None = None
+    tags: list[str] | None = None
+    environment: str | None = None
+    release: str | None = None
+    input: Any | None = Field(None, description="Trace input payload (any valid JSON)")
+    output: Any | None = Field(
+        None, description="Trace output payload (any valid JSON)"
+    )
+    engine: EngineRunSummary | None = None
+
+
+class EngineInstanceResponse(BaseModel):
+    instance_id: UUID
+    instance_key: str
+    definition_name: str
+    status: str
+    current_run: EngineRunSummary
+
+
+class EngineRunResponse(EngineRunSummary):
+    """
+    Engine run detail. Clients can identify `definition_version_mismatch`
+    from the existing `definition_name`, `definition_version`, and
+    `failure.error_code` fields without a dedicated mismatch endpoint.
+
+    """
+
+    instance_id: UUID
+
+
+class TraceList(BaseModel):
+    traces: list[Trace]
+    total: int
+
+
 class SessionNarrativeTrace(BaseModel):
     id: UUID
     trace_id: str = Field(
@@ -959,6 +948,22 @@ class ComparisonTooLargeError(BaseModel):
     code: str
     message: str
     detail: ComparisonTooLargeErrorDetail
+
+
+class CompareTraceHeader(BaseModel):
+    id: UUID
+    trace_id: str
+    name: str
+    status: Status2
+    user_id: str | None = None
+    started_at: AwareDatetime
+    ended_at: AwareDatetime | None = None
+    duration_ms: int | None = None
+    error_count: int | None = None
+    total_cost_usd: float | None = None
+    total_tokens_in: int | None = None
+    total_tokens_out: int | None = None
+    engine: EngineTraceInfo | None = None
 
 
 class SemanticDiffGroup(BaseModel):

--- a/sdks/python/tests/test_engine_control.py
+++ b/sdks/python/tests/test_engine_control.py
@@ -72,6 +72,41 @@ def _control_response(wake_applied: bool = True) -> dict[str, object]:
     }
 
 
+def test_engine_trace_info_preserves_expanded_schema_fields():
+    from continua.types import EngineRunStatus, EngineTraceInfo
+
+    payload = {
+        "run_id": RUN_ID,
+        "definition_name": "checkout",
+        "definition_version": "v1",
+        "projection_state": "summary_only",
+        "instance_key": "instance-1",
+        "status": "CONTINUED_AS_NEW",
+        "wait_state": {
+            "kind": "signal",
+            "signal_name": "approval_received",
+        },
+        "pending_work": {
+            "pending_activity_tasks": 2,
+            "pending_inbox_items": 3,
+        },
+        "updated_at": "2026-04-06T10:00:00Z",
+    }
+
+    info = EngineTraceInfo.model_validate(payload)
+    serialized = info.model_dump(mode="json")
+    reparsed = EngineTraceInfo.model_validate(serialized)
+
+    assert info.status == EngineRunStatus.CONTINUED_AS_NEW
+    assert serialized["instance_key"] == "instance-1"
+    assert serialized["status"] == "CONTINUED_AS_NEW"
+    assert serialized["wait_state"]["signal_name"] == "approval_received"
+    assert serialized["pending_work"]["pending_activity_tasks"] == 2
+    assert serialized["pending_work"]["pending_inbox_items"] == 3
+    assert serialized["updated_at"] == "2026-04-06T10:00:00Z"
+    assert reparsed == info
+
+
 def _backfill_response(
     *,
     dry_run: bool,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,10 +2,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { TracesPage } from './pages/TracesPage';
 import { TraceDetailPage } from './pages/TraceDetailPage';
+import { EngineRunsPage } from './pages/EngineRunsPage';
 import { SessionsPage } from './pages/SessionsPage';
 import { SessionDetailPage } from './pages/SessionDetailPage';
 import { SessionComparePage } from './pages/SessionComparePage';
 import { SettingsPage } from './pages/SettingsPage';
+import { EngineProjectionRepairPage } from './pages/EngineProjectionRepairPage';
 import { ProjectsPage } from './pages/ProjectsPage';
 import { ThemeProvider } from './hooks/ThemeProvider';
 import { AppShell } from './components/AppShell';
@@ -33,12 +35,14 @@ export function App() {
                 <Route element={<AppShell />}>
                   <Route path="/dashboard" element={<OverviewPage />} />
                   <Route path="/traces" element={<TracesPage />} />
+                  <Route path="/engine/runs" element={<EngineRunsPage />} />
                   <Route path="/traces/:id" element={<TraceDetailPage />} />
                   <Route path="/sessions" element={<SessionsPage />} />
                   <Route path="/sessions/:id" element={<SessionDetailPage />} />
                   <Route path="/sessions/:id/compare" element={<SessionComparePage />} />
                   <Route path="/projects" element={<ProjectsPage />} />
                   <Route path="/settings" element={<SettingsPage />} />
+                  <Route path="/tools/engine-projections" element={<EngineProjectionRepairPage />} />
                 </Route>
               </Route>
             </Routes>

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ApiError,
+  backfillEngineProjections,
   clearApiKey,
   fetchAPI,
   fetchRuntimeAuthConfig,
@@ -65,7 +66,7 @@ describe('client', () => {
     });
   });
 
-  it('does not append project_id to engine requests', async () => {
+  it('sends the selected project_id on engine operator requests', async () => {
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ run_id: 'run-1' }), {
         status: 200,
@@ -85,7 +86,54 @@ describe('client', () => {
       'http://localhost'
     );
     expect(requestUrl.pathname).toBe('/v1/engine/runs/run-1/pending-work');
-    expect(requestUrl.searchParams.get('project_id')).toBeNull();
+    expect(requestUrl.searchParams.get('project_id')).toBe(PROJECT_ID);
+  });
+
+  it('posts projection backfill requests with the engine preview header', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          dry_run: true,
+          limit: 50,
+          eligible_count: 0,
+          repair_requested_count: 0,
+          skipped_count: 0,
+          results: [],
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+    );
+    setAccessTokenProvider(async () => 'operator-token');
+    setSelectedProjectIdProvider(() => PROJECT_ID);
+
+    await backfillEngineProjections({
+      dry_run: true,
+      limit: 50,
+      engine_projection_state: 'summary_only',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const requestUrl = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+      'http://localhost'
+    );
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(requestUrl.pathname).toBe('/v1/engine/projections/backfill');
+    expect(requestUrl.searchParams.get('project_id')).toBe(PROJECT_ID);
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toMatchObject({
+      'X-Continua-Engine-Preview': '1',
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      dry_run: true,
+      limit: 50,
+      engine_projection_state: 'summary_only',
+    });
   });
 
   it('loads runtime auth config from the public endpoint without debugger auth', async () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -318,7 +318,7 @@ function buildRequestUrl(path: string): URL {
 
   if (
     selectedProjectId &&
-    url.pathname.startsWith('/api/') &&
+    (url.pathname.startsWith('/api/') || url.pathname.startsWith('/v1/engine/')) &&
     !url.searchParams.has('project_id')
   ) {
     url.searchParams.set('project_id', selectedProjectId);
@@ -362,6 +362,11 @@ export type EngineRepairReason =
   | 'repair_requested'
   | 'already_catching_up';
 
+export type EngineProjectionBackfillAction =
+  | 'would_repair'
+  | 'repair_requested'
+  | 'skipped';
+
 export type EnginePurgeMode = 'projection_only' | 'full';
 
 export interface EngineTraceInfo {
@@ -369,6 +374,11 @@ export interface EngineTraceInfo {
   definition_name: string;
   definition_version: string;
   projection_state: EngineProjectionState;
+  instance_key?: string;
+  status?: EngineRunStatus;
+  wait_state?: EngineWaitState;
+  pending_work?: EnginePendingWork;
+  updated_at?: string;
   parent_run_id?: string;
   root_run_id?: string;
   child_key?: string;
@@ -459,6 +469,28 @@ export interface EngineRunResponse extends EngineRunSummary {
   instance_id: string;
 }
 
+export interface EngineInstanceResponse {
+  instance_id: string;
+  instance_key: string;
+  definition_name: string;
+  status: string;
+  current_run: EngineRunSummary;
+}
+
+export interface EngineStartRunRequest {
+  instance_key: string;
+  definition_name: string;
+  definition_version: string;
+  request_key: string;
+  input?: JsonValue;
+}
+
+export interface EngineStartRunResponse {
+  run_id: string;
+  instance_key: string;
+  trace_id: string;
+}
+
 export interface EngineRunResultResponse {
   run_id: string;
   continued_from_run_id?: string;
@@ -468,6 +500,21 @@ export interface EngineRunResultResponse {
   status: EngineRunStatus;
   result: JsonValue | null;
   failure?: EngineFailureSummary;
+}
+
+export interface EngineHistoryEvent {
+  id: number;
+  sequence_no: number;
+  event_type: string;
+  payload?: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface EngineRunHistoryResponse {
+  events: EngineHistoryEvent[];
+  has_more: boolean;
+  next_after?: number;
+  expired?: boolean;
 }
 
 export interface EngineControlResponse {
@@ -494,6 +541,33 @@ export interface EngineRepairResponse {
   accepted: boolean;
   reason: EngineRepairReason;
   projection_state: EngineProjectionState;
+}
+
+export interface EngineProjectionBackfillRequest {
+  dry_run: boolean;
+  limit?: number;
+  older_than?: string;
+  engine_instance_key?: string;
+  engine_definition_name?: string;
+  engine_run_status?: EngineRunStatus;
+  engine_projection_state?: EngineProjectionState;
+}
+
+export interface EngineProjectionBackfillRunResult {
+  run_id: string;
+  trace_id: string;
+  projection_state: EngineProjectionState;
+  action: EngineProjectionBackfillAction;
+  reason?: EngineRepairReason;
+}
+
+export interface EngineProjectionBackfillResponse {
+  dry_run: boolean;
+  limit: number;
+  eligible_count: number;
+  repair_requested_count: number;
+  skipped_count: number;
+  results: EngineProjectionBackfillRunResult[];
 }
 
 export interface Trace {
@@ -1055,4 +1129,53 @@ export async function fetchEnginePendingWork(
   runId: string
 ): Promise<EnginePendingWorkResponse> {
   return fetchAPI<EnginePendingWorkResponse>(`/v1/engine/runs/${runId}/pending-work`);
+}
+
+export async function fetchEngineInstance(
+  instanceKey: string
+): Promise<EngineInstanceResponse> {
+  return fetchAPI<EngineInstanceResponse>(
+    `/v1/engine/instances/${encodeURIComponent(instanceKey)}`
+  );
+}
+
+export async function startEngineRun(
+  request: EngineStartRunRequest
+): Promise<EngineStartRunResponse> {
+  return fetchAPI<EngineStartRunResponse>(
+    '/v1/engine/runs',
+    withEnginePreviewHeader(withJsonBody(request))
+  );
+}
+
+export async function fetchEngineRunHistory(
+  runId: string,
+  options: { after?: number; limit?: number } = {}
+): Promise<EngineRunHistoryResponse> {
+  const params = new URLSearchParams();
+  if (options.after !== undefined) {
+    params.set('after', String(options.after));
+  }
+  if (options.limit !== undefined) {
+    params.set('limit', String(options.limit));
+  }
+  const query = params.size > 0 ? `?${params.toString()}` : '';
+  return fetchAPI<EngineRunHistoryResponse>(
+    `/v1/engine/runs/${runId}/history${query}`
+  );
+}
+
+export async function fetchEngineRunResult(
+  runId: string
+): Promise<EngineRunResultResponse> {
+  return fetchAPI<EngineRunResultResponse>(`/v1/engine/runs/${runId}/result`);
+}
+
+export async function backfillEngineProjections(
+  request: EngineProjectionBackfillRequest
+): Promise<EngineProjectionBackfillResponse> {
+  return fetchAPI<EngineProjectionBackfillResponse>(
+    '/v1/engine/projections/backfill',
+    withEnginePreviewHeader(withJsonBody(request))
+  );
 }

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -101,6 +101,15 @@ async function renderShell(
                     }
                   />
                   <Route
+                    path="/engine/runs"
+                    element={
+                      <>
+                        <div>Engine runs content</div>
+                        <LocationProbe />
+                      </>
+                    }
+                  />
+                  <Route
                     path="/sessions"
                     element={
                       <>
@@ -218,10 +227,17 @@ describe('AppShell', () => {
       'href',
       `/traces?project_id=${PRIMARY_PROJECT_ID}`
     );
+    expect(within(primaryNav).getByText('Engine Runs').closest('a')).toHaveAttribute(
+      'href',
+      `/engine/runs?project_id=${PRIMARY_PROJECT_ID}`
+    );
     expect(within(primaryNav).getByText('Sessions').closest('a')).toHaveAttribute(
       'aria-current',
       'page'
     );
+    expect(within(primaryNav).queryByText('Definitions')).not.toBeInTheDocument();
+    expect(within(primaryNav).queryByText('Schedules')).not.toBeInTheDocument();
+    expect(within(primaryNav).queryByText('Engine')).not.toBeInTheDocument();
     expect(screen.getByTestId('location-probe')).toHaveTextContent(
       `/sessions?project_id=${PRIMARY_PROJECT_ID}`
     );

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -4,7 +4,6 @@ import {
   Activity,
   ChevronDown,
   ChevronRight,
-  Clock,
   FolderKanban,
   LayoutDashboard,
   Menu,
@@ -13,8 +12,8 @@ import {
   Settings2,
   Sun,
   Waypoints,
+  Workflow,
   X,
-  Zap,
   type LucideIcon,
 } from 'lucide-react';
 import { Link, NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -50,6 +49,7 @@ const RUN_LOCALLY_DOCS_URL =
 const NAV_ITEMS: NavItem[] = [
   { path: '/dashboard', label: 'Overview', icon: LayoutDashboard },
   { path: '/traces', label: 'Traces', icon: Activity },
+  { path: '/engine/runs', label: 'Engine Runs', icon: Workflow },
   { path: '/sessions', label: 'Sessions', icon: Waypoints },
   { path: '/projects', label: 'Projects', icon: FolderKanban },
   { path: '/settings', label: 'Settings', icon: Settings2 },
@@ -580,14 +580,6 @@ function SidebarNav({
         ))}
       </div>
 
-      <div>
-        <div className="px-2.5 py-1.5 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-[var(--c-text-muted)]">
-          Engine
-        </div>
-        <DisabledEngineItem icon={Zap} label="Definitions" />
-        <DisabledEngineItem icon={Clock} label="Schedules" />
-      </div>
-
       {!isPublicDemo && settingsItem ? (
         <div>
           <div className="px-2.5 py-1.5 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-[var(--c-text-muted)]">
@@ -627,26 +619,6 @@ function SidebarNavLink({
       <Icon className="h-4 w-4 text-[var(--c-text-muted)]" />
       {item.label}
     </NavLink>
-  );
-}
-
-function DisabledEngineItem({
-  icon: Icon,
-  label,
-}: {
-  icon: LucideIcon;
-  label: string;
-}) {
-  return (
-    <button
-      type="button"
-      disabled
-      title="Engine controls are available on engine-backed traces."
-      className="mb-0.5 flex w-full items-center gap-2.5 rounded-[5px] px-2.5 py-1.5 text-left text-[13px] font-medium text-[var(--c-text-muted)] opacity-70"
-    >
-      <Icon className="h-4 w-4" />
-      {label}
-    </button>
   );
 }
 
@@ -795,6 +767,12 @@ function buildBreadcrumbs(pathname: string): string[] {
   }
   if (segments[0] === 'traces') {
     return segments[1] ? ['Traces', segments[1]] : ['Traces'];
+  }
+  if (segments[0] === 'engine') {
+    return ['Engine Runs'];
+  }
+  if (segments[0] === 'tools' && segments[1] === 'engine-projections') {
+    return ['Settings', 'Engine projection repair'];
   }
   if (segments[0] === 'sessions') {
     if (segments[2] === 'compare') {

--- a/web/src/components/WorkspaceShell.tsx
+++ b/web/src/components/WorkspaceShell.tsx
@@ -2,9 +2,7 @@ import { useState, type ReactNode } from 'react';
 
 export type MobileWorkspaceTabId =
   | 'summary'
-  | 'execution'
-  | 'timeline'
-  | 'state';
+  | 'execution';
 
 interface WorkspaceShellProps {
   isDesktop: boolean;
@@ -12,8 +10,6 @@ interface WorkspaceShellProps {
   waterfall: ReactNode;
   inspector: ReactNode;
   mobileSummary: ReactNode;
-  mobileTimeline: ReactNode;
-  mobileState: ReactNode;
   activeMobileTab: MobileWorkspaceTabId;
   onMobileTabChange: (tab: MobileWorkspaceTabId) => void;
 }
@@ -21,8 +17,6 @@ interface WorkspaceShellProps {
 const MOBILE_TABS: Array<{ id: MobileWorkspaceTabId; label: string }> = [
   { id: 'summary', label: 'Summary' },
   { id: 'execution', label: 'Execution' },
-  { id: 'timeline', label: 'Timeline' },
-  { id: 'state', label: 'State' },
 ];
 export function WorkspaceShell({
   isDesktop,
@@ -30,8 +24,6 @@ export function WorkspaceShell({
   waterfall,
   inspector,
   mobileSummary,
-  mobileTimeline,
-  mobileState,
   activeMobileTab,
   onMobileTabChange,
 }: WorkspaceShellProps) {
@@ -46,7 +38,10 @@ export function WorkspaceShell({
 
   return (
     <section className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[var(--c-app-bg)]">
-      <div className="border-b border-[var(--c-border)] bg-[var(--c-app-bg)] px-4">
+      <nav
+        aria-label="Mobile trace workspace"
+        className="border-b border-[var(--c-border)] bg-[var(--c-app-bg)] px-4"
+      >
         <div className="flex overflow-x-auto">
           {MOBILE_TABS.map((tab) => (
             <button
@@ -64,7 +59,7 @@ export function WorkspaceShell({
             </button>
           ))}
         </div>
-      </div>
+      </nav>
 
       <div className="min-h-0 flex-1">
         <div
@@ -78,18 +73,6 @@ export function WorkspaceShell({
           treeRail={treeRail}
           waterfall={waterfall}
         />
-        <div
-          className="h-full"
-          style={{ display: activeMobileTab === 'timeline' ? 'block' : 'none' }}
-        >
-          {mobileTimeline}
-        </div>
-        <div
-          className="h-full"
-          style={{ display: activeMobileTab === 'state' ? 'block' : 'none' }}
-        >
-          {mobileState}
-        </div>
       </div>
     </section>
   );

--- a/web/src/components/statusTone.ts
+++ b/web/src/components/statusTone.ts
@@ -1,8 +1,23 @@
 export const STATUS_TONE = {
+  QUEUED: {
+    dot: 'var(--c-muted)',
+    text: 'var(--c-muted-text)',
+    label: 'Queued',
+  },
   RUNNING: {
     dot: 'var(--c-blue)',
     text: 'var(--c-blue-text)',
     label: 'Running',
+  },
+  WAITING: {
+    dot: 'var(--c-amber)',
+    text: 'var(--c-amber-text)',
+    label: 'Waiting',
+  },
+  SUSPENDED: {
+    dot: 'var(--c-amber)',
+    text: 'var(--c-amber-text)',
+    label: 'Suspended',
   },
   STARTED: {
     dot: 'var(--c-blue)',
@@ -18,6 +33,21 @@ export const STATUS_TONE = {
     dot: 'var(--c-red)',
     text: 'var(--c-red-text)',
     label: 'Failed',
+  },
+  CANCELLED: {
+    dot: 'var(--c-red)',
+    text: 'var(--c-red-text)',
+    label: 'Cancelled',
+  },
+  TERMINATED: {
+    dot: 'var(--c-red)',
+    text: 'var(--c-red-text)',
+    label: 'Terminated',
+  },
+  CONTINUED_AS_NEW: {
+    dot: 'var(--c-green)',
+    text: 'var(--c-green-text)',
+    label: 'Continued as new',
   },
   SCHEDULED: {
     dot: 'var(--c-muted)',

--- a/web/src/pages/EngineProjectionRepairPage.tsx
+++ b/web/src/pages/EngineProjectionRepairPage.tsx
@@ -1,0 +1,489 @@
+import { useState, type ChangeEvent, type FormEvent, type ReactNode } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { AlertTriangle, RefreshCw, Wrench, X } from 'lucide-react';
+import {
+  ApiError,
+  backfillEngineProjections,
+  isAuthError,
+  type EngineProjectionBackfillRequest,
+  type EngineProjectionBackfillResponse,
+  type EngineProjectionState,
+  type EngineRunStatus,
+} from '../api/client';
+import { AuthErrorBanner } from '../components/AuthErrorBanner';
+import { Btn, Chip, DataTable, PageHeader, Td, Th, Tr } from '../components/DebuggerKit';
+import { formatProjectionStateLabel } from '../components/engineProjectionState';
+import {
+  buildProjectPath,
+  getProjectIdFromSearchParams,
+} from '../utils/projectSearchParams';
+
+const RUN_STATUSES: EngineRunStatus[] = [
+  'QUEUED',
+  'RUNNING',
+  'WAITING',
+  'SUSPENDED',
+  'COMPLETED',
+  'FAILED',
+  'CANCELLED',
+  'TERMINATED',
+  'CONTINUED_AS_NEW',
+];
+
+const PROJECTION_STATES: EngineProjectionState[] = [
+  'summary_only',
+  'up_to_date',
+  'catching_up',
+  'journal_expired',
+];
+
+type FormState = {
+  engine_instance_key: string;
+  engine_definition_name: string;
+  engine_run_status: '' | EngineRunStatus;
+  engine_projection_state: EngineProjectionState;
+  older_than: string;
+  limit: string;
+};
+
+type RequestMode = 'idle' | 'dry-run' | 'apply';
+
+function defaultFormState(): FormState {
+  return {
+    engine_instance_key: '',
+    engine_definition_name: '',
+    engine_run_status: '',
+    engine_projection_state: 'summary_only',
+    older_than: '',
+    limit: '50',
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
+function localDateTimeToUTC(value: string): string | undefined {
+  if (!value.trim()) {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed.toISOString();
+}
+
+function buildRequest(form: FormState, dryRun: boolean): EngineProjectionBackfillRequest {
+  return {
+    dry_run: dryRun,
+    limit: Number(form.limit || '50'),
+    ...(form.older_than ? { older_than: localDateTimeToUTC(form.older_than) } : {}),
+    ...(form.engine_instance_key.trim()
+      ? { engine_instance_key: form.engine_instance_key.trim() }
+      : {}),
+    ...(form.engine_definition_name.trim()
+      ? { engine_definition_name: form.engine_definition_name.trim() }
+      : {}),
+    ...(form.engine_run_status ? { engine_run_status: form.engine_run_status } : {}),
+    engine_projection_state: form.engine_projection_state,
+  };
+}
+
+function classifyBackfillError(error: unknown): { title: string; message: string; auth: boolean } {
+  if (isAuthError(error)) {
+    return {
+      auth: true,
+      title: 'Authentication required',
+      message: errorMessage(error),
+    };
+  }
+  if (error instanceof ApiError) {
+    if (error.status === 400) {
+      return {
+        auth: false,
+        title: 'Request needs correction',
+        message: error.message,
+      };
+    }
+    if (error.status === 404) {
+      return {
+        auth: false,
+        title: 'Engine API disabled',
+        message: 'The projection repair endpoint is not available on this server.',
+      };
+    }
+    if (error.status >= 500) {
+      return {
+        auth: false,
+        title: 'Backend failure',
+        message: error.message,
+      };
+    }
+  }
+  return {
+    auth: false,
+    title: 'Backend failure',
+    message: errorMessage(error),
+  };
+}
+
+export function EngineProjectionRepairPage() {
+  const location = useLocation();
+  const projectId = getProjectIdFromSearchParams(new URLSearchParams(location.search));
+  const [form, setForm] = useState<FormState>(defaultFormState);
+  const [result, setResult] = useState<EngineProjectionBackfillResponse | null>(null);
+  const [lastEligibleCount, setLastEligibleCount] = useState<number | null>(null);
+  const [hasDryRun, setHasDryRun] = useState(false);
+  const [stale, setStale] = useState(false);
+  const [requestMode, setRequestMode] = useState<RequestMode>('idle');
+  const [limitError, setLimitError] = useState<string | null>(null);
+  const [requestError, setRequestError] = useState<ReturnType<typeof classifyBackfillError> | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const isApplying = requestMode === 'apply';
+  const isDryRunning = requestMode === 'dry-run';
+  const formDisabled = isApplying;
+  const applyDisabled =
+    isApplying ||
+    isDryRunning ||
+    stale ||
+    lastEligibleCount === null ||
+    lastEligibleCount === 0;
+  const applyDisabledCopy = stale
+    ? 'Run a fresh dry run to apply.'
+    : lastEligibleCount === 0
+      ? 'No eligible runs to repair.'
+      : null;
+
+  const updateField = (field: keyof FormState) => (
+    event: ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    setForm((current) => ({ ...current, [field]: event.target.value }));
+    setRequestError(null);
+    if (result || hasDryRun) {
+      setResult(null);
+      setStale(true);
+    }
+    if (field === 'limit') {
+      const value = Number(event.target.value);
+      setLimitError(value > 100 ? 'Limit must be 100 or less.' : null);
+    }
+  };
+
+  const runBackfill = async (dryRun: boolean) => {
+    if (requestMode !== 'idle') {
+      return;
+    }
+    const limit = Number(form.limit || '50');
+    if (limit > 100) {
+      setLimitError('Limit must be 100 or less.');
+      return;
+    }
+    setLimitError(null);
+    setRequestError(null);
+    setRequestMode(dryRun ? 'dry-run' : 'apply');
+    try {
+      const response = await backfillEngineProjections(buildRequest(form, dryRun));
+      setResult(response);
+      if (dryRun) {
+        setHasDryRun(true);
+        setStale(false);
+        setLastEligibleCount(response.eligible_count);
+      } else {
+        setStale(false);
+        setLastEligibleCount(response.eligible_count);
+      }
+    } catch (error) {
+      setRequestError(classifyBackfillError(error));
+    } finally {
+      setRequestMode('idle');
+      setConfirmOpen(false);
+    }
+  };
+
+  const handleDryRun = (event: FormEvent) => {
+    event.preventDefault();
+    void runBackfill(true);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader
+        description="Preview and repair stale engine trace projections."
+        title="Engine projection repair"
+      />
+
+      <form
+        className="grid gap-4 border-b border-[var(--c-border)] bg-[var(--c-app-bg)] px-6 py-4"
+        onSubmit={handleDryRun}
+      >
+        <fieldset disabled={formDisabled} className="grid gap-4 lg:grid-cols-3">
+          <RepairField label="Instance key">
+            <input
+              className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+              value={form.engine_instance_key}
+              onChange={updateField('engine_instance_key')}
+            />
+          </RepairField>
+          <RepairField label="Definition name">
+            <input
+              className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+              value={form.engine_definition_name}
+              onChange={updateField('engine_definition_name')}
+            />
+          </RepairField>
+          <RepairField label="Run status">
+            <select
+              className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+              value={form.engine_run_status}
+              onChange={updateField('engine_run_status')}
+            >
+              <option value="">Any status</option>
+              {RUN_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </RepairField>
+          <RepairField
+            label="Projection state"
+            helper="Default repair target is summary_only. up_to_date, catching_up, and journal_expired return zero eligible rows."
+          >
+            <select
+              className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+              value={form.engine_projection_state}
+              onChange={updateField('engine_projection_state')}
+            >
+              {PROJECTION_STATES.map((state) => (
+                <option key={state} value={state}>
+                  {formatProjectionStateLabel(state)}
+                </option>
+              ))}
+            </select>
+          </RepairField>
+          <RepairField label="Older than" helper="Times entered are converted to UTC before submission.">
+            <input
+              className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+              type="datetime-local"
+              value={form.older_than}
+              onChange={updateField('older_than')}
+            />
+          </RepairField>
+          <RepairField label="Limit" helper={limitError ?? 'Maximum 100 runs per request.'}>
+            <input
+              className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+              min="1"
+              max="100"
+              step="1"
+              type="number"
+              value={form.limit}
+              onChange={updateField('limit')}
+            />
+          </RepairField>
+        </fieldset>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Btn kind="primary" leadingIcon={RefreshCw} type="submit" disabled={isDryRunning || isApplying}>
+            {isDryRunning ? 'Running…' : 'Run dry run'}
+          </Btn>
+          {hasDryRun ? (
+            <Btn
+              kind="secondary"
+              leadingIcon={Wrench}
+              type="button"
+              disabled={applyDisabled}
+              onClick={() => setConfirmOpen(true)}
+            >
+              {isApplying ? 'Applying…' : 'Apply repair'}
+            </Btn>
+          ) : null}
+          {applyDisabledCopy ? (
+            <span className="text-xs text-[var(--c-text-muted)]">{applyDisabledCopy}</span>
+          ) : null}
+        </div>
+      </form>
+
+      {requestError ? (
+        requestError.auth ? (
+          <AuthErrorBanner message={requestError.message} />
+        ) : (
+          <div className="border-b border-[var(--c-red-border)] bg-[var(--c-red-faint)] px-6 py-3 text-sm text-[var(--c-red-text)]">
+            <span className="font-semibold">{requestError.title}</span>: {requestError.message}
+            <button
+              type="button"
+              className="ml-3 font-semibold underline underline-offset-2"
+              onClick={() => void runBackfill(true)}
+            >
+              Retry dry run
+            </button>
+          </div>
+        )
+      ) : null}
+
+      <BackfillResultTable result={result} projectId={projectId} />
+
+      {confirmOpen && lastEligibleCount !== null ? (
+        <ApplyConfirmation
+          count={lastEligibleCount}
+          isApplying={isApplying}
+          onCancel={() => setConfirmOpen(false)}
+          onConfirm={() => void runBackfill(false)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function RepairField({
+  children,
+  helper,
+  label,
+}: {
+  children: ReactNode;
+  helper?: string;
+  label: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-semibold text-[var(--c-text-primary)]">{label}</span>
+      <div className="mt-1.5">{children}</div>
+      {helper ? <span className="mt-1.5 block text-xs text-[var(--c-text-muted)]">{helper}</span> : null}
+    </label>
+  );
+}
+
+function BackfillResultTable({
+  projectId,
+  result,
+}: {
+  projectId?: string;
+  result: EngineProjectionBackfillResponse | null;
+}) {
+  if (!result) {
+    return (
+      <div className="app-empty-state">
+        Run a dry run to preview eligible projection repairs.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="grid gap-3 border-b border-[var(--c-border)] px-6 py-4 sm:grid-cols-4">
+        <ResultStat label="Eligible" value={result.eligible_count} />
+        <ResultStat label="Repair requested" value={result.repair_requested_count} />
+        <ResultStat label="Skipped" value={result.skipped_count} />
+        <ResultStat label="Mode" value={result.dry_run ? 'Dry run' : 'Apply'} />
+      </div>
+      {result.eligible_count === 0 && result.results.length === 0 ? (
+        <div className="app-empty-state">
+          <h2 className="text-base font-semibold text-[var(--c-text-primary)]">
+            No eligible runs
+          </h2>
+          <p className="mt-2">The dry run completed successfully and found no repair targets.</p>
+        </div>
+      ) : (
+        <DataTable>
+          <thead>
+            <tr>
+              <Th>Run</Th>
+              <Th>Trace</Th>
+              <Th>Projection</Th>
+              <Th>Action</Th>
+              <Th>Reason</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.results.map((row) => (
+              <Tr key={row.run_id}>
+                <Td mono>{row.run_id}</Td>
+                <Td>
+                  <Link
+                    className="font-mono text-[var(--c-accent-text)] hover:underline"
+                    to={buildProjectPath(`/traces/${row.trace_id}`, projectId)}
+                  >
+                    {row.trace_id}
+                  </Link>
+                </Td>
+                <Td>
+                  <Chip tone={row.projection_state === 'summary_only' ? 'amber' : 'muted'}>
+                    {formatProjectionStateLabel(row.projection_state)}
+                  </Chip>
+                </Td>
+                <Td>{row.action}</Td>
+                <Td>{row.reason ?? '—'}</Td>
+              </Tr>
+            ))}
+          </tbody>
+        </DataTable>
+      )}
+    </>
+  );
+}
+
+function ResultStat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 py-2">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--c-text-muted)]">
+        {label}
+      </div>
+      <div className="mt-1 font-mono text-lg font-semibold text-[var(--c-text-primary)]">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function ApplyConfirmation({
+  count,
+  isApplying,
+  onCancel,
+  onConfirm,
+}: {
+  count: number;
+  isApplying: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-slate-950/45 p-4">
+      <div className="w-full max-w-md rounded-lg border border-[var(--c-red-border)] bg-[var(--c-app-bg)] shadow-2xl">
+        <div className="flex items-start justify-between gap-3 border-b border-[var(--c-red-border)] px-5 py-4">
+          <div className="flex gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 text-[var(--c-red-text)]" />
+            <div>
+              <h2 className="text-base font-semibold text-[var(--c-text-primary)]">
+                Apply projection repair
+              </h2>
+              <p className="mt-2 text-sm text-[var(--c-text-secondary)]">
+                Last dry run found {count} eligible runs. Backend state may have changed since the dry-run.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label="Close confirmation"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-[var(--c-border)]"
+            onClick={onCancel}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        <div className="flex justify-end gap-2 px-5 py-4">
+          <Btn kind="secondary" type="button" disabled={isApplying} onClick={onCancel}>
+            Cancel
+          </Btn>
+          <button
+            type="button"
+            disabled={isApplying}
+            className="inline-flex h-8 items-center justify-center rounded-md border border-[var(--c-red-border)] bg-[var(--c-red-faint)] px-3 text-[13px] font-semibold text-[var(--c-red-text)] disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={onConfirm}
+          >
+            {isApplying ? 'Applying…' : 'Apply repair'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/EngineRunsPage.test.tsx
+++ b/web/src/pages/EngineRunsPage.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { clearApiKey, setApiKey } from '../api/client';
+import { TRACE_ONE } from '../test/traceFixtures';
+import { ThemeProvider } from '../hooks/ThemeProvider';
+import { jsonResponse, readRequestUrl, type RequestInput } from './testUtils';
+import { EngineRunsPage } from './EngineRunsPage';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function renderEngineRunsPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <MemoryRouter initialEntries={['/engine/runs']}>
+          <EngineRunsPage />
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  localStorage.clear();
+  setApiKey('test-key');
+});
+
+afterEach(() => {
+  clearApiKey();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('EngineRunsPage', () => {
+  it('requests engine-only traces and renders engine status labels', async () => {
+    fetchMock.mockImplementation((input: RequestInput) => {
+      const url = new URL(readRequestUrl(input), 'http://localhost');
+      if (url.pathname !== '/api/traces') {
+        throw new Error(`Unhandled request: ${url.pathname}`);
+      }
+
+      return jsonResponse({
+        traces: [
+          {
+            ...TRACE_ONE,
+            id: 'engine-trace-1',
+            name: 'Darklaunch run',
+            error_count: 0,
+            engine: {
+              run_id: '123e4567-e89b-12d3-a456-426614174100',
+              definition_name: 'darklaunch.demo',
+              definition_version: 'v1',
+              projection_state: 'up_to_date',
+              instance_key: 'darklaunch-1',
+              status: 'QUEUED',
+              pending_work: {
+                pending_activity_tasks: 0,
+                pending_inbox_items: 0,
+              },
+              updated_at: '2026-03-14T10:00:03.000Z',
+            },
+          },
+        ],
+        total: 1,
+      });
+    });
+
+    renderEngineRunsPage();
+
+    expect(await screen.findByText('darklaunch.demo · v1')).toBeInTheDocument();
+    expect(screen.getByText('Queued')).toBeInTheDocument();
+    expect(screen.queryByText('darklaunch.demo · vv1')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      const requestUrl = new URL(
+        readRequestUrl(fetchMock.mock.calls[0]?.[0] as RequestInput),
+        'http://localhost'
+      );
+      expect(requestUrl.pathname).toBe('/api/traces');
+      expect(requestUrl.searchParams.get('engine_only')).toBe('true');
+    });
+  });
+});

--- a/web/src/pages/EngineRunsPage.tsx
+++ b/web/src/pages/EngineRunsPage.tsx
@@ -1,0 +1,544 @@
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState, type FormEvent, type ReactNode } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { ArrowRight, Play, RefreshCw, X } from 'lucide-react';
+import {
+  ApiError,
+  fetchEngineInstance,
+  fetchTraces,
+  isAuthError,
+  startEngineRun,
+  type EngineRunStatus,
+  type JsonValue,
+  type Trace,
+} from '../api/client';
+import { AuthErrorBanner } from '../components/AuthErrorBanner';
+import {
+  Btn,
+  Chip,
+  DataTable,
+  PageHeader,
+  StatusDot,
+  Td,
+  Th,
+  Tr,
+} from '../components/DebuggerKit';
+import { formatProjectionStateLabel } from '../components/engineProjectionState';
+import { PaginationControls } from '../components/PaginationControls';
+import { describeEngineWaitState } from './engineWaitState';
+import { DEFAULT_PAGE_SIZE } from '../utils/pagination';
+import { formatRelativeTime, formatTimestamp } from '../utils/format';
+import {
+  buildProjectPath,
+  getProjectIdFromSearchParams,
+} from '../utils/projectSearchParams';
+
+const EMPTY_TRACES: Trace[] = [];
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
+function generateRequestKey(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `req-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function pendingBreakdown(trace: Trace): { label: string; title: string; total: number } {
+  const activities = trace.engine?.pending_work?.pending_activity_tasks ?? 0;
+  const inbox = trace.engine?.pending_work?.pending_inbox_items ?? 0;
+  const total = activities + inbox;
+  return {
+    label: String(total),
+    title: `${activities} activities, ${inbox} pending inbox items`,
+    total,
+  };
+}
+
+function updatedAt(trace: Trace): string {
+  return trace.engine?.updated_at ?? trace.started_at;
+}
+
+function formatEngineDefinitionLabel(engine: Trace['engine']): string {
+  if (!engine) {
+    return '—';
+  }
+  return engine.definition_version
+    ? `${engine.definition_name} · ${engine.definition_version}`
+    : engine.definition_name;
+}
+
+export function EngineRunsPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const projectId = getProjectIdFromSearchParams(new URLSearchParams(location.search));
+  const [offset, setOffset] = useState(0);
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const queryParams = {
+    engine_only: true,
+    limit: pageSize,
+    offset,
+  };
+  const runsQuery = useQuery({
+    queryKey: ['engine-runs', projectId ?? null, offset, pageSize],
+    queryFn: () => fetchTraces(queryParams),
+    placeholderData: keepPreviousData,
+    refetchInterval: 5000,
+  });
+  const traces = runsQuery.data?.traces ?? EMPTY_TRACES;
+  const total = runsQuery.data?.total ?? 0;
+  const returnTo = buildProjectPath('/engine/runs', projectId);
+  const definitionVersions = useMemo(() => {
+    const versions = new Map<string, Set<string>>();
+    for (const trace of traces) {
+      const name = trace.engine?.definition_name;
+      const version = trace.engine?.definition_version;
+      if (!name || !version) {
+        continue;
+      }
+      const set = versions.get(name) ?? new Set<string>();
+      set.add(version);
+      versions.set(name, set);
+    }
+    return versions;
+  }, [traces]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader
+        actions={
+          <>
+            <Btn kind="secondary" leadingIcon={RefreshCw} size="sm" onClick={() => void runsQuery.refetch()}>
+              Refresh
+            </Btn>
+            <Btn kind="primary" leadingIcon={Play} size="sm" onClick={() => setDialogOpen(true)}>
+              Start run
+            </Btn>
+          </>
+        }
+        description={`${traces.length} of ${total} engine-backed traces · auto-refreshing every 5s`}
+        title="Engine Runs"
+      />
+
+      {runsQuery.error ? (
+        isAuthError(runsQuery.error) ? (
+          <AuthErrorBanner message={getErrorMessage(runsQuery.error)} />
+        ) : (
+          <div className="border-b border-[var(--c-red-border)] bg-[var(--c-red-faint)] px-6 py-3 text-sm text-[var(--c-red-text)]">
+            <span>Could not load engine runs</span>: {getErrorMessage(runsQuery.error)}
+            <button
+              type="button"
+              className="ml-3 font-semibold underline underline-offset-2"
+              onClick={() => void runsQuery.refetch()}
+            >
+              Retry
+            </button>
+          </div>
+        )
+      ) : null}
+
+      {runsQuery.isPending && !runsQuery.data ? (
+        <div className="app-empty-state">Loading engine runs...</div>
+      ) : runsQuery.error && !runsQuery.data ? (
+        <div className="app-empty-state">Retry the request to continue.</div>
+      ) : traces.length === 0 ? (
+        <div className="app-empty-state">
+          <h2 className="text-base font-semibold text-[var(--c-text-primary)]">
+            No engine runs yet
+          </h2>
+          <p className="mt-2">Start a workflow run to inspect its projected trace here.</p>
+          <div className="mt-4">
+            <Btn kind="primary" leadingIcon={Play} onClick={() => setDialogOpen(true)}>
+              Start run
+            </Btn>
+          </div>
+        </div>
+      ) : (
+        <>
+          <DataTable>
+            <colgroup>
+              <col className="w-[110px]" />
+              <col className="w-[220px]" />
+              <col className="w-[220px]" />
+              <col className="w-[220px]" />
+              <col className="w-[90px]" />
+              <col className="w-[140px]" />
+              <col className="w-[150px]" />
+              <col className="w-10" />
+            </colgroup>
+            <thead>
+              <tr>
+                <Th>Status</Th>
+                <Th>Definition</Th>
+                <Th>Instance key</Th>
+                <Th>Wait</Th>
+                <Th align="right">Pending</Th>
+                <Th>Projection</Th>
+                <Th>Updated</Th>
+                <Th align="center">→</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {traces.map((trace) => {
+                const waitSummary = describeEngineWaitState(trace.engine?.wait_state);
+                const pending = pendingBreakdown(trace);
+                const updated = updatedAt(trace);
+                const to = buildProjectPath(`/traces/${trace.id}`, projectId);
+                const definition = formatEngineDefinitionLabel(trace.engine);
+                return (
+                  <Tr key={trace.id} className="hover:bg-[var(--c-row-hover-bg)]">
+                    <Td>
+                      <StatusDot status={trace.engine?.status} />
+                    </Td>
+                    <Td>
+                      <span title={definition}>{definition}</span>
+                    </Td>
+                    <Td mono>
+                      <span title={trace.engine?.instance_key ?? '—'}>{trace.engine?.instance_key ?? '—'}</span>
+                    </Td>
+                    <Td>
+                      <span title={waitSummary ? `${waitSummary.heading}: ${waitSummary.detail}` : 'No wait state'}>
+                        {waitSummary ? `${waitSummary.heading} · ${waitSummary.detail}` : '—'}
+                      </span>
+                    </Td>
+                    <Td align="right">
+                      <span title={pending.title}>{pending.label}</span>
+                    </Td>
+                    <Td>
+                      {trace.engine?.projection_state ? (
+                        <Chip tone={trace.engine.projection_state === 'up_to_date' ? 'success' : 'amber'}>
+                          {formatProjectionStateLabel(trace.engine.projection_state)}
+                        </Chip>
+                      ) : (
+                        '—'
+                      )}
+                    </Td>
+                    <Td>
+                      <span title={formatTimestamp(updated)}>{formatRelativeTime(updated)}</span>
+                    </Td>
+                    <Td align="center">
+                      <Link
+                        aria-label={`Open ${trace.id}`}
+                        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-[var(--c-border)] text-[var(--c-text-secondary)] hover:text-[var(--c-text-primary)]"
+                        state={{ returnTo }}
+                        to={to}
+                      >
+                        <ArrowRight className="h-3.5 w-3.5" />
+                      </Link>
+                    </Td>
+                  </Tr>
+                );
+              })}
+            </tbody>
+          </DataTable>
+          <PaginationControls
+            currentItemCount={traces.length}
+            offset={offset}
+            pageSize={pageSize}
+            total={total}
+            onOffsetChange={setOffset}
+            onPageSizeChange={(nextPageSize) => {
+              setPageSize(nextPageSize);
+              setOffset(0);
+            }}
+          />
+        </>
+      )}
+
+      {dialogOpen ? (
+        <StartEngineRunDialog
+          definitionVersions={definitionVersions}
+          projectId={projectId}
+          onClose={() => setDialogOpen(false)}
+          onSuccess={(traceId) => {
+            setDialogOpen(false);
+            navigate(buildProjectPath(`/traces/${traceId}`, projectId), {
+              state: { returnTo },
+            });
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function StartEngineRunDialog({
+  definitionVersions,
+  onClose,
+  onSuccess,
+  projectId,
+}: {
+  definitionVersions: Map<string, Set<string>>;
+  onClose: () => void;
+  onSuccess: (traceId: string) => void;
+  projectId?: string;
+}) {
+  const queryClient = useQueryClient();
+  const [instanceKey, setInstanceKey] = useState('');
+  const [definitionName, setDefinitionName] = useState('');
+  const [definitionVersion, setDefinitionVersion] = useState('');
+  const [requestKey, setRequestKey] = useState(generateRequestKey);
+  const [inputText, setInputText] = useState('');
+  const [fieldError, setFieldError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [definitionError, setDefinitionError] = useState(false);
+  const [preflight, setPreflight] = useState<
+    | { state: 'idle' }
+    | { state: 'checking' }
+    | { state: 'available' }
+    | { state: 'exists'; definition?: string; status?: EngineRunStatus }
+    | { state: 'unknown'; message: string }
+  >({ state: 'idle' });
+  const [submitting, setSubmitting] = useState(false);
+  const versionSuggestions = definitionName
+    ? Array.from(definitionVersions.get(definitionName) ?? [])
+    : [];
+
+  const runPreflight = async (): Promise<void> => {
+    const key = instanceKey.trim();
+    if (!key) {
+      setPreflight({ state: 'idle' });
+      return;
+    }
+    setPreflight({ state: 'checking' });
+    try {
+      const instance = await fetchEngineInstance(key);
+      setPreflight({
+        state: 'exists',
+        definition: instance.current_run.definition_name,
+        status: instance.current_run.status,
+      });
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        setPreflight({ state: 'available' });
+        return;
+      }
+      setPreflight({
+        state: 'unknown',
+        message: getErrorMessage(error),
+      });
+    }
+  };
+
+  const handleDefinitionNameChange = (value: string) => {
+    setDefinitionName(value);
+    setDefinitionVersion('');
+    setDefinitionError(false);
+  };
+
+  const parseInput = (): JsonValue | undefined => {
+    const trimmed = inputText.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = JSON.parse(trimmed) as JsonValue;
+    return parsed;
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (submitting) {
+      return;
+    }
+    setFieldError(null);
+    setSubmitError(null);
+    setDefinitionError(false);
+
+    let input: JsonValue | undefined;
+    try {
+      input = parseInput();
+    } catch {
+      setFieldError('Input must be valid JSON.');
+      return;
+    }
+
+    if (!instanceKey.trim() || !definitionName.trim() || !definitionVersion.trim() || !requestKey.trim()) {
+      setFieldError('Instance key, definition, version, and idempotency key are required.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await runPreflight();
+      const response = await startEngineRun({
+        instance_key: instanceKey.trim(),
+        definition_name: definitionName.trim(),
+        definition_version: definitionVersion.trim(),
+        request_key: requestKey.trim(),
+        ...(input !== undefined ? { input } : {}),
+      });
+      await queryClient.invalidateQueries({ queryKey: ['engine-runs', projectId ?? null] });
+      onSuccess(response.trace_id);
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 409 && error.code === 'instance_conflict') {
+        setSubmitError('Instance conflict. Recheck the durable workflow identity and run preflight again.');
+      } else if (error instanceof ApiError && error.code === 'definition_not_registered') {
+        setDefinitionError(true);
+        setSubmitError('Definition is not registered. Check the engine definition configuration before retrying.');
+      } else {
+        setSubmitError(getErrorMessage(error));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-slate-950/45 p-4">
+      <form
+        className="max-h-[92vh] w-full max-w-2xl overflow-y-auto rounded-lg border border-[var(--c-border)] bg-[var(--c-app-bg)] shadow-2xl"
+        onSubmit={(event) => void handleSubmit(event)}
+      >
+        <div className="flex items-center justify-between border-b border-[var(--c-border)] px-5 py-4">
+          <div>
+            <h2 className="text-base font-semibold text-[var(--c-text-primary)]">Start run</h2>
+            <p className="mt-1 text-sm text-[var(--c-text-secondary)]">
+              Launch an engine workflow and open its projected trace.
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close Start run"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--c-border)]"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="grid gap-4 px-5 py-4">
+          <FormField label="Instance key" helper="The durable workflow identity, not a run id.">
+            <div className="flex gap-2">
+              <input
+                className="app-input h-9 flex-1 rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+                value={instanceKey}
+                onBlur={() => void runPreflight()}
+                onChange={(event) => {
+                  setInstanceKey(event.target.value);
+                  setPreflight({ state: 'idle' });
+                }}
+              />
+              <Btn kind="secondary" type="button" onClick={() => void runPreflight()}>
+                Check
+              </Btn>
+            </div>
+            <PreflightNotice state={preflight} />
+          </FormField>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField label="Definition name">
+              <input
+                aria-invalid={definitionError}
+                className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+                value={definitionName}
+                onChange={(event) => handleDefinitionNameChange(event.target.value)}
+                list="engine-definition-names"
+              />
+              <datalist id="engine-definition-names">
+                {Array.from(definitionVersions.keys()).map((name) => (
+                  <option key={name} value={name} />
+                ))}
+              </datalist>
+            </FormField>
+            <FormField label="Definition version">
+              <input
+                className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+                value={definitionVersion}
+                onChange={(event) => setDefinitionVersion(event.target.value)}
+                list="engine-definition-versions"
+              />
+              <datalist id="engine-definition-versions">
+                {versionSuggestions.map((version) => (
+                  <option key={version} value={version} />
+                ))}
+              </datalist>
+            </FormField>
+          </div>
+
+          <FormField label="Idempotency key" helper="Idempotency key — change only when retrying a prior start.">
+            <input
+              className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 font-mono text-sm"
+              value={requestKey}
+              onChange={(event) => setRequestKey(event.target.value)}
+            />
+          </FormField>
+
+          <FormField label="Input JSON">
+            <textarea
+              className="app-input min-h-28 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 py-2 font-mono text-sm"
+              placeholder='{"example": true}'
+              value={inputText}
+              onChange={(event) => setInputText(event.target.value)}
+            />
+          </FormField>
+
+          {fieldError ? <div className="app-alert-error">{fieldError}</div> : null}
+          {submitError ? <div className="app-alert-error">{submitError}</div> : null}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-[var(--c-border)] px-5 py-4">
+          <Btn kind="secondary" type="button" onClick={onClose}>
+            Cancel
+          </Btn>
+          <Btn kind="primary" type="submit" disabled={submitting}>
+            {submitting ? 'Starting…' : 'Start run'}
+          </Btn>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function FormField({
+  children,
+  helper,
+  label,
+}: {
+  children: ReactNode;
+  helper?: string;
+  label: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-semibold text-[var(--c-text-primary)]">{label}</span>
+      <div className="mt-1.5">{children}</div>
+      {helper ? <span className="mt-1.5 block text-xs text-[var(--c-text-muted)]">{helper}</span> : null}
+    </label>
+  );
+}
+
+function PreflightNotice({
+  state,
+}: {
+  state:
+    | { state: 'idle' }
+    | { state: 'checking' }
+    | { state: 'available' }
+    | { state: 'exists'; definition?: string; status?: EngineRunStatus }
+    | { state: 'unknown'; message: string };
+}) {
+  if (state.state === 'idle') {
+    return null;
+  }
+  if (state.state === 'checking') {
+    return <p className="mt-2 text-xs text-[var(--c-text-muted)]">Checking instance key…</p>;
+  }
+  if (state.state === 'available') {
+    return <p className="mt-2 text-xs text-[var(--c-green-text)]">Instance key is available.</p>;
+  }
+  if (state.state === 'exists') {
+    return (
+      <p className="mt-2 text-xs text-[var(--c-amber-text)]">
+        Active instance exists{state.definition ? ` for ${state.definition}` : ''}{state.status ? ` (${state.status})` : ''}.
+      </p>
+    );
+  }
+  return (
+    <p className="mt-2 text-xs text-[var(--c-amber-text)]">
+      Preflight unavailable. Submit remains enabled. {state.message}
+    </p>
+  );
+}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearApiKey } from '../api/client';
 import { RuntimeAuthStateProvider } from '../auth/runtime';
 import { ThemeProvider } from '../hooks/ThemeProvider';
+import { buildProjectPath } from '../utils/projectSearchParams';
 import { renderTraceRoutes } from './testUtils';
 import { SettingsPage } from './SettingsPage';
 
@@ -97,6 +98,36 @@ describe('SettingsPage', () => {
     );
 
     expect(screen.getByText('Demo dashboard')).toBeInTheDocument();
+  });
+
+  it('links to engine projection repair while preserving project scope', () => {
+    const projectId = '123e4567-e89b-12d3-a456-426614174000';
+
+    render(
+      <ThemeProvider>
+        <RuntimeAuthStateProvider
+          auth={{
+            status: 'ready',
+            enabled: true,
+          }}
+        >
+          <MemoryRouter initialEntries={[`/settings?project_id=${projectId}`]}>
+            <Routes>
+              <Route path="/settings" element={<SettingsPage />} />
+            </Routes>
+          </MemoryRouter>
+        </RuntimeAuthStateProvider>
+      </ThemeProvider>
+    );
+
+    const link = screen
+      .getByText('Engine projection repair')
+      .closest('a');
+
+    expect(link).toHaveAttribute(
+      'href',
+      buildProjectPath('/tools/engine-projections', projectId)
+    );
   });
 
   it('lets local self-hosted users save and clear the project API key', async () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,9 +1,13 @@
 import { useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Link, Navigate, useLocation } from 'react-router-dom';
 import { clearApiKey, getApiKey, setApiKey } from '../api/client';
 import { useTheme } from '../hooks/useTheme';
 import { useOperatorAuth, useRuntimeAuth } from '../auth/runtime';
 import { PageHeader } from '../components/DebuggerKit';
+import {
+  buildProjectPath,
+  getProjectIdFromSearchParams,
+} from '../utils/projectSearchParams';
 
 const THEME_OPTIONS = [
   { id: 'system', label: 'System' },
@@ -12,6 +16,7 @@ const THEME_OPTIONS = [
 ] as const;
 
 export function SettingsPage() {
+  const location = useLocation();
   const runtimeAuth = useRuntimeAuth();
   const { logout, user } = useOperatorAuth();
   const { mode, resolvedTheme, setMode } = useTheme();
@@ -21,6 +26,7 @@ export function SettingsPage() {
     runtimeAuth.public_demo_enabled !== true;
   const [localApiKeyDraft, setLocalApiKeyDraft] = useState(() => getApiKey() ?? '');
   const [localApiKeySaved, setLocalApiKeySaved] = useState(() => Boolean(getApiKey()));
+  const projectId = getProjectIdFromSearchParams(new URLSearchParams(location.search));
 
   if (runtimeAuth.public_demo_enabled) {
     return <Navigate to="/dashboard" replace />;
@@ -120,6 +126,28 @@ export function SettingsPage() {
               {resolvedTheme}
             </div>
           </div>
+
+          <section className="mt-8">
+            <div className="mb-4">
+              <h2 className="text-sm font-semibold text-[var(--c-text-primary)]">
+                Operations
+              </h2>
+              <p className="mt-1 text-sm text-[var(--c-text-secondary)]">
+                Operator tools for maintaining engine projections.
+              </p>
+            </div>
+            <Link
+              className="block rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-4 py-3 transition hover:border-[var(--c-border-strong)]"
+              to={buildProjectPath('/tools/engine-projections', projectId)}
+            >
+              <span className="block text-sm font-semibold text-[var(--c-text-primary)]">
+                Engine projection repair
+              </span>
+              <span className="mt-1 block text-sm text-[var(--c-text-secondary)]">
+                Re-run engine projections for stale or expired runs.
+              </span>
+            </Link>
+          </section>
         </section>
       </div>
     </div>

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -335,6 +335,7 @@ describe('TraceDetailPage', () => {
   });
 
   it('renders engine projection, wait summary, tabs, and control actions', async () => {
+    const user = userEvent.setup();
     fetchMock.mockImplementation(
       buildFetchHandler({
         detail: () => jsonResponse(createEngineTraceDetail()),
@@ -344,12 +345,24 @@ describe('TraceDetailPage', () => {
     renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
 
     expect(await screen.findByText('checkout')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Engine state' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Engine state' }));
+
+    expect(screen.getByRole('button', { name: 'Overview 0' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'Pending 0' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Engine history 0' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Result 0' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Summary retained' })).toBeInTheDocument();
     expect(screen.getByText('Waiting on signal')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Signal' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Suspend' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Signal' })).toHaveLength(1);
+
+    await user.click(screen.getByRole('button', { name: 'Pending 0' }));
+    expect(screen.getAllByRole('button', { name: 'Signal' })).toHaveLength(1);
   });
 
   it('shows pending engine work in the mobile summary workspace', async () => {
@@ -401,6 +414,39 @@ describe('TraceDetailPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Summary' }));
     expect(screen.getAllByText('Needle child').length).toBeGreaterThan(0);
+  });
+
+  it('does not expose duplicate mobile timeline and state workspaces inside overview', async () => {
+    setMatchMediaMatches(false);
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        timeline: () =>
+          jsonResponse({
+            events: [
+              createTimelineEvent({
+                event_type: 'span_started',
+                message: 'checkout started',
+              }),
+            ],
+            trace_status: 'RUNNING',
+            has_more: false,
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    const mobileWorkspace = await screen.findByRole('navigation', {
+      name: 'Mobile trace workspace',
+    });
+    expect(within(mobileWorkspace).getByRole('button', { name: 'Summary' })).toBeInTheDocument();
+    expect(within(mobileWorkspace).getByRole('button', { name: 'Execution' })).toBeInTheDocument();
+    expect(within(mobileWorkspace).queryByRole('button', { name: 'Timeline' })).not.toBeInTheDocument();
+    expect(within(mobileWorkspace).queryByRole('button', { name: 'State' })).not.toBeInTheDocument();
+
+    const sectionTabs = screen.getByRole('navigation', { name: 'Trace detail sections' });
+    await userEvent.click(within(sectionTabs).getByRole('button', { name: /Timeline/i }));
+    expect(screen.getByRole('heading', { name: 'Timeline' })).toBeInTheDocument();
   });
 
   it('surfaces failure-first guidance in the mobile summary workspace', async () => {

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -365,6 +365,29 @@ describe('TraceDetailPage', () => {
     expect(screen.getAllByRole('button', { name: 'Signal' })).toHaveLength(1);
   });
 
+  it('counts terminal engine result panes without requiring failure context', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () =>
+          jsonResponse(
+            createEngineTraceDetail({
+              engine: {
+                ...createEngineTraceDetail().engine!,
+                status: 'TERMINATED',
+                failure: undefined,
+              },
+            })
+          ),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await user.click(await screen.findByRole('button', { name: 'Engine state' }));
+    expect(screen.getByRole('button', { name: 'Result 1' })).toBeInTheDocument();
+  });
+
   it('shows pending engine work in the mobile summary workspace', async () => {
     setMatchMediaMatches(false);
     fetchMock.mockImplementation(

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -365,7 +365,7 @@ describe('TraceDetailPage', () => {
     expect(screen.getAllByRole('button', { name: 'Signal' })).toHaveLength(1);
   });
 
-  it('counts terminal engine result panes without requiring failure context', async () => {
+  it('counts continued-as-new engine result panes and marks the state closed', async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(
       buildFetchHandler({
@@ -374,7 +374,7 @@ describe('TraceDetailPage', () => {
             createEngineTraceDetail({
               engine: {
                 ...createEngineTraceDetail().engine!,
-                status: 'TERMINATED',
+                status: 'CONTINUED_AS_NEW',
                 failure: undefined,
               },
             })
@@ -386,6 +386,8 @@ describe('TraceDetailPage', () => {
 
     await user.click(await screen.findByRole('button', { name: 'Engine state' }));
     expect(screen.getByRole('button', { name: 'Result 1' })).toBeInTheDocument();
+    expect(screen.getAllByText('Closed').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('Closing')).toHaveLength(0);
   });
 
   it('shows pending engine work in the mobile summary workspace', async () => {

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -2867,7 +2867,7 @@ function buildEngineStateMachine(status: EngineRunStatus): StateMachineStep[] {
     },
     {
       id: 'closed',
-      label: isFailed ? 'Failed' : status === 'COMPLETED' ? 'Closed' : 'Closing',
+      label: isFailed ? 'Failed' : isClosed ? 'Closed' : 'Closing',
       done: isClosed,
       current: isClosed,
       error: isFailed,

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useRef,
   useState,
   useMemo,
   type Dispatch,
@@ -13,8 +14,11 @@ import {
   fetchTraces,
   fetchSpans,
   fetchTrace,
+  fetchEngineRunHistory,
+  fetchEngineRunResult,
   isAuthError,
   type EngineRunStatus,
+  type EngineHistoryEvent,
   type Span,
   type Trace,
   type TimelineEvent,
@@ -29,10 +33,8 @@ import { ExecutionWaterfall } from '../components/ExecutionWaterfall';
 import { FailureSummary } from '../components/FailureSummary';
 import { ReasoningTab } from '../components/ReasoningTab';
 import { SpanDetail } from '../components/SpanDetail';
-import { StateDiffViewer } from '../components/StateDiffViewer';
 import { StatusBadge } from '../components/StatusBadge';
 import { TreeRail } from '../components/TreeRail';
-import { Timeline } from '../components/Timeline';
 import { TruncationBanner } from '../components/TruncationBanner';
 import {
   MobileWorkspaceTabId,
@@ -66,7 +68,6 @@ import {
   buildSpanIndex,
 } from '../utils/failureAnalysis';
 import { getWaitDetails } from '../utils/eventSemantics';
-import { extractStateChanges } from '../utils/stateChanges';
 import {
   buildReasoningEntries,
   buildTraceCostSeries,
@@ -209,10 +210,6 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
   const totalTokens = trace
     ? (trace.total_tokens_in ?? 0) + (trace.total_tokens_out ?? 0)
     : 0;
-  const stateChanges = useMemo(
-    () => extractStateChanges(timeline.events),
-    [timeline.events]
-  );
   const reasoningEntries = useMemo(
     () => buildReasoningEntries(timeline.events, spans),
     [spans, timeline.events]
@@ -368,25 +365,12 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
     />
   );
 
-  const timelineContent = (
-    <Timeline
-      events={timeline.events}
-      traceStatus={timelineStatus}
-      isLive={timeline.isLive}
-      isLoading={timeline.isLoading}
-      error={timelineAuthError ? null : timeline.error}
-      selectedSpanId={selectedSpanExternalId}
-      onSelectSpan={handleSelectSpanAndShowDetails}
-      spanIndex={spanIndex}
-    />
-  );
   const reasoningContent = (
     <ReasoningTab
       entries={reasoningEntries}
       onSelectSpan={handleSelectSpanAndShowDetails}
     />
   );
-  const stateContent = <StateDiffViewer changes={stateChanges} />;
   const mobileSummaryContent = (
     <div className="grid h-full gap-4 overflow-y-auto p-4">
       <TraceLineageCard
@@ -430,9 +414,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
       spanIndex={spanIndex}
       spanTree={spanTree}
       spans={spans}
-      stateContent={stateContent}
       traceCostSeries={traceCostSeries}
-      timelineContent={timelineContent}
       traceEndedAt={trace.ended_at}
       traceStartedAt={trace.started_at}
     />
@@ -497,6 +479,7 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
           pendingWork={pendingWorkQuery.data}
           runningStateAssessment={waitStallAssessment}
           spanIndex={spanIndex}
+          traceId={traceId}
         />
       </TraceSectionSurface>
     ) : activeSection === 'replay' && replayPreviewEnabled ? (
@@ -525,10 +508,20 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
             <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--c-text-muted)]">
               <Link
                 to={returnTo}
-                aria-label={returnTo.startsWith('/sessions/') ? '← Session' : '← Traces'}
+                aria-label={
+                  returnTo.startsWith('/sessions/')
+                    ? '← Session'
+                    : returnTo.startsWith('/engine/runs')
+                      ? '← Engine Runs'
+                      : '← Traces'
+                }
                 className="inline-flex items-center gap-1 font-medium text-[var(--c-text-secondary)] transition hover:text-[var(--c-accent-text)]"
               >
-                ‹ {returnTo.startsWith('/sessions/') ? 'Session' : 'Traces'}
+                ‹ {returnTo.startsWith('/sessions/')
+                  ? 'Session'
+                  : returnTo.startsWith('/engine/runs')
+                    ? 'Engine Runs'
+                    : 'Traces'}
               </Link>
               <span aria-hidden="true">›</span>
               <span className="font-mono">{trace.trace_id ?? trace.id}</span>
@@ -661,17 +654,9 @@ function TraceDetailContent({ traceId }: TraceDetailContentProps) {
         <AuthErrorBanner message={queryErrorMessage(timeline.rawError)} />
       ) : null}
 
-      <EngineProjectionBanner projectionState={trace.engine?.projection_state} />
       {trace.engine?.failure?.error_code === 'definition_version_mismatch' ? (
         <DefinitionVersionMismatchBanner />
       ) : null}
-      {trace.engine ? (
-        <EngineControlBar
-          engine={trace.engine}
-          traceId={traceId}
-        />
-      ) : null}
-
       <div className="flex min-h-0 flex-1 flex-col">
         {sectionContent}
       </div>
@@ -1149,9 +1134,7 @@ interface TraceWorkspaceProps {
   spanIndex: ReadonlyMap<string, Span>;
   spanTree: SpanTreeNode[];
   spans: Span[];
-  stateContent: ReactNode;
   traceCostSeries: TraceCostSeries | null;
-  timelineContent: ReactNode;
   traceEndedAt?: string;
   traceStartedAt?: string;
 }
@@ -1179,9 +1162,7 @@ function TraceWorkspace({
   spanIndex,
   spanTree,
   spans,
-  stateContent,
   traceCostSeries,
-  timelineContent,
   traceEndedAt,
   traceStartedAt,
 }: TraceWorkspaceProps) {
@@ -1239,8 +1220,6 @@ function TraceWorkspace({
         />
       }
       mobileSummary={mobileSummaryContent}
-      mobileTimeline={timelineContent}
-      mobileState={stateContent}
       activeMobileTab={activeMobileTab}
       onMobileTabChange={onMobileTabChange}
     />
@@ -1538,6 +1517,8 @@ function getReturnToDestination(state: unknown): string {
   const { returnTo } = state;
   return returnTo === '/traces' ||
     returnTo.startsWith('/traces?') ||
+    returnTo === '/engine/runs' ||
+    returnTo.startsWith('/engine/runs?') ||
     returnTo.startsWith('/sessions/')
     ? returnTo
     : '/traces';
@@ -2854,7 +2835,7 @@ function TraceMetricsPanel({
   );
 }
 
-type EngineStatePane = 'journal' | 'pending' | 'wait' | 'failure';
+type EngineStatePane = 'overview' | 'pending' | 'history' | 'result';
 
 interface StateMachineStep {
   id: string;
@@ -2968,10 +2949,10 @@ function EngineKvSmall({ label, value }: { label: string; value: string }) {
 }
 
 const ENGINE_PANES: Array<{ id: EngineStatePane; label: string }> = [
-  { id: 'journal', label: 'Journal' },
-  { id: 'pending', label: 'Pending tasks' },
-  { id: 'wait', label: 'Wait state' },
-  { id: 'failure', label: 'Failure' },
+  { id: 'overview', label: 'Overview' },
+  { id: 'pending', label: 'Pending' },
+  { id: 'history', label: 'Engine history' },
+  { id: 'result', label: 'Result' },
 ];
 
 function TraceEngineStatePanel({
@@ -2985,6 +2966,7 @@ function TraceEngineStatePanel({
   pendingWork,
   runningStateAssessment,
   spanIndex,
+  traceId,
 }: {
   engine: TraceDetail['engine'];
   errorMessage: string;
@@ -2996,8 +2978,9 @@ function TraceEngineStatePanel({
   pendingWork: EnginePendingWorkResponse | undefined;
   runningStateAssessment: WaitStallAssessment | null;
   spanIndex: ReadonlyMap<string, Span>;
+  traceId: string;
 }) {
-  const [pane, setPane] = useState<EngineStatePane>('journal');
+  const [pane, setPane] = useState<EngineStatePane>('overview');
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
 
   if (!engine) {
@@ -3017,6 +3000,9 @@ function TraceEngineStatePanel({
 
   const checkpointCount = events.filter((event) => event.event_type === 'snapshot_marker').length;
   const stateChangeCount = events.filter((event) => event.event_type === 'state_change').length;
+  const decisionCount = events.filter((event) => event.event_type === 'decision').length;
+  const effectCount = events.filter((event) => event.event_type === 'effect').length;
+  const waitCount = events.filter((event) => event.event_type === 'wait').length;
   const pendingCount =
     (pendingWork?.activities.length ?? 0) +
     (pendingWork?.timers.length ?? 0) +
@@ -3026,10 +3012,10 @@ function TraceEngineStatePanel({
   const hasWait = Boolean(waitState && Object.keys(waitState).length > 0);
 
   const paneCounts: Record<EngineStatePane, number> = {
-    journal: journalEvents.length,
+    overview: journalEvents.length,
     pending: pendingCount,
-    wait: hasWait ? 1 : 0,
-    failure: hasFailure ? 1 : 0,
+    history: 0,
+    result: engine.status === 'COMPLETED' || hasFailure ? 1 : 0,
   };
 
   const selectedEvent = selectedEventId
@@ -3083,6 +3069,11 @@ function TraceEngineStatePanel({
           <StateMachine steps={stateMachine} />
         </div>
 
+        <div className="mt-4 space-y-3">
+          <EngineControlBar engine={engine} traceId={traceId} />
+          <EngineProjectionBanner projectionState={engine.projection_state} />
+        </div>
+
         <div className="mt-4 flex border-b border-[var(--c-border)]">
           {ENGINE_PANES.map((tab) => {
             const active = pane === tab.id;
@@ -3108,72 +3099,29 @@ function TraceEngineStatePanel({
         </div>
 
         <div className="mt-3">
-          {pane === 'journal' ? (
-            journalEvents.length === 0 ? (
-              <EngineEmptyCard>No engine semantic events recorded for this run.</EngineEmptyCard>
-            ) : (
-              <div className="overflow-hidden rounded-lg border border-[var(--c-border)] bg-[var(--c-surface)]">
-                <div
-                  className="grid border-b border-[var(--c-border)] bg-[var(--c-table-head-bg)] px-3.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--c-text-muted)]"
-                  style={{ gridTemplateColumns: '50px 110px 200px minmax(0,1fr)' }}
-                >
-                  <span>Seq</span>
-                  <span>Time</span>
-                  <span>Event</span>
-                  <span>Detail</span>
-                </div>
-                {journalEvents.map((event, index) => {
-                  const isCheckpoint = event.event_type === 'snapshot_marker';
-                  const isError = event.event_type === 'span_failed';
-                  return (
-                    <button
-                      key={event.id}
-                      type="button"
-                      onClick={() => {
-                        setSelectedEventId(event.id);
-                        if (event.span_id && spanIndex.has(event.span_id)) {
-                          onSelectSpan(event.span_id);
-                        }
-                      }}
-                      className={`grid w-full items-baseline gap-0 px-3.5 py-1.5 text-left font-mono text-[11.5px] transition ${
-                        selectedEventId === event.id
-                          ? 'bg-[var(--c-row-selected-bg)]'
-                          : 'hover:bg-[var(--c-row-hover-bg)]'
-                      }`}
-                      style={{
-                        gridTemplateColumns: '50px 110px 200px minmax(0,1fr)',
-                        borderBottom:
-                          index < journalEvents.length - 1
-                            ? '1px solid var(--c-border-subtle)'
-                            : 'none',
-                      }}
-                    >
-                      <span className="tabular-nums text-[var(--c-text-muted)]">
-                        {event.sequence ?? index + 1}
-                      </span>
-                      <span className="text-[var(--c-text-muted)]">
-                        {formatTimestamp(event.timestamp)}
-                      </span>
-                      <span
-                        className="truncate font-semibold"
-                        style={{
-                          color: isError
-                            ? 'var(--c-red-text)'
-                            : isCheckpoint
-                              ? 'var(--c-accent-text)'
-                              : 'var(--c-text-primary)',
-                        }}
-                      >
-                        {event.event_type}
-                      </span>
-                      <span className="truncate text-[var(--c-text-secondary)]">
-                        {event.message ?? event.span_name ?? '—'}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            )
+          {pane === 'overview' ? (
+            <EngineOverviewPane
+              checkpointCount={checkpointCount}
+              decisionCount={decisionCount}
+              effectCount={effectCount}
+              engine={engine}
+              events={journalEvents}
+              hasWait={hasWait}
+              onSelectEvent={(event) => {
+                setSelectedEventId(event.id);
+                if (event.span_id && spanIndex.has(event.span_id)) {
+                  onSelectSpan(event.span_id);
+                }
+              }}
+              runningStateAssessment={runningStateAssessment}
+              openWaits={openWaits}
+              selectedEventId={selectedEventId}
+              spanIndex={spanIndex}
+              stateChangeCount={stateChangeCount}
+              waitCount={waitCount}
+              waitState={waitState}
+              onSelectSpan={onSelectSpan}
+            />
           ) : pane === 'pending' ? (
             isLoading ? (
               <EngineEmptyCard>Loading pending work…</EngineEmptyCard>
@@ -3187,43 +3135,10 @@ function TraceEngineStatePanel({
                 errorMessage={errorMessage}
               />
             )
-          ) : pane === 'wait' ? (
-            runningStateAssessment ? (
-              <RunningStatePanel
-                assessment={runningStateAssessment}
-                events={events}
-                openWaits={openWaits}
-                spanIndex={spanIndex}
-                onSelectSpan={onSelectSpan}
-              />
-            ) : hasWait && waitState ? (
-              <div className="rounded-lg border border-[var(--c-border)] bg-[var(--c-surface)] p-3.5">
-                <div className="text-[10.5px] font-semibold uppercase tracking-[0.05em] text-[var(--c-text-muted)]">
-                  Current wait
-                </div>
-                <div className="mt-3 rounded border border-[var(--c-border-subtle)] bg-[var(--c-app-bg)] p-3">
-                  <CompactPayloadInspector value={waitState} />
-                </div>
-              </div>
-            ) : (
-              <EngineEmptyCard>No wait state for this run.</EngineEmptyCard>
-            )
-          ) : pane === 'failure' ? (
-            engine.failure ? (
-              <div className="rounded-lg border border-[var(--c-red-border)] bg-[var(--c-red-faint)] p-3.5">
-                <div className="text-[10.5px] font-semibold uppercase tracking-[0.05em] text-[var(--c-red-text)]">
-                  Failure
-                </div>
-                <div className="mt-2 font-mono text-xs text-[var(--c-red-text)]">
-                  {engine.failure.error_code}
-                </div>
-                <p className="mt-2 text-sm text-[var(--c-text-primary)]">
-                  {engine.failure.error_message}
-                </p>
-              </div>
-            ) : (
-              <EngineEmptyCard>This run terminated cleanly.</EngineEmptyCard>
-            )
+          ) : pane === 'history' ? (
+            <EngineHistoryPane runId={engine.run_id} />
+          ) : pane === 'result' ? (
+            <EngineResultPane runId={engine.run_id} status={engine.status} />
           ) : null}
         </div>
 
@@ -3262,6 +3177,331 @@ function TraceEngineStatePanel({
           )}
         </div>
       </aside>
+    </div>
+  );
+}
+
+function EngineOverviewPane({
+  checkpointCount,
+  decisionCount,
+  effectCount,
+  engine,
+  events,
+  hasWait,
+  onSelectEvent,
+  onSelectSpan,
+  openWaits,
+  runningStateAssessment,
+  selectedEventId,
+  spanIndex,
+  stateChangeCount,
+  waitCount,
+  waitState,
+}: {
+  checkpointCount: number;
+  decisionCount: number;
+  effectCount: number;
+  engine: NonNullable<TraceDetail['engine']>;
+  events: TimelineEvent[];
+  hasWait: boolean;
+  onSelectEvent: (event: TimelineEvent) => void;
+  onSelectSpan: (spanId: string) => void;
+  openWaits: OpenWait[];
+  runningStateAssessment: WaitStallAssessment | null;
+  selectedEventId: string | null;
+  spanIndex: ReadonlyMap<string, Span>;
+  stateChangeCount: number;
+  waitCount: number;
+  waitState: EnginePendingWorkResponse['current_wait'] | NonNullable<TraceDetail['engine']>['wait_state'] | null;
+}) {
+  return (
+    <div className="space-y-4">
+      {hasWait && runningStateAssessment ? (
+        <RunningStatePanel
+          assessment={runningStateAssessment}
+          events={events}
+          openWaits={openWaits}
+          spanIndex={spanIndex}
+          onSelectSpan={onSelectSpan}
+        />
+      ) : hasWait && waitState ? (
+        <div className="rounded-lg border border-[var(--c-border)] bg-[var(--c-surface)] p-3.5">
+          <div className="text-[10.5px] font-semibold uppercase tracking-[0.05em] text-[var(--c-text-muted)]">
+            Current wait
+          </div>
+          <div className="mt-3 rounded border border-[var(--c-border-subtle)] bg-[var(--c-app-bg)] p-3">
+            <CompactPayloadInspector value={waitState} />
+          </div>
+        </div>
+      ) : (
+        <EngineEmptyCard>No wait state for this run.</EngineEmptyCard>
+      )}
+
+      {engine.failure ? (
+        <div className="rounded-lg border border-[var(--c-red-border)] bg-[var(--c-red-faint)] p-3.5">
+          <div className="text-[10.5px] font-semibold uppercase tracking-[0.05em] text-[var(--c-red-text)]">
+            Failure
+          </div>
+          <div className="mt-2 font-mono text-xs text-[var(--c-red-text)]">
+            {engine.failure.error_code}
+          </div>
+          <p className="mt-2 text-sm text-[var(--c-text-primary)]">
+            {engine.failure.error_message}
+          </p>
+        </div>
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        <EngineKvSmall label="Run" value={engine.run_id} />
+        <EngineKvSmall label="Instance" value={engine.instance_key ?? '—'} />
+        <EngineKvSmall label="Definition" value={engine.definition_name ?? '—'} />
+        <EngineKvSmall label="Version" value={engine.definition_version ?? '—'} />
+        <EngineKvSmall label="Updated" value={formatTimestamp(engine.updated_at)} />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-5">
+        <JournalCount label="State changes" value={stateChangeCount} />
+        <JournalCount label="Decisions" value={decisionCount} />
+        <JournalCount label="Effects" value={effectCount} />
+        <JournalCount label="Waits" value={waitCount} />
+        <JournalCount label="Snapshots" value={checkpointCount} />
+      </div>
+
+      {events.length === 0 ? (
+        <EngineEmptyCard>No projected journal summary is available for this run.</EngineEmptyCard>
+      ) : (
+        <ProjectedJournalSummary
+          events={events}
+          onSelectEvent={onSelectEvent}
+          selectedEventId={selectedEventId}
+          spanIndex={spanIndex}
+        />
+      )}
+    </div>
+  );
+}
+
+function JournalCount({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-[var(--c-border)] bg-[var(--c-surface)] px-3 py-2">
+      <div className="text-[10.5px] font-semibold uppercase tracking-[0.05em] text-[var(--c-text-muted)]">
+        {label}
+      </div>
+      <div className="mt-1 font-mono text-lg font-semibold text-[var(--c-text-primary)]">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function ProjectedJournalSummary({
+  events,
+  onSelectEvent,
+  selectedEventId,
+}: {
+  events: TimelineEvent[];
+  onSelectEvent: (event: TimelineEvent) => void;
+  selectedEventId: string | null;
+  spanIndex: ReadonlyMap<string, Span>;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-[var(--c-border)] bg-[var(--c-surface)]">
+      <div
+        className="grid border-b border-[var(--c-border)] bg-[var(--c-table-head-bg)] px-3.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--c-text-muted)]"
+        style={{ gridTemplateColumns: '50px 110px 200px minmax(0,1fr)' }}
+      >
+        <span>Seq</span>
+        <span>Time</span>
+        <span>Event</span>
+        <span>Detail</span>
+      </div>
+      {events.slice(0, 12).map((event, index) => {
+        const isCheckpoint = event.event_type === 'snapshot_marker';
+        const isError = event.event_type === 'span_failed';
+        return (
+          <button
+            key={event.id}
+            type="button"
+            onClick={() => onSelectEvent(event)}
+            className={`grid w-full items-baseline gap-0 px-3.5 py-1.5 text-left font-mono text-[11.5px] transition ${
+              selectedEventId === event.id
+                ? 'bg-[var(--c-row-selected-bg)]'
+                : 'hover:bg-[var(--c-row-hover-bg)]'
+            }`}
+            style={{
+              gridTemplateColumns: '50px 110px 200px minmax(0,1fr)',
+              borderBottom:
+                index < Math.min(events.length, 12) - 1
+                  ? '1px solid var(--c-border-subtle)'
+                  : 'none',
+            }}
+          >
+            <span className="tabular-nums text-[var(--c-text-muted)]">
+              {event.sequence ?? index + 1}
+            </span>
+            <span className="text-[var(--c-text-muted)]">
+              {formatTimestamp(event.timestamp)}
+            </span>
+            <span
+              className="truncate font-semibold"
+              style={{
+                color: isError
+                  ? 'var(--c-red-text)'
+                  : isCheckpoint
+                    ? 'var(--c-accent-text)'
+                    : 'var(--c-text-primary)',
+              }}
+            >
+              {event.event_type}
+            </span>
+            <span className="truncate text-[var(--c-text-secondary)]">
+              {event.message ?? event.span_name ?? '—'}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function EngineHistoryPane({ runId }: { runId: string }) {
+  const [after, setAfter] = useState<number | undefined>();
+  const [events, setEvents] = useState<EngineHistoryEvent[]>([]);
+  const loadedPageKeys = useRef(new Set<string>());
+  const historyQuery = useQuery({
+    queryKey: ['engineRunHistory', runId, after ?? null],
+    queryFn: () => fetchEngineRunHistory(runId, { after, limit: 50 }),
+  });
+
+  useEffect(() => {
+    if (!historyQuery.data) {
+      return;
+    }
+    const pageKey = after === undefined ? 'initial' : String(after);
+    if (loadedPageKeys.current.has(pageKey)) {
+      return;
+    }
+    loadedPageKeys.current.add(pageKey);
+    setEvents((current) => [...current, ...historyQuery.data.events]);
+  }, [after, historyQuery.data]);
+
+  if (historyQuery.isLoading && events.length === 0) {
+    return <EngineEmptyCard>Loading engine history…</EngineEmptyCard>;
+  }
+  if (historyQuery.isError) {
+    return <EngineEmptyCard>Engine history is temporarily unavailable.</EngineEmptyCard>;
+  }
+  if (historyQuery.data?.expired) {
+    return <EngineEmptyCard>History expired. Retained history for this run has been purged.</EngineEmptyCard>;
+  }
+  if (events.length === 0) {
+    return <EngineEmptyCard>No retained engine history events.</EngineEmptyCard>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-hidden rounded-lg border border-[var(--c-border)] bg-[var(--c-surface)]">
+        {events.map((event, index) => (
+          <div
+            key={`${event.id}-${index}`}
+            className="grid gap-3 border-b border-[var(--c-border-subtle)] px-3.5 py-2 last:border-b-0"
+            style={{ gridTemplateColumns: '70px 150px minmax(0,1fr)' }}
+          >
+            <span className="font-mono text-xs text-[var(--c-text-muted)]">
+              {event.sequence_no}
+            </span>
+            <span className="font-mono text-xs text-[var(--c-text-secondary)]">
+              {formatTimestamp(event.created_at)}
+            </span>
+            <div className="min-w-0">
+              <div className="font-mono text-xs font-semibold text-[var(--c-text-primary)]">
+                {event.event_type}
+              </div>
+              {event.payload ? (
+                <div className="mt-2 rounded border border-[var(--c-border-subtle)] bg-[var(--c-app-bg)] p-2">
+                  <CompactPayloadInspector value={event.payload} />
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+      {historyQuery.data?.has_more && historyQuery.data.next_after !== undefined ? (
+        <Btn
+          kind="secondary"
+          type="button"
+          disabled={historyQuery.isFetching}
+          onClick={() => setAfter(historyQuery.data?.next_after)}
+        >
+          {historyQuery.isFetching ? 'Loading…' : 'Load more'}
+        </Btn>
+      ) : null}
+    </div>
+  );
+}
+
+function EngineResultPane({
+  runId,
+  status,
+}: {
+  runId: string;
+  status: EngineRunStatus;
+}) {
+  const terminal =
+    status === 'COMPLETED' ||
+    status === 'FAILED' ||
+    status === 'CANCELLED' ||
+    status === 'TERMINATED' ||
+    status === 'CONTINUED_AS_NEW';
+  const resultQuery = useQuery({
+    queryKey: ['engineRunResult', runId],
+    queryFn: () => fetchEngineRunResult(runId),
+    enabled: terminal,
+  });
+
+  if (!terminal) {
+    return <EngineEmptyCard>Result is not available until the run reaches a terminal state.</EngineEmptyCard>;
+  }
+  if (resultQuery.isLoading) {
+    return <EngineEmptyCard>Loading engine result…</EngineEmptyCard>;
+  }
+  if (resultQuery.isError || !resultQuery.data) {
+    return <EngineEmptyCard>Engine result is temporarily unavailable.</EngineEmptyCard>;
+  }
+
+  const result = resultQuery.data;
+  if (result.status === 'COMPLETED') {
+    return (
+      <div className="rounded-lg border border-[var(--c-border)] bg-[var(--c-surface)] p-3.5">
+        <div className="text-[10.5px] font-semibold uppercase tracking-[0.05em] text-[var(--c-text-muted)]">
+          Completed result
+        </div>
+        <div className="mt-3 rounded border border-[var(--c-border-subtle)] bg-[var(--c-app-bg)] p-3">
+          <CompactPayloadInspector value={result.result} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-[var(--c-red-border)] bg-[var(--c-red-faint)] p-3.5">
+      <div className="text-[10.5px] font-semibold uppercase tracking-[0.05em] text-[var(--c-red-text)]">
+        {result.status} result shell
+      </div>
+      {result.failure ? (
+        <>
+          <div className="mt-2 font-mono text-xs text-[var(--c-red-text)]">
+            {result.failure.error_code}
+          </div>
+          <p className="mt-2 text-sm text-[var(--c-text-primary)]">
+            {result.failure.error_message}
+          </p>
+        </>
+      ) : (
+        <p className="mt-2 text-sm text-[var(--c-text-primary)]">
+          Workflow result payload is null for this terminal shell.
+        </p>
+      )}
     </div>
   );
 }

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -3015,7 +3015,7 @@ function TraceEngineStatePanel({
     overview: journalEvents.length,
     pending: pendingCount,
     history: 0,
-    result: engine.status === 'COMPLETED' || hasFailure ? 1 : 0,
+    result: isTerminalEngineStatus(engine.status) || hasFailure ? 1 : 0,
   };
 
   const selectedEvent = selectedEventId
@@ -3447,12 +3447,7 @@ function EngineResultPane({
   runId: string;
   status: EngineRunStatus;
 }) {
-  const terminal =
-    status === 'COMPLETED' ||
-    status === 'FAILED' ||
-    status === 'CANCELLED' ||
-    status === 'TERMINATED' ||
-    status === 'CONTINUED_AS_NEW';
+  const terminal = isTerminalEngineStatus(status);
   const resultQuery = useQuery({
     queryKey: ['engineRunResult', runId],
     queryFn: () => fetchEngineRunResult(runId),
@@ -3503,6 +3498,16 @@ function EngineResultPane({
         </p>
       )}
     </div>
+  );
+}
+
+function isTerminalEngineStatus(status: EngineRunStatus): boolean {
+  return (
+    status === 'COMPLETED' ||
+    status === 'FAILED' ||
+    status === 'CANCELLED' ||
+    status === 'TERMINATED' ||
+    status === 'CONTINUED_AS_NEW'
   );
 }
 

--- a/web/src/utils/tracesSearchParams.test.ts
+++ b/web/src/utils/tracesSearchParams.test.ts
@@ -174,6 +174,33 @@ describe('tracesSearchParams', () => {
     );
   });
 
+  it('round-trips engine-only URL filter params', () => {
+    const parsed = parseTracesParams(
+      new URLSearchParams({
+        engine_only: 'true',
+        offset: '20',
+      })
+    );
+
+    expect(parsed).toMatchObject({
+      limit: 20,
+      offset: 20,
+      engine_only: true,
+    });
+    expect(serializeTracesParams(parsed).toString()).toBe(
+      'offset=20&engine_only=true'
+    );
+    expect(deriveActiveChips(parsed)).toContainEqual({
+      key: 'engine_only',
+      label: 'Engine runs',
+      value: 'Only engine-backed traces',
+    });
+    expect(clearChip(parsed, 'engine_only')).toMatchObject({
+      offset: 0,
+      engine_only: undefined,
+    });
+  });
+
   it('derives human-readable engine filter chips and clears them individually', () => {
     const state = parseTracesParams(
       new URLSearchParams({

--- a/web/src/utils/tracesSearchParams.test.ts
+++ b/web/src/utils/tracesSearchParams.test.ts
@@ -165,6 +165,15 @@ describe('tracesSearchParams', () => {
     );
   });
 
+  it('preserves engine-only fetch params in canonical query strings', () => {
+    expect(buildCanonicalQueryString({ engine_only: true })).toBe(
+      'engine_only=true'
+    );
+    expect(buildCanonicalQueryString({ engine_only: true, limit: 20 })).toBe(
+      'limit=20&engine_only=true'
+    );
+  });
+
   it('derives human-readable engine filter chips and clears them individually', () => {
     const state = parseTracesParams(
       new URLSearchParams({

--- a/web/src/utils/tracesSearchParams.ts
+++ b/web/src/utils/tracesSearchParams.ts
@@ -107,6 +107,7 @@ export interface TracesFilterState {
   engine_child_key?: string;
   engine_child_depth?: number;
   engine_projection_state?: EngineProjectionStateFilter;
+  engine_only?: boolean;
   has_errors?: boolean;
   min_duration_ms?: number;
 }
@@ -458,6 +459,7 @@ export function parseTracesParams(searchParams: URLSearchParams): TracesFilterSt
     engine_child_depth: searchParams.get('engine_child_depth') ?? undefined,
     engine_projection_state:
       searchParams.get('engine_projection_state') ?? undefined,
+    engine_only: searchParams.get('engine_only') ?? undefined,
     has_errors: searchParams.get('has_errors') ?? undefined,
     min_duration_ms: searchParams.get('min_duration_ms') ?? undefined,
   });
@@ -484,6 +486,7 @@ export function parseTracesParams(searchParams: URLSearchParams): TracesFilterSt
     engine_child_key: normalized.engine_child_key,
     engine_child_depth: normalized.engine_child_depth,
     engine_projection_state: normalized.engine_projection_state,
+    engine_only: normalized.engine_only,
     has_errors: normalized.has_errors,
     min_duration_ms: normalized.min_duration_ms,
   };
@@ -648,6 +651,13 @@ export function deriveActiveChips(state: TracesFilterState): Chip[] {
       ),
     });
   }
+  if (normalized.engine_only) {
+    chips.push({
+      key: 'engine_only',
+      label: 'Engine runs',
+      value: 'Only engine-backed traces',
+    });
+  }
   if (normalized.has_errors) {
     chips.push({ key: 'has_errors', label: 'Errors', value: 'Only traces with errors' });
   }
@@ -708,6 +718,8 @@ export function clearChip(
         ...normalized,
         engine_projection_state: undefined,
       });
+    case 'engine_only':
+      return resetOffset({ ...normalized, engine_only: undefined });
     case 'has_errors':
       return resetOffset({ ...normalized, has_errors: undefined });
     case 'min_duration_ms':

--- a/web/src/utils/tracesSearchParams.ts
+++ b/web/src/utils/tracesSearchParams.ts
@@ -80,6 +80,7 @@ export interface FetchTracesParams {
   engine_child_key?: string;
   engine_child_depth?: number;
   engine_projection_state?: EngineProjectionStateFilter;
+  engine_only?: boolean;
   has_errors?: boolean;
   min_duration_ms?: number;
 }
@@ -163,6 +164,7 @@ const CANONICAL_PARAM_ORDER: Array<keyof FetchTracesParams> = [
   'engine_child_key',
   'engine_child_depth',
   'engine_projection_state',
+  'engine_only',
   'has_errors',
   'min_duration_ms',
 ];
@@ -307,6 +309,7 @@ function normalizeTracesParams(
     engine_projection_state: normalizeEngineProjectionState(
       params.engine_projection_state
     ),
+    engine_only: normalizeBooleanTrue(params.engine_only),
     has_errors: normalizeBooleanTrue(params.has_errors),
     min_duration_ms: normalizePositiveInteger(params.min_duration_ms),
   };
@@ -385,6 +388,9 @@ function toQueryEntries(
   }
   if (params.engine_projection_state) {
     entries.push(['engine_projection_state', params.engine_projection_state]);
+  }
+  if (params.engine_only !== undefined) {
+    entries.push(['engine_only', params.engine_only ? 'true' : 'false']);
   }
   if (params.has_errors) {
     entries.push(['has_errors', 'true']);


### PR DESCRIPTION
## Summary
- add engine-only trace filtering and hydrated engine run metadata to the trace listing API
- add the Engine Runs console, start-run dialog, and projection repair tool
- add trace-detail engine panes for overview, pending work, history, and result, with responsive cleanup for the mobile workspace

## Validation
- go test ./internal/api/... ./internal/store/...
- pnpm --filter web test -- --run src/pages/TraceDetailPage.test.tsx src/pages/EngineRunsPage.test.tsx src/utils/tracesSearchParams.test.ts src/api/client.test.ts
- make type-check
- make lint-js
- openspec validate add-engine-runs-console --strict

Note: make lint-js still reports the existing Redocly warning for /api/auth/config missing a 4XX response, but exits successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Engine Runs page to view and start engine-backed runs
  * Engine projection repair tool with dry-run preview and apply workflow
  * New trace filter: engine_only to show only engine-backed traces

* **Improvements**
  * Trace details show instance ID, run status, wait state, pending work, and updated time
  * Added engine statuses: QUEUED, WAITING, SUSPENDED, CANCELLED, TERMINATED, CONTINUED_AS_NEW
  * Simplified mobile workspace tabs

* **Other**
  * Authentication/error text updated to consistently reference “credentials”

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->