### PR TITLE
Seed engine demo data

### DIFF
--- a/internal/api/engine_handlers.go
+++ b/internal/api/engine_handlers.go
@@ -7,6 +7,7 @@ import (
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
+	"github.com/continua-ai/continua/internal/api/middleware"
 	"github.com/continua-ai/continua/internal/enginecontrol"
 )
 
@@ -271,6 +272,10 @@ func (s *Server) BackfillEngineProjections(w http.ResponseWriter, r *http.Reques
 	backfillReq, err := engineProjectionBackfillRequestFromAPI(&req)
 	if err != nil {
 		writeEngineError(w, err, "Invalid engine projection backfill request")
+		return
+	}
+	if mode, ok := middleware.GetAuthMode(r.Context()); ok && mode == middleware.AuthModePublicDemo && !backfillReq.DryRun {
+		writeError(w, http.StatusForbidden, "public_demo_read_only", "Public demo projection repair only allows dry runs")
 		return
 	}
 

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -2243,6 +2243,62 @@ func TestBackfillEngineProjections_DryRunReturnsWouldRepairWithoutMutation(t *te
 	assert.Equal(t, "summary_only", projectionState)
 }
 
+func TestBackfillEngineProjections_PublicDemoAllowsOnlyDryRun(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	start := decodeJSONBody[EngineStartRunResponse](t, invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       "instance-backfill-public-demo",
+		RequestKey:        "req-backfill-public-demo",
+	}))
+
+	trace, err := platformStore.Queries().GetTraceByExternalID(ctx, platformdb.GetTraceByExternalIDParams{
+		ProjectID: projectID,
+		TraceID:   start.TraceId,
+	})
+	require.NoError(t, err)
+
+	latestHistoryID, err := engineQueries.GetLatestHistoryIDByRun(ctx, start.RunId)
+	require.NoError(t, err)
+	setEngineProjectionCheckpoint(t, ctx, platformStore, trace.ID, "summary_only", latestHistoryID, latestHistoryID-1)
+
+	dryRun := true
+	dryRunResp := decodeJSONBody[EngineProjectionBackfillResponse](t, invokeBackfillEngineProjectionsWithAuthMode(
+		t,
+		server,
+		projectID,
+		middleware.AuthModePublicDemo,
+		&EngineProjectionBackfillRequest{DryRun: &dryRun},
+	))
+	assert.True(t, dryRunResp.DryRun)
+	assert.Equal(t, 1, dryRunResp.EligibleCount)
+	require.Len(t, dryRunResp.Results, 1)
+	assert.Equal(t, EngineProjectionBackfillActionWouldRepair, dryRunResp.Results[0].Action)
+
+	apply := false
+	applyRec := invokeBackfillEngineProjectionsWithAuthMode(
+		t,
+		server,
+		projectID,
+		middleware.AuthModePublicDemo,
+		&EngineProjectionBackfillRequest{DryRun: &apply},
+	)
+	require.Equal(t, http.StatusForbidden, applyRec.Code)
+	applyResp := decodeJSONBody[Error](t, applyRec)
+	assert.Equal(t, "public_demo_read_only", applyResp.Code)
+
+	var projectionState string
+	err = platformStore.Pool().QueryRow(ctx, `
+		SELECT engine_projection_state
+		FROM traces
+		WHERE id = $1
+	`, trace.ID).Scan(&projectionState)
+	require.NoError(t, err)
+	assert.Equal(t, "summary_only", projectionState)
+}
+
 func TestBackfillEngineProjections_ApplyRequestsRepairAndFlipsState(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
@@ -3202,6 +3258,18 @@ func invokeBackfillEngineProjections(
 ) *httptest.ResponseRecorder {
 	t.Helper()
 
+	return invokeBackfillEngineProjectionsWithAuthMode(t, server, projectID, "", reqBody)
+}
+
+func invokeBackfillEngineProjectionsWithAuthMode(
+	t *testing.T,
+	server *Server,
+	projectID uuid.UUID,
+	authMode middleware.AuthMode,
+	reqBody *EngineProjectionBackfillRequest,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
 	var body *bytes.Reader
 	if reqBody != nil {
 		payload, err := json.Marshal(reqBody)
@@ -3214,6 +3282,9 @@ func invokeBackfillEngineProjections(
 	req := httptest.NewRequest(http.MethodPost, "/v1/engine/projections/backfill", body)
 	req.Header.Set(enginePreviewHeader, "1")
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
+	if authMode != "" {
+		req = req.WithContext(context.WithValue(req.Context(), middleware.AuthModeKey, authMode))
+	}
 	rec := httptest.NewRecorder()
 
 	server.BackfillEngineProjections(rec, req, BackfillEngineProjectionsParams{XContinuaEnginePreview: "1"})

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -97,7 +97,7 @@ func (a *Authenticator) Middleware() func(http.Handler) http.Handler {
 			case routeProtectionAPIKeyOnly:
 				a.serveAPIKeyOnly(next, w, r)
 			case routeProtectionComposite:
-				if a.publicDemo != nil && isPublicDemoReadRequest(r.Method, r.URL.Path) {
+				if a.publicDemo != nil && isPublicDemoAllowedRequest(r.Method, r.URL.Path) {
 					a.servePublicDemoRead(next, w, r)
 					return
 				}
@@ -332,6 +332,13 @@ func isPublicDemoReadRequest(method, path string) bool {
 	default:
 		return false
 	}
+}
+
+func isPublicDemoAllowedRequest(method, path string) bool {
+	if isPublicDemoReadRequest(method, path) {
+		return true
+	}
+	return method == http.MethodPost && path == "/v1/engine/projections/backfill"
 }
 
 func isProjectBootstrapRoute(method, path string) bool {

--- a/internal/api/middleware/composite_auth_test.go
+++ b/internal/api/middleware/composite_auth_test.go
@@ -64,6 +64,14 @@ func TestPublicDemoReadRequest_OnlyMatchesDebuggerReadRoutes(t *testing.T) {
 	assert.False(t, isPublicDemoReadRequest(http.MethodGet, "/v1/ingest"))
 }
 
+func TestPublicDemoAllowedRequest_IncludesProjectionBackfillDryRunRoute(t *testing.T) {
+	assert.True(t, isPublicDemoAllowedRequest(http.MethodGet, "/api/traces"))
+	assert.True(t, isPublicDemoAllowedRequest(http.MethodPost, "/v1/engine/projections/backfill"))
+	assert.False(t, isPublicDemoAllowedRequest(http.MethodPost, "/v1/engine/runs"))
+	assert.False(t, isPublicDemoAllowedRequest(http.MethodPost, "/v1/engine/runs/run-123/signal"))
+	assert.False(t, isPublicDemoAllowedRequest(http.MethodPost, "/api/traces"))
+}
+
 func TestCompositeAuthRejectsMissingCredentialsOnDebuggerRoutes(t *testing.T) {
 	authenticator := &Authenticator{}
 	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -351,6 +359,32 @@ func TestCompositeAuthAllowsPublicDemoReadWithoutCredentials(t *testing.T) {
 		"/api/traces?project_id=22222222-2222-2222-2222-222222222222",
 		nil,
 	)
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, AuthModePublicDemo, receivedMode)
+	assert.Equal(t, demoProjectID, receivedProjectID)
+}
+
+func TestCompositeAuthAllowsPublicDemoProjectionBackfillWithoutCredentials(t *testing.T) {
+	demoProjectID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	authenticator := &Authenticator{
+		publicDemo: &publicDemoAccess{projectID: demoProjectID},
+	}
+
+	var receivedMode AuthMode
+	var receivedProjectID uuid.UUID
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
+		receivedMode, ok = GetAuthMode(r.Context())
+		require.True(t, ok)
+		receivedProjectID, ok = GetProjectID(r.Context())
+		require.True(t, ok)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/projections/backfill", nil)
 	rec := httptest.NewRecorder()
 
 	protectedHandler.ServeHTTP(rec, req)

--- a/scripts/seed-demo.sh
+++ b/scripts/seed-demo.sh
@@ -48,6 +48,12 @@ VALUES (
 );
 SQL
 
+echo "==> Seeding deterministic engine demo fixtures"
+psql "${DATABASE_URL}" \
+  -v ON_ERROR_STOP=1 \
+  -v demo_project_id="${DEMO_PROJECT_ID}" \
+  -f "${ROOT_DIR}/scripts/seed-engine-demo.sql"
+
 echo "==> Seeding demo traces through the ingest API at ${API_URL}"
 (
   cd "${ROOT_DIR}/sdks/python"

--- a/scripts/seed-engine-demo.sql
+++ b/scripts/seed-engine-demo.sql
@@ -1,0 +1,590 @@
+-- Deterministic engine fixtures for the public demo project.
+--
+-- This file is intentionally direct SQL instead of API calls. The public demo
+-- should be inspectable after seeding without requiring a workflow worker.
+
+DELETE FROM traces
+WHERE (
+    project_id = :'demo_project_id'::uuid
+    AND (
+      engine_run_id IS NOT NULL
+      OR trace_id IN (
+        'engine:20000000-0000-4000-8000-000000000001',
+        'engine:20000000-0000-4000-8000-000000000002',
+        'engine:20000000-0000-4000-8000-000000000003',
+        'engine:demo:checkout-approval',
+        'engine:demo:checkout-completed',
+        'engine:demo:darklaunch-stale'
+      )
+    )
+  )
+  OR engine_run_id IN (
+    '20000000-0000-4000-8000-000000000001'::uuid,
+    '20000000-0000-4000-8000-000000000002'::uuid,
+    '20000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR trace_id IN (
+    'engine:20000000-0000-4000-8000-000000000001',
+    'engine:20000000-0000-4000-8000-000000000002',
+    'engine:20000000-0000-4000-8000-000000000003',
+    'engine:demo:checkout-approval',
+    'engine:demo:checkout-completed',
+    'engine:demo:darklaunch-stale'
+  );
+
+DELETE FROM engine.activity_tasks
+WHERE project_id = :'demo_project_id'::uuid
+  OR run_id IN (
+    '20000000-0000-4000-8000-000000000001'::uuid,
+    '20000000-0000-4000-8000-000000000002'::uuid,
+    '20000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR instance_id IN (
+    '10000000-0000-4000-8000-000000000001'::uuid,
+    '10000000-0000-4000-8000-000000000002'::uuid,
+    '10000000-0000-4000-8000-000000000003'::uuid
+  );
+
+DELETE FROM engine.inbox
+WHERE project_id = :'demo_project_id'::uuid
+  OR run_id IN (
+    '20000000-0000-4000-8000-000000000001'::uuid,
+    '20000000-0000-4000-8000-000000000002'::uuid,
+    '20000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR instance_id IN (
+    '10000000-0000-4000-8000-000000000001'::uuid,
+    '10000000-0000-4000-8000-000000000002'::uuid,
+    '10000000-0000-4000-8000-000000000003'::uuid
+  );
+
+DELETE FROM engine.request_dedupe
+WHERE project_id = :'demo_project_id'::uuid
+  OR run_id IN (
+    '20000000-0000-4000-8000-000000000001'::uuid,
+    '20000000-0000-4000-8000-000000000002'::uuid,
+    '20000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR instance_id IN (
+    '10000000-0000-4000-8000-000000000001'::uuid,
+    '10000000-0000-4000-8000-000000000002'::uuid,
+    '10000000-0000-4000-8000-000000000003'::uuid
+  );
+
+DELETE FROM engine.child_workflows
+WHERE project_id = :'demo_project_id'::uuid
+  OR parent_instance_id IN (
+    '10000000-0000-4000-8000-000000000001'::uuid,
+    '10000000-0000-4000-8000-000000000002'::uuid,
+    '10000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR child_instance_id IN (
+    '10000000-0000-4000-8000-000000000001'::uuid,
+    '10000000-0000-4000-8000-000000000002'::uuid,
+    '10000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR parent_run_id IN (
+    '20000000-0000-4000-8000-000000000001'::uuid,
+    '20000000-0000-4000-8000-000000000002'::uuid,
+    '20000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR current_child_run_id IN (
+    '20000000-0000-4000-8000-000000000001'::uuid,
+    '20000000-0000-4000-8000-000000000002'::uuid,
+    '20000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR terminal_child_run_id IN (
+    '20000000-0000-4000-8000-000000000001'::uuid,
+    '20000000-0000-4000-8000-000000000002'::uuid,
+    '20000000-0000-4000-8000-000000000003'::uuid
+  );
+
+DELETE FROM engine.history
+WHERE project_id = :'demo_project_id'::uuid
+  OR run_id IN (
+    '20000000-0000-4000-8000-000000000001'::uuid,
+    '20000000-0000-4000-8000-000000000002'::uuid,
+    '20000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR instance_id IN (
+    '10000000-0000-4000-8000-000000000001'::uuid,
+    '10000000-0000-4000-8000-000000000002'::uuid,
+    '10000000-0000-4000-8000-000000000003'::uuid
+  );
+
+DELETE FROM engine.runs
+WHERE project_id = :'demo_project_id'::uuid
+  OR id IN (
+    '20000000-0000-4000-8000-000000000001'::uuid,
+    '20000000-0000-4000-8000-000000000002'::uuid,
+    '20000000-0000-4000-8000-000000000003'::uuid
+  )
+  OR instance_id IN (
+    '10000000-0000-4000-8000-000000000001'::uuid,
+    '10000000-0000-4000-8000-000000000002'::uuid,
+    '10000000-0000-4000-8000-000000000003'::uuid
+  );
+
+DELETE FROM engine.instances
+WHERE project_id = :'demo_project_id'::uuid
+  OR id IN (
+    '10000000-0000-4000-8000-000000000001'::uuid,
+    '10000000-0000-4000-8000-000000000002'::uuid,
+    '10000000-0000-4000-8000-000000000003'::uuid
+  );
+
+INSERT INTO engine.definition_catalog (definition_name, definition_version, published_at, updated_at)
+VALUES
+  ('checkout', 'v1', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days'),
+  ('darklaunch.demo', 'v1', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days')
+ON CONFLICT (definition_name, definition_version) DO UPDATE
+SET updated_at = EXCLUDED.updated_at;
+
+INSERT INTO engine.instances (
+    id,
+    project_id,
+    instance_key,
+    definition_name,
+    status,
+    metadata,
+    created_at,
+    updated_at
+)
+VALUES
+  (
+    '10000000-0000-4000-8000-000000000001',
+    :'demo_project_id'::uuid,
+    'demo-checkout-approval',
+    'checkout',
+    'active',
+    '{"demo": true, "scenario": "waiting_for_approval"}'::jsonb,
+    NOW() - INTERVAL '55 minutes',
+    NOW() - INTERVAL '2 minutes'
+  ),
+  (
+    '10000000-0000-4000-8000-000000000002',
+    :'demo_project_id'::uuid,
+    'demo-checkout-completed',
+    'checkout',
+    'completed',
+    '{"demo": true, "scenario": "completed_checkout"}'::jsonb,
+    NOW() - INTERVAL '2 hours',
+    NOW() - INTERVAL '85 minutes'
+  ),
+  (
+    '10000000-0000-4000-8000-000000000003',
+    :'demo_project_id'::uuid,
+    'demo-darklaunch-stale',
+    'darklaunch.demo',
+    'completed',
+    '{"demo": true, "scenario": "projection_repair"}'::jsonb,
+    NOW() - INTERVAL '3 hours',
+    NOW() - INTERVAL '150 minutes'
+  );
+
+INSERT INTO engine.runs (
+    id,
+    project_id,
+    instance_id,
+    run_number,
+    definition_version,
+    status,
+    ready_at,
+    result,
+    custom_status,
+    waiting_for,
+    completed_at,
+    root_run_id,
+    child_depth,
+    created_at,
+    updated_at
+)
+VALUES
+  (
+    '20000000-0000-4000-8000-000000000001',
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000001',
+    1,
+    'v1',
+    'waiting',
+    NOW() - INTERVAL '55 minutes',
+    NULL,
+    '{"phase": "awaiting approval", "cart_total": 129.99}'::jsonb,
+    '{"kind": "signal", "signal_name": "approval_received"}'::jsonb,
+    NULL,
+    '20000000-0000-4000-8000-000000000001',
+    0,
+    NOW() - INTERVAL '55 minutes',
+    NOW() - INTERVAL '2 minutes'
+  ),
+  (
+    '20000000-0000-4000-8000-000000000002',
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000002',
+    1,
+    'v1',
+    'completed',
+    NOW() - INTERVAL '2 hours',
+    '{"order_id": "demo-order-1001", "approved": true, "total": 84.25}'::jsonb,
+    '{"phase": "fulfilled"}'::jsonb,
+    NULL,
+    NOW() - INTERVAL '85 minutes',
+    '20000000-0000-4000-8000-000000000002',
+    0,
+    NOW() - INTERVAL '2 hours',
+    NOW() - INTERVAL '85 minutes'
+  ),
+  (
+    '20000000-0000-4000-8000-000000000003',
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000003',
+    1,
+    'v1',
+    'completed',
+    NOW() - INTERVAL '3 hours',
+    '{"variant": "treatment", "converted": true}'::jsonb,
+    '{"phase": "summary retained"}'::jsonb,
+    NULL,
+    NOW() - INTERVAL '150 minutes',
+    '20000000-0000-4000-8000-000000000003',
+    0,
+    NOW() - INTERVAL '3 hours',
+    NOW() - INTERVAL '150 minutes'
+  );
+
+INSERT INTO engine.history (
+    project_id,
+    instance_id,
+    run_id,
+    sequence_no,
+    event_type,
+    payload,
+    created_at
+)
+VALUES
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000001',
+    '20000000-0000-4000-8000-000000000001',
+    1,
+    'workflow.started',
+    '{"definition_name": "checkout", "definition_version": "v1", "instance_key": "demo-checkout-approval", "input": {"cart_id": "demo-cart-42", "total": 129.99}}'::jsonb,
+    NOW() - INTERVAL '55 minutes'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000001',
+    '20000000-0000-4000-8000-000000000001',
+    2,
+    'activity.scheduled',
+    '{"activity_key": "reserve-inventory", "activity_type": "inventory.reserve", "input": {"sku": "demo-sku-7", "quantity": 1}}'::jsonb,
+    NOW() - INTERVAL '54 minutes'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000001',
+    '20000000-0000-4000-8000-000000000001',
+    3,
+    'timer.scheduled',
+    jsonb_build_object('timer_key', 'approval-timeout', 'due_at', to_jsonb(NOW() + INTERVAL '5 minutes')),
+    NOW() - INTERVAL '53 minutes'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000002',
+    '20000000-0000-4000-8000-000000000002',
+    1,
+    'workflow.started',
+    '{"definition_name": "checkout", "definition_version": "v1", "instance_key": "demo-checkout-completed", "input": {"cart_id": "demo-cart-17", "total": 84.25}}'::jsonb,
+    NOW() - INTERVAL '2 hours'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000002',
+    '20000000-0000-4000-8000-000000000002',
+    2,
+    'activity.completed',
+    '{"activity_key": "charge-card", "activity_type": "payments.charge", "output": {"charge_id": "demo-charge-1001", "approved": true}}'::jsonb,
+    NOW() - INTERVAL '90 minutes'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000002',
+    '20000000-0000-4000-8000-000000000002',
+    3,
+    'workflow.completed',
+    '{"result": {"order_id": "demo-order-1001", "approved": true, "total": 84.25}}'::jsonb,
+    NOW() - INTERVAL '85 minutes'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000003',
+    '20000000-0000-4000-8000-000000000003',
+    1,
+    'workflow.started',
+    '{"definition_name": "darklaunch.demo", "definition_version": "v1", "instance_key": "demo-darklaunch-stale", "input": {"account_id": "demo-account-9"}}'::jsonb,
+    NOW() - INTERVAL '3 hours'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000003',
+    '20000000-0000-4000-8000-000000000003',
+    2,
+    'custom_status.updated',
+    '{"status": {"phase": "evaluating rollout", "percent": 25}}'::jsonb,
+    NOW() - INTERVAL '170 minutes'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000003',
+    '20000000-0000-4000-8000-000000000003',
+    3,
+    'workflow.completed',
+    '{"result": {"variant": "treatment", "converted": true}}'::jsonb,
+    NOW() - INTERVAL '150 minutes'
+  );
+
+INSERT INTO engine.activity_tasks (
+    project_id,
+    instance_id,
+    run_id,
+    history_id,
+    activity_key,
+    activity_type,
+    input,
+    available_at,
+    execution_target,
+    max_attempts
+)
+VALUES (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000001',
+    '20000000-0000-4000-8000-000000000001',
+    (
+      SELECT id
+      FROM engine.history
+      WHERE run_id = '20000000-0000-4000-8000-000000000001'
+        AND sequence_no = 2
+    ),
+    'reserve-inventory',
+    'inventory.reserve',
+    '{"sku": "demo-sku-7", "quantity": 1}'::jsonb,
+    NOW() - INTERVAL '54 minutes',
+    'local',
+    3
+);
+
+INSERT INTO engine.inbox (
+    project_id,
+    instance_id,
+    run_id,
+    history_id,
+    kind,
+    payload,
+    available_at,
+    dedupe_key
+)
+VALUES
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000001',
+    '20000000-0000-4000-8000-000000000001',
+    (
+      SELECT id
+      FROM engine.history
+      WHERE run_id = '20000000-0000-4000-8000-000000000001'
+        AND sequence_no = 3
+    ),
+    'timer',
+    jsonb_build_object('timer_key', 'approval-timeout', 'due_at', to_jsonb(NOW() + INTERVAL '5 minutes')),
+    NOW() + INTERVAL '5 minutes',
+    'demo-checkout-approval:approval-timeout'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    '10000000-0000-4000-8000-000000000001',
+    '20000000-0000-4000-8000-000000000001',
+    NULL,
+    'signal',
+    '{"signal_name": "approval_received", "payload": {"approved": true}}'::jsonb,
+    NOW() - INTERVAL '2 minutes',
+    'demo-checkout-approval:approval-received'
+  );
+
+INSERT INTO traces (
+    project_id,
+    trace_id,
+    name,
+    user_id,
+    tags,
+    environment,
+    release,
+    metadata,
+    input,
+    output,
+    status,
+    start_time,
+    end_time,
+    duration_ms,
+    total_spans,
+    total_cost,
+    error_count,
+    total_tokens_in,
+    total_tokens_out,
+    engine_run_id,
+    engine_instance_key,
+    engine_run_status,
+    engine_custom_status,
+    engine_wait_state,
+    engine_pending_activity_tasks,
+    engine_pending_inbox_items,
+    engine_definition_name,
+    engine_definition_version,
+    engine_parent_run_id,
+    engine_root_run_id,
+    engine_child_key,
+    engine_child_depth,
+    engine_projection_state,
+    engine_latest_history_id,
+    engine_last_projected_history_id,
+    engine_projection_updated_at
+)
+VALUES
+  (
+    :'demo_project_id'::uuid,
+    'engine:20000000-0000-4000-8000-000000000001',
+    'checkout',
+    'demo-user',
+    ARRAY['engine', 'demo', 'checkout'],
+    'demo',
+    'public-demo',
+    '{"demo": true, "scenario": "waiting_for_approval"}'::jsonb,
+    '{"cart_id": "demo-cart-42", "total": 129.99}'::jsonb,
+    NULL,
+    'running',
+    NOW() - INTERVAL '55 minutes',
+    NULL,
+    NULL,
+    1,
+    0,
+    0,
+    0,
+    0,
+    '20000000-0000-4000-8000-000000000001',
+    'demo-checkout-approval',
+    'waiting',
+    '{"phase": "awaiting approval", "cart_total": 129.99}'::jsonb,
+    '{"kind": "signal", "signal_name": "approval_received"}'::jsonb,
+    1,
+    2,
+    'checkout',
+    'v1',
+    NULL,
+    '20000000-0000-4000-8000-000000000001',
+    NULL,
+    0,
+    'up_to_date',
+    (
+      SELECT MAX(id)
+      FROM engine.history
+      WHERE run_id = '20000000-0000-4000-8000-000000000001'
+    ),
+    (
+      SELECT MAX(id)
+      FROM engine.history
+      WHERE run_id = '20000000-0000-4000-8000-000000000001'
+    ),
+    NOW() - INTERVAL '2 minutes'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    'engine:20000000-0000-4000-8000-000000000002',
+    'checkout',
+    'demo-user',
+    ARRAY['engine', 'demo', 'checkout'],
+    'demo',
+    'public-demo',
+    '{"demo": true, "scenario": "completed_checkout"}'::jsonb,
+    '{"cart_id": "demo-cart-17", "total": 84.25}'::jsonb,
+    '{"order_id": "demo-order-1001", "approved": true, "total": 84.25}'::jsonb,
+    'ok',
+    NOW() - INTERVAL '2 hours',
+    NOW() - INTERVAL '85 minutes',
+    2100000,
+    1,
+    0,
+    0,
+    0,
+    0,
+    '20000000-0000-4000-8000-000000000002',
+    'demo-checkout-completed',
+    'completed',
+    '{"phase": "fulfilled"}'::jsonb,
+    NULL,
+    0,
+    0,
+    'checkout',
+    'v1',
+    NULL,
+    '20000000-0000-4000-8000-000000000002',
+    NULL,
+    0,
+    'up_to_date',
+    (
+      SELECT MAX(id)
+      FROM engine.history
+      WHERE run_id = '20000000-0000-4000-8000-000000000002'
+    ),
+    (
+      SELECT MAX(id)
+      FROM engine.history
+      WHERE run_id = '20000000-0000-4000-8000-000000000002'
+    ),
+    NOW() - INTERVAL '85 minutes'
+  ),
+  (
+    :'demo_project_id'::uuid,
+    'engine:20000000-0000-4000-8000-000000000003',
+    'darklaunch.demo',
+    'demo-user',
+    ARRAY['engine', 'demo', 'projection-repair'],
+    'demo',
+    'public-demo',
+    '{"demo": true, "scenario": "projection_repair"}'::jsonb,
+    '{"account_id": "demo-account-9"}'::jsonb,
+    '{"variant": "treatment", "converted": true}'::jsonb,
+    'ok',
+    NOW() - INTERVAL '3 hours',
+    NOW() - INTERVAL '150 minutes',
+    1800000,
+    1,
+    0,
+    0,
+    0,
+    0,
+    '20000000-0000-4000-8000-000000000003',
+    'demo-darklaunch-stale',
+    'completed',
+    '{"phase": "summary retained"}'::jsonb,
+    NULL,
+    0,
+    0,
+    'darklaunch.demo',
+    'v1',
+    NULL,
+    '20000000-0000-4000-8000-000000000003',
+    NULL,
+    0,
+    'summary_only',
+    (
+      SELECT MAX(id)
+      FROM engine.history
+      WHERE run_id = '20000000-0000-4000-8000-000000000003'
+    ),
+    (
+      SELECT MAX(id) - 1
+      FROM engine.history
+      WHERE run_id = '20000000-0000-4000-8000-000000000003'
+    ),
+    NOW() - INTERVAL '140 minutes'
+  );

--- a/scripts/seed_engine_demo_test.go
+++ b/scripts/seed_engine_demo_test.go
@@ -1,0 +1,160 @@
+package scripts_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestSeedDemoIncludesEngineFixtures(t *testing.T) {
+	repoRoot := repoRoot(t)
+
+	seedScript := readFile(t, filepath.Join(repoRoot, "scripts", "seed-demo.sh"))
+	assertContains(t, seedScript, "scripts/seed-engine-demo.sql")
+
+	fixtureSQL := readFile(t, filepath.Join(repoRoot, "scripts", "seed-engine-demo.sql"))
+	for _, expected := range []string{
+		"engine:20000000-0000-4000-8000-000000000001",
+		"engine:20000000-0000-4000-8000-000000000002",
+		"engine:20000000-0000-4000-8000-000000000003",
+		"'summary_only'",
+		"demo-checkout-approval:approval-timeout",
+		"approval_received",
+	} {
+		assertContains(t, fixtureSQL, expected)
+	}
+}
+
+func TestSeedDemoScriptSyntax(t *testing.T) {
+	repoRoot := repoRoot(t)
+
+	cmd := exec.Command("bash", "-n", filepath.Join(repoRoot, "scripts", "seed-demo.sh"))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed-demo.sh has invalid shell syntax: %v\n%s", err, output)
+	}
+}
+
+func TestSeedEngineDemoSQLCreatesUsableEngineFixtures(t *testing.T) {
+	if _, err := exec.LookPath("psql"); err != nil {
+		t.Skipf("psql is required for seed fixture smoke test: %v", err)
+	}
+
+	repoRoot := repoRoot(t)
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		dbURL = testutil.DefaultTestDBURL
+	}
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	projectID := uuid.New()
+
+	_, err := pool.Exec(ctx, `DELETE FROM projects WHERE id = $1`, projectID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO projects (id, name, api_key_hash)
+		VALUES ($1, 'engine demo fixture smoke', 'engine-demo-fixture-smoke-key')
+	`, projectID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO traces (project_id, trace_id, name, status)
+		VALUES ($1, 'sdk-demo-trace', 'sdk demo trace', 'ok')
+	`, projectID)
+	require.NoError(t, err)
+
+	cmd := exec.Command(
+		"psql",
+		dbURL,
+		"-v",
+		"ON_ERROR_STOP=1",
+		"-v",
+		"demo_project_id="+projectID.String(),
+		"-f",
+		filepath.Join(repoRoot, "scripts", "seed-engine-demo.sql"),
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	var engineTraceCount int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM traces
+		WHERE project_id = $1
+		  AND engine_run_id IS NOT NULL
+	`, projectID).Scan(&engineTraceCount))
+	assert.Equal(t, 3, engineTraceCount)
+
+	var canonicalTraceIDCount int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM traces
+		WHERE project_id = $1
+		  AND engine_run_id IS NOT NULL
+		  AND trace_id = 'engine:' || engine_run_id::text
+	`, projectID).Scan(&canonicalTraceIDCount))
+	assert.Equal(t, 3, canonicalTraceIDCount)
+
+	var repairCandidateCount int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM traces AS t
+		INNER JOIN engine.runs AS r
+		    ON r.project_id = t.project_id
+		   AND r.id = t.engine_run_id
+		INNER JOIN LATERAL (
+		    SELECT COALESCE(MAX(h.id), 0)::bigint AS latest_retained_history_id
+		    FROM engine.history AS h
+		    WHERE h.run_id = r.id
+		) AS hist ON true
+		WHERE t.project_id = $1
+		  AND t.engine_projection_state = 'summary_only'
+		  AND hist.latest_retained_history_id > COALESCE(t.engine_last_projected_history_id, 0)
+	`, projectID).Scan(&repairCandidateCount))
+	assert.Equal(t, 1, repairCandidateCount)
+
+	var nonEngineTraceCount int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM traces
+		WHERE project_id = $1
+		  AND trace_id = 'sdk-demo-trace'
+		  AND engine_run_id IS NULL
+	`, projectID).Scan(&nonEngineTraceCount))
+	assert.Equal(t, 1, nonEngineTraceCount)
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	return filepath.Dir(cwd)
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(contents)
+}
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+
+	if !strings.Contains(haystack, needle) {
+		t.Fatalf("expected file contents to include %q", needle)
+	}
+}


### PR DESCRIPTION
## Summary
- seed deterministic engine runs for the public demo so `/engine/runs` has real data
- keep public demo read-only while allowing projection repair dry-runs
- add DB-backed fixture coverage for canonical engine trace IDs and repair eligibility

## Validation
- `go test -count=1 ./scripts`
- `go test -count=1 ./internal/api -run 'TestBackfillEngineProjections_PublicDemoAllowsOnlyDryRun'`
- `go test -count=1 ./internal/api/middleware -run 'TestPublicDemo|TestCompositeAuthAllowsPublicDemoProjectionBackfill'`
- `go test -count=1 ./internal/api/... ./internal/store/... ./scripts`
- `openspec validate add-engine-runs-console --strict` in the original checkout where the gitignored OpenSpec change is present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public demo mode now permits dry-run backfill operations to test repair functionality
  * Non-dry-run backfill requests in public demo are restricted (read-only access)
  * Demo environment now includes pre-seeded engine workflow scenarios with multiple states for comprehensive testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->