### PR TITLE
docs: correct schema drift in data-model and engine-foundation concept pages

### DIFF
--- a/docs-site/concepts/data-model.mdx
+++ b/docs-site/concepts/data-model.mdx
@@ -8,9 +8,12 @@ erDiagram
   projects ||--o{ ingest_batches : "owns"
   projects ||--o{ sessions : "owns"
   projects ||--o{ traces : "owns"
+  projects ||--o{ spans : "owns"
+  projects ||--o{ span_events : "owns"
   sessions ||--o{ traces : "groups"
   traces ||--o{ spans : "contains"
-  spans ||--o{ span_events : "emits"
+  traces ||--o{ span_events : "contains"
+  spans ||--o{ span_events : "emits via span_id"
 
   projects {
     uuid id PK
@@ -43,20 +46,27 @@ erDiagram
   }
   spans {
     uuid id PK
+    uuid project_id FK
     uuid trace_id FK
     string span_id
     string parent_span_id
     string name
-    string kind
+    string type
+    string status
     jsonb input
     jsonb output
   }
   span_events {
     uuid id PK
-    uuid span_id FK
-    string type
+    uuid project_id FK
+    uuid trace_id FK
+    string span_id
+    string event_type
+    string level
+    timestamptz event_ts
+    timestamptz server_ingested_at
     jsonb payload
-    timestamptz occurred_at
+    string idempotency_key
   }
 ```
 
@@ -103,15 +113,32 @@ has:
 `spans` represent operations within a trace. Each row has:
 
 - An internal UUID primary key
-- An external `span_id`
-- An external `parent_span_id` for tree reconstruction
-- `kind`, `status`, timing, cost/token fields, model/provider fields, metadata, and
+- A `project_id` foreign key (`REFERENCES projects(id) ON DELETE CASCADE`) — every span is
+  scoped directly to its project, not only through its parent trace
+- A `trace_id` foreign key to the owning trace
+- An external `span_id` (TEXT)
+- An external `parent_span_id` (TEXT, no foreign key) for tree reconstruction
+- A `type` column for the span kind (`llm`, `tool`, `retrieval`, `agent`, `custom`); the
+  read API exposes this column as `kind`
+- `status`, `level`, timing, cost/token fields, model/provider fields, metadata, and
   span-level payloads
 
 ### Span event
 
 `span_events` store explicit append-only events such as logs, errors, exceptions, metrics,
-and semantic debugger events.
+and semantic debugger events. Each row has:
+
+- A `project_id` foreign key (`REFERENCES projects(id) ON DELETE CASCADE`) — every event is
+  scoped directly to its project, not only through a parent span
+- A `trace_id` foreign key to the owning trace
+- An external `span_id` (TEXT, no foreign key) linking the event to its span; the link is
+  intentionally soft so events that arrive before their span are still ingested
+- `event_type`, `level`, a client-supplied `event_ts`, a `server_ingested_at` stamp,
+  `sequence`, `message`, and a JSONB `payload`
+- An optional `idempotency_key`, deduplicated by a partial unique index on
+  `(project_id, idempotency_key)`
+
+Other notes:
 
 - Explicit events are stored separately from spans
 - Trace timelines merge explicit events with synthetic lifecycle events derived from spans
@@ -122,6 +149,7 @@ and semantic debugger events.
 - `sessions.external_id` is the user-facing session identifier
 - `traces.trace_id` is the external trace identifier
 - `spans.span_id` and `spans.parent_span_id` are external span identifiers
+- `span_events.span_id` is the same external span identifier (TEXT, no foreign key to `spans`)
 - Internal UUIDs are the persistence identity used inside the database and server code
 
 ## Payload notes

--- a/docs-site/concepts/data-model.mdx
+++ b/docs-site/concepts/data-model.mdx
@@ -18,7 +18,7 @@ erDiagram
   projects {
     uuid id PK
     string name
-    string api_key
+    string api_key_hash
     timestamptz created_at
   }
   ingest_batches {
@@ -41,8 +41,8 @@ erDiagram
     uuid session_id FK
     string trace_id
     string status
-    timestamptz started_at
-    timestamptz ended_at
+    timestamptz start_time
+    timestamptz end_time
   }
   spans {
     uuid id PK
@@ -154,8 +154,8 @@ Other notes:
 
 ## Payload notes
 
-- There is no standalone runtime `payloads` table for trace/span request and response
-  bodies
+- The legacy `payloads` table still exists in the schema but is dormant — the current
+  runtime does not store trace/span request and response bodies in it
 - Trace payloads live on `traces`
 - Span payloads live on `spans`
 - Accepted async payload blobs live temporarily in `ingest_batch_payloads`

--- a/docs-site/concepts/engine-foundation.mdx
+++ b/docs-site/concepts/engine-foundation.mdx
@@ -26,7 +26,7 @@ Core tables:
 | Table | Holds |
 | --- | --- |
 | `engine.instances` | The logical workflow instance keyed by `instance_key` |
-| `engine.runs` | Per-run state (status, started_at, terminal_state) |
+| `engine.runs` | Per-run lifecycle state (status, run_number, attempt_count, claim/lease fields) |
 | `engine.history` | Append-only event log per run |
 | `engine.inbox` | Pending inbox items (signals, child completions, etc.) |
 | `engine.activity_tasks` | Activity tasks ready for workers to claim |


### PR DESCRIPTION
## What

Corrects schema drift in two `docs-site/concepts` pages so the documented shapes match the live Postgres schema. **Docs-only** — no migration, query, or Go changes.

### `data-model.mdx`
- **`spans` and `span_events` now carry their own `project_id` FK** (`REFERENCES projects(id) ON DELETE CASCADE`). Both tables are scoped directly to a project, not only through their parent. The old ER diagram omitted this, which misled an architecture review into concluding these tables "carry no project_id."
- `spans`: the span-type column is `type` (not `kind`); `span_id`/`parent_span_id` are external TEXT with no FK.
- `span_events`: dropped the nonexistent `span_id` FK to `spans` (it's external TEXT, a soft link kept for out-of-order tolerance); corrected columns to `event_type`, `event_ts`, `server_ingested_at`; documented the `(project_id, idempotency_key)` partial unique index. Added ownership edges and updated the Span / Span event prose + identity rules.
- `projects`: `api_key` → `api_key_hash`. `traces`: `started_at`/`ended_at` → `start_time`/`end_time`.
- Clarified that the legacy `payloads` table still exists but is dormant; trace/span bodies live inline on `traces`/`spans`.

### `engine-foundation.mdx`
- The `engine.runs` row listed `started_at` and `terminal_state`, which exist in **no** engine migration. Replaced with real columns (`status`, `run_number`, `attempt_count`, claim/lease fields); terminal states are values of the `status` lifecycle enum.

## Why
Repo rule: the live code/schema is the source of truth; when a doc conflicts with code, fix the doc.

## Verification
- Reconciled every field and relationship against all 21 `db/platform/migrations/postgres/*` migrations, the sqlc-generated `db/gen/go/platform/models.go`, and the spans/events queries; engine claims checked against `engine/db/migrations/postgres/*`.
- Intentionally left `kind` (span type) and `api_key` as-is in the **SDK/API-facing** pages — those are the correct SDK/API surface names, even though the DB columns are `type`/`api_key_hash`.
- Mermaid validated by inspection (no runnable local docs build in this environment).
