### PR TITLE
Publish Docker image to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -258,22 +261,49 @@ jobs:
           retention-days: 3
 
   docker:
-    name: Docker Build
+    name: Publish Docker Image
     runs-on: ubuntu-latest
     needs: [build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build Docker image
+      - name: Resolve image name
+        id: image
+        run: echo "image=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.image.outputs.image }}
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short,prefix=sha-
+
+      - name: Build and publish Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: deploy/docker/Dockerfile
-          push: false
-          tags: continua:${{ github.sha }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Publish the Continua Docker image to GitHub Container Registry from CI after the main-branch build passes.
- Add GHCR login, Docker metadata, `latest` and short-SHA tags, and image build args for version/commit metadata.
- Scope package write permission to the Docker publish job.

## Validation

- Parsed `.github/workflows/ci.yml` as YAML.
- Ran `actionlint` against `.github/workflows/ci.yml`.
- Verified the GHCR image-name normalization command resolves `aryanVijaywargia/Continua` to `ghcr.io/aryanvijaywargia/continua`.
- Verified referenced Docker action tags resolve through GitHub.

## Note

A local Docker build could not run because the Docker daemon is not running on this machine.
