### PR TITLE
build: pin sqlc to v1.27.0 in make generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ GO_BIN_DIR := $(shell go env GOPATH)/bin
 PATH := $(GO_BIN_DIR):$(PATH)
 export PATH
 GOLANGCI_LINT := $(GO_BIN_DIR)/golangci-lint
+
+# sqlc is pinned: generated output is version-stamped, so a mismatched sqlc dirties
+# db/gen and engine/db/gen. $(GO_BIN_DIR) is prepended to PATH above and may hold a
+# different sqlc that would shadow the pinned one, so select the pinned binary explicitly.
+SQLC_VERSION := v1.27.0
+SQLC := $(shell for c in '$(GO_BIN_DIR)/sqlc' /opt/homebrew/bin/sqlc /usr/local/bin/sqlc "$$(command -v sqlc 2>/dev/null)"; do \
+	  [ -x "$$c" ] && [ "$$($$c version 2>/dev/null)" = "$(SQLC_VERSION)" ] && { echo "$$c"; break; }; \
+	done)
 GO_BUILD_CACHE ?= /tmp/continua-go-build
 GOLANGCI_LINT_CACHE ?= /tmp/continua-golangci-cache
 LINT_ENV := GOCACHE=$(GO_BUILD_CACHE) GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE)
@@ -40,10 +48,16 @@ setup: ## Install all dependencies
 generate: ## Generate ALL code (contracts, sqlc, API types)
 	@echo "==> Generating contracts..."
 	pnpm --filter @continua/contracts generate
-	@echo "==> Generating platform database code..."
-	cd db/platform && sqlc generate
+	@if [ -z "$(SQLC)" ]; then \
+		echo "❌ sqlc $(SQLC_VERSION) not found; this repo pins $(SQLC_VERSION)."; \
+		echo "   Note: \$$GOPATH/bin is prepended to PATH and may shadow a pinned Homebrew sqlc."; \
+		echo "   Install sqlc $(SQLC_VERSION) (e.g. 'brew install sqlc' or the pinned release)."; \
+		exit 1; \
+	fi
+	@echo "==> Generating platform database code (using $(SQLC), $(SQLC_VERSION))..."
+	cd db/platform && $(SQLC) generate
 	@echo "==> Generating engine database code..."
-	cd engine/db && sqlc generate
+	cd engine/db && $(SQLC) generate
 	@echo "==> Copying generated Go types..."
 	@mkdir -p internal/api
 	@if [ -f contracts/generated/go/server_gen.go ]; then \


### PR DESCRIPTION
## What

Make the `generate` target in the Makefile use the pinned **sqlc v1.27.0** deterministically, and fail fast with a clear message if it is missing.

## Why

The Makefile prepends `$(go env GOPATH)/bin` to `PATH` (for golangci-lint and other go-installed tools). On machines that also have a go-installed sqlc, that directory shadows the pinned Homebrew `sqlc` v1.27.0 with a different version (e.g. v1.30.0 in `~/go/bin`). sqlc stamps its version into generated output, so `make generate` silently restamps every file under `db/gen` and `engine/db/gen`, dirtying the tree and tripping CI drift checks.

Reproduced directly: with `$GOPATH/bin` prepended, `sqlc` resolves to `~/go/bin/sqlc` → v1.30.0 instead of `/opt/homebrew/bin/sqlc` → v1.27.0.

## What changed

- Added `SQLC_VERSION := v1.27.0` and an `SQLC` variable that scans known locations (`$GOPATH/bin`, Homebrew, `/usr/local/bin`, and `command -v sqlc`) and selects the **absolute path** of the binary whose `sqlc version` matches the pin.
- `generate` now invokes `$(SQLC) generate` (absolute path) for both `db/platform` and `engine/db`, so PATH ordering can no longer pick the wrong version.
- Fails fast with an actionable message if no v1.27.0 binary is found.

## Notes for reviewers

- The pinned-invocation alternative `go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.27.0` was rejected: sqlc v1.27.0 embeds a cgo `pg_query` parser that fails to compile against the current macOS SDK (`strchrnul` redeclaration) — which is exactly why the repo relies on the prebuilt binary.
- Storing an **absolute** path is deliberate: an earlier attempt that kept bare `sqlc` as a candidate matched v1.27.0 at parse time (Homebrew-first parse PATH) but would have invoked v1.30.0 at recipe time (`$GOPATH/bin`-first). Absolute-path candidates avoid that mismatch.

## Verification

- `SQLC` resolves to `/opt/homebrew/bin/sqlc` (v1.27.0).
- Running the pinned sqlc against `db/platform` and `engine/db` leaves `db/gen` and `engine/db/gen` clean (no diff).
- Fail-fast guard renders the intended message when no v1.27.0 binary is present.

Note: the full `make generate` could not be run end-to-end in this environment because its first step (`pnpm --filter @continua/contracts generate`) needs `node_modules`/`redocly` that aren't installed in the worktree — a pre-existing setup gap that runs before sqlc and is unrelated to this change.