### PR TITLE
Seed public demo with real agent traces

### DIFF
--- a/scripts/seed-demo.sh
+++ b/scripts/seed-demo.sh
@@ -12,6 +12,12 @@ if [[ -z "${DATABASE_URL:-}" ]]; then
   exit 1
 fi
 
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  echo "OPENAI_API_KEY must be set before running the public demo seed." >&2
+  echo "The demo seed records real provider-backed agent runs and refuses synthetic data." >&2
+  exit 1
+fi
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 API_URL="${CONTINUA_API_URL:-${CONTINUA_ENDPOINT:-http://localhost:8080}}"
 DEMO_PROJECT_ID="${CONTINUA_DEMO_PROJECT_ID:-${PUBLIC_DEMO_PROJECT_ID:-11111111-1111-4111-8111-111111111111}}"
@@ -48,13 +54,13 @@ VALUES (
 );
 SQL
 
-echo "==> Seeding deterministic engine demo fixtures"
+echo "==> Cleaning stale engine demo rows"
 psql "${DATABASE_URL}" \
   -v ON_ERROR_STOP=1 \
   -v demo_project_id="${DEMO_PROJECT_ID}" \
   -f "${ROOT_DIR}/scripts/seed-engine-demo.sql"
 
-echo "==> Seeding demo traces through the ingest API at ${API_URL}"
+echo "==> Running real OpenAI-backed demo agents through the ingest API at ${API_URL}"
 (
   cd "${ROOT_DIR}/sdks/python"
   CONTINUA_DEMO_PROJECT_ID="${DEMO_PROJECT_ID}" \
@@ -62,6 +68,7 @@ echo "==> Seeding demo traces through the ingest API at ${API_URL}"
   CONTINUA_API_KEY="${DEMO_API_KEY}" \
   CONTINUA_PRINT_API_KEY=0 \
   CONTINUA_DEMO_RUN_ID="${DEMO_RUN_ID}" \
+  CONTINUA_DEMO_AGENT_MODE=openai \
   uv run python examples/e2e_demo.py
 )
 

--- a/scripts/seed-engine-demo.sql
+++ b/scripts/seed-engine-demo.sql
@@ -1,590 +1,80 @@
--- Deterministic engine fixtures for the public demo project.
+-- Clean stale engine state for the public demo project.
 --
--- This file is intentionally direct SQL instead of API calls. The public demo
--- should be inspectable after seeding without requiring a workflow worker.
+-- The real-agent demo currently records provider-backed SDK traces only. Engine
+-- run shells are intentionally not seeded here because catalog-only definitions
+-- would stay queued until matching compiled workflow definitions exist.
 
 DELETE FROM traces
-WHERE (
-    project_id = :'demo_project_id'::uuid
-    AND (
-      engine_run_id IS NOT NULL
-      OR trace_id IN (
-        'engine:20000000-0000-4000-8000-000000000001',
-        'engine:20000000-0000-4000-8000-000000000002',
-        'engine:20000000-0000-4000-8000-000000000003',
-        'engine:demo:checkout-approval',
-        'engine:demo:checkout-completed',
-        'engine:demo:darklaunch-stale'
-      )
-    )
-  )
-  OR engine_run_id IN (
-    '20000000-0000-4000-8000-000000000001'::uuid,
-    '20000000-0000-4000-8000-000000000002'::uuid,
-    '20000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR trace_id IN (
-    'engine:20000000-0000-4000-8000-000000000001',
-    'engine:20000000-0000-4000-8000-000000000002',
-    'engine:20000000-0000-4000-8000-000000000003',
-    'engine:demo:checkout-approval',
-    'engine:demo:checkout-completed',
-    'engine:demo:darklaunch-stale'
+WHERE project_id = :'demo_project_id'::uuid
+  AND (
+    engine_run_id IS NOT NULL
+    OR trace_id LIKE 'engine:%'
   );
 
 DELETE FROM engine.activity_tasks
 WHERE project_id = :'demo_project_id'::uuid
-  OR run_id IN (
-    '20000000-0000-4000-8000-000000000001'::uuid,
-    '20000000-0000-4000-8000-000000000002'::uuid,
-    '20000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR instance_id IN (
-    '10000000-0000-4000-8000-000000000001'::uuid,
-    '10000000-0000-4000-8000-000000000002'::uuid,
-    '10000000-0000-4000-8000-000000000003'::uuid
-  );
+   OR run_id IN (
+     SELECT id FROM engine.runs WHERE project_id = :'demo_project_id'::uuid
+   )
+   OR instance_id IN (
+     SELECT id FROM engine.instances WHERE project_id = :'demo_project_id'::uuid
+   );
 
 DELETE FROM engine.inbox
 WHERE project_id = :'demo_project_id'::uuid
-  OR run_id IN (
-    '20000000-0000-4000-8000-000000000001'::uuid,
-    '20000000-0000-4000-8000-000000000002'::uuid,
-    '20000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR instance_id IN (
-    '10000000-0000-4000-8000-000000000001'::uuid,
-    '10000000-0000-4000-8000-000000000002'::uuid,
-    '10000000-0000-4000-8000-000000000003'::uuid
-  );
+   OR run_id IN (
+     SELECT id FROM engine.runs WHERE project_id = :'demo_project_id'::uuid
+   )
+   OR instance_id IN (
+     SELECT id FROM engine.instances WHERE project_id = :'demo_project_id'::uuid
+   );
 
 DELETE FROM engine.request_dedupe
 WHERE project_id = :'demo_project_id'::uuid
-  OR run_id IN (
-    '20000000-0000-4000-8000-000000000001'::uuid,
-    '20000000-0000-4000-8000-000000000002'::uuid,
-    '20000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR instance_id IN (
-    '10000000-0000-4000-8000-000000000001'::uuid,
-    '10000000-0000-4000-8000-000000000002'::uuid,
-    '10000000-0000-4000-8000-000000000003'::uuid
-  );
+   OR run_id IN (
+     SELECT id FROM engine.runs WHERE project_id = :'demo_project_id'::uuid
+   )
+   OR instance_id IN (
+     SELECT id FROM engine.instances WHERE project_id = :'demo_project_id'::uuid
+   );
 
 DELETE FROM engine.child_workflows
 WHERE project_id = :'demo_project_id'::uuid
-  OR parent_instance_id IN (
-    '10000000-0000-4000-8000-000000000001'::uuid,
-    '10000000-0000-4000-8000-000000000002'::uuid,
-    '10000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR child_instance_id IN (
-    '10000000-0000-4000-8000-000000000001'::uuid,
-    '10000000-0000-4000-8000-000000000002'::uuid,
-    '10000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR parent_run_id IN (
-    '20000000-0000-4000-8000-000000000001'::uuid,
-    '20000000-0000-4000-8000-000000000002'::uuid,
-    '20000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR current_child_run_id IN (
-    '20000000-0000-4000-8000-000000000001'::uuid,
-    '20000000-0000-4000-8000-000000000002'::uuid,
-    '20000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR terminal_child_run_id IN (
-    '20000000-0000-4000-8000-000000000001'::uuid,
-    '20000000-0000-4000-8000-000000000002'::uuid,
-    '20000000-0000-4000-8000-000000000003'::uuid
-  );
+   OR parent_run_id IN (
+     SELECT id FROM engine.runs WHERE project_id = :'demo_project_id'::uuid
+   )
+   OR current_child_run_id IN (
+     SELECT id FROM engine.runs WHERE project_id = :'demo_project_id'::uuid
+   )
+   OR terminal_child_run_id IN (
+     SELECT id FROM engine.runs WHERE project_id = :'demo_project_id'::uuid
+   )
+   OR parent_instance_id IN (
+     SELECT id FROM engine.instances WHERE project_id = :'demo_project_id'::uuid
+   )
+   OR child_instance_id IN (
+     SELECT id FROM engine.instances WHERE project_id = :'demo_project_id'::uuid
+   );
 
 DELETE FROM engine.history
 WHERE project_id = :'demo_project_id'::uuid
-  OR run_id IN (
-    '20000000-0000-4000-8000-000000000001'::uuid,
-    '20000000-0000-4000-8000-000000000002'::uuid,
-    '20000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR instance_id IN (
-    '10000000-0000-4000-8000-000000000001'::uuid,
-    '10000000-0000-4000-8000-000000000002'::uuid,
-    '10000000-0000-4000-8000-000000000003'::uuid
-  );
+   OR run_id IN (
+     SELECT id FROM engine.runs WHERE project_id = :'demo_project_id'::uuid
+   )
+   OR instance_id IN (
+     SELECT id FROM engine.instances WHERE project_id = :'demo_project_id'::uuid
+   );
 
 DELETE FROM engine.runs
-WHERE project_id = :'demo_project_id'::uuid
-  OR id IN (
-    '20000000-0000-4000-8000-000000000001'::uuid,
-    '20000000-0000-4000-8000-000000000002'::uuid,
-    '20000000-0000-4000-8000-000000000003'::uuid
-  )
-  OR instance_id IN (
-    '10000000-0000-4000-8000-000000000001'::uuid,
-    '10000000-0000-4000-8000-000000000002'::uuid,
-    '10000000-0000-4000-8000-000000000003'::uuid
-  );
+WHERE project_id = :'demo_project_id'::uuid;
 
 DELETE FROM engine.instances
-WHERE project_id = :'demo_project_id'::uuid
-  OR id IN (
-    '10000000-0000-4000-8000-000000000001'::uuid,
-    '10000000-0000-4000-8000-000000000002'::uuid,
-    '10000000-0000-4000-8000-000000000003'::uuid
-  );
+WHERE project_id = :'demo_project_id'::uuid;
 
-INSERT INTO engine.definition_catalog (definition_name, definition_version, published_at, updated_at)
-VALUES
-  ('checkout', 'v1', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days'),
-  ('darklaunch.demo', 'v1', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days')
-ON CONFLICT (definition_name, definition_version) DO UPDATE
-SET updated_at = EXCLUDED.updated_at;
-
-INSERT INTO engine.instances (
-    id,
-    project_id,
-    instance_key,
-    definition_name,
-    status,
-    metadata,
-    created_at,
-    updated_at
-)
-VALUES
-  (
-    '10000000-0000-4000-8000-000000000001',
-    :'demo_project_id'::uuid,
-    'demo-checkout-approval',
-    'checkout',
-    'active',
-    '{"demo": true, "scenario": "waiting_for_approval"}'::jsonb,
-    NOW() - INTERVAL '55 minutes',
-    NOW() - INTERVAL '2 minutes'
-  ),
-  (
-    '10000000-0000-4000-8000-000000000002',
-    :'demo_project_id'::uuid,
-    'demo-checkout-completed',
-    'checkout',
-    'completed',
-    '{"demo": true, "scenario": "completed_checkout"}'::jsonb,
-    NOW() - INTERVAL '2 hours',
-    NOW() - INTERVAL '85 minutes'
-  ),
-  (
-    '10000000-0000-4000-8000-000000000003',
-    :'demo_project_id'::uuid,
-    'demo-darklaunch-stale',
-    'darklaunch.demo',
-    'completed',
-    '{"demo": true, "scenario": "projection_repair"}'::jsonb,
-    NOW() - INTERVAL '3 hours',
-    NOW() - INTERVAL '150 minutes'
-  );
-
-INSERT INTO engine.runs (
-    id,
-    project_id,
-    instance_id,
-    run_number,
-    definition_version,
-    status,
-    ready_at,
-    result,
-    custom_status,
-    waiting_for,
-    completed_at,
-    root_run_id,
-    child_depth,
-    created_at,
-    updated_at
-)
-VALUES
-  (
-    '20000000-0000-4000-8000-000000000001',
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000001',
-    1,
-    'v1',
-    'waiting',
-    NOW() - INTERVAL '55 minutes',
-    NULL,
-    '{"phase": "awaiting approval", "cart_total": 129.99}'::jsonb,
-    '{"kind": "signal", "signal_name": "approval_received"}'::jsonb,
-    NULL,
-    '20000000-0000-4000-8000-000000000001',
-    0,
-    NOW() - INTERVAL '55 minutes',
-    NOW() - INTERVAL '2 minutes'
-  ),
-  (
-    '20000000-0000-4000-8000-000000000002',
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000002',
-    1,
-    'v1',
-    'completed',
-    NOW() - INTERVAL '2 hours',
-    '{"order_id": "demo-order-1001", "approved": true, "total": 84.25}'::jsonb,
-    '{"phase": "fulfilled"}'::jsonb,
-    NULL,
-    NOW() - INTERVAL '85 minutes',
-    '20000000-0000-4000-8000-000000000002',
-    0,
-    NOW() - INTERVAL '2 hours',
-    NOW() - INTERVAL '85 minutes'
-  ),
-  (
-    '20000000-0000-4000-8000-000000000003',
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000003',
-    1,
-    'v1',
-    'completed',
-    NOW() - INTERVAL '3 hours',
-    '{"variant": "treatment", "converted": true}'::jsonb,
-    '{"phase": "summary retained"}'::jsonb,
-    NULL,
-    NOW() - INTERVAL '150 minutes',
-    '20000000-0000-4000-8000-000000000003',
-    0,
-    NOW() - INTERVAL '3 hours',
-    NOW() - INTERVAL '150 minutes'
-  );
-
-INSERT INTO engine.history (
-    project_id,
-    instance_id,
-    run_id,
-    sequence_no,
-    event_type,
-    payload,
-    created_at
-)
-VALUES
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000001',
-    '20000000-0000-4000-8000-000000000001',
-    1,
-    'workflow.started',
-    '{"definition_name": "checkout", "definition_version": "v1", "instance_key": "demo-checkout-approval", "input": {"cart_id": "demo-cart-42", "total": 129.99}}'::jsonb,
-    NOW() - INTERVAL '55 minutes'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000001',
-    '20000000-0000-4000-8000-000000000001',
-    2,
-    'activity.scheduled',
-    '{"activity_key": "reserve-inventory", "activity_type": "inventory.reserve", "input": {"sku": "demo-sku-7", "quantity": 1}}'::jsonb,
-    NOW() - INTERVAL '54 minutes'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000001',
-    '20000000-0000-4000-8000-000000000001',
-    3,
-    'timer.scheduled',
-    jsonb_build_object('timer_key', 'approval-timeout', 'due_at', to_jsonb(NOW() + INTERVAL '5 minutes')),
-    NOW() - INTERVAL '53 minutes'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000002',
-    '20000000-0000-4000-8000-000000000002',
-    1,
-    'workflow.started',
-    '{"definition_name": "checkout", "definition_version": "v1", "instance_key": "demo-checkout-completed", "input": {"cart_id": "demo-cart-17", "total": 84.25}}'::jsonb,
-    NOW() - INTERVAL '2 hours'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000002',
-    '20000000-0000-4000-8000-000000000002',
-    2,
-    'activity.completed',
-    '{"activity_key": "charge-card", "activity_type": "payments.charge", "output": {"charge_id": "demo-charge-1001", "approved": true}}'::jsonb,
-    NOW() - INTERVAL '90 minutes'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000002',
-    '20000000-0000-4000-8000-000000000002',
-    3,
-    'workflow.completed',
-    '{"result": {"order_id": "demo-order-1001", "approved": true, "total": 84.25}}'::jsonb,
-    NOW() - INTERVAL '85 minutes'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000003',
-    '20000000-0000-4000-8000-000000000003',
-    1,
-    'workflow.started',
-    '{"definition_name": "darklaunch.demo", "definition_version": "v1", "instance_key": "demo-darklaunch-stale", "input": {"account_id": "demo-account-9"}}'::jsonb,
-    NOW() - INTERVAL '3 hours'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000003',
-    '20000000-0000-4000-8000-000000000003',
-    2,
-    'custom_status.updated',
-    '{"status": {"phase": "evaluating rollout", "percent": 25}}'::jsonb,
-    NOW() - INTERVAL '170 minutes'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000003',
-    '20000000-0000-4000-8000-000000000003',
-    3,
-    'workflow.completed',
-    '{"result": {"variant": "treatment", "converted": true}}'::jsonb,
-    NOW() - INTERVAL '150 minutes'
-  );
-
-INSERT INTO engine.activity_tasks (
-    project_id,
-    instance_id,
-    run_id,
-    history_id,
-    activity_key,
-    activity_type,
-    input,
-    available_at,
-    execution_target,
-    max_attempts
-)
-VALUES (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000001',
-    '20000000-0000-4000-8000-000000000001',
-    (
-      SELECT id
-      FROM engine.history
-      WHERE run_id = '20000000-0000-4000-8000-000000000001'
-        AND sequence_no = 2
-    ),
-    'reserve-inventory',
-    'inventory.reserve',
-    '{"sku": "demo-sku-7", "quantity": 1}'::jsonb,
-    NOW() - INTERVAL '54 minutes',
-    'local',
-    3
-);
-
-INSERT INTO engine.inbox (
-    project_id,
-    instance_id,
-    run_id,
-    history_id,
-    kind,
-    payload,
-    available_at,
-    dedupe_key
-)
-VALUES
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000001',
-    '20000000-0000-4000-8000-000000000001',
-    (
-      SELECT id
-      FROM engine.history
-      WHERE run_id = '20000000-0000-4000-8000-000000000001'
-        AND sequence_no = 3
-    ),
-    'timer',
-    jsonb_build_object('timer_key', 'approval-timeout', 'due_at', to_jsonb(NOW() + INTERVAL '5 minutes')),
-    NOW() + INTERVAL '5 minutes',
-    'demo-checkout-approval:approval-timeout'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    '10000000-0000-4000-8000-000000000001',
-    '20000000-0000-4000-8000-000000000001',
-    NULL,
-    'signal',
-    '{"signal_name": "approval_received", "payload": {"approved": true}}'::jsonb,
-    NOW() - INTERVAL '2 minutes',
-    'demo-checkout-approval:approval-received'
-  );
-
-INSERT INTO traces (
-    project_id,
-    trace_id,
-    name,
-    user_id,
-    tags,
-    environment,
-    release,
-    metadata,
-    input,
-    output,
-    status,
-    start_time,
-    end_time,
-    duration_ms,
-    total_spans,
-    total_cost,
-    error_count,
-    total_tokens_in,
-    total_tokens_out,
-    engine_run_id,
-    engine_instance_key,
-    engine_run_status,
-    engine_custom_status,
-    engine_wait_state,
-    engine_pending_activity_tasks,
-    engine_pending_inbox_items,
-    engine_definition_name,
-    engine_definition_version,
-    engine_parent_run_id,
-    engine_root_run_id,
-    engine_child_key,
-    engine_child_depth,
-    engine_projection_state,
-    engine_latest_history_id,
-    engine_last_projected_history_id,
-    engine_projection_updated_at
-)
-VALUES
-  (
-    :'demo_project_id'::uuid,
-    'engine:20000000-0000-4000-8000-000000000001',
-    'checkout',
-    'demo-user',
-    ARRAY['engine', 'demo', 'checkout'],
-    'demo',
-    'public-demo',
-    '{"demo": true, "scenario": "waiting_for_approval"}'::jsonb,
-    '{"cart_id": "demo-cart-42", "total": 129.99}'::jsonb,
-    NULL,
-    'running',
-    NOW() - INTERVAL '55 minutes',
-    NULL,
-    NULL,
-    1,
-    0,
-    0,
-    0,
-    0,
-    '20000000-0000-4000-8000-000000000001',
-    'demo-checkout-approval',
-    'waiting',
-    '{"phase": "awaiting approval", "cart_total": 129.99}'::jsonb,
-    '{"kind": "signal", "signal_name": "approval_received"}'::jsonb,
-    1,
-    2,
-    'checkout',
-    'v1',
-    NULL,
-    '20000000-0000-4000-8000-000000000001',
-    NULL,
-    0,
-    'up_to_date',
-    (
-      SELECT MAX(id)
-      FROM engine.history
-      WHERE run_id = '20000000-0000-4000-8000-000000000001'
-    ),
-    (
-      SELECT MAX(id)
-      FROM engine.history
-      WHERE run_id = '20000000-0000-4000-8000-000000000001'
-    ),
-    NOW() - INTERVAL '2 minutes'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    'engine:20000000-0000-4000-8000-000000000002',
-    'checkout',
-    'demo-user',
-    ARRAY['engine', 'demo', 'checkout'],
-    'demo',
-    'public-demo',
-    '{"demo": true, "scenario": "completed_checkout"}'::jsonb,
-    '{"cart_id": "demo-cart-17", "total": 84.25}'::jsonb,
-    '{"order_id": "demo-order-1001", "approved": true, "total": 84.25}'::jsonb,
-    'ok',
-    NOW() - INTERVAL '2 hours',
-    NOW() - INTERVAL '85 minutes',
-    2100000,
-    1,
-    0,
-    0,
-    0,
-    0,
-    '20000000-0000-4000-8000-000000000002',
-    'demo-checkout-completed',
-    'completed',
-    '{"phase": "fulfilled"}'::jsonb,
-    NULL,
-    0,
-    0,
-    'checkout',
-    'v1',
-    NULL,
-    '20000000-0000-4000-8000-000000000002',
-    NULL,
-    0,
-    'up_to_date',
-    (
-      SELECT MAX(id)
-      FROM engine.history
-      WHERE run_id = '20000000-0000-4000-8000-000000000002'
-    ),
-    (
-      SELECT MAX(id)
-      FROM engine.history
-      WHERE run_id = '20000000-0000-4000-8000-000000000002'
-    ),
-    NOW() - INTERVAL '85 minutes'
-  ),
-  (
-    :'demo_project_id'::uuid,
-    'engine:20000000-0000-4000-8000-000000000003',
-    'darklaunch.demo',
-    'demo-user',
-    ARRAY['engine', 'demo', 'projection-repair'],
-    'demo',
-    'public-demo',
-    '{"demo": true, "scenario": "projection_repair"}'::jsonb,
-    '{"account_id": "demo-account-9"}'::jsonb,
-    '{"variant": "treatment", "converted": true}'::jsonb,
-    'ok',
-    NOW() - INTERVAL '3 hours',
-    NOW() - INTERVAL '150 minutes',
-    1800000,
-    1,
-    0,
-    0,
-    0,
-    0,
-    '20000000-0000-4000-8000-000000000003',
-    'demo-darklaunch-stale',
-    'completed',
-    '{"phase": "summary retained"}'::jsonb,
-    NULL,
-    0,
-    0,
-    'darklaunch.demo',
-    'v1',
-    NULL,
-    '20000000-0000-4000-8000-000000000003',
-    NULL,
-    0,
-    'summary_only',
-    (
-      SELECT MAX(id)
-      FROM engine.history
-      WHERE run_id = '20000000-0000-4000-8000-000000000003'
-    ),
-    (
-      SELECT MAX(id) - 1
-      FROM engine.history
-      WHERE run_id = '20000000-0000-4000-8000-000000000003'
-    ),
-    NOW() - INTERVAL '140 minutes'
+DELETE FROM engine.definition_catalog
+WHERE definition_version = 'v1'
+  AND definition_name IN (
+    'agent.research',
+    'agent.code_review',
+    'agent.incident_response'
   );

--- a/scripts/seed_engine_demo_test.go
+++ b/scripts/seed_engine_demo_test.go
@@ -15,23 +15,24 @@ import (
 	"github.com/continua-ai/continua/internal/testutil"
 )
 
-func TestSeedDemoIncludesEngineFixtures(t *testing.T) {
+func TestSeedDemoRequiresRealAgentRuns(t *testing.T) {
 	repoRoot := repoRoot(t)
 
 	seedScript := readFile(t, filepath.Join(repoRoot, "scripts", "seed-demo.sh"))
 	assertContains(t, seedScript, "scripts/seed-engine-demo.sql")
+	assertContains(t, seedScript, "OPENAI_API_KEY must be set")
+	assertContains(t, seedScript, "CONTINUA_DEMO_AGENT_MODE=openai")
+	assertNotContains(t, seedScript, "CONTINUA_DEMO_SEED_ENGINE_RUNS=1")
 
 	fixtureSQL := readFile(t, filepath.Join(repoRoot, "scripts", "seed-engine-demo.sql"))
 	for _, expected := range []string{
-		"engine:20000000-0000-4000-8000-000000000001",
-		"engine:20000000-0000-4000-8000-000000000002",
-		"engine:20000000-0000-4000-8000-000000000003",
-		"'summary_only'",
-		"demo-checkout-approval:approval-timeout",
-		"approval_received",
+		"catalog-only definitions",
+		"DELETE FROM engine.runs",
+		"DELETE FROM engine.instances",
 	} {
 		assertContains(t, fixtureSQL, expected)
 	}
+	assertNotContains(t, fixtureSQL, "INSERT INTO engine.definition_catalog")
 }
 
 func TestSeedDemoScriptSyntax(t *testing.T) {
@@ -43,7 +44,7 @@ func TestSeedDemoScriptSyntax(t *testing.T) {
 	}
 }
 
-func TestSeedEngineDemoSQLCreatesUsableEngineFixtures(t *testing.T) {
+func TestSeedEngineDemoSQLCleansStaleEngineRowsWithoutRegisteringDefinitions(t *testing.T) {
 	if _, err := exec.LookPath("psql"); err != nil {
 		t.Skipf("psql is required for seed fixture smoke test: %v", err)
 	}
@@ -69,6 +70,38 @@ func TestSeedEngineDemoSQLCreatesUsableEngineFixtures(t *testing.T) {
 		VALUES ($1, 'sdk-demo-trace', 'sdk demo trace', 'ok')
 	`, projectID)
 	require.NoError(t, err)
+	instanceID := uuid.New()
+	runID := uuid.New()
+	_, err = pool.Exec(ctx, `
+		INSERT INTO engine.instances (id, project_id, instance_key, definition_name, status)
+		VALUES ($1, $2, 'stale-demo-instance', 'agent.research', 'active')
+	`, instanceID, projectID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO engine.runs (
+			id,
+			project_id,
+			instance_id,
+			run_number,
+			definition_version,
+			status,
+			ready_at,
+			root_run_id,
+			child_depth
+		)
+		VALUES ($1, $2, $3, 1, 'v1', 'queued', NOW(), $1, 0)
+	`, runID, projectID, instanceID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO engine.history (project_id, instance_id, run_id, sequence_no, event_type)
+		VALUES ($1, $2, $3, 1, 'workflow.started')
+	`, projectID, instanceID, runID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO traces (project_id, trace_id, name, status, engine_run_id)
+		VALUES ($1, 'engine:' || $2::text, 'stale engine trace', 'running', $2::uuid)
+	`, projectID, runID)
+	require.NoError(t, err)
 
 	cmd := exec.Command(
 		"psql",
@@ -83,42 +116,15 @@ func TestSeedEngineDemoSQLCreatesUsableEngineFixtures(t *testing.T) {
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
-	var engineTraceCount int
+	var engineRowCount int
 	require.NoError(t, pool.QueryRow(ctx, `
-		SELECT COUNT(*)
-		FROM traces
-		WHERE project_id = $1
-		  AND engine_run_id IS NOT NULL
-	`, projectID).Scan(&engineTraceCount))
-	assert.Equal(t, 3, engineTraceCount)
-
-	var canonicalTraceIDCount int
-	require.NoError(t, pool.QueryRow(ctx, `
-		SELECT COUNT(*)
-		FROM traces
-		WHERE project_id = $1
-		  AND engine_run_id IS NOT NULL
-		  AND trace_id = 'engine:' || engine_run_id::text
-	`, projectID).Scan(&canonicalTraceIDCount))
-	assert.Equal(t, 3, canonicalTraceIDCount)
-
-	var repairCandidateCount int
-	require.NoError(t, pool.QueryRow(ctx, `
-		SELECT COUNT(*)
-		FROM traces AS t
-		INNER JOIN engine.runs AS r
-		    ON r.project_id = t.project_id
-		   AND r.id = t.engine_run_id
-		INNER JOIN LATERAL (
-		    SELECT COALESCE(MAX(h.id), 0)::bigint AS latest_retained_history_id
-		    FROM engine.history AS h
-		    WHERE h.run_id = r.id
-		) AS hist ON true
-		WHERE t.project_id = $1
-		  AND t.engine_projection_state = 'summary_only'
-		  AND hist.latest_retained_history_id > COALESCE(t.engine_last_projected_history_id, 0)
-	`, projectID).Scan(&repairCandidateCount))
-	assert.Equal(t, 1, repairCandidateCount)
+		SELECT
+			(SELECT COUNT(*) FROM traces WHERE project_id = $1 AND engine_run_id IS NOT NULL)
+			+ (SELECT COUNT(*) FROM engine.history WHERE project_id = $1)
+			+ (SELECT COUNT(*) FROM engine.runs WHERE project_id = $1)
+			+ (SELECT COUNT(*) FROM engine.instances WHERE project_id = $1)
+	`, projectID).Scan(&engineRowCount))
+	assert.Equal(t, 0, engineRowCount)
 
 	var nonEngineTraceCount int
 	require.NoError(t, pool.QueryRow(ctx, `
@@ -129,6 +135,15 @@ func TestSeedEngineDemoSQLCreatesUsableEngineFixtures(t *testing.T) {
 		  AND engine_run_id IS NULL
 	`, projectID).Scan(&nonEngineTraceCount))
 	assert.Equal(t, 1, nonEngineTraceCount)
+
+	var definitionCount int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM engine.definition_catalog
+		WHERE definition_version = 'v1'
+		  AND definition_name = ANY($1::text[])
+	`, []string{"agent.research", "agent.code_review", "agent.incident_response"}).Scan(&definitionCount))
+	assert.Equal(t, 0, definitionCount)
 }
 
 func repoRoot(t *testing.T) string {
@@ -156,5 +171,13 @@ func assertContains(t *testing.T, haystack, needle string) {
 
 	if !strings.Contains(haystack, needle) {
 		t.Fatalf("expected file contents to include %q", needle)
+	}
+}
+
+func assertNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+
+	if strings.Contains(haystack, needle) {
+		t.Fatalf("expected file contents not to include %q", needle)
 	}
 }

--- a/sdks/python/examples/e2e_demo.py
+++ b/sdks/python/examples/e2e_demo.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402,I001
 """
 End-to-End Demo for Continua Python SDK
 
 This script demonstrates:
 1. SDK initialization
 2. Creating traces with nested spans
-3. Simulating LLM, tool, and agent spans
+3. Recording real provider-backed LLM, tool, and agent spans when requested
 4. Verifying data via API
 
 Usage:
@@ -13,12 +14,15 @@ Usage:
     uv run python examples/e2e_demo.py
 """
 
+import json
 import os
-import random
+import re
 import sys
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -30,6 +34,7 @@ if str(SDK_SRC) not in sys.path:
 
 # Import the SDK
 from continua import Continua, session, span, trace
+from continua.engine_control import EngineControlClient
 
 
 # Configuration
@@ -49,148 +54,438 @@ DEMO_RUN_ID = os.environ.get(
     "CONTINUA_DEMO_RUN_ID",
     datetime.now().strftime("%Y%m%d%H%M%S"),
 )
+AGENT_MODE = os.environ.get("CONTINUA_DEMO_AGENT_MODE", "offline").strip().lower()
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_MODEL = os.environ.get("CONTINUA_DEMO_OPENAI_MODEL", "gpt-4.1-mini")
+OPENAI_API_URL = os.environ.get(
+    "CONTINUA_DEMO_OPENAI_API_URL",
+    "https://api.openai.com/v1/chat/completions",
+)
+SEED_ENGINE_RUNS = os.environ.get("CONTINUA_DEMO_SEED_ENGINE_RUNS", "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
 SESSION_IDS = [
     f"demo-sdk-{DEMO_RUN_ID}-research",
     f"demo-sdk-{DEMO_RUN_ID}-incident",
 ]
-SAMPLE_CODE = """
-def hello_world():
-    print("Hello, World!")
-    return True
-"""
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CODE_REVIEW_TARGET = REPO_ROOT / "sdks" / "python" / "src" / "continua" / "trace.py"
+DOC_SEARCH_ROOT = REPO_ROOT / "docs-site" / "concepts"
 
 
-def simulate_llm_call(prompt: str) -> str:
-    """Simulate an LLM API call with realistic latency."""
-    time.sleep(random.uniform(0.1, 0.3))  # Simulate network latency
-    responses = [
-        "I'll help you with that task.",
-        "Based on my analysis, here's what I found...",
-        "Let me process that information for you.",
-        "Here's the result of the computation.",
-    ]
-    return random.choice(responses)
+@dataclass(frozen=True)
+class ModelCallResult:
+    content: str
+    model: str
+    provider: str
+    prompt_tokens: int | None
+    completion_tokens: int | None
+    response_id: str | None = None
 
 
-def simulate_tool_call(tool_name: str, args: dict) -> dict:
-    """Simulate a tool execution."""
-    time.sleep(random.uniform(0.05, 0.15))
-    return {"status": "success", "tool": tool_name, "result": f"Executed {tool_name}"}
+def require_real_agent_backend() -> None:
+    if AGENT_MODE != "openai":
+        return
+    if not OPENAI_API_KEY:
+        raise RuntimeError(
+            "OPENAI_API_KEY is required when CONTINUA_DEMO_AGENT_MODE=openai. "
+            "Public demo seeding requires real provider-backed agent runs."
+        )
+
+
+def call_openai_chat(
+    *,
+    purpose: str,
+    messages: list[dict[str, str]],
+    response_format: dict[str, str] | None = None,
+) -> ModelCallResult:
+    """Call OpenAI directly through HTTP so the demo has no SDK dependency."""
+    require_real_agent_backend()
+    request_body: dict[str, Any] = {
+        "model": OPENAI_MODEL,
+        "messages": messages,
+        "temperature": 0.2,
+    }
+    if response_format is not None:
+        request_body["response_format"] = response_format
+
+    with httpx.Client(timeout=45.0) as client:
+        response = client.post(
+            OPENAI_API_URL,
+            headers={
+                "Authorization": f"Bearer {OPENAI_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json=request_body,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    choice = payload.get("choices", [{}])[0]
+    content = str(choice.get("message", {}).get("content", "")).strip()
+    usage = payload.get("usage") or {}
+    if not content:
+        raise RuntimeError(f"OpenAI returned an empty response for {purpose}")
+    return ModelCallResult(
+        content=content,
+        model=str(payload.get("model") or OPENAI_MODEL),
+        provider="openai",
+        prompt_tokens=usage.get("prompt_tokens"),
+        completion_tokens=usage.get("completion_tokens"),
+        response_id=payload.get("id"),
+    )
+
+
+def call_agent_model(
+    *,
+    purpose: str,
+    messages: list[dict[str, str]],
+    response_format: dict[str, str] | None = None,
+) -> ModelCallResult:
+    """Run an agent model call, using OpenAI for seeded demos and offline only by opt-in."""
+    if AGENT_MODE == "openai":
+        return call_openai_chat(
+            purpose=purpose,
+            messages=messages,
+            response_format=response_format,
+        )
+    if AGENT_MODE != "offline":
+        raise RuntimeError("CONTINUA_DEMO_AGENT_MODE must be 'openai' or 'offline'")
+
+    prompt_text = "\n".join(message["content"] for message in messages)
+    return ModelCallResult(
+        content=(
+            f"Offline demo response for {purpose}. "
+            f"Input length: {len(prompt_text)} characters."
+        ),
+        model="offline-demo-model",
+        provider="offline",
+        prompt_tokens=max(1, len(prompt_text) // 4),
+        completion_tokens=16,
+        response_id=None,
+    )
+
+
+def parse_json_object(value: str) -> dict[str, Any]:
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return {"raw_response": value}
+    return decoded if isinstance(decoded, dict) else {"raw_response": decoded}
+
+
+def search_docs(query: str, *, limit: int = 4) -> list[dict[str, Any]]:
+    terms = {term.lower() for term in re.findall(r"[a-zA-Z][a-zA-Z0-9_-]{2,}", query)}
+    results: list[dict[str, Any]] = []
+    for path in sorted(DOC_SEARCH_ROOT.glob("*.mdx")):
+        text = path.read_text(encoding="utf-8")
+        score = sum(text.lower().count(term) for term in terms)
+        if score == 0:
+            continue
+        snippet = " ".join(text.split())[:700]
+        results.append(
+            {"path": str(path.relative_to(REPO_ROOT)), "score": score, "snippet": snippet}
+        )
+    return sorted(results, key=lambda item: item["score"], reverse=True)[:limit]
+
+
+def analyze_python_source(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    functions = re.findall(r"^\s*def\s+([a-zA-Z_][a-zA-Z0-9_]*)\(", text, flags=re.MULTILINE)
+    classes = re.findall(r"^\s*class\s+([a-zA-Z_][a-zA-Z0-9_]*)\(", text, flags=re.MULTILINE)
+    return {
+        "path": str(path.relative_to(REPO_ROOT)),
+        "line_count": len(text.splitlines()),
+        "function_count": len(functions),
+        "class_count": len(classes),
+        "functions": functions[:12],
+        "classes": classes[:8],
+        "sample": text[:1800],
+    }
+
+
+def probe_unavailable_dependency() -> dict[str, Any]:
+    target = "http://127.0.0.1:9/continua-demo-health"
+    started = time.monotonic()
+    try:
+        httpx.get(target, timeout=0.5)
+    except httpx.HTTPError as exc:
+        return {
+            "target": target,
+            "status": "failed",
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+            "duration_ms": round((time.monotonic() - started) * 1000, 2),
+        }
+    return {
+        "target": target,
+        "status": "unexpectedly_available",
+        "duration_ms": round((time.monotonic() - started) * 1000, 2),
+    }
 
 
 @trace(name="research_agent")
 def run_research_agent(query: str):
     """
-    Simulate a research agent that:
+    Run a research agent that:
     1. Plans the research
     2. Searches for information
     3. Synthesizes results
     """
     print(f"  Starting research agent for: {query}")
+    plan_data: dict[str, Any]
+    docs_results: list[dict[str, Any]]
 
     # Step 1: Planning span
     with span("plan_research", kind="llm") as s:
-        s.set_input({"query": query, "instruction": "Create a research plan"})
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a concise research agent. Return a JSON object with "
+                    "keys plan, chosen_focus, and alternatives."
+                ),
+            },
+            {"role": "user", "content": f"Create a research plan for: {query}"},
+        ]
+        s.set_input({"messages": messages})
         s.log("Planning research steps", payload={"query": query})
-        plan = simulate_llm_call(f"Plan research for: {query}")
-        s.set_output({"plan": plan})
-        s.set_tokens(prompt=50, completion=100)
-        s.set_model("gpt-4", provider="openai")
+        plan = call_agent_model(
+            purpose="research_plan",
+            messages=messages,
+            response_format={"type": "json_object"} if AGENT_MODE == "openai" else None,
+        )
+        plan_data = parse_json_object(plan.content)
+        s.set_llm_response(
+            plan.model,
+            messages,
+            plan_data,
+            tokens_in=plan.prompt_tokens,
+            tokens_out=plan.completion_tokens,
+            provider=plan.provider,
+        )
+        s.decision(
+            "Which research focus should the agent pursue?",
+            plan_data.get("chosen_focus", "observability value and failure debugging"),
+            alternatives=plan_data.get("alternatives")
+            if isinstance(plan_data.get("alternatives"), list)
+            else None,
+            reasoning=str(plan_data.get("plan", plan.content))[:600],
+            message="Selected research focus",
+        )
         print("    - Created research plan")
 
-    # Step 2: Search tool calls
-    with span("web_search", kind="tool") as s:
-        s.set_input({"query": query, "num_results": 5})
-        results = simulate_tool_call("web_search", {"query": query})
-        s.set_output(results)
-        print("    - Executed web search")
-
-    with span("database_lookup", kind="tool") as s:
-        s.set_input({"query": query, "database": "knowledge_base"})
-        results = simulate_tool_call("database_lookup", {"query": query})
-        s.set_output(results)
-        print("    - Executed database lookup")
+    # Step 2: Real local documentation search
+    with span("docs_search", kind="tool") as s:
+        args = {"query": query, "root": str(DOC_SEARCH_ROOT.relative_to(REPO_ROOT)), "limit": 4}
+        docs_results = search_docs(query)
+        s.set_tool_call(
+            "docs_search",
+            args,
+            {"matches": docs_results},
+            has_external_side_effect=False,
+        )
+        s.metric("match_count", len(docs_results), payload={"stage": "retrieval"})
+        print("    - Searched current docs-site concepts")
 
     # Step 3: Synthesis
     with span("synthesize_results", kind="llm") as s:
-        s.set_input({"sources": ["web", "database"], "query": query})
-        synthesis = simulate_llm_call("Synthesize all gathered information")
-        s.set_output({"synthesis": synthesis, "confidence": 0.85})
-        s.set_tokens(prompt=200, completion=300)
-        s.set_model("gpt-4", provider="openai")
-        s.metric("confidence_score", 0.85, payload={"stage": "synthesis"})
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You synthesize retrieved project docs for a demo trace. "
+                    "Return concise JSON with keys synthesis, risks, and confidence."
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {"query": query, "plan": plan_data, "retrieved_docs": docs_results},
+                    ensure_ascii=False,
+                ),
+            },
+        ]
+        s.set_input({"messages": messages})
+        synthesis = call_agent_model(
+            purpose="research_synthesis",
+            messages=messages,
+            response_format={"type": "json_object"} if AGENT_MODE == "openai" else None,
+        )
+        synthesis_data = parse_json_object(synthesis.content)
+        s.set_llm_response(
+            synthesis.model,
+            messages,
+            synthesis_data,
+            tokens_in=synthesis.prompt_tokens,
+            tokens_out=synthesis.completion_tokens,
+            provider=synthesis.provider,
+        )
+        confidence = synthesis_data.get("confidence", 0.78)
+        if isinstance(confidence, (int, float)):
+            s.metric("confidence_score", confidence, payload={"stage": "synthesis"})
+        s.snapshot_marker(
+            "Research synthesis complete",
+            marker_kind="agent_step",
+            payload={"source_count": len(docs_results)},
+        )
         print("    - Synthesized results")
 
-    return {"status": "completed", "query": query}
+    return {"status": "completed", "query": query, "retrieved_sources": len(docs_results)}
 
 
 @trace(name="code_review_agent")
-def run_code_review_agent(code: str):
+def run_code_review_agent(target_path: Path = CODE_REVIEW_TARGET):
     """
-    Simulate a code review agent that:
+    Run a code review agent that:
     1. Analyzes code structure
     2. Checks for issues
     3. Provides recommendations
     """
     print("  Starting code review agent")
+    analysis: dict[str, Any]
+    issue_scan: dict[str, Any]
 
     # Analysis chain
     with span("code_analysis_chain", kind="chain"):
 
         with span("parse_code", kind="tool") as s:
-            s.set_input({"code": code[:100] + "..."})
-            time.sleep(0.05)
-            s.set_output({"parsed": True, "lines": 50, "functions": 3})
+            analysis = analyze_python_source(target_path)
+            s.set_tool_call(
+                "parse_python_source",
+                {"path": str(target_path.relative_to(REPO_ROOT))},
+                analysis,
+                has_external_side_effect=False,
+            )
             print("    - Parsed code structure")
 
-        with span("security_scan", kind="tool") as s:
-            s.set_input({"scan_type": "security"})
-            time.sleep(0.1)
-            s.set_output({"vulnerabilities": 0, "warnings": 2})
-            print("    - Completed security scan")
-
-        with span("style_check", kind="tool") as s:
-            s.set_input({"style_guide": "PEP8"})
-            time.sleep(0.05)
-            s.set_output({"issues": 5, "auto_fixable": 3})
-            print("    - Checked code style")
+        with span("local_quality_scan", kind="tool") as s:
+            sample = str(analysis.get("sample", ""))
+            issue_scan = {
+                "long_lines": sum(1 for line in sample.splitlines() if len(line) > 100),
+                "uses_contextvars": "ContextVar" in sample,
+                "sends_trace_start_before_user_input": "_send_trace_start" in sample,
+            }
+            s.set_tool_call(
+                "local_quality_scan",
+                {"path": analysis["path"]},
+                issue_scan,
+                has_external_side_effect=False,
+            )
+            print("    - Ran local quality scan")
 
     # Generate review
     with span("generate_review", kind="llm") as s:
-        s.set_input({"analysis_results": "combined"})
-        review = simulate_llm_call("Generate code review")
-        s.set_output({"review": review, "score": 8.5})
-        s.set_tokens(prompt=150, completion=250)
-        s.set_model("claude-3-opus", provider="anthropic")
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are reviewing a Python SDK tracing module. Return JSON with "
+                    "keys summary, findings, and score."
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {"static_analysis": analysis, "quality_scan": issue_scan},
+                    ensure_ascii=False,
+                ),
+            },
+        ]
+        s.set_input({"messages": messages})
+        review = call_agent_model(
+            purpose="code_review",
+            messages=messages,
+            response_format={"type": "json_object"} if AGENT_MODE == "openai" else None,
+        )
+        review_data = parse_json_object(review.content)
+        s.set_llm_response(
+            review.model,
+            messages,
+            review_data,
+            tokens_in=review.prompt_tokens,
+            tokens_out=review.completion_tokens,
+            provider=review.provider,
+        )
+        s.decision(
+            "Should this module pass the demo review?",
+            "pass_with_notes",
+            alternatives=["fail", "pass_with_notes", "pass"],
+            reasoning=str(review_data.get("summary", review.content))[:600],
+            message="Completed code review decision",
+        )
         print("    - Generated review")
 
-    return {"status": "completed", "score": 8.5}
+    return {"status": "completed", "target": str(target_path.relative_to(REPO_ROOT))}
 
 
 @trace(name="failing_agent")
 def run_failing_agent():
-    """Simulate an agent that encounters an error."""
-    print("  Starting failing agent (intentional error)")
-    error_message = "Failed to reach external service"
+    """Run an incident agent against an unavailable dependency."""
+    print("  Starting failing agent (real dependency probe)")
+    error_message = "Dependency health check failed"
 
     with span("initial_step", kind="llm") as s:
-        s.set_input({"task": "process data"})
-        simulate_llm_call("Start processing")
-        s.set_output({"status": "ok"})
-        s.set_tokens(prompt=20, completion=30)
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are an incident triage agent. Return JSON with first_check "
+                    "and rationale."
+                ),
+            },
+            {
+                "role": "user",
+                "content": "Plan the first dependency check for a stalled agent workflow.",
+            },
+        ]
+        s.set_input({"messages": messages})
+        triage = call_agent_model(
+            purpose="incident_triage_plan",
+            messages=messages,
+            response_format={"type": "json_object"} if AGENT_MODE == "openai" else None,
+        )
+        triage_data = parse_json_object(triage.content)
+        s.set_llm_response(
+            triage.model,
+            messages,
+            triage_data,
+            tokens_in=triage.prompt_tokens,
+            tokens_out=triage.completion_tokens,
+            provider=triage.provider,
+        )
+        s.decision(
+            "Which dependency check should run first?",
+            triage_data.get("first_check", "health_probe"),
+            reasoning=str(triage_data.get("rationale", triage.content))[:500],
+            message="Planned dependency probe",
+        )
 
     with span("error_step", kind="tool") as s:
-        s.set_input({"operation": "risky_operation"})
-        time.sleep(0.1)
-        # Simulate an error
-        try:
-            raise TimeoutError(error_message)
-        except TimeoutError as exc:
-            s.error("Connection timeout", payload={"operation": "risky_operation"})
-            s.exception(exc, payload={"operation": "risky_operation"})
-            s.set_error("Connection timeout: Failed to reach external service")
-        s.set_output({"status": "failed"})
-        print("    - Encountered error (expected)")
+        probe = probe_unavailable_dependency()
+        s.set_tool_call(
+            "dependency_health_probe",
+            {"target": probe["target"]},
+            probe,
+            has_external_side_effect=False,
+        )
+        s.wait(
+            "dependency_health",
+            phase="resolved",
+            resolution="failed",
+            wait_id=f"dependency-probe-{DEMO_RUN_ID}",
+            payload=probe,
+        )
+        if probe["status"] == "failed":
+            exc = TimeoutError(error_message)
+            s.error(error_message, payload=probe)
+            s.exception(exc, payload=probe)
+            s.set_error(error_message)
+            print("    - Dependency probe failed (expected)")
+        else:
+            print("    - Dependency probe unexpectedly succeeded")
 
     raise TimeoutError(error_message)
 
@@ -310,7 +605,9 @@ def verify_demo_data() -> bool:
                 if session_obj.get("external_id") in SESSION_IDS
             }
 
-            missing_sessions = [session_id for session_id in SESSION_IDS if session_id not in sessions]
+            missing_sessions = [
+                session_id for session_id in SESSION_IDS if session_id not in sessions
+            ]
             if missing_sessions:
                 print(f"ERROR: Missing demo sessions: {missing_sessions}")
                 return False
@@ -366,11 +663,58 @@ def verify_demo_data() -> bool:
         return False
 
 
+def seed_engine_demo_run(
+    *,
+    definition_name: str,
+    instance_key: str,
+    request_key: str,
+    session_key: str,
+    trace_name: str,
+    input_payload: dict[str, Any],
+) -> str:
+    """Create an engine-projected trace through the public preview API."""
+    engine = EngineControlClient(endpoint=API_URL, api_key=API_KEY)
+    try:
+        response = engine.start(
+            {
+                "instance_key": instance_key,
+                "definition_name": definition_name,
+                "definition_version": "v1",
+                "request_key": request_key,
+                "input": input_payload,
+                "session": {
+                    "key": session_key,
+                    "name": f"Real agent demo: {session_key}",
+                    "metadata": {
+                        "demo": True,
+                        "run_id": DEMO_RUN_ID,
+                        "agent_mode": AGENT_MODE,
+                    },
+                },
+                "trace": {
+                    "name": trace_name,
+                    "user_id": "demo-user",
+                    "tags": ["engine", "demo", "real-agent"],
+                    "environment": "demo",
+                    "release": "public-demo",
+                    "metadata": {
+                        "demo": True,
+                        "seeded_by": "sdks/python/examples/e2e_demo.py",
+                        "agent_mode": AGENT_MODE,
+                    },
+                },
+            }
+        )
+    finally:
+        engine.close()
+    return response.trace_id
+
+
 def main():
     """Run the E2E demo."""
     global API_KEY
 
-    random.seed(42)
+    require_real_agent_backend()
     API_KEY = resolve_api_key()
 
     print("=" * 60)
@@ -379,6 +723,7 @@ def main():
     print(f"API URL: {API_URL}")
     print(f"API key: {printable_api_key(API_KEY)}")
     print(f"Demo run ID: {DEMO_RUN_ID}")
+    print(f"Agent mode: {AGENT_MODE}")
     print(f"Time: {datetime.now().isoformat()}")
     print()
 
@@ -402,11 +747,34 @@ def main():
         print("  [Agent 1: Research Agent]")
         result1 = run_research_agent("What are the benefits of AI observability?")
         print(f"  Result: {result1}")
+        if SEED_ENGINE_RUNS:
+            trace_id = seed_engine_demo_run(
+                definition_name="agent.research",
+                instance_key=f"demo-{DEMO_RUN_ID}-research-agent",
+                request_key=f"demo-{DEMO_RUN_ID}-research-agent-start",
+                session_key=SESSION_IDS[0],
+                trace_name="engine: research agent orchestration",
+                input_payload={
+                    "query": "What are the benefits of AI observability?",
+                    "agent_result": result1,
+                },
+            )
+            print(f"    - Created engine run trace {trace_id}")
         print()
 
         print("  [Agent 2: Code Review Agent]")
-        result2 = run_code_review_agent(SAMPLE_CODE)
+        result2 = run_code_review_agent(CODE_REVIEW_TARGET)
         print(f"  Result: {result2}")
+        if SEED_ENGINE_RUNS:
+            trace_id = seed_engine_demo_run(
+                definition_name="agent.code_review",
+                instance_key=f"demo-{DEMO_RUN_ID}-code-review-agent",
+                request_key=f"demo-{DEMO_RUN_ID}-code-review-agent-start",
+                session_key=SESSION_IDS[0],
+                trace_name="engine: code review agent orchestration",
+                input_payload={"target": result2.get("target"), "agent_result": result2},
+            )
+            print(f"    - Created engine run trace {trace_id}")
         print()
 
     print(f"  [Session 2: {SESSION_IDS[1]}]")
@@ -417,6 +785,16 @@ def main():
         except TimeoutError as exc:
             result3 = {"status": "failed", "error": str(exc)}
         print(f"  Result: {result3}")
+        if SEED_ENGINE_RUNS:
+            trace_id = seed_engine_demo_run(
+                definition_name="agent.incident_response",
+                instance_key=f"demo-{DEMO_RUN_ID}-incident-agent",
+                request_key=f"demo-{DEMO_RUN_ID}-incident-agent-start",
+                session_key=SESSION_IDS[1],
+                trace_name="engine: incident response agent orchestration",
+                input_payload={"agent_result": result3},
+            )
+            print(f"    - Created engine run trace {trace_id}")
         print()
 
     # Shutdown SDK (flushes remaining data)

--- a/sdks/python/tests/test_e2e_demo_seed.py
+++ b/sdks/python/tests/test_e2e_demo_seed.py
@@ -103,6 +103,30 @@ def test_resolve_api_key_rejects_wrong_demo_project(monkeypatch):
         demo.resolve_api_key()
 
 
+def test_openai_agent_mode_requires_openai_key():
+    demo = load_e2e_demo_module()
+
+    demo.AGENT_MODE = "openai"
+    demo.OPENAI_API_KEY = ""
+
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        demo.require_real_agent_backend()
+
+
+def test_offline_agent_mode_is_explicit_fallback():
+    demo = load_e2e_demo_module()
+
+    demo.AGENT_MODE = "offline"
+    result = demo.call_agent_model(
+        purpose="unit_test",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    assert result.provider == "offline"
+    assert result.model == "offline-demo-model"
+    assert "unit_test" in result.content
+
+
 def test_main_exits_nonzero_when_verification_fails(monkeypatch):
     demo = load_e2e_demo_module()
 


### PR DESCRIPTION
## Summary
- require OPENAI_API_KEY for public demo seeding so the seed records real provider-backed runs
- keep real OpenAI-backed SDK traces as the public demo data
- update the Cloudflare Pages worker fixture used by https://www.continua.in/dashboard so the hosted demo returns the same real public data instead of the old Checkout/Latency/Alpha rows
- clean stale engine demo rows and catalog-only agent definitions instead of seeding permanently queued engine run shells
- update seed tests for the real-agent seed path

## Validation
- go test ./scripts
- cd sdks/python && uv run pytest tests/test_e2e_demo_seed.py
- node --check web/public/_worker.js
- direct worker fetch smoke test for /api/auth/config, traces, sessions, spans, events, compare, and engine_only responses
- ran scripts/seed-demo.sh locally against http://localhost:8080 with OPENAI_API_KEY set before the engine-shell cleanup; confirmed OpenAI-backed spans were recorded
- ran scripts/seed-engine-demo.sql locally after the cleanup change; confirmed demo project has 0 engine traces, 0 engine runs, and 0 catalog-only agent.* definitions

## Live seed result from local validation
- recorded 4 OpenAI LLM spans using gpt-4.1-mini-2025-04-14
- token evidence in local DB: 1,651 prompt tokens and 881 completion tokens
- after cleanup, public demo trace API returns the 3 real SDK traces only: research_agent, code_review_agent, failing_agent

## Hosted dashboard data path
- https://www.continua.in/dashboard is currently served by the static SPA plus web/public/_worker.js API fixture, not by the Go/Postgres backend seed database
- this PR updates that worker fixture with the real local seed payloads so the hosted dashboard will show them after merge/deploy
- pnpm --filter web build could not complete in this checkout because web dependencies are not installed: tsc: command not found

## Engine demo note
- previous draft created engine-projected traces for catalog-only agent.* definitions, which remained QUEUED because no compiled runtime definitions existed
- this revision removes that broken engine seeding path and cleans stale catalog-only definitions
- follow-up OpenSpec change add-executable-agent-engine-demo plans executable agent engine workflows before the demo populates Engine Runs again