### PR TITLE
docs: refresh documentation formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ If `openspec/` is present in the working tree, open `@/openspec/AGENTS.md` when 
 - Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
 - Sounds ambiguous and you need the authoritative spec before coding
 
-`openspec/` is gitignored — it's the internal product-development record, present only on the maintainer's local checkout. External contributors will not have it; fall back to checked-in code and [docs-site/](./docs-site/) as the authoritative sources.
+`openspec/` is gitignored: it's the internal product-development record, present only on the maintainer's local checkout. External contributors will not have it; fall back to checked-in code and [docs-site/](./docs-site/) as the authoritative sources.
 
 Keep this managed block so 'openspec update' can refresh the instructions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ If `openspec/` is present in the working tree, open `@/openspec/AGENTS.md` when 
 - Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
 - Sounds ambiguous and you need the authoritative spec before coding
 
-`openspec/` is gitignored — it's the internal product-development record, present only on the maintainer's local checkout. External contributors will not have it; in that case, fall back to checked-in code and [docs-site/](./docs-site/) as the authoritative sources.
+`openspec/` is gitignored: it's the internal product-development record, present only on the maintainer's local checkout. External contributors will not have it; in that case, fall back to checked-in code and [docs-site/](./docs-site/) as the authoritative sources.
 
 Keep this managed block so 'openspec update' can refresh the instructions.
 
@@ -36,7 +36,7 @@ Start discovery from:
 - `.claude/skills/references/decisions.md` (if present locally)
 - the live package you are editing
 
-Use the checked-in code, contracts, and migrations as the authoritative current-state baseline. `docs/DEBUGGER_PLATFORM_BASELINE.md` and `docs/PHASE5_CURRENT_STATE_REPORT.md` are gitignored historical context — use them only if present locally; do not rely on them in external clones.
+Use the checked-in code, contracts, and migrations as the authoritative current-state baseline. `docs/DEBUGGER_PLATFORM_BASELINE.md` and `docs/PHASE5_CURRENT_STATE_REPORT.md` are gitignored historical context: use them only if present locally; do not rely on them in external clones.
 
 ## What Exists Today
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@
 
 Before making changes, skim:
 
-- [`docs-site/concepts/overview.mdx`](./docs-site/concepts/overview.mdx) — current architecture and runtime components
-- [`docs-site/concepts/data-model.mdx`](./docs-site/concepts/data-model.mdx) — persisted entity model and identity rules
-- [`AGENTS.md`](./AGENTS.md) — repo conventions, generated-file boundaries, testing expectations
+- [`docs-site/concepts/overview.mdx`](./docs-site/concepts/overview.mdx): current architecture and runtime components
+- [`docs-site/concepts/data-model.mdx`](./docs-site/concepts/data-model.mdx): persisted entity model and identity rules
+- [`AGENTS.md`](./AGENTS.md): repo conventions, generated-file boundaries, testing expectations
 
 ## Development workflow
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/banner.svg" alt="Continua — self-hosted debugging for AI agent runs" />
+  <img src="./assets/banner.svg" alt="Continua: self-hosted debugging for AI agent runs" />
 </p>
 
 <div align="center">
@@ -29,7 +29,7 @@
 
 ---
 
-Continua is a **local operator console for debugging AI agent executions**. It accepts traces over an authenticated REST ingest API, persists them in Postgres, processes async work with River, and serves a React debugger from the Go backend — in a single binary, on your own infrastructure.
+Continua is a **local operator console for debugging AI agent executions**. It accepts traces over an authenticated REST ingest API, persists them in Postgres, processes async work with River, and serves a React debugger from the Go backend as a single binary, on your own infrastructure.
 
 The current product is intentionally concrete: trace runs, inspect spans and payloads, compare session attempts, and keep enough durable state to understand why an agent failed, stalled, retried, or behaved differently than expected.
 
@@ -37,7 +37,7 @@ The current product is intentionally concrete: trace runs, inspect spans and pay
 > Public demo mode uses seeded sample traces only. Use the private local console path when you want to ingest and inspect your own traces.
 
 <p align="center">
-  <img src="./assets/screenshots/debugger-hero.png" alt="Continua debugger — failure-first trace view with execution waterfall and span detail" />
+  <img src="./assets/screenshots/debugger-hero.png" alt="Continua debugger: failure-first trace view with execution waterfall and span detail" />
 </p>
 
 ## Quickstart
@@ -82,15 +82,15 @@ It's most useful when you need to answer: what failed first, what changed during
 
 ![Continua features at a glance](./assets/diagrams/feature-strip.svg)
 
-- **Trace debugger** — span tree, execution waterfall, selected spans, payload inspection, breadcrumbs, truncation banners, and merged timeline events.
-- **Session workflows** — browse sessions, open session detail, read the experimental narrative summary, and compare baseline vs. candidate traces from the same workflow.
-- **Durable ingest path** — project-scoped API key auth, idempotent batches via `batch_key`, sync ingest, opt-in async ingest (`X-Continua-Async-Version: 2`), and batch polling.
-- **Background processing** — River workers handle async ingest, trace rollups, and payload cleanup.
-- **Embedded operator console** — the Vite React app is built into `internal/web/static/` and served by the Go binary. Includes a `⌘K` command palette, dark/light/system theming, and URL-driven filter state.
-- **Project & operator auth** — first-class `POST /api/projects` with rotate/delete/list endpoints, plus optional Auth0 operator login gated by an email allow-list (see [Auth0 setup](./docs-site/guides/auth0-setup.mdx)).
-- **Engine runs console** — `/engine/runs` lists durable engine runs, surfaces pending activity and inbox work, and exposes signal / suspend / resume / cancel / terminate against the engine control endpoints (preview).
-- **Python SDK** — `trace`, `span`, `session`, `event`, batching, retries, and async polling live under `sdks/python`. SDK also exports engine-control helpers for the scaffolded engine surface — see [Roadmap](./docs-site/roadmap.mdx) before relying on them.
-- **Typed events** — Continua emits 11 event kinds (`log`, `error`, `exception`, `message`, `metric`, `custom`, `state_change`, `decision`, `effect`, `wait`, `snapshot_marker`); see the [events concept guide](./docs-site/concepts/events.mdx).
+- **Trace debugger**: span tree, execution waterfall, selected spans, payload inspection, breadcrumbs, truncation banners, and merged timeline events.
+- **Session workflows**: browse sessions, open session detail, read the experimental narrative summary, and compare baseline vs. candidate traces from the same workflow.
+- **Durable ingest path**: project-scoped API key auth, idempotent batches via `batch_key`, sync ingest, opt-in async ingest (`X-Continua-Async-Version: 2`), and batch polling.
+- **Background processing**: River workers handle async ingest, trace rollups, and payload cleanup.
+- **Embedded operator console**: the Vite React app is built into `internal/web/static/` and served by the Go binary. Includes a `⌘K` command palette, dark/light/system theming, and URL-driven filter state.
+- **Project & operator auth**: first-class `POST /api/projects` with rotate/delete/list endpoints, plus optional Auth0 operator login gated by an email allow-list (see [Auth0 setup](./docs-site/guides/auth0-setup.mdx)).
+- **Engine runs console**: `/engine/runs` lists durable engine runs, surfaces pending activity and inbox work, and exposes signal / suspend / resume / cancel / terminate against the engine control endpoints (preview).
+- **Python SDK**: `trace`, `span`, `session`, `event`, batching, retries, and async polling live under `sdks/python`. SDK also exports engine-control helpers for the scaffolded engine surface; see [Roadmap](./docs-site/roadmap.mdx) before relying on them.
+- **Typed events**: Continua emits 11 event kinds (`log`, `error`, `exception`, `message`, `metric`, `custom`, `state_change`, `decision`, `effect`, `wait`, `snapshot_marker`); see the [events concept guide](./docs-site/concepts/events.mdx).
 
 ![Implemented event types](./assets/diagrams/event-types.svg)
 
@@ -112,7 +112,7 @@ flowchart LR
   postgres --> readapi --> ui
 ```
 
-A request hits the authenticated ingest API, gets validated and batched (sync or async), and lands in Postgres. River workers process async batches, compute rollups, and run cleanup. The debugger reads everything back through REST and polls `GET /api/traces/{id}/events` for live trace detail — there is no live WebSocket runtime in the current checkout.
+A request hits the authenticated ingest API, gets validated and batched (sync or async), and lands in Postgres. River workers process async batches, compute rollups, and run cleanup. The debugger reads everything back through REST and polls `GET /api/traces/{id}/events` for live trace detail. There is no live WebSocket runtime in the current checkout.
 
 ![Continua ingest flow](./assets/diagrams/ingest-flow.svg)
 
@@ -171,7 +171,7 @@ After changing OpenAPI, sqlc queries, WebSocket schemas, or migrations that affe
 
 ## Roadmap
 
-Continua is in alpha. The authoritative status breakdown — what's shippable, what's scaffolded, and what's coming next — lives at [`docs-site/roadmap.mdx`](./docs-site/roadmap.mdx).
+Continua is in alpha. The authoritative status breakdown of what's shippable, what's scaffolded, and what's coming next lives at [`docs-site/roadmap.mdx`](./docs-site/roadmap.mdx).
 
 Shippable today: authenticated REST ingest, Postgres persistence, River background jobs, trace/session/timeline/compare read APIs, the embedded React debugger (incl. engine runs console), project & API-key management, Auth0 operator login, the Python SDK, and the engine schema/store/control endpoints.
 
@@ -181,12 +181,12 @@ Scaffolded (don't rely on yet): live WebSocket runtime, proxy capture, replay ex
 
 The full documentation site lives under [`docs-site/`](./docs-site/) (Mintlify) and is organised into six tabs:
 
-- **Guides** — quickstart, [instrument your app](./docs-site/guides/instrument-your-app.mdx), [installation](./docs-site/guides/installation.mdx), [self-hosting](./docs-site/guides/self-hosting.mdx), [Auth0 setup](./docs-site/guides/auth0-setup.mdx), [managing projects](./docs-site/guides/managing-projects.mdx), and failure-debugging workflows.
-- **Concepts** — [architecture overview](./docs-site/concepts/overview.mdx), [data model](./docs-site/concepts/data-model.mdx), [traces / spans / sessions](./docs-site/concepts/traces-spans-sessions.mdx), [events](./docs-site/concepts/events.mdx), [ingest lifecycle](./docs-site/concepts/ingest-lifecycle.mdx), [cost & tokens](./docs-site/concepts/cost-and-tokens.mdx), [projects & auth](./docs-site/concepts/projects-and-auth.mdx), [engine foundation](./docs-site/concepts/engine-foundation.mdx).
-- **Debugger** — [tour of the UI](./docs-site/debugger/overview.mdx) plus per-page references for traces, trace detail, sessions, session compare, engine runs, command palette, and settings.
-- **Python SDK** — [overview](./docs-site/sdk/python/overview.mdx), tracing, sessions, span events, batching & ingest modes, exceptions.
-- **API Reference** — [auth & headers](./docs-site/api-reference/auth-and-headers.mdx) intro plus the auto-rendered OpenAPI playground.
-- **Roadmap** — [shippable vs scaffolded status](./docs-site/roadmap.mdx).
+- **Guides**: quickstart, [instrument your app](./docs-site/guides/instrument-your-app.mdx), [installation](./docs-site/guides/installation.mdx), [self-hosting](./docs-site/guides/self-hosting.mdx), [Auth0 setup](./docs-site/guides/auth0-setup.mdx), [managing projects](./docs-site/guides/managing-projects.mdx), and failure-debugging workflows.
+- **Concepts**: [architecture overview](./docs-site/concepts/overview.mdx), [data model](./docs-site/concepts/data-model.mdx), [traces / spans / sessions](./docs-site/concepts/traces-spans-sessions.mdx), [events](./docs-site/concepts/events.mdx), [ingest lifecycle](./docs-site/concepts/ingest-lifecycle.mdx), [cost & tokens](./docs-site/concepts/cost-and-tokens.mdx), [projects & auth](./docs-site/concepts/projects-and-auth.mdx), [engine foundation](./docs-site/concepts/engine-foundation.mdx).
+- **Debugger**: [tour of the UI](./docs-site/debugger/overview.mdx) plus per-page references for traces, trace detail, sessions, session compare, engine runs, command palette, and settings.
+- **Python SDK**: [overview](./docs-site/sdk/python/overview.mdx), tracing, sessions, span events, batching & ingest modes, exceptions.
+- **API Reference**: [auth & headers](./docs-site/api-reference/auth-and-headers.mdx) intro plus the auto-rendered OpenAPI playground.
+- **Roadmap**: [shippable vs scaffolded status](./docs-site/roadmap.mdx).
 
 Related: [`engine/README.md`](./engine/README.md) for the engine binary's CLI commands, and [`sdks/python/README.md`](./sdks/python/README.md) for SDK-local development.
 

--- a/docs-site/api-reference/auth-and-headers.mdx
+++ b/docs-site/api-reference/auth-and-headers.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Auth & headers"
-description: "What every Continua REST request looks like — auth schemes, project scoping, preview headers, and response codes."
+description: "What every Continua REST request looks like: auth schemes, project scoping, preview headers, and response codes."
 ---
 
 Every Continua REST endpoint is generated from
 [`contracts/openapi/openapi.yaml`](https://github.com/aryanVijaywargia/Continua/blob/main/contracts/openapi/openapi.yaml).
-This page covers the cross-cutting concerns — auth, scoping, preview gates — that don't
+This page covers the cross-cutting concerns: auth, scoping, and preview gates. They don't
 fit on individual endpoint pages.
 
 ## Authentication
@@ -27,12 +27,12 @@ Continua accepts two auth schemes, depending on the endpoint:
 - Operators select a project explicitly via `selected_project_id` (query or header).
 - See [Auth0 setup](/guides/auth0-setup) for the configuration walk-through.
 
-Some endpoints (project listing) are gated by auth scheme — for example, listing all
+Some endpoints (project listing) are gated by auth scheme: for example, listing all
 projects requires Auth0, not an API key.
 
 ## Health checks
 
-`GET /api/health` and `GET /api/auth/config` are public — no auth required. Everything
+`GET /api/health` and `GET /api/auth/config` are public: no auth required. Everything
 else is authenticated.
 
 ## Scoping requests
@@ -81,8 +81,8 @@ Continua follows standard REST semantics:
 idempotency token: re-sending the same `batch_key` will not double-write. Use this to
 make retries safe.
 
-Engine control endpoints accept an `Idempotency-Key` header for similar reasons —
-re-sending the same request key has no additional effect.
+Engine control endpoints accept an `Idempotency-Key` header for similar reasons.
+Re-sending the same request key has no additional effect.
 
 ## Pagination
 
@@ -101,7 +101,7 @@ a long-lived API key created specifically for docs / debugging.
 
 ## See also
 
-- [Projects & auth](/concepts/projects-and-auth) — auth model.
-- [Managing projects](/guides/managing-projects) — issue and rotate API keys.
-- [Ingest lifecycle](/concepts/ingest-lifecycle) — what `POST /v1/ingest` actually does.
-- [Engine foundation](/concepts/engine-foundation) — what the engine preview covers.
+- [Projects & auth](/concepts/projects-and-auth): auth model.
+- [Managing projects](/guides/managing-projects): issue and rotate API keys.
+- [Ingest lifecycle](/concepts/ingest-lifecycle): what `POST /v1/ingest` actually does.
+- [Engine foundation](/concepts/engine-foundation): what the engine preview covers.

--- a/docs-site/concepts/cost-and-tokens.mdx
+++ b/docs-site/concepts/cost-and-tokens.mdx
@@ -24,7 +24,7 @@ multiple places.
 4. The debugger reads the rollup on trace list / session list / overview pages, and the
    raw values on the trace detail page.
 
-This means **trace-level totals can lag span ingestion slightly** in async mode — the
+This means **trace-level totals can lag span ingestion slightly** in async mode. The
 rollup runs after a batch is processed.
 
 ## Token buckets
@@ -42,7 +42,7 @@ If you only set `prompt` and `completion`, the SDK and server compute `total` fo
 
 ## Cost
 
-`set_cost(value)` accepts a `float` (USD by default — Continua does not enforce a
+`set_cost(value)` accepts a `float` (USD by default; Continua does not enforce a
 currency). Costs are summed across spans into the trace and session totals.
 
 If your provider reports costs in micro-units, convert before calling `set_cost` so
@@ -60,13 +60,13 @@ totals are comparable across providers.
 
 ## Modelling tips
 
-- **Set costs on the leaf span that incurred them**, not on intermediate composite spans
-  — rollups will sum to the right total either way, but per-span costs are more useful
+- **Set costs on the leaf span that incurred them**, not on intermediate composite spans.
+  Rollups will sum to the right total either way, but per-span costs are more useful
   for debugging.
 - For agents that retry a call, set cost on each attempt span individually. The
   trace-level total will reflect the real spend even if the final logical answer used
   only one attempt.
-- If a span doesn't have cost data (e.g. a tool call to a free API), leave it unset —
+- If a span doesn't have cost data (e.g. a tool call to a free API), leave it unset;
   the rollup treats missing values as zero.
 - Combine `set_cost` with `set_metadata("pricing_tier", "...")` so you can later filter
   high-cost traces by tier.

--- a/docs-site/concepts/data-model.mdx
+++ b/docs-site/concepts/data-model.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Data model"
-description: "Projects, sessions, traces, spans, events — the persisted shapes that back the debugger."
+description: "Projects, sessions, traces, spans, events: the persisted shapes that back the debugger."
 ---
 
 ```mermaid

--- a/docs-site/concepts/engine-foundation.mdx
+++ b/docs-site/concepts/engine-foundation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Engine foundation"
-description: "The durable engine schema, store, and control surface — what's real today and where it stops."
+description: "The durable engine schema, store, and control surface: what's real today and where it stops."
 ---
 
 Continua ships a durable engine **foundation** today. The schema, store, control
@@ -36,8 +36,8 @@ Core tables:
 ### Store (real)
 
 [`engine/db/gen/go/`](https://github.com/aryanVijaywargia/Continua/tree/main/engine/db/gen/go)
-is the sqlc-generated store. The engine uses its own pgx pool and transaction boundary —
-it does not share a connection pool with the platform server. The engine can optionally
+is the sqlc-generated store. The engine uses its own pgx pool and transaction boundary.
+It does not share a connection pool with the platform server. The engine can optionally
 live in a separate Postgres via `ENGINE_DATABASE_URL`.
 
 ### Control endpoints (real)
@@ -73,7 +73,7 @@ the control bar. Polling-based.
   and produces a terminal result. The state machine accepts the right inputs but the
   end-to-end loop is incomplete.
 - **Workflow SDK.** The Python SDK exports `ActivityWorker`, `@activity`, and
-  `EngineControlClient` — they call the right endpoints, but without a working execution
+  `EngineControlClient`. They call the right endpoints, but without a working execution
   layer they don't form a usable workflow runtime today.
 - **Run history replay.** History is written; replay-from-history is not wired.
 
@@ -84,6 +84,6 @@ the control bar. Polling-based.
 - **Schema-level prototyping.** If you want to model a durable workflow without
   committing to an execution runtime, you can use the schema as a write target.
 
-For actual durable workflow execution, wait for the execution layer to land — track
+For actual durable workflow execution, wait for the execution layer to land. Track
 progress on [GitHub](https://github.com/aryanVijaywargia/Continua) or watch the
 [Roadmap](/roadmap) for status changes.

--- a/docs-site/concepts/events.mdx
+++ b/docs-site/concepts/events.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Events"
-description: "Semantic event types that explain what happened inside a span — state changes, decisions, effects, waits, and more."
+description: "Semantic event types that explain what happened inside a span: state changes, decisions, effects, waits, and more."
 ---
 
 Continua events are **debugger-facing observability signals**. They explain *what
@@ -38,16 +38,16 @@ flowchart LR
 
 ## Choosing an event type
 
-- **`state_change`** — observable state transitions you want shown as `old → new` in the
+- **`state_change`**: observable state transitions you want shown as `old → new` in the
   debugger.
-- **`decision`** — branch points where the system chooses between alternatives.
-- **`effect`** — external actions, model invocations, or side effects worth surfacing.
-- **`wait`** — progress blocked on a human, external dependency, or timer.
-- **`snapshot_marker`** — first-class debugger milestones with a compact label.
-- **`message`** — lightweight narrative milestones.
-- **`log`**, **`error`**, **`exception`** — operational logging and failures.
-- **`metric`** — structured numeric measurements.
-- **`custom`** — domain-specific payloads when no semantic type fits.
+- **`decision`**: branch points where the system chooses between alternatives.
+- **`effect`**: external actions, model invocations, or side effects worth surfacing.
+- **`wait`**: progress blocked on a human, external dependency, or timer.
+- **`snapshot_marker`**: first-class debugger milestones with a compact label.
+- **`message`**: lightweight narrative milestones.
+- **`log`**, **`error`**, **`exception`**: operational logging and failures.
+- **`metric`**: structured numeric measurements.
+- **`custom`**: domain-specific payloads when no semantic type fits.
 
 ## Event type reference
 

--- a/docs-site/concepts/ingest-lifecycle.mdx
+++ b/docs-site/concepts/ingest-lifecycle.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Ingest lifecycle"
-description: "How POST /v1/ingest works — sync vs. true-async, batch idempotency, and when to poll."
+description: "How POST /v1/ingest works: sync vs. true-async, batch idempotency, and when to poll."
 ---
 
 ```mermaid
@@ -30,7 +30,7 @@ via `ingest_mode` on `Continua.init(...)`:
 
 | Mode | When to use | Behavior |
 | --- | --- | --- |
-| `sync` | You need read-after-write — your code reads the data back immediately | Server writes synchronously and returns when persistence is complete |
+| `sync` | You need read-after-write: your code reads the data back immediately | Server writes synchronously and returns when persistence is complete |
 | `async_v2` | High throughput, fire-and-forget | Server accepts the batch, persists payload + idempotency, returns `202` with a `batch_id`. A River worker processes the batch shortly after. |
 | `server_default` | Defer to the server's rollout setting | Honors `INGEST_TRUE_ASYNC_DEFAULT` env var |
 
@@ -50,7 +50,7 @@ returns the existing batch row instead of duplicating writes.
 
 This means:
 
-- SDK retries are safe — a network blip will not double-ingest.
+- SDK retries are safe: a network blip will not double-ingest.
 - You can re-run a backfill script as long as `batch_key` is stable.
 
 The Python SDK generates `batch_key` per flush automatically.
@@ -80,8 +80,8 @@ The corresponding REST endpoint is
 | --- | --- |
 | `accepted` | Batch persisted, worker has not yet processed it |
 | `processing` | Worker is actively writing traces, spans, events |
-| `completed` | All writes succeeded — data is fully readable |
-| `failed` | Worker hit a non-retryable error — see batch row for details |
+| `completed` | All writes succeeded: data is fully readable |
+| `failed` | Worker hit a non-retryable error: see batch row for details |
 
 Failed batch payloads are retained for `INGEST_FAILED_PAYLOAD_RETENTION` before cleanup.
 
@@ -89,11 +89,11 @@ Failed batch payloads are retained for `INGEST_FAILED_PAYLOAD_RETENTION` before 
 
 Two River workers cooperate on the async path:
 
-- **Ingest batch worker** (`internal/jobs`) — reads accepted batches, validates, writes
+- **Ingest batch worker** (`internal/jobs`): reads accepted batches, validates, writes
   traces/spans/events through the shared write path in `internal/ingest/processor.go`.
-- **Trace rollup worker** — recomputes trace-level aggregate fields (status, duration,
+- **Trace rollup worker**: recomputes trace-level aggregate fields (status, duration,
   cost, token counts) after spans land.
-- **Cleanup worker** — deletes processed `ingest_batch_payloads` blobs after retention.
+- **Cleanup worker**: deletes processed `ingest_batch_payloads` blobs after retention.
 
 ## Choosing a mode
 

--- a/docs-site/concepts/overview.mdx
+++ b/docs-site/concepts/overview.mdx
@@ -81,14 +81,14 @@ GET /api/sessions
 GET /api/sessions/{id}
 GET /api/sessions/{id}/narrative
 GET /api/sessions/{id}/compare
-GET /api/projects             (list — Auth0 operators only)
+GET /api/projects             (list: Auth0 operators only)
 POST /api/projects            (create + receive plaintext key once)
 PATCH /api/projects/{id}      (update metadata)
 DELETE /api/projects/{id}     (soft delete)
 POST /api/projects/{id}/rotate (rotate API key)
 ```
 
-The full `/v1/engine/*` control surface is also implemented behind a preview flag — see
+The full `/v1/engine/*` control surface is also implemented behind a preview flag: see
 [Engine foundation](/concepts/engine-foundation).
 
 The trace detail UI does not use a live WebSocket runtime today. It polls the timeline API
@@ -107,13 +107,13 @@ Run `make generate` after changing any of the above.
 
 ## What is not implemented yet
 
-These surfaces are scaffolded — schema, types, or partial code exists, but they're not
+These surfaces are scaffolded: schema, types, or partial code exists, but they're not
 production-ready. See [Roadmap & status](/roadmap) for the full breakdown.
 
 - **Engine workflow execution.** The engine schema, store, control endpoints, and runs
-  console UI are real (see [Engine foundation](/concepts/engine-foundation)) — but the
+  console UI are real (see [Engine foundation](/concepts/engine-foundation)), but the
   runtime that takes a workflow definition and runs it to completion is not.
-- **Live WebSocket runtime** in `internal/ws` — trace detail is polling-based today.
+- **Live WebSocket runtime** in `internal/ws`: trace detail is polling-based today.
 - **Proxy capture runtime** in `internal/proxy`.
 - **Replay execution runtime** in `internal/replay`.
-- **Feature-complete TypeScript SDK** — the package is currently a typed-fetch stub.
+- **Feature-complete TypeScript SDK**: the package is currently a typed-fetch stub.

--- a/docs-site/concepts/projects-and-auth.mdx
+++ b/docs-site/concepts/projects-and-auth.mdx
@@ -15,23 +15,23 @@ to a project.
 | **Auth0 bearer** (operator JWT) | Debugger UI when `AUTH0_ENABLED=true` | The UI picks a project explicitly via `selected_project_id` (query or header). Operator can switch projects |
 | **Public demo** (no credentials) | Read-only landing on the demo deployment | Project id is hard-coded in `PUBLIC_DEMO_PROJECT_ID` |
 
-API keys and Auth0 are not mutually exclusive — you can run Auth0 for the UI and still
+API keys and Auth0 are not mutually exclusive. You can run Auth0 for the UI and still
 issue API keys for SDK ingest. Public demo mode is opt-in via env vars and serves a
 single read-only project to anyone.
 
 ## Lifecycle of a project
 
-1. **Create** — `POST /api/projects` returns the project record plus the plaintext API
+1. **Create**: `POST /api/projects` returns the project record plus the plaintext API
    key. **This is the only time the key is returned in plaintext.** Store it; the server
    only keeps the hash.
-2. **Use** — clients send `X-API-Key: <key>`. The middleware in
+2. **Use**: clients send `X-API-Key: <key>`. The middleware in
    [`internal/api/middleware/auth.go`](https://github.com/aryanVijaywargia/Continua/blob/main/internal/api/middleware/auth.go)
    resolves the key on every request.
-3. **Rotate** — `POST /api/projects/{id}/rotate` invalidates the old key and returns a
+3. **Rotate**: `POST /api/projects/{id}/rotate` invalidates the old key and returns a
    new plaintext key (also returned once). Rotation is the right tool for suspected key
    compromise.
-4. **Update metadata** — `PATCH /api/projects/{id}` for renames, description changes.
-5. **Delete** — `DELETE /api/projects/{id}` soft-deletes the project.
+4. **Update metadata**: `PATCH /api/projects/{id}` for renames, description changes.
+5. **Delete**: `DELETE /api/projects/{id}` soft-deletes the project.
 
 See the [Managing projects guide](/guides/managing-projects) for end-to-end how-to.
 
@@ -52,11 +52,11 @@ When `PUBLIC_DEMO_ENABLED=true`:
 - The server bootstraps a `PublicDemoConfig` with the configured `PUBLIC_DEMO_PROJECT_ID`
   and `PUBLIC_DEMO_LABEL`.
 - The UI loads without prompting for an API key.
-- Mutations are blocked — the demo is read-only.
+- Mutations are blocked: the demo is read-only.
 - The Settings page redirects to `/dashboard`.
 
 `make demo` boots a deployment with demo mode on, an idempotent demo project, and seeded
-traces — useful for evaluating Continua without standing up your own ingest pipeline.
+traces, which is useful for evaluating Continua without standing up your own ingest pipeline.
 
 ## See also
 

--- a/docs-site/concepts/traces-spans-sessions.mdx
+++ b/docs-site/concepts/traces-spans-sessions.mdx
@@ -9,7 +9,7 @@ and traces contain a tree of **spans**.
 ## Trace
 
 A **trace** is one end-to-end execution of an agent or workflow. It's typically the unit
-you care about when debugging — "the agent run that handled ticket #4842".
+you care about when debugging: "the agent run that handled ticket #4842".
 
 A trace has:
 
@@ -59,7 +59,7 @@ with span("call_openai", kind="llm") as s:
 
 ## Session
 
-A **session** groups related traces — typically a single user conversation, a multi-step
+A **session** groups related traces, typically a single user conversation, a multi-step
 job, or a continuous agent loop. Sessions are optional; many setups send standalone
 traces with no session.
 
@@ -85,7 +85,7 @@ with session("user-conversation-42") as sess:
 - **Session detail** shows the timeline of traces in that session, plus a session compare
   workspace.
 - **Traces list** (`/traces`) shows every trace with URL-driven filters.
-- **Trace detail** (`/traces/{id}`) opens **failure-first** — if the trace failed, it
+- **Trace detail** (`/traces/{id}`) opens **failure-first**. If the trace failed, it
   jumps you to the failing span. Otherwise it shows the span tree, payload inspector,
   state, and merged timeline.
 

--- a/docs-site/debugger/command-palette-and-shortcuts.mdx
+++ b/docs-site/debugger/command-palette-and-shortcuts.mdx
@@ -20,9 +20,9 @@ and works from any debugger page.
 
 The palette lists every top-level page in the debugger plus a few utilities:
 
-- **Navigate** — jump to Overview, Traces, Sessions, Engine runs, Projects, Settings.
-- **Search** — type any text to filter the command list.
-- **Recent** — when applicable, recently visited resources surface at the top.
+- **Navigate**: jump to Overview, Traces, Sessions, Engine runs, Projects, Settings.
+- **Search**: type any text to filter the command list.
+- **Recent**: when applicable, recently visited resources surface at the top.
 
 Selecting an item with `Enter` navigates immediately and closes the palette. `Esc` closes
 without navigating.
@@ -31,11 +31,11 @@ without navigating.
 
 Some pages add their own keyboard affordances:
 
-- **Traces / Sessions / Engine runs** — filter inputs respond to `Enter` to commit a
+- **Traces / Sessions / Engine runs**: filter inputs respond to `Enter` to commit a
   draft value and `Esc` to revert.
-- **Trace detail span tree** — `↑` / `↓` move the selection; `→` / `←` expand and
+- **Trace detail span tree**: `↑` / `↓` move the selection; `→` / `←` expand and
   collapse children.
-- **Payload inspector** — `/` focuses the in-payload search input.
+- **Payload inspector**: `/` focuses the in-payload search input.
 
 These are wired locally inside each component; the goal is that any frequently-needed
 action can be reached without taking your hands off the keyboard.

--- a/docs-site/debugger/engine-runs.mdx
+++ b/docs-site/debugger/engine-runs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Engine runs console"
-description: "Inspect durable engine workflow runs — list, detail, pending work, projection repair."
+description: "Inspect durable engine workflow runs: list, detail, pending work, projection repair."
 ---
 
 The Engine runs console at `/engine/runs` is the operator surface for the durable engine.
@@ -10,7 +10,7 @@ repair projection state.
 <Warning>
   The engine surface is in preview. Endpoints require `X-Continua-Engine-Preview` and
   `ENGINE_PUBLIC_API_ENABLED=true` on the server. Engine workflow execution itself is not
-  yet a supported product path — see [Engine foundation](/concepts/engine-foundation) and
+  yet a supported product path: see [Engine foundation](/concepts/engine-foundation) and
   [Roadmap](/roadmap).
 </Warning>
 

--- a/docs-site/debugger/overview.mdx
+++ b/docs-site/debugger/overview.mdx
@@ -13,9 +13,9 @@ This page is a map. Each section links to a deeper page covering that surface.
 
 | Page | Route | When to use |
 | --- | --- | --- |
-| [Overview](#dashboard) | `/dashboard` | Daily check-in — recent activity at a glance |
+| [Overview](#dashboard) | `/dashboard` | Daily check-in: recent activity at a glance |
 | [Traces](/debugger/traces) | `/traces` | Find a specific run, filter by status / user / engine instance |
-| [Trace detail](/debugger/trace-detail) | `/traces/:id` | Debug a single run — waterfall, spans, payloads, events |
+| [Trace detail](/debugger/trace-detail) | `/traces/:id` | Debug a single run: waterfall, spans, payloads, events |
 | [Sessions](/debugger/sessions) | `/sessions` | Group traces by user / conversation |
 | [Session compare](/debugger/session-compare) | `/sessions/:id/compare` | Diff baseline vs candidate traces in the same session |
 | [Engine runs](/debugger/engine-runs) | `/engine/runs` | Inspect durable engine workflow runs |
@@ -38,11 +38,11 @@ project without prompting for credentials. Useful for evaluations.
 
 ## Productivity surfaces
 
-- [Command palette](/debugger/command-palette-and-shortcuts) — `⌘K` / `Ctrl+K` opens a
+- [Command palette](/debugger/command-palette-and-shortcuts): `⌘K` / `Ctrl+K` opens a
   quick navigator.
-- [Settings & theming](/debugger/settings-and-theming) — dark / light / system theme,
+- [Settings & theming](/debugger/settings-and-theming): dark / light / system theme,
   API-key management, sign-out.
-- URL-driven state — every filter on Traces, Sessions, and Engine runs lives in the URL.
+- URL-driven state: every filter on Traces, Sessions, and Engine runs lives in the URL.
   Bookmark and share links freely.
 
 ## What the debugger does **not** do today

--- a/docs-site/debugger/session-compare.mdx
+++ b/docs-site/debugger/session-compare.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Session compare"
-description: "Diff a baseline and a candidate trace from the same session — span by span, payload by payload."
+description: "Diff a baseline and a candidate trace from the same session: span by span, payload by payload."
 ---
 
 Session compare answers a specific question: **"what changed between these two runs of
@@ -27,7 +27,7 @@ You can also build the URL by hand if you already have both trace ids.
 | --- | --- |
 | Header | Both traces side-by-side: status, duration, cost, token totals |
 | Semantic summary | High-level diff: which spans were added, removed, or changed |
-| Span diff table | Row per span pair — duration delta, payload delta, status delta |
+| Span diff table | Row per span pair: duration delta, payload delta, status delta |
 | Row expand | Inline payload diff for input, output, metadata, key events |
 | Engine projection state | When the traces are engine runs, projection-state labels for both sides |
 
@@ -48,7 +48,7 @@ limit. Mitigation options:
 ## Limitations
 
 - Compare works **within a single session**. Cross-session compare is not supported.
-- The diff is structural, not semantic — a JSON field reorder shows as a change even if
+- The diff is structural, not semantic: a JSON field reorder shows as a change even if
   the meaning is identical.
 - Comparison is read-only. The debugger does not re-execute either trace. See
   [Roadmap](/roadmap) for the replay workstream.

--- a/docs-site/debugger/sessions.mdx
+++ b/docs-site/debugger/sessions.mdx
@@ -3,7 +3,7 @@ title: "Sessions page"
 description: "Group traces by session, browse session detail, read the experimental narrative summary."
 ---
 
-Sessions group traces that belong together — usually one user conversation, one batch
+Sessions group traces that belong together, usually one user conversation, one batch
 job, or one long-running task.
 
 ## Sessions list (`/sessions`)
@@ -20,10 +20,10 @@ Like the [Traces page](/debugger/traces), filters live in the URL and are sharea
 
 Each session detail page shows:
 
-- **Header** — external id, user id, started-at / last-activity timestamps, trace count.
-- **Traces table** — every trace linked to the session, with status, duration, cost, and
+- **Header**: external id, user id, started-at / last-activity timestamps, trace count.
+- **Traces table**: every trace linked to the session, with status, duration, cost, and
   token totals.
-- **Narrative panel** — an experimental LLM-generated summary of what happened across
+- **Narrative panel**: an experimental LLM-generated summary of what happened across
   the session (see [Narrative](#narrative) below).
 
 Clicking a trace row opens the [Trace detail](/debugger/trace-detail) page for that run.
@@ -39,7 +39,7 @@ written as a few short paragraphs. It's useful when:
 - You're writing a postmortem and want a starting draft.
 
 <Note>
-  The narrative is experimental. Treat it as a starting point, not a system of record —
+  The narrative is experimental. Treat it as a starting point, not a system of record;
   inspect the raw traces for anything you'll act on.
 </Note>
 
@@ -54,5 +54,5 @@ conversation.
 
 - Not a persistent chat history. Sessions are an observability grouping, not a chat
   store. Don't depend on them for product state.
-- Not nestable. The SDK guards against nested `session()` blocks — set `session_id`
+- Not nestable. The SDK guards against nested `session()` blocks: set `session_id`
   directly on `@trace` if you need a different session inside.

--- a/docs-site/debugger/settings-and-theming.mdx
+++ b/docs-site/debugger/settings-and-theming.mdx
@@ -19,7 +19,7 @@ The Settings page at `/settings` adapts to the runtime auth mode of your deploym
 - A **General** card shows the operator account (email, name).
 - A **Sign out** button calls Auth0's `logout`.
 - The Appearance card behaves the same as in local mode.
-- The API keys card is hidden — operator auth doesn't use a local API key.
+- The API keys card is hidden: operator auth doesn't use a local API key.
 
 **Public demo mode** (`PUBLIC_DEMO_ENABLED=true`)
 
@@ -44,11 +44,11 @@ up read access:
 2. Copy the key into the Settings → API keys card and save.
 3. The UI uses the saved key as `X-API-Key` on every read call.
 
-Clear the key with the **Clear key** button — this signs the local UI out, but it does
+Clear the key with the **Clear key** button. This signs the local UI out, but it does
 not revoke the key server-side. To revoke, use the project rotate-key flow.
 
 ## What lives elsewhere
 
-- **Creating / rotating / deleting projects** — [Projects](/guides/managing-projects).
-- **Configuring Auth0 itself** — [Auth0 setup](/guides/auth0-setup).
-- **Server-side settings** (env vars, retention, queue sizes) — [Self-hosting](/guides/self-hosting).
+- **Creating / rotating / deleting projects**: [Projects](/guides/managing-projects).
+- **Configuring Auth0 itself**: [Auth0 setup](/guides/auth0-setup).
+- **Server-side settings** (env vars, retention, queue sizes): [Self-hosting](/guides/self-hosting).

--- a/docs-site/debugger/trace-detail.mdx
+++ b/docs-site/debugger/trace-detail.mdx
@@ -4,7 +4,7 @@ description: "Waterfall, span tree, payload inspector, timeline, and failure sum
 ---
 
 The Trace detail page at `/traces/:id` is where you actually debug a run. It's organised
-failure-first: when a span has errored, the page jumps you to the failing span and shows
+failure-first. When a span has errored, the page jumps you to the failing span and shows
 the surrounding context.
 
 ## Layout
@@ -13,7 +13,7 @@ The page is composed of these surfaces, all wired to the same selected span:
 
 | Surface | Component | What it shows |
 | --- | --- | --- |
-| Header | — | Trace name, status badge, duration, cost, token totals, copy-link button |
+| Header | None | Trace name, status badge, duration, cost, token totals, copy-link button |
 | Failure summary | `FailureSummary` | When the trace failed, a breadcrumb to the failing span + the error message |
 | Execution waterfall | `ExecutionWaterfall` | Time-axis bars for every span; nesting shown by indentation; bar colour by status |
 | Span tree | `SpanTree` | Collapsible hierarchical view; useful when there are many short spans |
@@ -32,19 +32,19 @@ The timeline merges two sources:
    always see span lifecycle on the same axis.
 
 The timeline polls `GET /api/traces/{id}/events` on a short interval, so a running trace
-fills in live as new events arrive. There is no WebSocket today — see [Roadmap](/roadmap).
+fills in live as new events arrive. There is no WebSocket today; see [Roadmap](/roadmap).
 
 ## Payload inspector
 
 Click any span to populate the inspector. Tabs include:
 
-- **Input / Output** — the JSON payload set via `set_input` / `set_output` on the SDK.
-- **Metadata** — key/value pairs set via `set_metadata`.
-- **Events** — chronological list of explicit events on this span.
-- **State diff** — when consecutive `state_change` events exist, a visual diff between
+- **Input / Output**: the JSON payload set via `set_input` / `set_output` on the SDK.
+- **Metadata**: key/value pairs set via `set_metadata`.
+- **Events**: chronological list of explicit events on this span.
+- **State diff**: consecutive `state_change` events produce a visual diff between
   before and after states.
-- **Reasoning** — when the span recorded reasoning tokens (Claude-style `set_tokens` with
-  a reasoning bucket), surfaces them in a focused tab.
+- **Reasoning**: spans with reasoning tokens (Claude-style `set_tokens` with a reasoning
+  bucket) surface them in a focused tab.
 
 Payloads larger than the configured truncation threshold are stored with a marker; the
 inspector shows a [`TruncationBanner`](https://github.com/aryanVijaywargia/Continua/blob/main/web/src/components/TruncationBanner.tsx)

--- a/docs-site/debugger/traces.mdx
+++ b/docs-site/debugger/traces.mdx
@@ -8,7 +8,7 @@ The Traces page at `/traces` is the primary entry point for finding a specific r
 ## Filters
 
 All filters are URL-driven. The page reads them from `location.search` and writes them
-back as you change them — so any view is a shareable link.
+back as you change them, so any view is a shareable link.
 
 | Filter | Type | What it matches |
 | --- | --- | --- |
@@ -32,7 +32,7 @@ The table supports a fixed sort by **start time descending**. Pagination uses
 ## Status counts
 
 The header shows a count of `RUNNING`, `COMPLETED`, and `FAILED` traces in the current
-filtered window. Counts reflect the current page of results, not the global total — they
+filtered window. Counts reflect the current page of results, not the global total; they
 are useful for quickly spotting unexpected state distributions during an incident.
 
 ## Drilling in
@@ -52,7 +52,7 @@ Because the page is URL-driven, you can:
 ## Performance notes
 
 The list endpoint (`GET /api/traces`) returns up to `limit` rows per request. The page
-uses TanStack Query's `keepPreviousData` so pagination feels instant — the previous page
+uses TanStack Query's `keepPreviousData` so pagination feels instant; the previous page
 stays rendered while the next page loads.
 
 For very large projects, prefer narrower filters (a user id or a status) over loading

--- a/docs-site/favicon.svg
+++ b/docs-site/favicon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
   <defs>
-    <linearGradient id="cont-grad-favicon" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+    <linearGradient id="cont-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#0075d6"/>
       <stop offset="1" stop-color="#005cab"/>
     </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="url(#cont-grad-favicon)"/>
-  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="#ffffff" stroke-width="6" stroke-linecap="round" fill="none"/>
-  <circle cx="46" cy="18" r="4" fill="#ffffff"/>
-  <circle cx="46" cy="46" r="4" fill="#ffffff"/>
+  <circle cx="32" cy="32" r="28" stroke="url(#cont-grad)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>
+  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad)" stroke-width="4.5" stroke-linecap="round"/>
+  <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad)"/>
+  <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad)"/>
 </svg>

--- a/docs-site/guides/auth0-setup.mdx
+++ b/docs-site/guides/auth0-setup.mdx
@@ -4,8 +4,8 @@ description: "Gate the debugger UI behind Auth0 with an email allow-list."
 ---
 
 By default the debugger expects a project API key entered on the Settings page. For
-shared deployments — multiple operators, an internal tool, or anything you don't want
-behind a single shared key — turn on Auth0.
+shared deployments with multiple operators, an internal tool, or anything you don't want
+behind a single shared key, turn on Auth0.
 
 ## What Auth0 mode gives you
 
@@ -21,12 +21,12 @@ behind a single shared key — turn on Auth0.
 | Variable | Purpose |
 | --- | --- |
 | `AUTH0_ENABLED` | Master switch. Set to `true` to turn Auth0 on |
-| `AUTH0_DOMAIN` | Auth0 tenant domain (e.g. `your-tenant.us.auth0.com`) — host only, no scheme |
+| `AUTH0_DOMAIN` | Auth0 tenant domain (e.g. `your-tenant.us.auth0.com`): host only, no scheme |
 | `AUTH0_CLIENT_ID` | Auth0 SPA application client id |
 | `AUTH0_AUDIENCE` | API audience identifier from your Auth0 API config |
 | `AUTH0_ALLOWED_EMAILS` | Comma-separated allow-list. At least one required when enabled |
 
-All four are required when `AUTH0_ENABLED=true` — the server fails to start otherwise,
+All four are required when `AUTH0_ENABLED=true`: the server fails to start otherwise,
 listing the missing variables.
 
 ## End-to-end setup
@@ -39,12 +39,12 @@ In your Auth0 tenant:
 2. Set **Allowed Callback URLs** and **Allowed Logout URLs** to your debugger origin
    (e.g. `https://debugger.example.com`).
 3. Set **Allowed Web Origins** to the same value.
-4. Note the **Domain** and **Client ID** — you'll need them as env vars.
+4. Note the **Domain** and **Client ID**: you'll need them as env vars.
 
 ### 2. Create the Auth0 API
 
 1. **APIs → Create API.**
-2. Name it, pick a unique identifier (e.g. `https://continua/api`) — this is your
+2. Name it, pick a unique identifier (e.g. `https://continua/api`): this is your
    `AUTH0_AUDIENCE`.
 3. Leave the signing algorithm at the default.
 
@@ -89,19 +89,19 @@ keep Auth0 for operator deployments.
 
 ## Troubleshooting
 
-- **`AUTH0_DOMAIN must be a valid domain`** — drop `https://` from the value. Domain is
+- **`AUTH0_DOMAIN must be a valid domain`**: drop `https://` from the value. Domain is
   host-only.
-- **`AUTH0_ALLOWED_EMAILS must include at least one email address`** — at least one
+- **`AUTH0_ALLOWED_EMAILS must include at least one email address`**: at least one
   syntactically-valid email is required when Auth0 is on.
-- **Redirect loop after sign-in** — check that the **Allowed Callback URLs** in Auth0
+- **Redirect loop after sign-in**: check that the **Allowed Callback URLs** in Auth0
   exactly matches the debugger origin you're hitting (no trailing slash mismatch, no
   protocol mismatch).
-- **403 after Auth0 sign-in completes** — your email isn't on `AUTH0_ALLOWED_EMAILS`.
+- **403 after Auth0 sign-in completes**: your email isn't on `AUTH0_ALLOWED_EMAILS`.
 
 ## See also
 
-- [Projects & auth](/concepts/projects-and-auth) — how Auth0, API keys, and demo mode
+- [Projects & auth](/concepts/projects-and-auth): how Auth0, API keys, and demo mode
   interact.
-- [Managing projects](/guides/managing-projects) — create the projects that operators
+- [Managing projects](/guides/managing-projects): create the projects that operators
   will see.
-- [Self-hosting](/guides/self-hosting) — full env var reference.
+- [Self-hosting](/guides/self-hosting): full env var reference.

--- a/docs-site/guides/comparing-sessions.mdx
+++ b/docs-site/guides/comparing-sessions.mdx
@@ -24,7 +24,7 @@ specific question that worked last week.
    - Look at the span where you call your LLM. The **Input** diff should show the new
      prompt vs the old one.
    - Look at the **Output** diff for the failure pattern.
-   - Look at downstream spans — sometimes a prompt change shifts cost or token counts
+   - Look at downstream spans. Sometimes a prompt change shifts cost or token counts
      even when the answer looks the same.
 
 ## Scenario B: model swap impact
@@ -57,9 +57,9 @@ Capture the compare URL and add it to your evaluation write-up.
 ## Tips for compare-friendly traces
 
 - **Stabilise non-deterministic fields** (timestamps, request ids) before setting them
-  on spans — otherwise every compare shows churn on those fields.
+  on spans. Otherwise every compare shows churn on those fields.
 - **Use `set_metadata` for version pins** (model name, prompt hash, retrieval index
-  version) — the compare view surfaces metadata deltas, so version pins become the most
+  version), and the compare view surfaces metadata deltas, so version pins become the most
   legible part of any diff.
 - **Tag deploys** (`tags=["release-v42"]`) so you can find a candidate trace from a
   specific release quickly.

--- a/docs-site/guides/debugging-failures.mdx
+++ b/docs-site/guides/debugging-failures.mdx
@@ -14,7 +14,7 @@ Open the [Traces page](/debugger/traces) and apply filters:
 - **User ID**: if a specific user reported the issue
 - **Start time**: a window around when the incident began
 
-Bookmark the resulting URL — you'll want to come back to it.
+Bookmark the resulting URL; you'll want to come back to it.
 
 ## 2. Open the trace
 
@@ -32,13 +32,13 @@ failures are still visible as red bars in the waterfall.
 
 The span detail pane on the right opens to the **Events** tab. Look for:
 
-- An `exception` event — usually contains the captured traceback.
-- A preceding `decision` or `state_change` event — tells you what the agent thought
+- An `exception` event, which usually contains the captured traceback.
+- A preceding `decision` or `state_change` event: tells you what the agent thought
   before the failure.
-- A `wait` event with a long duration — points at a stalled tool or model call.
+- A `wait` event with a long duration: points at a stalled tool or model call.
 
 Switch to **Input / Output** to see the payloads at the boundary of the failure. The
-inspector is searchable (`/` to focus) — useful for huge prompts.
+inspector is searchable (`/` to focus), which helps with huge prompts.
 
 ## 4. Look at the context
 
@@ -46,7 +46,7 @@ A failure is rarely an isolated event. Walk up the span tree:
 
 - Click the parent span. Was its input what you expected?
 - Click sibling spans. Did an earlier sibling produce bad output that fed the failure?
-- Open the **Timeline** to see explicit events across the whole trace in order — a
+- Open the **Timeline** to see explicit events across the whole trace in order: a
   `decision` event minutes earlier often explains the failure.
 
 ## 5. Compare against a known-good run
@@ -74,7 +74,7 @@ postmortem.
 
 ## 7. Fix at the source
 
-The debugger is read-only — it tells you what happened, not why. From here you go back
+The debugger is read-only. It tells you what happened, not why. From here you go back
 to the SDK-instrumented code, fix the offending span, and ship a release. Re-run the
 same scenario; the new trace should appear in your previously-bookmarked filtered list.
 
@@ -83,5 +83,5 @@ same scenario; the new trace should appear in your previously-bookmarked filtere
 - **Tag your traces at ingest** (`tags=["staging"]`, `tags=["release-v42"]`) so failure
   filtering can isolate a single deploy.
 - **Set `user_id` on traces** so user-reported issues map cleanly to filterable rows.
-- **Use `set_metadata` to record version pins** (model name, prompt hash) — these become
+- **Use `set_metadata` to record version pins** (model name, prompt hash). These become
   diff-able fields in the compare view.

--- a/docs-site/guides/installation.mdx
+++ b/docs-site/guides/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Run Continua locally — Docker for a quick demo, or native dev for live frontend iteration."
+description: "Run Continua locally: Docker for a quick demo, or native dev for live frontend iteration."
 ---
 
 Continua ships as a single Go binary plus a Postgres database. There are two supported
@@ -138,7 +138,7 @@ Common optional variables:
 | `RIVER_QUEUE_MAINTENANCE_WORKERS` | `1` | Cleanup / maintenance job concurrency |
 | `RIVER_QUEUE_DEFAULT_WORKERS` | `1` | Catch-all queue concurrency |
 
-Engine surface (preview — see [Roadmap](/roadmap) for status):
+Engine surface (preview: see [Roadmap](/roadmap) for status):
 
 | Variable | Default | Purpose |
 | --- | --- | --- |

--- a/docs-site/guides/instrument-your-app.mdx
+++ b/docs-site/guides/instrument-your-app.mdx
@@ -32,7 +32,7 @@ framework uses) before any traced code runs.
 
 ## 3. Wrap the entry point with `@trace`
 
-A trace should represent **one unit of work** — usually one user turn, one job, one
+A trace should represent **one unit of work**, usually one user turn, one job, one
 request. Anything narrower is a span, not a trace.
 
 ```python
@@ -55,7 +55,7 @@ def answer_question(question: str, user_id: str) -> str:
         return answer
 ```
 
-This shape — one outer `@trace`, several `span()` blocks inside — covers most agent
+This shape: one outer `@trace`, several `span()` blocks inside: covers most agent
 patterns. Reach for [`@session`](/sdk/python/sessions) when you want to group multiple
 turns under one user conversation.
 
@@ -129,7 +129,7 @@ Common refinements once a basic trace exists:
 - **Record costs and tokens** on every LLM call. Trace-level totals start rolling up
   automatically. See [Cost & tokens](/concepts/cost-and-tokens).
 - **Set `external_id` on sessions** so a re-run with the same id ends up in the same
-  session — that's what unlocks [Session compare](/debugger/session-compare).
+  session: that's what unlocks [Session compare](/debugger/session-compare).
 
 ## When to switch ingest modes
 
@@ -141,8 +141,8 @@ See [Batching & ingest modes](/sdk/python/batching-and-ingest-modes) for the tra
 
 ## See also
 
-- [Tracing](/sdk/python/tracing) — `@trace`, `@span` reference.
-- [Sessions](/sdk/python/sessions) — grouping traces.
-- [Span events](/sdk/python/span-events) — semantic events that make the timeline useful.
-- [Debugging a failed run](/guides/debugging-failures) — what to do when something
+- [Tracing](/sdk/python/tracing): `@trace`, `@span` reference.
+- [Sessions](/sdk/python/sessions): grouping traces.
+- [Span events](/sdk/python/span-events): semantic events that make the timeline useful.
+- [Debugging a failed run](/guides/debugging-failures): what to do when something
   breaks.

--- a/docs-site/guides/managing-projects.mdx
+++ b/docs-site/guides/managing-projects.mdx
@@ -11,9 +11,9 @@ and ingest batch belongs to exactly one project.
 The Projects page at `/projects` (sign in with Auth0 first if it's enabled) lists every
 project and lets you:
 
-- **Create** a project — name + description. On create, the UI shows the plaintext API
+- **Create** a project: name + description. On create, the UI shows the plaintext API
   key **once**. Copy it before you navigate away.
-- **Rotate** the API key — the old key is invalidated immediately and a new plaintext
+- **Rotate** the API key: the old key is invalidated immediately and a new plaintext
   key is shown once.
 - **Update** name / description.
 - **Delete** the project (soft delete).
@@ -53,7 +53,7 @@ curl -X POST https://continua.example.com/api/projects/{id}/rotate \
 ```
 
 The old key stops working immediately on success. The response includes the new
-plaintext key — again, only on this response. Rotate when:
+plaintext key: again, only on this response. Rotate when:
 
 - A key is suspected of being compromised.
 - An employee with access to the key leaves.
@@ -86,7 +86,7 @@ curl https://continua.example.com/api/projects \
 ```
 
 <Note>
-  Listing all projects is forbidden for API-key callers when Auth0 is enabled — only
+  Listing all projects is forbidden for API-key callers when Auth0 is enabled: only
   operator JWTs can list. API keys are scoped to the project they belong to.
 </Note>
 
@@ -102,7 +102,7 @@ curl https://continua.example.com/api/projects \
 
 ## See also
 
-- [Projects & auth](/concepts/projects-and-auth) — the auth model end to end.
-- [Auth0 setup](/guides/auth0-setup) — operator login.
+- [Projects & auth](/concepts/projects-and-auth): the auth model end to end.
+- [Auth0 setup](/guides/auth0-setup): operator login.
 - API reference: every project endpoint is listed under
   [API Reference → Endpoints](/api-reference/auth-and-headers).

--- a/docs-site/guides/quickstart.mdx
+++ b/docs-site/guides/quickstart.mdx
@@ -76,7 +76,7 @@ python hello.py
 
 Navigate to `http://localhost:8080/traces`. You should see a new trace named
 `hello_continua` with one span `think` (kind `llm`). Click into it for the failure-first
-detail view — span tree, payload inspector, state, and merged timeline.
+detail view: span tree, payload inspector, state, and merged timeline.
 
 ## What's next?
 

--- a/docs-site/guides/self-hosting.mdx
+++ b/docs-site/guides/self-hosting.mdx
@@ -87,9 +87,9 @@ make migrate-create name=<short_description>
 River workers run **inside** the platform server process. There is no separate worker
 binary to deploy today. The implemented queues are:
 
-- **ingest** — processes accepted async batches
-- **rollups** — recomputes trace-level aggregates (status, duration, cost, token counts)
-- **cleanup** — deletes processed async payload blobs after retention
+- **ingest**: processes accepted async batches
+- **rollups**: recomputes trace-level aggregates (status, duration, cost, token counts)
+- **cleanup**: deletes processed async payload blobs after retention
 
 Scale by increasing process count or tuning `RIVER_QUEUE_*` pool sizes.
 

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Continua"
-description: "Self-hosted debugging for AI agent runs — traces, spans, sessions, and events you can inspect locally."
+description: "Self-hosted debugging for AI agent runs: traces, spans, sessions, and events you can inspect locally."
 ---
 
 <Note>
   Continua is in alpha. The Python SDK, REST ingest, debugger UI, project & API-key
   management, Auth0 operator login, and the engine schema + runs console are shippable
   today. The TypeScript SDK, WebSocket runtime, proxy capture, replay, and end-to-end
-  engine workflow execution are scaffolded — see [Roadmap & status](/roadmap).
+  engine workflow execution are scaffolded: see [Roadmap & status](/roadmap).
 </Note>
 
 ## What is Continua?
@@ -38,17 +38,17 @@ Python SDK / custom client
     End-to-end: install the SDK, wrap your agent, and see your first real trace.
   </Card>
   <Card title="Debugger tour" icon="bug" href="/debugger/overview">
-    Traces, sessions, compare, engine runs — what each page in the UI does.
+    Traces, sessions, compare, engine runs: what each page in the UI does.
   </Card>
   <Card title="Concepts" icon="book-open" href="/concepts/overview">
-    Traces, spans, sessions, events — and how the async ingest lifecycle works.
+    Traces, spans, sessions, events: and how the async ingest lifecycle works.
   </Card>
 </CardGroup>
 
 ## Why Continua
 
 - **Self-hosted by default.** Postgres + a single Go binary. No vendor lock-in.
-- **Failure-first debugger.** Trace detail opens on the failure path — span tree, payloads,
+- **Failure-first debugger.** Trace detail opens on the failure path: span tree, payloads,
   state, and timeline in one workspace.
 - **Semantic events.** First-class `state_change`, `decision`, `effect`, and `wait` so the
   timeline shows *why* the agent did what it did, not just `log` spam.
@@ -61,7 +61,7 @@ Python SDK / custom client
 | --- | --- |
 | **Guides** | Quickstart, instrumentation, self-hosting, Auth0 setup, project management, failure-debugging workflows |
 | **Concepts** | Architecture, data model, observability model, projects & auth, cost & tokens, engine foundation |
-| **Debugger** | Tour of every page in the UI — traces, sessions, compare, engine runs, command palette, settings |
-| **Python SDK** | Full reference for `continua-sdk` — decorators, span events, sessions, batching, exceptions |
+| **Debugger** | Tour of every page in the UI: traces, sessions, compare, engine runs, command palette, settings |
+| **Python SDK** | Full reference for `continua-sdk`: decorators, span events, sessions, batching, exceptions |
 | **API Reference** | Auth & headers intro plus auto-rendered OpenAPI with a live playground |
 | **Roadmap** | What's shippable, what's scaffolded, and what's coming |

--- a/docs-site/logo/dark.svg
+++ b/docs-site/logo/dark.svg
@@ -1,16 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" role="img" aria-label="Continua">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" role="img" aria-label="Continua" fill="none">
   <defs>
-    <linearGradient id="cont-grad-dark" x1="4" y1="4" x2="36" y2="36" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#38BDF8"/>
-      <stop offset="1" stop-color="#0EA5E9"/>
+    <linearGradient id="cont-grad-dark" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#0ea5e9"/>
     </linearGradient>
   </defs>
-  <g fill="none" stroke="url(#cont-grad-dark)" stroke-linecap="round">
-    <circle cx="20" cy="20" r="14" stroke-width="1.9" stroke-dasharray="59 15 11 3" stroke-dashoffset="-16"/>
-    <path d="M 27 13 A 9 9 0 1 0 27 27" stroke-width="2.3"/>
+  <g transform="translate(0, -4)">
+    <circle cx="32" cy="32" r="24" stroke="url(#cont-grad-dark)" stroke-width="3" stroke-linecap="round" stroke-dasharray="100 26 18 5" stroke-dashoffset="-28"/>
+    <path d="M 44 18 A 14.5 14.5 0 1 0 44 46" stroke="url(#cont-grad-dark)" stroke-width="3.75" stroke-linecap="round"/>
+    <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-dark)"/>
+    <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-dark)"/>
   </g>
-  <circle cx="27" cy="13" r="1.7" fill="url(#cont-grad-dark)"/>
-  <circle cx="27" cy="27" r="1.7" fill="url(#cont-grad-dark)"/>
-  <text x="44" y="27" font-family="ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif"
-        font-size="20" font-weight="600" fill="#F1F5F9">Continua</text>
+  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#f8fafc">Continua</text>
 </svg>

--- a/docs-site/logo/light.svg
+++ b/docs-site/logo/light.svg
@@ -1,16 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" role="img" aria-label="Continua">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" role="img" aria-label="Continua" fill="none">
   <defs>
-    <linearGradient id="cont-grad-light" x1="4" y1="4" x2="36" y2="36" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0075D6"/>
-      <stop offset="1" stop-color="#005CAB"/>
+    <linearGradient id="cont-grad-light" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0075d6"/>
+      <stop offset="1" stop-color="#005cab"/>
     </linearGradient>
   </defs>
-  <g fill="none" stroke="url(#cont-grad-light)" stroke-linecap="round">
-    <circle cx="20" cy="20" r="14" stroke-width="1.9" stroke-dasharray="59 15 11 3" stroke-dashoffset="-16"/>
-    <path d="M 27 13 A 9 9 0 1 0 27 27" stroke-width="2.3"/>
+  <g transform="translate(0, -4)">
+    <circle cx="32" cy="32" r="24" stroke="url(#cont-grad-light)" stroke-width="3" stroke-linecap="round" stroke-dasharray="100 26 18 5" stroke-dashoffset="-28"/>
+    <path d="M 44 18 A 14.5 14.5 0 1 0 44 46" stroke="url(#cont-grad-light)" stroke-width="3.75" stroke-linecap="round"/>
+    <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-light)"/>
+    <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-light)"/>
   </g>
-  <circle cx="27" cy="13" r="1.7" fill="url(#cont-grad-light)"/>
-  <circle cx="27" cy="27" r="1.7" fill="url(#cont-grad-light)"/>
-  <text x="44" y="27" font-family="ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif"
-        font-size="20" font-weight="600" fill="#0F172A">Continua</text>
+  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#0f172a">Continua</text>
 </svg>

--- a/docs-site/roadmap.mdx
+++ b/docs-site/roadmap.mdx
@@ -5,7 +5,7 @@ description: "What's shippable today, what's scaffolded, and what we'd reach for
 
 This page is the honest line between the parts of Continua you can rely on today and the
 parts that are partially implemented or experimental. If a feature lives below the line,
-we may have endpoints, packages, or schema in the repo for it — but it isn't a supported
+we may have endpoints, packages, or schema in the repo for it, but it isn't a supported
 product path yet.
 
 ## Shippable today
@@ -26,7 +26,7 @@ shape. Everything in the rest of this docs site assumes they exist.
 | **Background jobs** | River workers for ingest, rollups, and payload cleanup |
 | **Self-hosting** | Single Go binary + Postgres, env-only config, embedded SPA, `continua migrate` + `continua-engine migrate` |
 
-## Scaffolded — not yet a supported product path
+## Scaffolded: not yet a supported product path
 
 These exist in the repo as types, schemas, or partial implementations. Don't depend on
 them. Calls into them won't get production behaviour, and the surface may change before
@@ -62,7 +62,7 @@ and execution (not real).
 ### Live WebSocket runtime
 
 The contract under [`contracts/websocket/events.ts`](https://github.com/aryanVijaywargia/Continua/tree/main/contracts/websocket)
-defines a live-update event schema. The debugger UI does **not** consume it today — trace
+defines a live-update event schema. The debugger UI does **not** consume it today: trace
 detail is polling-based via `GET /api/traces/{id}/events`. Server-side WebSocket handlers
 are stubbed.
 
@@ -90,4 +90,4 @@ Rough ordering, subject to change as feedback comes in:
 5. Replay execution as a layer on top of finished engine workflows.
 
 If you have a strong opinion on the order, open an issue on
-[GitHub](https://github.com/aryanVijaywargia/Continua/issues) — we read every one.
+[GitHub](https://github.com/aryanVijaywargia/Continua/issues): we read every one.

--- a/docs-site/sdk/python/batching-and-ingest-modes.mdx
+++ b/docs-site/sdk/python/batching-and-ingest-modes.mdx
@@ -40,8 +40,8 @@ The server supports three ways to accept a batch. The SDK picks one via the
 | Mode | Request shape | When it returns | Read-after-write? |
 | --- | --- | --- | --- |
 | `"sync"` | `POST /v1/ingest?sync=true` | After all rows are written | Yes |
-| `"async_v2"` | `POST /v1/ingest` with `X-Continua-Async-Version: 2` | Immediately with a `batch_id` (`202 Accepted`) | No — must poll |
-| `"server_default"` | No mode header — server uses `INGEST_TRUE_ASYNC_DEFAULT` | Depends on server config | Depends |
+| `"async_v2"` | `POST /v1/ingest` with `X-Continua-Async-Version: 2` | Immediately with a `batch_id` (`202 Accepted`) | No; must poll |
+| `"server_default"` | No mode header: server uses `INGEST_TRUE_ASYNC_DEFAULT` | Depends on server config | Depends |
 
 ```python
 Continua.init(
@@ -53,13 +53,13 @@ Continua.init(
 
 ### Which mode to use
 
-- **`sync`** — Tests, CLIs, scripts where the next step needs to read what you just
+- **`sync`**: Tests, CLIs, scripts where the next step needs to read what you just
   wrote. Simple and predictable. Throughput is bounded by the HTTP round-trip + the
   database write.
-- **`async_v2`** — Production agents and high-throughput services. The SDK returns
+- **`async_v2`**: Production agents and high-throughput services. The SDK returns
   control to your code as soon as the server has durably accepted the batch into
   `ingest_batches`. Background workers do the real work.
-- **`server_default`** — Library / framework code where the deployment owner gets to
+- **`server_default`**: Library / framework code where the deployment owner gets to
   pick. Pairs well with `INGEST_TRUE_ASYNC_DEFAULT` set per environment.
 
 See [Ingest lifecycle](/concepts/ingest-lifecycle) for the server-side state machine.
@@ -116,7 +116,7 @@ exhausted does the corresponding `ContinuaError` propagate.
 
 ## See also
 
-- [Ingest lifecycle](/concepts/ingest-lifecycle) — the server-side state machine.
-- [Exceptions](/sdk/python/exceptions) — which errors come back when.
-- [Self-hosting](/guides/self-hosting) — `INGEST_TRUE_ASYNC_DEFAULT`, retention,
+- [Ingest lifecycle](/concepts/ingest-lifecycle): the server-side state machine.
+- [Exceptions](/sdk/python/exceptions): which errors come back when.
+- [Self-hosting](/guides/self-hosting): `INGEST_TRUE_ASYNC_DEFAULT`, retention,
   worker queue sizing.

--- a/docs-site/sdk/python/exceptions.mdx
+++ b/docs-site/sdk/python/exceptions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Exceptions"
-description: "Every exception class the SDK raises — when each is thrown and how to handle it."
+description: "Every exception class the SDK raises: when each is thrown and how to handle it."
 ---
 
 All exceptions inherit from `ContinuaError`. Catch that base class if you want to handle
@@ -30,7 +30,7 @@ ContinuaError
 ```
 
 `NonRetryableError` is raised **by you** inside an activity handler to mark a task as
-permanently failed — it does not derive from `ContinuaError`.
+permanently failed. It does not derive from `ContinuaError`.
 
 ## Ingest / client errors
 
@@ -85,7 +85,7 @@ except NetworkError as exc:
 ## Engine errors
 
 These are raised by `EngineControlClient` when interacting with the durable engine
-surface. The engine surface is scaffolded today — see [Roadmap](/roadmap) before
+surface. The engine surface is scaffolded today: see [Roadmap](/roadmap) before
 depending on it.
 
 ### `EngineRunNotTerminalError`

--- a/docs-site/sdk/python/installation.mdx
+++ b/docs-site/sdk/python/installation.mdx
@@ -51,7 +51,7 @@ After init, use `Continua.get_instance()` anywhere in your process to retrieve t
 
 ## Ingest modes
 
-A quick summary — see [Batching & ingest modes](/sdk/python/batching-and-ingest-modes)
+A quick summary: see [Batching & ingest modes](/sdk/python/batching-and-ingest-modes)
 for the full trade-offs and [Ingest lifecycle](/concepts/ingest-lifecycle) for the
 server-side state machine.
 
@@ -96,12 +96,12 @@ ping()
 Continua.get_instance().flush()
 ```
 
-Open `http://localhost:8080/traces` — you should see a `connectivity_check` trace.
+Open `http://localhost:8080/traces`: you should see a `connectivity_check` trace.
 
 ## Examples
 
 The SDK ships with two runnable examples under `sdks/python/examples/`:
 
-- `e2e_demo.py` — end-to-end: traces with nested spans, LLM / tool / agent simulation,
+- `e2e_demo.py`: end-to-end: traces with nested spans, LLM / tool / agent simulation,
   API verification.
-- `agentic_flow_stress.py` — stress test with complex agent flows and OpenAI integration.
+- `agentic_flow_stress.py`: stress test with complex agent flows and OpenAI integration.

--- a/docs-site/sdk/python/overview.mdx
+++ b/docs-site/sdk/python/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "The continua-sdk Python package — what it does and how its pieces fit together."
+description: "The continua-sdk Python package: what it does and how its pieces fit together."
 ---
 
 `continua-sdk` is the official Python client for Continua. It sends AI agent traces,
@@ -27,14 +27,14 @@ The full public surface from `continua/__init__.py`:
 
 ### Core client
 
-- [`Continua`](/sdk/python/installation) — the singleton client (`Continua.init()`,
+- [`Continua`](/sdk/python/installation): the singleton client (`Continua.init()`,
   `add_trace()`, `add_span()`, `add_event()`, `flush()`, `wait_for_batch()`, `shutdown()`)
 
 ### Decorators and context managers
 
-- [`@trace`](/sdk/python/tracing) — wrap a top-level agent function
-- [`@span`](/sdk/python/tracing) — open a span context manager
-- [`@session`](/sdk/python/sessions) — group traces under a session
+- [`@trace`](/sdk/python/tracing): wrap a top-level agent function
+- [`@span`](/sdk/python/tracing): open a span context manager
+- [`@session`](/sdk/python/sessions): group traces under a session
 
 ### Context classes
 
@@ -42,7 +42,7 @@ The full public surface from `continua/__init__.py`:
 
 <Note>
   The SDK also exports `EngineControlClient`, `ActivityWorker`, and `ActivityTaskContext`
-  for the durable engine surface. That surface is scaffolded today — see
+  for the durable engine surface. That surface is scaffolded today: see
   [Roadmap & status](/roadmap) before depending on it.
 </Note>
 
@@ -62,9 +62,9 @@ The full public surface from `continua/__init__.py`:
 | `continua.trace` | `@trace` decorator + `TraceContext` |
 | `continua.span` | `@span` context manager + `SpanContext` (see [Span events](/sdk/python/span-events) for every method) |
 | `continua.session` | `@session` context manager + `SessionContext` |
-| `continua.worker` | `ActivityWorker`, `@activity` decorator (engine surface — scaffolded, see [Roadmap](/roadmap)) |
-| `continua.engine_control` | `EngineControlClient` (engine surface — scaffolded, see [Roadmap](/roadmap)) |
-| `continua.exceptions` | Exception hierarchy — see [Exceptions](/sdk/python/exceptions) |
+| `continua.worker` | `ActivityWorker`, `@activity` decorator (engine surface: scaffolded, see [Roadmap](/roadmap)) |
+| `continua.engine_control` | `EngineControlClient` (engine surface: scaffolded, see [Roadmap](/roadmap)) |
+| `continua.exceptions` | Exception hierarchy: see [Exceptions](/sdk/python/exceptions) |
 | `continua.types` | Generated Pydantic models from the OpenAPI contract |
 
 ## Typical usage
@@ -101,13 +101,13 @@ def answer_question(question: str) -> str:
     Install, initialize, and configure ingest modes.
   </Card>
   <Card title="Tracing" icon="route" href="/sdk/python/tracing">
-    `@trace` and `@span` — decorators and context managers in depth.
+    `@trace` and `@span`: decorators and context managers in depth.
   </Card>
   <Card title="Sessions" icon="layer-group" href="/sdk/python/sessions">
-    `@session` — group multiple traces under one conversation.
+    `@session`: group multiple traces under one conversation.
   </Card>
   <Card title="Span events" icon="list-tree" href="/sdk/python/span-events">
-    Every method on `SpanContext` — `set_input`, `log`, `error`, `llm_response`, etc.
+    Every method on `SpanContext`: `set_input`, `log`, `error`, `llm_response`, etc.
   </Card>
   <Card title="Batching & ingest modes" icon="rocket" href="/sdk/python/batching-and-ingest-modes">
     Sync vs async, idempotency, `wait_for_batch`, tuning the queue.

--- a/docs-site/sdk/python/sessions.mdx
+++ b/docs-site/sdk/python/sessions.mdx
@@ -3,7 +3,7 @@ title: "Sessions"
 description: "Group traces under a shared session id with the @session context manager."
 ---
 
-A **session** groups traces that belong together — usually one user conversation, one
+A **session** groups traces that belong together, usually one user conversation, one
 job, or one long-running interaction. Sessions are the right unit when you want to ask
 "what happened across all these turns?" rather than "what happened in this one call?".
 
@@ -40,7 +40,7 @@ def session(
 | Parameter | Description |
 | --- | --- |
 | `session_id` | External session identifier. If `None`, no session key is attached |
-| `user_id` | Optional user identifier — propagates to every trace inside |
+| `user_id` | Optional user identifier: propagates to every trace inside |
 | `metadata` | Optional metadata dictionary |
 
 ## Accessing the current session
@@ -60,7 +60,7 @@ The SDK uses Python `contextvars`:
 
 - `session()` sets the current session for the duration of the `with` block.
 - `@trace` reads the current session on entry and pins the trace to it.
-- `span()` doesn't need to read the session — it inherits via its parent trace.
+- `span()` doesn't need to read the session. It inherits via its parent trace.
 
 Async code that preserves `contextvars` (e.g. `asyncio`) propagates correctly. Threads
 need explicit context propagation.
@@ -95,13 +95,13 @@ database and use the Continua session id as a foreign key.
 ### Re-using session ids across runs
 
 If you re-use the same `session_id` across re-runs (intentional or accidental), traces
-from both runs appear under the same session. That can be helpful — it's how
+from both runs appear under the same session. That can be helpful: it's how
 [Session compare](/debugger/session-compare) finds baseline + candidate pairs. It can
 also surprise you. When in doubt, suffix the id with a run nonce.
 
 ## See also
 
-- [Tracing](/sdk/python/tracing) — `@trace` and `@span` (where most of the work happens).
-- [Sessions page](/debugger/sessions) — how sessions render in the debugger.
-- [Session compare](/debugger/session-compare) — diff two traces in the same session.
-- [Comparing baseline and candidate](/guides/comparing-sessions) — guided workflow.
+- [Tracing](/sdk/python/tracing): `@trace` and `@span` (where most of the work happens).
+- [Sessions page](/debugger/sessions): how sessions render in the debugger.
+- [Session compare](/debugger/session-compare): diff two traces in the same session.
+- [Comparing baseline and candidate](/guides/comparing-sessions): guided workflow.

--- a/docs-site/sdk/python/span-events.mdx
+++ b/docs-site/sdk/python/span-events.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Span events"
-description: "Every method on SpanContext — set_input/output, log, error, llm_response, tool_call, and the semantic events."
+description: "Every method on SpanContext: set_input/output, log, error, llm_response, tool_call, and the semantic events."
 ---
 
 `SpanContext` exposes a comprehensive set of methods for attaching data, events, and
 semantics to a span. They fall into four groups:
 
-1. **Payload setters** — `set_input`, `set_output`, metadata, tokens, cost, model
-2. **High-level helpers** — `set_llm_response`, `set_tool_call` (these also emit implicit
+1. **Payload setters**: `set_input`, `set_output`, metadata, tokens, cost, model
+2. **High-level helpers**: `set_llm_response`, `set_tool_call` (these also emit implicit
    `effect` events)
-3. **Explicit events** — `log`, `error`, `exception`, `metric`
-4. **Semantic events** — `state_change`, `decision`, `effect`, `wait`, `snapshot_marker`
+3. **Explicit events**: `log`, `error`, `exception`, `metric`
+4. **Semantic events**: `state_change`, `decision`, `effect`, `wait`, `snapshot_marker`
 
 For the conceptual model behind events, see [Events](/concepts/events).
 
@@ -43,7 +43,7 @@ s.set_model("gpt-4.1-mini", provider="openai")
 ### `set_tokens(*, prompt=None, completion=None, total=None)`
 
 Record token counts. Keyword-only. At least one of `prompt` or `completion` must be
-provided — `total` alone raises `ValueError`.
+provided: `total` alone raises `ValueError`.
 
 ```python
 s.set_tokens(prompt=120, completion=48)
@@ -232,7 +232,7 @@ s.snapshot_marker(
 
 | Method | Event type emitted | Default level |
 | --- | --- | --- |
-| `set_input`, `set_output`, `set_model`, `set_tokens`, `set_cost`, `set_metadata`, `set_error` | _(no event — fields on the span)_ | — |
+| `set_input`, `set_output`, `set_model`, `set_tokens`, `set_cost`, `set_metadata`, `set_error` | _(no event; fields on the span)_ | None |
 | `set_llm_response` | implicit `effect` (`model_call`) | `info` |
 | `set_tool_call` | implicit `effect` (`tool_call`) | `info` |
 | `log` | `log` | `info` |

--- a/docs-site/sdk/python/tracing.mdx
+++ b/docs-site/sdk/python/tracing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Tracing"
-description: "@trace, @span, and @session — decorators and context managers for instrumenting agent code."
+description: "@trace, @span, and @session: decorators and context managers for instrumenting agent code."
 ---
 
 The SDK exposes three context managers (also usable as decorators): `trace`, `span`, and
@@ -75,7 +75,7 @@ current = get_current_trace()  # TraceContext | None
 
 ## `span`
 
-Open a span as a context manager. Spans nest automatically — a `span()` opened inside
+Open a span as a context manager. Spans nest automatically: a `span()` opened inside
 another `span()` is a child of the outer one.
 
 ```python


### PR DESCRIPTION
## Summary

- refreshed README and docs-site punctuation for a cleaner public reading flow
- tightened wording in several docs pages without changing product behavior or API details
- left Markdown/frontmatter/table/code syntax intact where required

## Validation

- `rg -n '—' -g 'README*' -g '*.md' -g '*.mdx' -g '*.txt'`
- `rg -n -e '\bAI-powered\b|\bseamless\b|\brobust\b|\bleverage\b|\bunleash\b|\brevolutionary\b|\bcutting-edge\b|\bgame-changing\b|\belevate\b|\beffortlessly\b|\bsupercharge\b|\bAI slop\b' -g 'README*' -g '*.md' -g '*.mdx' -g '*.txt'`
- `git diff --check`
