### PR TITLE
fix(engine): heartbeat/lease extension for long-running local activities

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -24,6 +24,12 @@ What is still **preview / not yet there**:
 - no production path to register arbitrary user workflow definitions (the dark-launch runtime runs a fixed demo project)
 - the public `/v1/engine/*` REST control plane is gated behind `X-Continua-Engine-Preview` + `ENGINE_PUBLIC_API_ENABLED`
 
+## Activity Leases
+
+Local activity workers heartbeat claimed tasks at half of the configured activity lease TTL while the handler is running. If the worker process crashes, the heartbeat stops, the lease expires, and the task becomes claimable by another worker.
+
+Activity handlers must therefore be idempotent: activity execution is at-least-once across process crashes. If a running handler loses its lease, its context is cancelled, but a reclaimed execution may already be running concurrently in crash or lease-loss scenarios.
+
 ## Storage Model
 
 `engine/` is an isolated Go module, but not a mandate for a separate physical database.

--- a/engine/README.md
+++ b/engine/README.md
@@ -28,7 +28,7 @@ What is still **preview / not yet there**:
 
 Local activity workers heartbeat claimed tasks at half of the configured activity lease TTL while the handler is running. If the worker process crashes, the heartbeat stops, the lease expires, and the task becomes claimable by another worker.
 
-Activity handlers must therefore be idempotent: activity execution is at-least-once across process crashes. If a running handler loses its lease, its context is cancelled, but a reclaimed execution may already be running concurrently in crash or lease-loss scenarios.
+Activity handlers must therefore be idempotent: activity execution is at-least-once across process crashes. If a running handler loses its lease, such as due to a slow heartbeat, its context is cancelled, but a reclaimed execution may briefly run concurrently until cancellation takes effect. After a genuine process crash, the prior execution is gone; a new worker resumes the task sequentially once the lease expires.
 
 ## Storage Model
 

--- a/engine/db/gen/go/activity_tasks.sql.go
+++ b/engine/db/gen/go/activity_tasks.sql.go
@@ -818,6 +818,60 @@ func (q *Queries) GetActivityTaskRemoteConflictState(ctx context.Context, arg Ge
 	return i, err
 }
 
+const heartbeatLocalActivityTask = `-- name: HeartbeatLocalActivityTask :one
+UPDATE engine.activity_tasks
+SET lease_expires_at = NOW() + (lease_duration_ms * INTERVAL '1 millisecond'),
+    updated_at = NOW()
+WHERE id = $1
+  AND execution_target = 'local'
+  AND status = 'claimed'
+  AND claimed_by = $2
+  AND lease_duration_ms IS NOT NULL
+  AND lease_duration_ms > 0
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
+`
+
+type HeartbeatLocalActivityTaskParams struct {
+	ID        uuid.UUID `json:"id"`
+	ClaimedBy *string   `json:"claimed_by"`
+}
+
+func (q *Queries) HeartbeatLocalActivityTask(ctx context.Context, arg HeartbeatLocalActivityTaskParams) (EngineActivityTask, error) {
+	row := q.db.QueryRow(ctx, heartbeatLocalActivityTask, arg.ID, arg.ClaimedBy)
+	var i EngineActivityTask
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.InstanceID,
+		&i.RunID,
+		&i.HistoryID,
+		&i.ActivityKey,
+		&i.ActivityType,
+		&i.Input,
+		&i.Output,
+		&i.Status,
+		&i.AvailableAt,
+		&i.AttemptCount,
+		&i.ClaimedBy,
+		&i.ClaimedAt,
+		&i.LeaseExpiresAt,
+		&i.LastErrorCode,
+		&i.LastErrorMessage,
+		&i.CompletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.MaxAttempts,
+		&i.InitialBackoffMs,
+		&i.MaxBackoffMs,
+		&i.BackoffMultiplier,
+		&i.ExecutionTarget,
+		&i.LeaseDurationMs,
+	)
+	return i, err
+}
+
 const heartbeatRemoteActivityTask = `-- name: HeartbeatRemoteActivityTask :one
 UPDATE engine.activity_tasks
 SET lease_expires_at = NOW() + (lease_duration_ms * INTERVAL '1 millisecond'),

--- a/engine/db/queries/activity_tasks.sql
+++ b/engine/db/queries/activity_tasks.sql
@@ -150,6 +150,20 @@ WHERE id = sqlc.arg(id)
   AND lease_expires_at > NOW()
 RETURNING *;
 
+-- name: HeartbeatLocalActivityTask :one
+UPDATE engine.activity_tasks
+SET lease_expires_at = NOW() + (lease_duration_ms * INTERVAL '1 millisecond'),
+    updated_at = NOW()
+WHERE id = sqlc.arg(id)
+  AND execution_target = 'local'
+  AND status = 'claimed'
+  AND claimed_by = sqlc.arg(claimed_by)
+  AND lease_duration_ms IS NOT NULL
+  AND lease_duration_ms > 0
+  AND lease_expires_at IS NOT NULL
+  AND lease_expires_at > NOW()
+RETURNING *;
+
 -- name: CompleteRemoteActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'completed',

--- a/engine/internal/activity/worker.go
+++ b/engine/internal/activity/worker.go
@@ -2,6 +2,7 @@ package activity
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -47,7 +48,7 @@ func (w *Worker) PollOnce(ctx context.Context, workerID string) error {
 		return w.failTask(ctx, task.ID, task.RunID, workerID, &code, &message)
 	}
 
-	output, handlerErr := handler(ctx, task.Input)
+	output, handlerErr := w.runHandlerWithHeartbeat(ctx, handler, task, workerID)
 	if handlerErr != nil {
 		if w.shouldRetryTask(&task, handlerErr) {
 			return w.retryTask(ctx, &task, workerID, handlerErr)
@@ -82,6 +83,59 @@ func (w *Worker) PollOnce(ctx context.Context, workerID string) error {
 		}
 	}
 	return tx.Commit(ctx)
+}
+
+type handlerResult struct {
+	output json.RawMessage
+	err    error
+}
+
+func (w *Worker) runHandlerWithHeartbeat(
+	ctx context.Context,
+	handler Handler,
+	task enginedb.EngineActivityTask,
+	workerID string,
+) (json.RawMessage, error) {
+	handlerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make(chan handlerResult, 1)
+	go func() {
+		output, err := handler(handlerCtx, task.Input)
+		results <- handlerResult{output: output, err: err}
+	}()
+
+	heartbeatInterval := w.activityLeaseTTL / 2
+	if heartbeatInterval <= 0 {
+		heartbeatInterval = 50 * time.Millisecond
+	}
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+	heartbeatC := ticker.C
+	ctxDone := ctx.Done()
+
+	for {
+		select {
+		case result := <-results:
+			return result.output, result.err
+		case <-ctxDone:
+			cancel()
+			ticker.Stop()
+			heartbeatC = nil
+			ctxDone = nil
+		case <-heartbeatC:
+			if _, err := w.store.HeartbeatLocalActivityTask(ctx, task.ID, workerID); err != nil {
+				if errors.Is(err, store.ErrStaleClaim) || errors.Is(err, store.ErrNotFound) {
+					log.Printf("activity worker lost lease for task %s", task.ID)
+					cancel()
+					ticker.Stop()
+					heartbeatC = nil
+					continue
+				}
+				log.Printf("activity worker heartbeat failed for task %s: %v", task.ID, err)
+			}
+		}
+	}
 }
 
 func (w *Worker) retryTask(

--- a/engine/internal/activity/worker.go
+++ b/engine/internal/activity/worker.go
@@ -109,6 +109,10 @@ func (w *Worker) runHandlerWithHeartbeat(
 	if heartbeatInterval <= 0 {
 		heartbeatInterval = 50 * time.Millisecond
 	}
+	heartbeatTimeout := heartbeatInterval / 2
+	if heartbeatTimeout <= 0 {
+		heartbeatTimeout = heartbeatInterval
+	}
 	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
 	heartbeatC := ticker.C
@@ -124,7 +128,10 @@ func (w *Worker) runHandlerWithHeartbeat(
 			heartbeatC = nil
 			ctxDone = nil
 		case <-heartbeatC:
-			if _, err := w.store.HeartbeatLocalActivityTask(ctx, task.ID, workerID); err != nil {
+			heartbeatCtx, heartbeatCancel := context.WithTimeout(ctx, heartbeatTimeout)
+			_, err := w.store.HeartbeatLocalActivityTask(heartbeatCtx, task.ID, workerID)
+			heartbeatCancel()
+			if err != nil {
 				if errors.Is(err, store.ErrStaleClaim) || errors.Is(err, store.ErrNotFound) {
 					log.Printf("activity worker lost lease for task %s", task.ID)
 					cancel()

--- a/engine/internal/activity/worker.go
+++ b/engine/internal/activity/worker.go
@@ -48,7 +48,7 @@ func (w *Worker) PollOnce(ctx context.Context, workerID string) error {
 		return w.failTask(ctx, task.ID, task.RunID, workerID, &code, &message)
 	}
 
-	output, handlerErr := w.runHandlerWithHeartbeat(ctx, handler, task, workerID)
+	output, handlerErr := w.runHandlerWithHeartbeat(ctx, handler, &task, workerID)
 	if handlerErr != nil {
 		if w.shouldRetryTask(&task, handlerErr) {
 			return w.retryTask(ctx, &task, workerID, handlerErr)
@@ -93,7 +93,7 @@ type handlerResult struct {
 func (w *Worker) runHandlerWithHeartbeat(
 	ctx context.Context,
 	handler Handler,
-	task enginedb.EngineActivityTask,
+	task *enginedb.EngineActivityTask,
 	workerID string,
 ) (json.RawMessage, error) {
 	handlerCtx, cancel := context.WithCancel(ctx)

--- a/engine/internal/activity/worker_test.go
+++ b/engine/internal/activity/worker_test.go
@@ -136,6 +136,186 @@ func TestWorkerLateCompletionAfterTerminateReturnsNoOp(t *testing.T) {
 	}
 }
 
+func TestWorkerLongRunningLocalActivityHeartbeatsLease(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	_, _, task := createRunWithPendingActivity(
+		t,
+		store,
+		enginetest.DefaultPlatformProjectID,
+		"instance-activity-heartbeat",
+		"long-running-local",
+	)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	registry, err := NewRegistry(map[string]Handler{
+		testActivityType: func(context.Context, json.RawMessage) (json.RawMessage, error) {
+			close(started)
+			<-release
+			return []byte(`{"ok":true}`), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	leaseTTL := 300 * time.Millisecond
+	worker := NewWorker(store, registry, leaseTTL)
+	workerDone := make(chan error, 1)
+	go func() {
+		workerDone <- worker.PollOnce(ctx, "activity-worker")
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("activity handler did not start")
+	}
+
+	originalClaim, err := store.GetActivityTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask(original claim) error = %v", err)
+	}
+	if !originalClaim.LeaseExpiresAt.Valid {
+		t.Fatalf("expected claimed task lease_expires_at, got %+v", originalClaim)
+	}
+	originalLeaseExpiresAt := originalClaim.LeaseExpiresAt.Time
+
+	var renewedTask enginedb.EngineActivityTask
+	waitUntil(t, 5*time.Second, func() bool {
+		current, err := store.GetActivityTask(ctx, task.ID)
+		if err != nil {
+			t.Fatalf("GetActivityTask(mid-run) error = %v", err)
+		}
+		if !current.LeaseExpiresAt.Valid {
+			return false
+		}
+		if current.LeaseExpiresAt.Time.After(originalLeaseExpiresAt) {
+			renewedTask = current
+		}
+		return time.Now().After(originalLeaseExpiresAt.Add(2*leaseTTL)) &&
+			current.LeaseExpiresAt.Time.After(originalLeaseExpiresAt)
+	})
+
+	_, err = store.ClaimNextActivityTask(ctx, "competing-worker", leaseTTL)
+	if !errors.Is(err, enginestore.ErrNotFound) {
+		t.Fatalf("expected renewed local activity lease to block competing claim, got %v", err)
+	}
+	if !renewedTask.LeaseExpiresAt.Valid || !renewedTask.LeaseExpiresAt.Time.After(originalLeaseExpiresAt) {
+		t.Fatalf("expected heartbeat to advance lease beyond %s, got %+v", originalLeaseExpiresAt, renewedTask)
+	}
+
+	close(release)
+
+	select {
+	case err := <-workerDone:
+		if err != nil {
+			t.Fatalf("PollOnce() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("activity worker did not finish after release")
+	}
+
+	completedTask, err := store.GetActivityTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask(completed) error = %v", err)
+	}
+	if completedTask.Status != enginedb.EngineActivityTaskStatusCompleted {
+		t.Fatalf("expected completed activity task, got %+v", completedTask)
+	}
+	if completedTask.AttemptCount != 1 {
+		t.Fatalf("expected attempt_count=1, got %+v", completedTask)
+	}
+	var completedOutput struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal(completedTask.Output, &completedOutput); err != nil {
+		t.Fatalf("json.Unmarshal(completed output) error = %v", err)
+	}
+	if !completedOutput.OK {
+		t.Fatalf("expected completed output ok=true, got %s", string(completedTask.Output))
+	}
+}
+
+func TestWorkerLocalActivityLeaseLossCancelsHandlerContext(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	_, _, task := createRunWithPendingActivity(
+		t,
+		store,
+		enginetest.DefaultPlatformProjectID,
+		"instance-activity-lease-lost",
+		"lease-lost-local",
+	)
+
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	registry, err := NewRegistry(map[string]Handler{
+		testActivityType: func(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+			close(started)
+			<-ctx.Done()
+			close(cancelled)
+			return []byte(`{"ok":true}`), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	worker := NewWorker(store, registry, 200*time.Millisecond)
+	workerDone := make(chan error, 1)
+	go func() {
+		workerDone <- worker.PollOnce(ctx, "activity-worker")
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("activity handler did not start")
+	}
+
+	if _, err := db.Pool.Exec(ctx, `
+		UPDATE engine.activity_tasks
+		SET claimed_by = 'other-worker',
+		    lease_expires_at = NOW() + INTERVAL '1 minute',
+		    updated_at = NOW()
+		WHERE id = $1
+	`, task.ID); err != nil {
+		t.Fatalf("lease loss setup update error = %v", err)
+	}
+
+	select {
+	case <-cancelled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("activity handler context was not cancelled after lease loss")
+	}
+
+	select {
+	case err := <-workerDone:
+		if err != nil {
+			t.Fatalf("PollOnce() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("activity worker did not finish after lease loss")
+	}
+
+	staleTask, err := store.GetActivityTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask(stale) error = %v", err)
+	}
+	if staleTask.Status == enginedb.EngineActivityTaskStatusCompleted {
+		t.Fatalf("expected stale worker not to complete task, got %+v", staleTask)
+	}
+	if staleTask.ClaimedBy == nil || *staleTask.ClaimedBy != "other-worker" {
+		t.Fatalf("expected lease loss to preserve other worker claim, got %+v", staleTask)
+	}
+}
+
 func TestComputeRetryDelayMS(t *testing.T) {
 	initial := int64(333)
 	maxBackoff := int64(1000)
@@ -782,6 +962,22 @@ func createWaitingRunWithPendingActivity(
 	t.Helper()
 	cfg.waiting = true
 	return createRunWithPendingActivityConfig(t, store, cfg)
+}
+
+func waitUntil(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if condition() {
+		return
+	}
+	t.Fatalf("condition was not met within %s", timeout)
 }
 
 func mustJSON(t *testing.T, value any) json.RawMessage {

--- a/engine/internal/store/activity_tasks.go
+++ b/engine/internal/store/activity_tasks.go
@@ -104,6 +104,21 @@ func (o *storeOps) HeartbeatRemoteActivityTask(
 	return enginedb.EngineActivityTask{}, o.classifyRemoteActivityTaskCASMiss(ctx, projectID, id, err)
 }
 
+func (o *storeOps) HeartbeatLocalActivityTask(
+	ctx context.Context,
+	id uuid.UUID,
+	claimedBy string,
+) (enginedb.EngineActivityTask, error) {
+	task, err := o.q.HeartbeatLocalActivityTask(ctx, enginedb.HeartbeatLocalActivityTaskParams{
+		ID:        id,
+		ClaimedBy: nullableWorkerID(claimedBy),
+	})
+	if err == nil {
+		return task, nil
+	}
+	return enginedb.EngineActivityTask{}, o.classifyActivityTaskCASMiss(ctx, id, err)
+}
+
 func (o *storeOps) CompleteActivityTask(
 	ctx context.Context,
 	id uuid.UUID,


### PR DESCRIPTION
## What / why

Local activities run synchronously in `activity.Worker.PollOnce` under a fixed lease (`ENGINE_ACTIVITY_LEASE_TTL`, default 5m) with no heartbeat, while `ClaimNextActivityTask` treats claimed tasks with expired leases as claimable. Any handler running longer than the lease — routine for LLM/agent activities — was reclaimed and executed again concurrently. Remote tasks already had `HeartbeatRemoteActivityTask`; local tasks did not.

Now the worker heartbeats a claimed local task at half the lease TTL while the handler runs, so long-running activities keep their lease; a worker that genuinely dies stops heartbeating and the task frees via lease expiry; and a handler whose lease is lost gets its context cancelled while the existing claimed-by CAS paths turn its late outcome into a logged no-op.

## Changes

- **`engine/db/queries/activity_tasks.sql`** — new `HeartbeatLocalActivityTask` query: extends `lease_expires_at` by `lease_duration_ms`, CAS-guarded on `id + claimed_by + execution_target='local' + status='claimed' + unexpired lease` (mirror of the remote heartbeat, matching the local CAS pattern of `CompleteActivityTask`/`FailActivityTask`). Regenerated sqlc output (`engine/db/gen/go/activity_tasks.sql.go`); no schema change, no migration.
- **`engine/internal/store/activity_tasks.go`** — thin `HeartbeatLocalActivityTask` wrapper; CAS misses classify to `ErrStaleClaim` via the existing `classifyActivityTaskCASMiss`.
- **`engine/internal/activity/worker.go`** — `PollOnce` now runs the handler in a goroutine under a cancellable child context and heartbeats on a TTL/2 ticker (50ms floor for tiny test TTLs). `ErrStaleClaim`/`ErrNotFound` on renewal cancels the handler context and stops heartbeating; transient DB errors are logged and heartbeating continues. `PollOnce` stays synchronous, never leaks the handler goroutine, and uses the outer context for all bookkeeping. Completion/retry/failure paths are unchanged — their claimed-by CAS already no-ops stale outcomes.
- **`engine/README.md`** — documents the heartbeat and at-least-once semantics: handlers must be idempotent; execution can duplicate across process crashes.

## Plan / process

Implementation by Codex (GPT-5 via codex CLI, effort high) in an isolated worktree from a Fable-written plan; reviewed and verified independently before this PR.

## Tests

- `TestWorkerLongRunningLocalActivityHeartbeatsLease` — handler outlives a 300ms lease TTL; asserts the lease visibly advances, a competing `ClaimNextActivityTask` from another worker returns `ErrNotFound` mid-run, and the task completes exactly once (`status='completed'`, `attempt_count=1`, expected output).
- `TestWorkerLocalActivityLeaseLossCancelsHandlerContext` — claim stolen via direct SQL mid-run; asserts the heartbeat CAS miss cancels the handler context within a bounded wait, `PollOnce` returns nil (stale no-op), and the thief's claim is preserved untouched.

## Verification (fresh throwaway DB)

- `make generate` with the pinned sqlc v1.27.0 → working tree byte-identical (no generated drift)
- `go test ./engine/internal/activity/...` — pass
- `go test ./engine/internal/store/...` — pass
- `go test ./engine/cmd/continua-engine/...` (incl. restart-recovery runtime e2e) — pass
- `go test -race -count=2 -run "Heartbeat|LeaseLoss" ./engine/internal/activity/...` — pass

Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local activities now keep their claim alive while running, reducing unexpected takeover during long tasks.
  * If a worker loses its lease, the running activity is canceled more quickly and safely handed off.

* **Bug Fixes**
  * Improved handling of worker crashes so claimed tasks can expire and be reclaimed reliably.
  * Reduced the risk of duplicate execution by clearly enforcing at-least-once behavior for local activities.

* **Documentation**
  * Added guidance on local activity lease behavior and the need for idempotent handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->