### PR TITLE
docs: refresh brand asset paths

### DIFF
--- a/docs-site/brand/continua-mark.svg
+++ b/docs-site/brand/continua-mark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
+  <defs>
+    <linearGradient id="cont-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0075d6"/>
+      <stop offset="1" stop-color="#005cab"/>
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="28" stroke="url(#cont-grad)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>
+  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad)" stroke-width="4.5" stroke-linecap="round"/>
+  <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad)"/>
+  <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad)"/>
+</svg>

--- a/docs-site/brand/continua-wordmark-dark.svg
+++ b/docs-site/brand/continua-wordmark-dark.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" role="img" aria-label="Continua" fill="none">
+  <defs>
+    <linearGradient id="cont-grad-dark" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#0ea5e9"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(0, -4)">
+    <circle cx="32" cy="32" r="24" stroke="url(#cont-grad-dark)" stroke-width="3" stroke-linecap="round" stroke-dasharray="100 26 18 5" stroke-dashoffset="-28"/>
+    <path d="M 44 18 A 14.5 14.5 0 1 0 44 46" stroke="url(#cont-grad-dark)" stroke-width="3.75" stroke-linecap="round"/>
+    <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-dark)"/>
+    <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-dark)"/>
+  </g>
+  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#f8fafc">Continua</text>
+</svg>

--- a/docs-site/brand/continua-wordmark-light.svg
+++ b/docs-site/brand/continua-wordmark-light.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" role="img" aria-label="Continua" fill="none">
+  <defs>
+    <linearGradient id="cont-grad-light" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0075d6"/>
+      <stop offset="1" stop-color="#005cab"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(0, -4)">
+    <circle cx="32" cy="32" r="24" stroke="url(#cont-grad-light)" stroke-width="3" stroke-linecap="round" stroke-dasharray="100 26 18 5" stroke-dashoffset="-28"/>
+    <path d="M 44 18 A 14.5 14.5 0 1 0 44 46" stroke="url(#cont-grad-light)" stroke-width="3.75" stroke-linecap="round"/>
+    <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-light)"/>
+    <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-light)"/>
+  </g>
+  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#0f172a">Continua</text>
+</svg>

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -8,13 +8,13 @@
     "light": "#7aaeff",
     "dark": "#005cab"
   },
-  "favicon": "/favicon.svg",
+  "favicon": "/brand/continua-mark.svg",
   "appearance": {
     "default": "system"
   },
   "logo": {
-    "light": "/logo/light.svg",
-    "dark": "/logo/dark.svg",
+    "light": "/brand/continua-wordmark-light.svg",
+    "dark": "/brand/continua-wordmark-dark.svg",
     "href": "https://www.continua.in"
   },
   "navigation": {


### PR DESCRIPTION
## Summary

- points Mintlify docs branding config at new versioned asset paths
- adds dedicated docs brand SVGs for the Continua mark and light/dark wordmarks
- keeps the existing SVG assets intact as fallback files

## Validation

- checked the live docs page and confirmed the rendered navbar logo is served through Mintlify CDN URLs
- verified the generated docs favicon endpoint renders the outlined Continua mark
- `xmllint --noout docs-site/brand/continua-mark.svg docs-site/brand/continua-wordmark-light.svg docs-site/brand/continua-wordmark-dark.svg docs-site/favicon.svg docs-site/logo/light.svg docs-site/logo/dark.svg`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated branding assets in the documentation site, including favicon and light/dark logo variants for consistent visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aryanVijaywargia/Continua/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->