### PR TITLE
test(api): reject catalog-only definitions after registry-truth sync

### DIFF
--- a/docs-site/concepts/engine-foundation.mdx
+++ b/docs-site/concepts/engine-foundation.mdx
@@ -48,6 +48,15 @@ state from the platform server's own `DATABASE_URL` pool (the platform does not 
 console, the engine schema and its projections into `public.traces` must live in the
 **same** physical Postgres as the platform.
 
+### Definition catalog (registry truth)
+
+`engine.definition_catalog` is a runtime-synced catalog of definitions registered in the
+live engine process. When `continua-engine serve` starts, it upserts the registered
+definitions and deletes stale catalog rows. `POST /v1/engine/runs` validates start
+requests against this catalog; inserting catalog rows directly is unsupported, and those
+rows are removed on the next serve start. Richer liveness metadata is future work tracked
+by the "definition catalog as registry truth" issue (#163).
+
 ### Control endpoints (real)
 
 | Endpoint | Purpose |

--- a/engine/README.md
+++ b/engine/README.md
@@ -36,6 +36,15 @@ Current implemented guidance is:
 - use a separate engine connection pool so workflow/activity workers do not starve control-plane or debugger traffic
 - avoid cross-schema foreign keys to `public.projects` in the foundation phase
 
+### Definition Catalog
+
+`engine.definition_catalog` reflects the definitions registered in the live engine runtime.
+At `continua-engine serve` startup, the runtime rewrites the catalog by upserting the
+registered definitions and deleting stale rows. The platform `StartRun` path validates
+requests against this catalog, so inserting catalog rows out of band is unsupported; those
+rows are removed at the next serve start. Richer liveness metadata is future work tracked
+by the "definition catalog as registry truth" issue (#163).
+
 ## Module Isolation
 
 This is a fully isolated Go module with its own internal packages and generated DB layer.

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -321,12 +321,10 @@ func TestStartEngineRun_RejectsUnknownDefinitionAndInstanceConflict(t *testing.T
 func TestStartEngineRun_RejectsCatalogOnlyDefinitionAfterRegistryTruthSync(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
 
-	_, err := platformStore.Pool().Exec(ctx, `
-		INSERT INTO engine.definition_catalog (definition_name, definition_version)
-		VALUES ('agent.research', 'v1')
-		ON CONFLICT (definition_name, definition_version) DO UPDATE SET
-			updated_at = NOW()
-	`)
+	_, err := engineQueries.UpsertDefinitionCatalogEntry(ctx, enginedb.UpsertDefinitionCatalogEntryParams{
+		DefinitionName:    "agent.research",
+		DefinitionVersion: "v1",
+	})
 	require.NoError(t, err)
 
 	catalogOnly := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
@@ -338,7 +336,7 @@ func TestStartEngineRun_RejectsCatalogOnlyDefinitionAfterRegistryTruthSync(t *te
 	require.Equal(t, http.StatusOK, catalogOnly.Code)
 	_ = decodeJSONBody[EngineStartRunResponse](t, catalogOnly)
 
-	beforeSync := countEngineRowsForProject(t, ctx, platformStore, projectID)
+	beforeSync := countEngineRowsForProject(ctx, t, platformStore, projectID)
 	assert.Equal(t, 1, beforeSync.instances)
 	assert.Equal(t, 1, beforeSync.runs)
 
@@ -362,7 +360,7 @@ func TestStartEngineRun_RejectsCatalogOnlyDefinitionAfterRegistryTruthSync(t *te
 	resp := decodeJSONBody[Error](t, rejected)
 	assert.Equal(t, "definition_not_registered", resp.Code)
 
-	afterReject := countEngineRowsForProject(t, ctx, platformStore, projectID)
+	afterReject := countEngineRowsForProject(ctx, t, platformStore, projectID)
 	assert.Equal(t, beforeSync, afterReject)
 
 	_, err = engineQueries.GetInstanceByProjectAndKey(ctx, enginedb.GetInstanceByProjectAndKeyParams{
@@ -3268,7 +3266,7 @@ type engineProjectRowCounts struct {
 	runs      int
 }
 
-func countEngineRowsForProject(t *testing.T, ctx context.Context, platformStore *store.Store, projectID uuid.UUID) engineProjectRowCounts {
+func countEngineRowsForProject(ctx context.Context, t *testing.T, platformStore *store.Store, projectID uuid.UUID) engineProjectRowCounts {
 	t.Helper()
 
 	var counts engineProjectRowCounts

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -318,6 +318,60 @@ func TestStartEngineRun_RejectsUnknownDefinitionAndInstanceConflict(t *testing.T
 	assert.Equal(t, "instance_conflict", replayedResp.Code)
 }
 
+func TestStartEngineRun_RejectsCatalogOnlyDefinitionAfterRegistryTruthSync(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+
+	_, err := platformStore.Pool().Exec(ctx, `
+		INSERT INTO engine.definition_catalog (definition_name, definition_version)
+		VALUES ('agent.research', 'v1')
+		ON CONFLICT (definition_name, definition_version) DO UPDATE SET
+			updated_at = NOW()
+	`)
+	require.NoError(t, err)
+
+	catalogOnly := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "agent.research",
+		DefinitionVersion: "v1",
+		InstanceKey:       "catalog-only-before-sync",
+		RequestKey:        "req-catalog-only-before-sync",
+	})
+	require.Equal(t, http.StatusOK, catalogOnly.Code)
+	_ = decodeJSONBody[EngineStartRunResponse](t, catalogOnly)
+
+	beforeSync := countEngineRowsForProject(t, ctx, platformStore, projectID)
+	assert.Equal(t, 1, beforeSync.instances)
+	assert.Equal(t, 1, beforeSync.runs)
+
+	require.NoError(t, syncDefinitionCatalogToRegistry(ctx, engineQueries, []definitionCatalogTestEntry{
+		{name: "checkout", version: "v1"},
+	}))
+
+	_, err = engineQueries.GetDefinitionCatalogEntry(ctx, enginedb.GetDefinitionCatalogEntryParams{
+		DefinitionName:    "agent.research",
+		DefinitionVersion: "v1",
+	})
+	require.True(t, errors.Is(err, pgx.ErrNoRows))
+
+	rejected := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "agent.research",
+		DefinitionVersion: "v1",
+		InstanceKey:       "catalog-only-after-sync",
+		RequestKey:        "req-catalog-only-after-sync",
+	})
+	require.Equal(t, http.StatusBadRequest, rejected.Code)
+	resp := decodeJSONBody[Error](t, rejected)
+	assert.Equal(t, "definition_not_registered", resp.Code)
+
+	afterReject := countEngineRowsForProject(t, ctx, platformStore, projectID)
+	assert.Equal(t, beforeSync, afterReject)
+
+	_, err = engineQueries.GetInstanceByProjectAndKey(ctx, enginedb.GetInstanceByProjectAndKeyParams{
+		ProjectID:   projectID,
+		InstanceKey: "catalog-only-after-sync",
+	})
+	require.True(t, errors.Is(err, pgx.ErrNoRows))
+}
+
 func TestStartEngineRun_RejectsMissingRequiredFields(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
@@ -3170,6 +3224,61 @@ func publishEngineDefinition(ctx context.Context, queries *enginedb.Queries, nam
 		DefinitionVersion: "v1",
 	})
 	return err
+}
+
+type definitionCatalogTestEntry struct {
+	name    string
+	version string
+}
+
+func syncDefinitionCatalogToRegistry(ctx context.Context, queries *enginedb.Queries, entries []definitionCatalogTestEntry) error {
+	// Mirrors engine/internal/catalog/publisher.go without importing across the engine module's internal boundary.
+	liveDefinitions := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		liveDefinitions[entry.name+"@"+entry.version] = struct{}{}
+		if _, err := queries.UpsertDefinitionCatalogEntry(ctx, enginedb.UpsertDefinitionCatalogEntryParams{
+			DefinitionName:    entry.name,
+			DefinitionVersion: entry.version,
+		}); err != nil {
+			return err
+		}
+	}
+
+	rows, err := queries.ListDefinitionCatalog(ctx)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if _, ok := liveDefinitions[row.DefinitionName+"@"+row.DefinitionVersion]; ok {
+			continue
+		}
+		if _, err := queries.DeleteDefinitionCatalogEntry(ctx, enginedb.DeleteDefinitionCatalogEntryParams{
+			DefinitionName:    row.DefinitionName,
+			DefinitionVersion: row.DefinitionVersion,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type engineProjectRowCounts struct {
+	instances int
+	runs      int
+}
+
+func countEngineRowsForProject(t *testing.T, ctx context.Context, platformStore *store.Store, projectID uuid.UUID) engineProjectRowCounts {
+	t.Helper()
+
+	var counts engineProjectRowCounts
+	err := platformStore.Pool().QueryRow(ctx, `
+		SELECT
+			(SELECT COUNT(*) FROM engine.instances WHERE project_id = $1),
+			(SELECT COUNT(*) FROM engine.runs WHERE project_id = $1)
+	`, projectID).Scan(&counts.instances, &counts.runs)
+	require.NoError(t, err)
+	return counts
 }
 
 func invokeStartEngineRun(t *testing.T, server *Server, projectID uuid.UUID, req EngineStartRunRequest) *httptest.ResponseRecorder {


### PR DESCRIPTION
## What / why

`StartRun` validates start requests against `engine.definition_catalog`, which is only synced to the live runtime registry at `continua-engine serve` start. Historically the demo seed inserted catalog-only `agent.*` definitions with no runtime backing, so `POST /v1/engine/runs` accepted them and the runs sat `QUEUED` forever in the Engine Runs console.

The seed-side half of the fix already landed on `main` (the seed no longer inserts catalog rows and deletes the stale `agent.*` entries). This PR closes the remaining gap: a regression test pinning the catalog↔registry sync as the load-bearing invariant, and documentation of the sync contract.

## Changes

- **`internal/api/engine_handlers_test.go`** — `TestStartEngineRun_RejectsCatalogOnlyDefinitionAfterRegistryTruthSync`: inserts a legacy-style catalog-only `agent.research@v1` row, shows StartRun *accepts* it (the documented hazard), applies the serve-start registry-truth sync via a test helper that mirrors `engine/internal/catalog/publisher.go` through the shared `enginedb` generated queries (the publisher itself is not importable across the engine module's `internal` boundary), then asserts the row is deleted, a second StartRun is rejected with `definition_not_registered`, and no `engine.instances`/`engine.runs` rows leak.
- **`engine/README.md`**, **`docs-site/concepts/engine-foundation.mdx`** — document the "definition catalog reflects registry truth" contract: the catalog is rewritten (upsert live + delete stale) at `continua-engine serve` start; out-of-band catalog inserts are unsupported and removed at the next serve start; richer liveness metadata is deferred to #163.

`scripts/seed_engine_demo_test.go` was left unchanged: it already asserts the seed removes all demo-project engine rows (including queued runs) and that stale `agent.*` catalog rows are absent.

No contract, query, or migration changes; `make generate` not needed.

## Verification

Implementation by Codex (GPT-5 via codex CLI), reviewed and verified independently:

- `go test ./internal/api/...` — pass (fresh DB)
- `go test ./scripts/...` — pass
- `go test ./engine/...` incl. the `engine/cmd/continua-engine` runtime e2e suite — pass
- Diff review: test-and-docs only, no generated files touched, no `engine/internal` changes

Closes #152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance on how the definition catalog works during engine startup and run submission.
  * Documented that catalog entries are refreshed automatically and manually inserted entries may be removed on the next startup.
  * Noted that richer liveness details are planned for a future update.

* **Bug Fixes**
  * Improved validation coverage for engine run requests to ensure only registered definitions are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->