### PR TITLE
docs: reposition as durable execution engine with built-in observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 ## Current Repo Baseline
 - Treat the checked-in code as the primary truth. Historical phase docs and some older architecture docs drift from the current implementation.
-- The live product path today is: authenticated REST ingest -> Postgres persistence -> River background jobs -> REST read APIs -> embedded React debugger operator console.
+- Continua has two runtimes. (1) Observability platform (production-shaped): authenticated REST ingest -> Postgres persistence -> River background jobs -> REST read APIs -> embedded React debugger operator console. (2) Durable execution engine (preview): the `continua-engine` worker runtime executes Go-defined workflows end-to-end (activities, timers, signals, child workflows, cancellation, continue-as-new) with event-sourced history and crash-recovery replay, projecting run state into the platform tables.
 - For current-state architecture, start with [`docs-site/concepts/`](./docs-site/concepts/) (overview, data-model, traces-spans-sessions, events, ingest-lifecycle).
 - Use the checked-in code, contracts, and migrations as the authoritative current-state baseline.
 - `docs/DEBUGGER_PLATFORM_BASELINE.md` and `docs/PHASE5_CURRENT_STATE_REPORT.md` are gitignored historical context. Use them only if present locally.
@@ -33,8 +33,9 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 - Active backend packages: `internal/api`, `internal/ingest`, `internal/jobs`, `internal/store`, `internal/config`, `internal/web`.
 - Active frontend areas: `web/src/pages`, `web/src/components`, `web/src/utils`, `web/src/hooks`.
 - Active SDK: `sdks/python`.
-- Mostly scaffolded or placeholder today: `engine/`, `internal/proxy`, `internal/ws`, `internal/replay`, `internal/alerts`, `internal/export`, `internal/state`, `internal/telemetry`, `sdks/typescript`.
-- Do not describe WebSockets, proxy capture, replay, framework adapters, or the durable engine as implemented unless you have added that code in the current task.
+- Durable engine (`engine/`): a working preview runtime — workflow/activity workers, event-sourced history, replay, projector, and the `continua-engine` CLI. Caveats: Go-only workflow authoring, no production definition-loading path (dark-launch uses a fixed demo project), preview-gated `/v1/engine/*` REST.
+- Mostly scaffolded or placeholder today: `internal/proxy`, `internal/ws`, `internal/replay`, `internal/alerts`, `internal/export`, `internal/state`, `internal/telemetry`, `sdks/typescript`.
+- Do not describe WebSockets, proxy capture, replay, or framework adapters as implemented unless you have added that code in the current task. Describe the durable engine as a working preview — not as production-ready, and not as unimplemented.
 
 ## Source Of Truth
 - REST contract: `contracts/openapi/openapi.yaml`.
@@ -54,7 +55,7 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 - `web`: Vite React debugger UI.
 - `sdks/python`: functional SDK with batching, trace/span/session helpers, and async ingest polling.
 - `sdks/typescript`: early stub package, not a feature-complete SDK.
-- `engine`: separate Go module reserved for future durable execution work.
+- `engine`: separate Go module implementing the durable execution runtime (preview) — workflow/activity workers, event-sourced history + replay, projector, and the `continua-engine` CLI.
 
 ## Architecture Conventions
 - Keep handlers feature-split in `internal/api/`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Current Baseline
 
-Continua is currently a Go/React monorepo whose real product path is:
+Continua is a Go/React monorepo with two runtimes:
 
-1. authenticated ingest over REST
-2. Postgres-backed storage
-3. River workers for async ingest, rollups, and cleanup
-4. React debugger UI for traces, sessions, span trees, payload inspection, and merged timelines
+1. **Observability platform** (production-shaped): authenticated REST ingest → Postgres storage → River workers (async ingest, rollups, cleanup) → REST read APIs → embedded React debugger UI for traces, sessions, span trees, payload inspection, and merged timelines.
+2. **Durable execution engine** (preview): the `continua-engine` worker runtime executes Go-defined workflows end-to-end — activities, timers, signals, child workflows, cancellation, continue-as-new — with event-sourced history and crash-recovery replay. It projects run state into the platform's tables for the engine-runs console.
 
-Do not assume replay, WebSocket runtime, proxy capture, durable engine workflows, or a real TypeScript SDK are already implemented. Most of those areas are scaffolded only.
+Engine caveats (keep these accurate): workflow authoring is Go-only, there's no production path for registering arbitrary user workflow definitions (the dark-launch runtime uses a fixed demo project), and the public `/v1/engine/*` REST control plane is preview-gated. Do not assume replay, WebSocket runtime, proxy capture, or a real TypeScript SDK are implemented — those are scaffolded only.
 
 Start discovery from:
 - `AGENTS.md`
@@ -48,9 +46,9 @@ Use the checked-in code, contracts, and migrations as the authoritative current-
 - `internal/store`: sqlc-backed store wrappers and trace search
 - `web/src`: traces list, sessions list/detail, trace detail, payload inspector, failure-first UI
 - `sdks/python`: real SDK with batching, trace/span/session helpers, async ingest polling
+- `engine/`: durable execution runtime (preview) — workflow/activity workers, event-sourced history, replay, projector; `continua-engine` CLI (`serve`, `start`, `signal`, `cancel`, `inspect`)
 
 ### Mostly scaffolded
-- `engine/`
 - `internal/proxy`
 - `internal/ws`
 - `internal/replay`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="./assets/banner.svg" alt="Continua: self-hosted debugging for AI agent runs" />
+  <img src="./assets/banner.svg" alt="Continua: self-hosted durable execution engine with built-in observability for AI agent runs" />
 </p>
 
 <div align="center">
 
   # Continua
 
-  **Self-hosted debugging for AI agent runs.**
+  **Self-hosted durable execution engine with built-in observability for AI agent runs.**
 
   <p>
     <a href="#quickstart"><b>Quickstart</b></a> ·
@@ -29,9 +29,9 @@
 
 ---
 
-Continua is a **local operator console for debugging AI agent executions**. It accepts traces over an authenticated REST ingest API, persists them in Postgres, processes async work with River, and serves a React debugger from the Go backend as a single binary, on your own infrastructure.
+Continua is a self-hosted **durable execution engine for AI agents, with built-in observability**. It runs agent workflows durably: they survive restarts and crashes through event-sourced history and replay, with activities, retries, timers, signals, and child workflows; and it captures every run as traces, spans, sessions, and events you inspect in an embedded React debugger. One Go binary plus Postgres, on your own infrastructure.
 
-The current product is intentionally concrete: trace runs, inspect spans and payloads, compare session attempts, and keep enough durable state to understand why an agent failed, stalled, retried, or behaved differently than expected.
+Two pillars, one binary. The **observability** path (REST ingest, Postgres storage, read APIs, the failure-first debugger, and the Python SDK) is production-shaped: trace runs, inspect spans and payloads, compare session attempts, and keep enough durable state to understand why an agent failed, stalled, retried, or diverged. The **durable engine** runs Go-defined workflows end-to-end today (preview); see the [roadmap & status](./docs-site/roadmap.mdx) for exactly what's shippable versus preview.
 
 > [!NOTE]
 > Public demo mode uses seeded sample traces only. Use the private local console path when you want to ingest and inspect your own traces.
@@ -82,6 +82,7 @@ It's most useful when you need to answer: what failed first, what changed during
 
 ![Continua features at a glance](./assets/diagrams/feature-strip.svg)
 
+- **Durable execution engine (preview)**: run Go-defined agent workflows that survive restarts and crashes: event-sourced history + replay, activities with retries/backoff, timers, signals, child workflows, cancellation, and continue-as-new. Driven by the `continua-engine` worker runtime and projected into the debugger. See [Roadmap](./docs-site/roadmap.mdx) for preview scope.
 - **Trace debugger**: span tree, execution waterfall, selected spans, payload inspection, breadcrumbs, truncation banners, and merged timeline events.
 - **Session workflows**: browse sessions, open session detail, read the experimental narrative summary, and compare baseline vs. candidate traces from the same workflow.
 - **Durable ingest path**: project-scoped API key auth, idempotent batches via `batch_key`, sync ingest, opt-in async ingest (`X-Continua-Async-Version: 2`), and batch polling.
@@ -89,7 +90,7 @@ It's most useful when you need to answer: what failed first, what changed during
 - **Embedded operator console**: the Vite React app is built into `internal/web/static/` and served by the Go binary. Includes a `⌘K` command palette, dark/light/system theming, and URL-driven filter state.
 - **Project & operator auth**: first-class `POST /api/projects` with rotate/delete/list endpoints, plus optional Auth0 operator login gated by an email allow-list (see [Auth0 setup](./docs-site/guides/auth0-setup.mdx)).
 - **Engine runs console**: `/engine/runs` lists durable engine runs, surfaces pending activity and inbox work, and exposes signal / suspend / resume / cancel / terminate against the engine control endpoints (preview).
-- **Python SDK**: `trace`, `span`, `session`, `event`, batching, retries, and async polling live under `sdks/python`. SDK also exports engine-control helpers for the scaffolded engine surface; see [Roadmap](./docs-site/roadmap.mdx) before relying on them.
+- **Python SDK**: `trace`, `span`, `session`, `event`, batching, retries, and async polling live under `sdks/python`. SDK also exports engine-control helpers for the preview engine surface; see [Roadmap](./docs-site/roadmap.mdx) before relying on them in production.
 - **Typed events**: Continua emits 11 event kinds (`log`, `error`, `exception`, `message`, `metric`, `custom`, `state_change`, `decision`, `effect`, `wait`, `snapshot_marker`); see the [events concept guide](./docs-site/concepts/events.mdx).
 
 ![Implemented event types](./assets/diagrams/event-types.svg)
@@ -113,6 +114,8 @@ flowchart LR
 ```
 
 A request hits the authenticated ingest API, gets validated and batched (sync or async), and lands in Postgres. River workers process async batches, compute rollups, and run cleanup. The debugger reads everything back through REST and polls `GET /api/traces/{id}/events` for live trace detail. There is no live WebSocket runtime in the current checkout.
+
+Alongside the platform server, the **`continua-engine` worker runtime** executes durable workflows: it claims runs, drives activities / timers / signals, and replays event-sourced history to recover across restarts, then projects run state back into the same Postgres so the debugger's engine-runs console can read it. Workflow execution is preview: Go-defined workflows, with the public `/v1/engine/*` control plane gated behind a preview flag. See the [engine concept guide](./docs-site/concepts/engine-foundation.mdx).
 
 ![Continua ingest flow](./assets/diagrams/ingest-flow.svg)
 
@@ -171,11 +174,13 @@ After changing OpenAPI, sqlc queries, WebSocket schemas, or migrations that affe
 
 ## Roadmap
 
-Continua is in alpha. The authoritative status breakdown of what's shippable, what's scaffolded, and what's coming next lives at [`docs-site/roadmap.mdx`](./docs-site/roadmap.mdx).
+Continua is in alpha. The authoritative status breakdown of what's shippable, what's preview, and what's coming next lives at [`docs-site/roadmap.mdx`](./docs-site/roadmap.mdx).
 
-Shippable today: authenticated REST ingest, Postgres persistence, River background jobs, trace/session/timeline/compare read APIs, the embedded React debugger (incl. engine runs console), project & API-key management, Auth0 operator login, the Python SDK, and the engine schema/store/control endpoints.
+Shippable today: authenticated REST ingest, Postgres persistence, River background jobs, trace/session/timeline/compare read APIs, the embedded React debugger (incl. engine runs console), project & API-key management, Auth0 operator login, and the Python SDK.
 
-Scaffolded (don't rely on yet): live WebSocket runtime, proxy capture, replay execution, full TypeScript SDK, end-to-end engine workflow execution.
+Preview: durable engine workflow execution: the `continua-engine` worker runtime runs Go-defined workflows end-to-end with crash-recovery (event-sourced history + replay, activities, timers, signals, child workflows), but the public `/v1/engine/*` REST control plane is preview-gated, authoring is Go-only, and there's no production path for registering arbitrary workflow definitions yet.
+
+Scaffolded (don't rely on yet): live WebSocket runtime, proxy capture, replay execution, full TypeScript SDK.
 
 ## Documentation
 
@@ -186,7 +191,7 @@ The full documentation site lives under [`docs-site/`](./docs-site/) (Mintlify) 
 - **Debugger**: [tour of the UI](./docs-site/debugger/overview.mdx) plus per-page references for traces, trace detail, sessions, session compare, engine runs, command palette, and settings.
 - **Python SDK**: [overview](./docs-site/sdk/python/overview.mdx), tracing, sessions, span events, batching & ingest modes, exceptions.
 - **API Reference**: [auth & headers](./docs-site/api-reference/auth-and-headers.mdx) intro plus the auto-rendered OpenAPI playground.
-- **Roadmap**: [shippable vs scaffolded status](./docs-site/roadmap.mdx).
+- **Roadmap**: [shippable, preview, and scaffolded status](./docs-site/roadmap.mdx).
 
 Related: [`engine/README.md`](./engine/README.md) for the engine binary's CLI commands, and [`sdks/python/README.md`](./sdks/python/README.md) for SDK-local development.
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
 
 ---
 
-Continua is a self-hosted **durable execution engine for AI agents, with built-in observability**. It runs agent workflows durably: they survive restarts and crashes through event-sourced history and replay, with activities, retries, timers, signals, and child workflows; and it captures every run as traces, spans, sessions, and events you inspect in an embedded React debugger. One Go binary plus Postgres, on your own infrastructure.
+Continua is a self-hosted **durable execution engine for AI agents, with built-in observability**. It runs agent workflows durably: they survive restarts and crashes through event-sourced history and replay, with activities, retries, timers, signals, and child workflows; and it captures every run as traces, spans, sessions, and events you inspect in an embedded React debugger. Self-hosted on your own infrastructure: a Go platform server plus the `continua-engine` worker runtime, sharing one Postgres.
 
-Two pillars, one binary. The **observability** path (REST ingest, Postgres storage, read APIs, the failure-first debugger, and the Python SDK) is production-shaped: trace runs, inspect spans and payloads, compare session attempts, and keep enough durable state to understand why an agent failed, stalled, retried, or diverged. The **durable engine** runs Go-defined workflows end-to-end today (preview); see the [roadmap & status](./docs-site/roadmap.mdx) for exactly what's shippable versus preview.
+Two pillars, one Postgres. The **observability** path (REST ingest, Postgres storage, read APIs, the failure-first debugger, and the Python SDK) is production-shaped: trace runs, inspect spans and payloads, compare session attempts, and keep enough durable state to understand why an agent failed, stalled, retried, or diverged. The **durable engine** runs Go-defined workflows end-to-end today (preview); see the [roadmap & status](./docs-site/roadmap.mdx) for exactly what's shippable versus preview.
 
 > [!NOTE]
 > Public demo mode uses seeded sample traces only. Use the private local console path when you want to ingest and inspect your own traces.

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,6 +1,6 @@
 <svg width="2400" height="600" viewBox="0 0 2400 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="bannerTitle bannerDesc">
-  <title id="bannerTitle">Continua — self-hosted debugging for AI agent runs</title>
-  <desc id="bannerDesc">Continua banner showing the wordmark, tagline, and an abstract span-waterfall motif representing the trace debugger.</desc>
+  <title id="bannerTitle">Continua — self-hosted durable execution engine with built-in observability for AI agent runs</title>
+  <desc id="bannerDesc">Continua banner showing the wordmark, tagline, and an abstract span-waterfall motif representing durable runs and the trace debugger.</desc>
 
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="2400" y2="600" gradientUnits="userSpaceOnUse">
@@ -62,10 +62,10 @@
   <text x="270" y="200" fill="#F8FAFC" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="128" font-weight="800" letter-spacing="-3">Continua</text>
 
   <!-- tagline -->
-  <text x="142" y="290" fill="#CBD5E1" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="40" font-weight="500">Self-hosted debugging for AI agent runs.</text>
+  <text x="142" y="290" fill="#CBD5E1" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="40" font-weight="500">Durable execution engine for AI agents.</text>
 
   <!-- subtag -->
-  <text x="142" y="346" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="26">Trace, inspect, and compare executions — from ingest to UI, on your own infrastructure.</text>
+  <text x="142" y="346" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="26">With built-in observability — trace, inspect, and compare every run.</text>
 
   <!-- pill chips -->
   <g font-family="Inter, ui-sans-serif, system-ui, Arial, sans-serif" font-size="22" font-weight="600">

--- a/docs-site/concepts/engine-foundation.mdx
+++ b/docs-site/concepts/engine-foundation.mdx
@@ -1,13 +1,15 @@
 ---
 title: "Engine foundation"
-description: "The durable engine schema, store, and control surface: what's real today and where it stops."
+description: "The durable engine: schema, store, control surface, and the workflow runtime that executes Go-defined workflows end-to-end (preview)."
 ---
 
-Continua ships a durable engine **foundation** today. The schema, store, control
-endpoints, and runs console UI are real. The execution runtime that takes a workflow
-definition and runs it to completion is not.
+Continua ships a working durable engine in **preview**. The `continua-engine` worker
+runtime executes Go-defined workflows end-to-end: it claims runs, schedules activities,
+fires timers, delivers signals, spawns child workflows, and replays event-sourced history
+to drive each run to a terminal result, recovering across process restarts. The schema,
+store, control endpoints, and runs console UI around it are real too.
 
-This page draws the line.
+This page draws the line between what runs today and what's still preview-limited.
 
 <Warning>
   The engine is preview. Endpoints require `X-Continua-Engine-Preview` and
@@ -56,34 +58,52 @@ live in a separate Postgres via `ENGINE_DATABASE_URL`.
 | `POST /v1/engine/activities/claim` / `{id}/heartbeat` / `complete` / `fail` | Worker protocol |
 | `POST /v1/engine/projections/backfill` | Rebuild projection checkpoints |
 
+### Runtime (real)
+
+`continua-engine serve` runs four workers in-process: a **workflow worker** (claims runs,
+replays history, drives them forward), an **activity worker** (claims tasks, runs
+handlers, records completions/failures with retry backoff), a **maintenance worker**
+(timers, lease expiry, dedupe TTLs), and a **projector** (mirrors run state into
+`public.traces`). Durable primitives: activities, timers, signals, child workflows,
+cancellation, and continue-as-new, all crash-recoverable across restarts via leases and
+history replay. The end-to-end behaviour is covered by the runtime suite in
+[`engine/cmd/continua-engine/`](https://github.com/aryanVijaywargia/Continua/tree/main/engine/cmd/continua-engine),
+including timer/signal persistence and mid-activity restart recovery.
+
 ### CLI (real)
 
-A separate binary `continua-engine` with `version` and `migrate up` / `migrate down`
-commands. Migrations are independent from platform migrations.
+A separate binary `continua-engine` with `version`, `migrate up` / `migrate down`, and the
+runtime commands `serve`, `start`, `signal`, `cancel`, and `inspect`. Migrations are
+independent from platform migrations.
 
 ### Runs console UI (real)
 
 See [Engine runs](/debugger/engine-runs). Lists runs, shows pending work, and exposes
 the control bar. Polling-based.
 
-## What is **not** implemented
+## What's still limited in preview
 
-- **Workflow definition execution.** There is no runtime that takes a workflow function,
-  hands activity tasks to workers, processes their results, drives the workflow forward,
-  and produces a terminal result. The state machine accepts the right inputs but the
-  end-to-end loop is incomplete.
-- **Workflow SDK.** The Python SDK exports `ActivityWorker`, `@activity`, and
-  `EngineControlClient`. They call the right endpoints, but without a working execution
-  layer they don't form a usable workflow runtime today.
-- **Run history replay.** History is written; replay-from-history is not wired.
+- **Go-only authoring.** Workflows and activities are written as Go functions registered
+  with the runtime. There is no TypeScript/Python SDK for *authoring* workflows yet (the
+  Python SDK's `ActivityWorker` / `@activity` / `EngineControlClient` target this surface
+  but aren't a full authoring runtime).
+- **No production definition loading.** The runtime today registers definitions through a
+  built-in "dark-launch" harness against a fixed demo project. There's no supported path
+  yet to register and version arbitrary user workflow definitions in a multi-tenant
+  deployment.
+- **Preview-gated REST control plane.** The `/v1/engine/*` endpoints require
+  `X-Continua-Engine-Preview` + `ENGINE_PUBLIC_API_ENABLED`, and shapes may change
+  before GA.
 
-## When to use the engine surface today
+## When to use the engine today
 
-- **Operator tooling.** The control endpoints + console are useful for instrumenting an
-  external engine that posts run state into Continua.
-- **Schema-level prototyping.** If you want to model a durable workflow without
-  committing to an execution runtime, you can use the schema as a write target.
+- **Durable Go workflows (preview).** If you can define your workflow and activities in
+  Go, the runtime will execute them end-to-end with retries, timers, signals, child
+  workflows, and crash-recovery. Run it with `continua-engine serve`. Don't put it on a
+  production-critical path yet, it's preview.
+- **Operator tooling & inspection.** The control endpoints + runs console are useful for
+  driving and observing run state, pending work, and history.
 
-For actual durable workflow execution, wait for the execution layer to land. Track
+For multi-tenant definition loading, non-Go authoring, and a GA REST control plane, track
 progress on [GitHub](https://github.com/aryanVijaywargia/Continua) or watch the
-[Roadmap](/roadmap) for status changes.
+[Roadmap](/roadmap).

--- a/docs-site/concepts/engine-foundation.mdx
+++ b/docs-site/concepts/engine-foundation.mdx
@@ -38,9 +38,15 @@ Core tables:
 ### Store (real)
 
 [`engine/db/gen/go/`](https://github.com/aryanVijaywargia/Continua/tree/main/engine/db/gen/go)
-is the sqlc-generated store. The engine uses its own pgx pool and transaction boundary.
-It does not share a connection pool with the platform server. The engine can optionally
-live in a separate Postgres via `ENGINE_DATABASE_URL`.
+is the sqlc-generated store. The engine uses its own pgx pool and transaction boundary;
+it does not share a connection pool with the platform server.
+
+The standalone `continua-engine` runtime can point at a separate database via
+`ENGINE_DATABASE_URL`. The integrated control plane and debugger, however, read engine
+state from the platform server's own `DATABASE_URL` pool (the platform does not read
+`ENGINE_DATABASE_URL`) — so to see runs through `/v1/engine/*` and the `/engine/runs`
+console, the engine schema and its projections into `public.traces` must live in the
+**same** physical Postgres as the platform.
 
 ### Control endpoints (real)
 
@@ -97,9 +103,11 @@ the control bar. Polling-based.
 
 ## When to use the engine today
 
-- **Durable Go workflows (preview).** If you can define your workflow and activities in
-  Go, the runtime will execute them end-to-end with retries, timers, signals, child
-  workflows, and crash-recovery. Run it with `continua-engine serve`. Don't put it on a
+- **Durable Go workflows (preview).** Go-defined workflows and activities registered with
+  the runtime execute end-to-end with retries, timers, signals, child workflows, and
+  crash-recovery. Today they register through the built-in dark-launch harness
+  (`continua-engine serve`); running your *own* workflow means adding it to that registry
+  and rebuilding, as there's no dynamic definition loading yet. Don't put it on a
   production-critical path yet, it's preview.
 - **Operator tooling & inspection.** The control endpoints + runs console are useful for
   driving and observing run state, pending work, and history.

--- a/docs-site/concepts/overview.mdx
+++ b/docs-site/concepts/overview.mdx
@@ -3,8 +3,9 @@ title: "Architecture overview"
 description: "How the Go server, Postgres, River workers, and embedded debugger fit together."
 ---
 
-Continua is a single Go server plus an embedded React debugger operator console. The
-active request path is:
+Continua has two runtimes: a **platform server** (REST ingest, reads, background jobs, and
+the embedded React debugger) and a **durable engine worker runtime** (`continua-engine`)
+that executes workflows. They share one Postgres. The platform's active request path is:
 
 ```mermaid
 flowchart LR
@@ -56,6 +57,15 @@ River workers run inside the platform server process and currently handle:
 - Async ingest batch processing
 - Trace rollup computation (status, duration, cost, token counts)
 - Failed payload cleanup
+
+### Engine worker runtime (preview)
+
+A separate `continua-engine` process runs the durable execution runtime: a workflow worker
+(claims runs, replays event-sourced history, drives them to a terminal result), an activity
+worker (retries with backoff), a maintenance worker (timers, leases), and a projector that
+mirrors run state into `public.traces`. It executes Go-defined workflows end-to-end with
+crash-recovery across restarts. Preview: Go-only authoring, preview-gated REST. See
+[Engine foundation](/concepts/engine-foundation).
 
 ### SDKs
 
@@ -110,9 +120,6 @@ Run `make generate` after changing any of the above.
 These surfaces are scaffolded: schema, types, or partial code exists, but they're not
 production-ready. See [Roadmap & status](/roadmap) for the full breakdown.
 
-- **Engine workflow execution.** The engine schema, store, control endpoints, and runs
-  console UI are real (see [Engine foundation](/concepts/engine-foundation)), but the
-  runtime that takes a workflow definition and runs it to completion is not.
 - **Live WebSocket runtime** in `internal/ws`: trace detail is polling-based today.
 - **Proxy capture runtime** in `internal/proxy`.
 - **Replay execution runtime** in `internal/replay`.

--- a/docs-site/debugger/engine-runs.mdx
+++ b/docs-site/debugger/engine-runs.mdx
@@ -63,18 +63,22 @@ The page calls `POST /v1/engine/projections/backfill` and reports per-run progre
 
 ## What's real and what isn't
 
-**Real today:**
+**Real today (preview):**
 
+- End-to-end execution of Go-defined workflows via the `continua-engine` worker runtime —
+  activities, timers, signals, child workflows, cancellation, continue-as-new, and
+  crash-recovery replay — projected into this console
 - Engine schema + store with reversible migrations
 - Run lifecycle endpoints (start, get, suspend, resume, cancel, terminate, signal)
 - Activity-task endpoints (claim, heartbeat, complete, fail)
 - Projection backfill + repair tooling
 - Engine runs console UI (this page)
 
-**Not real today:**
+**Not yet:**
 
-- End-to-end workflow execution against a real definition. The state machine accepts
-  control inputs and records history, but workflows do not run to completion in
-  production.
+- Non-Go workflow authoring, and a production path to register arbitrary workflow
+  definitions (the runtime registers a fixed dark-launch set today)
+- A GA, non-preview `/v1/engine/*` control plane
 
-For the full status breakdown, see [Engine foundation](/concepts/engine-foundation).
+For the full status breakdown, see [Engine foundation](/concepts/engine-foundation) and
+[Roadmap](/roadmap).

--- a/docs-site/debugger/engine-runs.mdx
+++ b/docs-site/debugger/engine-runs.mdx
@@ -9,8 +9,9 @@ repair projection state.
 
 <Warning>
   The engine surface is in preview. Endpoints require `X-Continua-Engine-Preview` and
-  `ENGINE_PUBLIC_API_ENABLED=true` on the server. Engine workflow execution itself is not
-  yet a supported product path: see [Engine foundation](/concepts/engine-foundation) and
+  `ENGINE_PUBLIC_API_ENABLED=true` on the server. Workflow execution works (Go-defined
+  workflows), but it's preview, not production-hardened, so don't put it on a
+  production-critical path yet. See [Engine foundation](/concepts/engine-foundation) and
   [Roadmap](/roadmap).
 </Warning>
 

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "Continua",
-  "description": "Self-hosted debugging for AI agent runs. Traces, spans, sessions, and events for production agents.",
+  "description": "Self-hosted durable execution engine with built-in observability for AI agent runs. Run agent workflows durably, then inspect every run as traces, spans, sessions, and events.",
   "colors": {
     "primary": "#0075d6",
     "light": "#7aaeff",

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -1,23 +1,24 @@
 ---
 title: "Continua"
-description: "Self-hosted debugging for AI agent runs: traces, spans, sessions, and events you can inspect locally."
+description: "Self-hosted durable execution engine for AI agents, with built-in observability: run workflows durably, then inspect every run as traces, spans, sessions, and events."
 ---
 
 <Note>
   Continua is in alpha. The Python SDK, REST ingest, debugger UI, project & API-key
-  management, Auth0 operator login, and the engine schema + runs console are shippable
-  today. The TypeScript SDK, WebSocket runtime, proxy capture, replay, and end-to-end
-  engine workflow execution are scaffolded: see [Roadmap & status](/roadmap).
+  management, and Auth0 operator login are shippable today. Durable engine workflow
+  execution runs Go-defined workflows end-to-end in **preview**. The TypeScript SDK,
+  WebSocket runtime, proxy capture, and replay are scaffolded: see [Roadmap &
+  status](/roadmap).
 </Note>
 
 ## What is Continua?
 
-Continua is a self-hosted observability platform for AI agents. You send traces, spans,
-sessions, and events over a small REST API; Continua persists them in Postgres and serves
-an embedded React debugger that lets you triage failures, inspect payloads, and compare
-runs.
+Continua is a self-hosted **durable execution engine for AI agents, with built-in
+observability**. Run agent workflows durably: they survive restarts and crashes through
+event-sourced history and replay; and capture every run as traces, spans, sessions, and
+events in an embedded React debugger.
 
-The active product path is:
+The **observability** path is production-shaped:
 
 ```
 Python SDK / custom client
@@ -27,6 +28,12 @@ Python SDK / custom client
   → REST read APIs
   → embedded React debugger
 ```
+
+The **durable engine** is preview: the `continua-engine` worker runtime executes
+Go-defined workflows end-to-end (activities, timers, signals, child workflows) with
+crash-recovery, and projects run state into the same Postgres for the debugger's
+engine-runs console. See [Engine foundation](/concepts/engine-foundation) and
+[Roadmap & status](/roadmap).
 
 ## Get started in 60 seconds
 
@@ -47,6 +54,9 @@ Python SDK / custom client
 
 ## Why Continua
 
+- **Durable by construction.** Agent workflows run on an event-sourced engine that replays
+  history to recover across restarts and crashes: activities, retries, timers, signals, and
+  child workflows included (preview).
 - **Self-hosted by default.** Postgres + a single Go binary. No vendor lock-in.
 - **Failure-first debugger.** Trace detail opens on the failure path: span tree, payloads,
   state, and timeline in one workspace.
@@ -64,4 +74,4 @@ Python SDK / custom client
 | **Debugger** | Tour of every page in the UI: traces, sessions, compare, engine runs, command palette, settings |
 | **Python SDK** | Full reference for `continua-sdk`: decorators, span events, sessions, batching, exceptions |
 | **API Reference** | Auth & headers intro plus auto-rendered OpenAPI with a live playground |
-| **Roadmap** | What's shippable, what's scaffolded, and what's coming |
+| **Roadmap** | What's shippable, what's preview, and what's coming |

--- a/docs-site/roadmap.mdx
+++ b/docs-site/roadmap.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Roadmap & status"
-description: "What's shippable today, what's scaffolded, and what we'd reach for next."
+description: "What's shippable today, what's preview, and what we'd reach for next."
 ---
 
-This page is the honest line between the parts of Continua you can rely on today and the
-parts that are partially implemented or experimental. If a feature lives below the line,
-we may have endpoints, packages, or schema in the repo for it, but it isn't a supported
-product path yet.
+This page is the honest line between the parts of Continua you can rely on today, the
+parts that work but are still **preview**, and the parts that are **scaffolded**. If a
+feature lives in the scaffolded section, we may have endpoints, packages, or schema in the
+repo for it, but it isn't a supported product path yet.
 
 ## Shippable today
 
@@ -22,9 +22,37 @@ shape. Everything in the rest of this docs site assumes they exist.
 | **Public demo mode** | Read-only seeded project for evaluations |
 | **Python SDK** | Decorators, context managers, batching, sync / async / server-default ingest modes, polling helpers |
 | **Debugger UI** | Traces list, trace detail (waterfall, span tree, timeline, payload inspector), sessions list / detail / compare, settings, command palette, theming |
-| **Engine schema + control endpoints** | Postgres engine schema with reversible migrations, `/v1/engine/*` control endpoints behind a preview flag, runs console UI |
+| **Engine schema + control + console** | Postgres engine schema with reversible migrations, `/v1/engine/*` control endpoints (preview-gated), and the runs console UI. The execution runtime is **preview**, see below |
 | **Background jobs** | River workers for ingest, rollups, and payload cleanup |
 | **Self-hosting** | Single Go binary + Postgres, env-only config, embedded SPA, `continua migrate` + `continua-engine migrate` |
+
+## Preview: works, but not production-hardened
+
+These have real implementations and end-to-end tests, but carry caveats that keep them out
+of "shippable today." Use them, just not on a production-critical path.
+
+### Durable engine workflow execution
+
+The `continua-engine` worker runtime executes **Go-defined** workflows end-to-end:
+
+- It claims runs, schedules activities, fires timers, delivers signals, spawns child
+  workflows, and replays event-sourced history to drive each run to a terminal result.
+- Activities retry with exponential backoff; runs and activities recover across process
+  restarts via leases + history replay (covered by the restart suite in
+  [`engine/cmd/continua-engine/`](https://github.com/aryanVijaywargia/Continua/tree/main/engine/cmd/continua-engine)).
+- Run state is projected into `public.traces` for the [engine runs](/debugger/engine-runs)
+  console.
+
+Preview caveats:
+
+- **Go-only authoring**: no TypeScript/Python SDK for authoring workflows yet.
+- **No production definition loading**: definitions register through a built-in
+  dark-launch harness against a fixed demo project; there's no multi-tenant
+  register-and-version path yet.
+- **Preview-gated REST**: `/v1/engine/*` requires `X-Continua-Engine-Preview` +
+  `ENGINE_PUBLIC_API_ENABLED`, and shapes may change before GA.
+
+See [Engine foundation](/concepts/engine-foundation) for the full picture.
 
 ## Scaffolded: not yet a supported product path
 
@@ -41,23 +69,6 @@ fetch client over the contracts.
 
 **Use the Python SDK** if you need real instrumentation today. TypeScript instrumentation
 is on the roadmap; tracking the work in the repo is the most reliable signal.
-
-### Engine workflow execution
-
-The engine schema, store, and control endpoints are real. **Workflow definition execution
-is not.** That means:
-
-- You can call `POST /v1/engine/runs` and it will durably record the run, but the
-  workflow body won't execute end-to-end.
-- `ActivityWorker` and the `@activity` decorator in the Python SDK exist and will poll
-  `/v1/engine/activities/claim`, but there is no production workload feeding the queue.
-- `EngineControlClient` exposes signal / suspend / resume / cancel / terminate, and the
-  state machine accepts them, but workflow continuation behaviour is incomplete.
-
-What **does** work today: the engine runs console UI for inspecting durable run state,
-history, pending activity tasks, and projection repair. See [Engine
-foundation](/concepts/engine-foundation) for the line between schema/control (real)
-and execution (not real).
 
 ### Live WebSocket runtime
 
@@ -85,9 +96,9 @@ Rough ordering, subject to change as feedback comes in:
 
 1. Finish the TypeScript SDK to parity with Python for trace / span / session instrumentation.
 2. WebSocket runtime so the trace detail page can drop polling.
-3. End-to-end engine workflow execution on top of the existing schema and control surface.
+3. Graduate the durable engine from preview: multi-tenant workflow definition loading, non-Go (TypeScript/Python) workflow authoring, and a GA `/v1/engine/*` control plane.
 4. Proxy capture for zero-code instrumentation.
-5. Replay execution as a layer on top of finished engine workflows.
+5. Replay execution as a layer on top of durable engine workflows.
 
 If you have a strong opinion on the order, open an issue on
 [GitHub](https://github.com/aryanVijaywargia/Continua/issues): we read every one.

--- a/docs-site/sdk/python/exceptions.mdx
+++ b/docs-site/sdk/python/exceptions.mdx
@@ -85,8 +85,8 @@ except NetworkError as exc:
 ## Engine errors
 
 These are raised by `EngineControlClient` when interacting with the durable engine
-surface. The engine surface is scaffolded today: see [Roadmap](/roadmap) before
-depending on it.
+surface. The engine surface is **preview** today: see [Roadmap](/roadmap) before
+depending on it in production.
 
 ### `EngineRunNotTerminalError`
 

--- a/docs-site/sdk/python/overview.mdx
+++ b/docs-site/sdk/python/overview.mdx
@@ -42,8 +42,9 @@ The full public surface from `continua/__init__.py`:
 
 <Note>
   The SDK also exports `EngineControlClient`, `ActivityWorker`, and `ActivityTaskContext`
-  for the durable engine surface. That surface is scaffolded today: see
-  [Roadmap & status](/roadmap) before depending on it.
+  for the durable engine surface. The engine runtime executes Go-defined workflows
+  end-to-end, but this surface is **preview** (Go-only authoring, preview-gated REST): see
+  [Roadmap & status](/roadmap) before depending on it in production.
 </Note>
 
 ### Context getters
@@ -62,8 +63,8 @@ The full public surface from `continua/__init__.py`:
 | `continua.trace` | `@trace` decorator + `TraceContext` |
 | `continua.span` | `@span` context manager + `SpanContext` (see [Span events](/sdk/python/span-events) for every method) |
 | `continua.session` | `@session` context manager + `SessionContext` |
-| `continua.worker` | `ActivityWorker`, `@activity` decorator (engine surface: scaffolded, see [Roadmap](/roadmap)) |
-| `continua.engine_control` | `EngineControlClient` (engine surface: scaffolded, see [Roadmap](/roadmap)) |
+| `continua.worker` | `ActivityWorker`, `@activity` decorator (engine surface: preview, see [Roadmap](/roadmap)) |
+| `continua.engine_control` | `EngineControlClient` (engine surface: preview, see [Roadmap](/roadmap)) |
 | `continua.exceptions` | Exception hierarchy: see [Exceptions](/sdk/python/exceptions) |
 | `continua.types` | Generated Pydantic models from the OpenAPI contract |
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -2,24 +2,27 @@
 
 The durable execution engine for AI agent workflows.
 
-**Status:** Schema/store foundation implemented. Runtime workflow execution is still future work.
+**Status:** Durable runtime implemented (preview). Executes Go-defined workflows end-to-end — activities, timers, signals, child workflows, cancellation, continue-as-new — with event-sourced history and crash-recovery replay across restarts. The public REST control plane is preview-gated and workflow authoring is Go-only.
 
-## Foundation Scope
+## Scope
 
-The engine module now ships the Phase 10.1 foundation:
+The engine module ships a working durable runtime:
 
 - a dedicated Postgres `engine` schema with reversible migrations
 - sqlc-backed query generation under `engine/db/gen/go/`
 - an engine-local store with its own pgx connection pool and transaction support
-- a `continua-engine` CLI with `version`, `migrate up`, and `migrate down <steps>`
+- a workflow worker that claims runs, replays event-sourced history, and drives them to a terminal result
+- an activity worker that claims tasks, runs handlers, and records completions/failures with retry backoff
+- durable primitives: activities, timers, signals, child workflows, cancellation, and continue-as-new
+- crash-recovery: runs and activities resume across process restarts via leases + history replay (see the restart suite in `cmd/continua-engine/runtime_e2e_test.go`)
+- projection of run state into `public.traces` for the debugger's engine-runs console
+- a `continua-engine` CLI with `version`, `migrate`, `serve`, `start`, `signal`, `cancel`, and `inspect`
 
-What this does **not** include yet:
+What is still **preview / not yet there**:
 
-- workflow execution
-- history replay
-- activity workers
-- public execution APIs
-- debugger UI for engine state
+- workflow authoring is Go-only — no TypeScript/Python authoring SDK
+- no production path to register arbitrary user workflow definitions (the dark-launch runtime runs a fixed demo project)
+- the public `/v1/engine/*` REST control plane is gated behind `X-Continua-Engine-Preview` + `ENGINE_PUBLIC_API_ENABLED`
 
 ## Storage Model
 
@@ -56,6 +59,13 @@ The engine CLI is built as `bin/continua-engine`.
 bin/continua-engine version
 bin/continua-engine migrate up
 bin/continua-engine migrate down 1
+
+# durable runtime (dark-launch demo project)
+bin/continua-engine serve                                   # run workflow + activity + maintenance + projector workers
+bin/continua-engine start  --instance-key <k> --definition <name> --version <v> --request-key <r> [--input <json>]
+bin/continua-engine signal --instance-key <k> --signal-name <s> [--payload <json>]
+bin/continua-engine cancel --instance-key <k>
+bin/continua-engine inspect --instance-key <k>              # dump instance state + history as JSON
 ```
 
 Database config is env-only:

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,7 +1,8 @@
 # Continua SDK for Python
 
-Python SDK for sending AI agent traces, spans, sessions, events, and engine control
-requests to Continua.
+Python SDK for Continua — the self-hosted durable execution engine with built-in
+observability for AI agents. Sends traces, spans, sessions, events, and engine-control
+requests to a Continua server.
 
 ## Installation
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "continua-sdk"
 version = "0.1.0"
-description = "Python SDK for Continua agent observability and debugging"
+description = "Python SDK for Continua — AI-agent observability and durable-engine control"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
@@ -12,9 +12,11 @@ keywords = [
     "agents",
     "ai",
     "debugging",
+    "durable-execution",
     "llm",
     "observability",
     "tracing",
+    "workflows",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@continua/sdk",
   "version": "0.0.0",
-  "description": "Continua SDK for TypeScript/JavaScript",
+  "description": "Continua SDK for TypeScript/JavaScript (early stub)",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/web/src/pages/LandingPage.test.tsx
+++ b/web/src/pages/LandingPage.test.tsx
@@ -99,7 +99,7 @@ describe('LandingPage', () => {
     expect(screen.queryByText(/TypeScript SDK/i)).not.toBeInTheDocument();
     expect(document.body).toHaveTextContent(/from continua import Continua, span, trace/i);
     expect(screen.getByRole('heading', { name: /Your agent's black box\. Opened\./i })).toBeInTheDocument();
-    expect(document.body).toHaveTextContent(/AI agent observability today, durable execution tomorrow/i);
+    expect(document.body).toHaveTextContent(/Durable execution engine for AI agents, with built-in observability/i);
     expect(screen.getByRole('tablist', { name: 'Python SDK examples' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'agent.py' })).toHaveAttribute('aria-selected', 'true');
     expect(document.body).toHaveTextContent(/MIT licensed/i);

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -388,7 +388,7 @@ function Hero({
             <p className="mt-6 max-w-xl text-[15.5px] leading-relaxed text-[var(--c-text-secondary)]">
               Open-source durable execution engine for AI agents, with built-in observability. Run
               workflows that survive restarts and crashes — then inspect every retry, payload, and
-              state transition from a self-hosted console that runs in one binary.
+              state transition from a console you self-host on your own infrastructure.
             </p>
             {isPublicDemo ? (
               <p className="mt-3 max-w-xl text-[13px] leading-6 text-[var(--c-text-muted)]">

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -386,9 +386,9 @@ function Hero({
               </span>
             </h1>
             <p className="mt-6 max-w-xl text-[15.5px] leading-relaxed text-[var(--c-text-secondary)]">
-              Open-source observability for AI agents. Capture every retry, payload, and state
-              transition as it happens — and inspect them from a self-hosted console that runs in
-              one binary.
+              Open-source durable execution engine for AI agents, with built-in observability. Run
+              workflows that survive restarts and crashes — then inspect every retry, payload, and
+              state transition from a self-hosted console that runs in one binary.
             </p>
             {isPublicDemo ? (
               <p className="mt-3 max-w-xl text-[13px] leading-6 text-[var(--c-text-muted)]">
@@ -684,7 +684,7 @@ function StatsStrip() {
     { value: 'REST', label: 'Ingest API', hint: 'Authenticated trace, session, span, and event writes', pct: 88 },
     { value: 'SQLC', label: 'Postgres store', hint: 'Typed queries backed by platform migrations', pct: 99 },
     { value: 'River', label: 'Async jobs', hint: 'Background ingest, rollups, and payload cleanup', pct: 72 },
-    { value: 'Preview', label: 'Engine surface', hint: 'Control APIs and contracts for durable execution work', pct: 56, zero: true },
+    { value: 'Preview', label: 'Durable engine', hint: 'Runs Go workflows end-to-end: activities, timers, signals, replay', pct: 56, zero: true },
   ];
 
   return (
@@ -935,7 +935,7 @@ function StackDiagram() {
               <Connector label="POST /v1/ingest · HTTPS" />
               <Layer label="Continua service · Go" sub="auth · ingest · mappers" tone="primary" split={[['Postgres', 'sqlc + migrations'], ['River', 'async workers']]} />
               <Connector label="engine preview surface" />
-              <Layer label="Durable engine · planned runtime" sub="control APIs · pending work · history" tone="muted" />
+              <Layer label="Durable engine · preview runtime" sub="workflows · activities · timers · signals" tone="muted" />
               <Connector label="GET /api/*" />
               <Layer label="Operator console · React" sub="traces · sessions · settings" tone="accent" />
             </div>
@@ -1139,7 +1139,7 @@ function Footer({
               <Logo />
               <span className="text-[14px] font-semibold tracking-tight">Continua</span>
             </div>
-            <p className="mt-4 max-w-xs text-[12px] leading-5 text-[var(--c-text-muted)]">AI agent observability today, durable execution tomorrow. MIT licensed.</p>
+            <p className="mt-4 max-w-xs text-[12px] leading-5 text-[var(--c-text-muted)]">Durable execution engine for AI agents, with built-in observability. MIT licensed.</p>
             <div className="mt-5 font-mono text-[10px] text-[var(--c-text-muted)]">© 2026 · alpha</div>
           </div>
           {columns.map((col) => (
@@ -1624,7 +1624,7 @@ function RepoCard() {
             {[
               ['Observability', 'REST ingest, Postgres persistence, async River jobs, trace/session read APIs'],
               ['Debugger console', 'Embedded React operator workspace for traces, sessions, payloads, and comparisons'],
-              ['Durable engine', 'Preview control surface and contracts; workflow runtime is still on the roadmap'],
+              ['Durable engine', 'Preview runtime that executes Go workflows end-to-end: activities, timers, signals, replay'],
             ].map(([label, value]) => (
               <div key={label} className="rounded-md border bg-[var(--c-app-bg)] px-3 py-2" style={{ borderColor: 'var(--c-border)' }}>
                 <div className="font-mono text-[10.5px] font-semibold text-[var(--c-text-primary)]">{label}</div>


### PR DESCRIPTION
## What & why

The GitHub "About" was updated to **"Self-hosted durable execution engine with built-in observability for AI agent runs,"** but the README, docs site, and AI-assistant guidance still described Continua as a *debugging/observability console* and — in several places — claimed the durable engine runtime was *not implemented*. That second part is **factually stale**: the `continua-engine` worker runtime executes Go-defined workflows end-to-end, verified by the passing suite under `engine/cmd/continua-engine/`.

This PR repositions the docs to lead with **durable execution engine + built-in observability**, and corrects the stale "not implemented" claims to a **working preview** with honest caveats. Observability stays a co-equal, production-shaped pillar.

## Commits

1. **Reposition (marketing/positioning)** — README hero/intro, docs landing (`index.mdx` + `docs.json`), `banner.svg`, landing-page copy, and SDK package metadata.
2. **Engine status corrections** — `roadmap.mdx` (new *Preview* tier), `concepts/overview.mdx`, `engine-foundation.mdx`, `debugger/engine-runs.mdx`, Python SDK engine notes, and `engine/README.md`: from "execution not implemented" → working preview.
3. **AI guidance** — `CLAUDE.md` and `AGENTS.md` reframed as two runtimes (platform + preview engine).

## Honest framing kept

Engine execution is presented as **preview**, not production-ready: Go-only workflow authoring, no production path for registering arbitrary workflow definitions (dark-launch demo project), and a preview-gated `/v1/engine/*` REST control plane. WebSocket runtime, proxy capture, replay execution, and the TypeScript SDK remain accurately marked as scaffolded.

## Verification

- `go test ./cmd/continua-engine/ ./internal/...` (engine module) — all pass, backing the runtime claims.
- `mint broken-links` on `docs-site/` — no broken links / MDX errors.
- Docs-only change; no application code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation Updates**
  * Repositioned Continua as a self-hosted durable execution engine with built-in observability and an end-to-end preview runtime.
  * Clarified preview boundaries and caveats (Go-only workflow authoring, preview-gated control plane, limited production readiness).
  * Expanded docs on the engine worker, CLI/run console, event-sourced replay, and crash-recovery behavior.
  * Updated roadmap, SDK/package descriptions, and marketing/landing copy to reflect preview status and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->