### PR TITLE
feat(engine): deterministic time API — workflow Now()/Sleep(d)/SideEffect recorded in history

### DIFF
--- a/docs-site/concepts/engine-foundation.mdx
+++ b/docs-site/concepts/engine-foundation.mdx
@@ -85,6 +85,19 @@ history replay. The end-to-end behaviour is covered by the runtime suite in
 [`engine/cmd/continua-engine/`](https://github.com/aryanVijaywargia/Continua/tree/main/engine/cmd/continua-engine),
 including timer/signal persistence and mid-activity restart recovery.
 
+### Deterministic workflow authoring
+
+Workflow code is replayed from history after crashes, so wall-clock time, randomness, and
+other non-deterministic values must be captured through workflow APIs instead of calling
+process-local sources directly. Use `ctx.Now()` to read a replay-stable timestamp,
+`ctx.Sleep(key, duration)` for relative timers, and `ctx.SideEffect(key, fn, out)` to run
+non-deterministic code once and store its JSON value in history. On replay, recorded
+values are returned without re-running the side effect.
+
+`ctx.SleepUntil(key, at)` remains available for absolute deadlines, but the deadline must
+already be deterministic. For example, prefer `ctx.Sleep("wait", 5*time.Minute)` over
+`ctx.SleepUntil("wait", time.Now().Add(5*time.Minute))`.
+
 ### CLI (real)
 
 A separate binary `continua-engine` with `version`, `migrate up` / `migrate down`, and the

--- a/engine/cmd/continua-engine/internal/darklaunch/workflow.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/workflow.go
@@ -19,11 +19,18 @@ const (
 	RetryHandledDefinitionVersion    = "v1"
 	InvalidRetryDefinitionName       = "darklaunch.invalid-retry-policy"
 	InvalidRetryDefinitionVersion    = "v1"
+	SleepDemoDefinitionName          = "darklaunch.sleep-demo"
+	SleepDemoDefinitionVersion       = "v1"
 )
 
 type WorkflowInput struct {
 	Name    string `json:"name"`
 	TimerAt string `json:"timer_at"`
+}
+
+type SleepDemoInput struct {
+	Name    string `json:"name"`
+	SleepMS int    `json:"sleep_ms"`
 }
 
 type SignalPayload struct {
@@ -67,6 +74,11 @@ func Definitions() []workflow.Definition {
 			Version: InvalidRetryDefinitionVersion,
 			Run:     runInvalidRetryWorkflow,
 		},
+		{
+			Name:    SleepDemoDefinitionName,
+			Version: SleepDemoDefinitionVersion,
+			Run:     runSleepDemoWorkflow,
+		},
 	}
 }
 
@@ -99,6 +111,30 @@ func runInvalidRetryWorkflow(ctx workflow.Context) error {
 		&output,
 		workflow.ActivityOptions{RetryPolicy: &workflow.RetryPolicy{MaxAttempts: 0}},
 	)
+}
+
+func runSleepDemoWorkflow(ctx workflow.Context) error {
+	var input SleepDemoInput
+	if err := ctx.Input(&input); err != nil {
+		return err
+	}
+	if input.Name == "" {
+		input.Name = "world"
+	}
+
+	if err := ctx.Sleep("sleep", time.Duration(input.SleepMS)*time.Millisecond); err != nil {
+		return err
+	}
+
+	var signal SignalPayload
+	if err := ctx.ReceiveSignal("approval", &signal); err != nil {
+		return err
+	}
+
+	return ctx.SetResult(WorkflowResult{
+		Greeting: "hello, " + input.Name,
+		Approval: signal.Approval,
+	})
 }
 
 func runRetryWorkflow(ctx workflow.Context, maxAttempts int, handleActivityFailure bool) error {

--- a/engine/cmd/continua-engine/runtime_time_api_e2e_test.go
+++ b/engine/cmd/continua-engine/runtime_time_api_e2e_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+
+	"github.com/continua-ai/continua/engine/cmd/continua-engine/internal/darklaunch"
+)
+
+// A workflow that sleeps for a duration (not an absolute input-provided
+// deadline) must survive a mid-sleep binary restart: the reclaimed run replays
+// against the recorded deadline instead of recomputing it from wall time.
+func TestEngineRuntimeSleepDurationSurvivesRestartWithoutReplayMismatch(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+
+	serve := startServe(t)
+
+	instanceKey := "runtime-restart-sleep-duration"
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", instanceKey,
+		"--definition", darklaunch.SleepDemoDefinitionName,
+		"--version", darklaunch.SleepDemoDefinitionVersion,
+		"--request-key", "req-sleep-duration-restart",
+		"--input", `{"name":"Sleepy","sleep_ms":1500}`,
+	); err != nil {
+		t.Fatalf("start sleep demo workflow: %v", err)
+	}
+
+	waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "timer")
+	})
+	serve.stop(t)
+
+	time.Sleep(time.Second)
+
+	serve = startServe(t)
+	defer serve.stop(t)
+
+	waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "signal")
+	})
+
+	if _, _, err := executeCommand(t,
+		"signal",
+		"--instance-key", instanceKey,
+		"--signal-name", "approval",
+		"--payload", `{"approval":"restart-approved"}`,
+	); err != nil {
+		t.Fatalf("signal sleep demo workflow: %v", err)
+	}
+
+	state := waitForInspect(t, instanceKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusCompleted)
+	})
+
+	var result darklaunch.WorkflowResult
+	if err := json.Unmarshal(state.Result, &result); err != nil {
+		t.Fatalf("Unmarshal(result) error = %v", err)
+	}
+	if result.Greeting != "hello, Sleepy" || result.Approval != "restart-approved" {
+		t.Fatalf("unexpected sleep demo result: %+v", result)
+	}
+
+	for _, event := range state.History {
+		if event.EventType == enginehistory.EventWorkflowReplayMismatch {
+			t.Fatalf("run hit replay_mismatch after restart: %+v", event)
+		}
+	}
+}

--- a/engine/internal/history/events.go
+++ b/engine/internal/history/events.go
@@ -7,31 +7,33 @@ import (
 )
 
 const (
-	EventWorkflowStarted         = publichistory.EventWorkflowStarted
-	EventWorkflowCompleted       = publichistory.EventWorkflowCompleted
-	EventWorkflowFailed          = publichistory.EventWorkflowFailed
-	EventWorkflowCancelled       = publichistory.EventWorkflowCancelled
-	EventWorkflowContinuedAsNew  = publichistory.EventWorkflowContinuedAsNew
-	EventWorkflowSuspended       = publichistory.EventWorkflowSuspended
-	EventWorkflowResumed         = publichistory.EventWorkflowResumed
-	EventWorkflowTerminated      = publichistory.EventWorkflowTerminated
-	EventWorkflowReplayMismatch  = publichistory.EventWorkflowReplayMismatch
-	EventActivityScheduled       = publichistory.EventActivityScheduled
-	EventActivityCompleted       = publichistory.EventActivityCompleted
-	EventActivityFailed          = publichistory.EventActivityFailed
-	EventActivityRetryScheduled  = publichistory.EventActivityRetryScheduled
-	EventChildWorkflowScheduled  = publichistory.EventChildWorkflowScheduled
-	EventChildWorkflowStarted    = publichistory.EventChildWorkflowStarted
-	EventChildWorkflowCompleted  = publichistory.EventChildWorkflowCompleted
-	EventChildWorkflowFailed     = publichistory.EventChildWorkflowFailed
-	EventChildWorkflowCancelled  = publichistory.EventChildWorkflowCancelled
-	EventChildWorkflowTerminated = publichistory.EventChildWorkflowTerminated
-	EventChildWorkflowWaitFailed = publichistory.EventChildWorkflowWaitFailed
-	EventTimerScheduled          = publichistory.EventTimerScheduled
-	EventTimerFired              = publichistory.EventTimerFired
-	EventSignalReceived          = publichistory.EventSignalReceived
-	EventCancelRequested         = publichistory.EventCancelRequested
-	EventCustomStatusUpdated     = publichistory.EventCustomStatusUpdated
+	EventWorkflowStarted            = publichistory.EventWorkflowStarted
+	EventWorkflowCompleted          = publichistory.EventWorkflowCompleted
+	EventWorkflowFailed             = publichistory.EventWorkflowFailed
+	EventWorkflowCancelled          = publichistory.EventWorkflowCancelled
+	EventWorkflowContinuedAsNew     = publichistory.EventWorkflowContinuedAsNew
+	EventWorkflowSuspended          = publichistory.EventWorkflowSuspended
+	EventWorkflowResumed            = publichistory.EventWorkflowResumed
+	EventWorkflowTerminated         = publichistory.EventWorkflowTerminated
+	EventWorkflowReplayMismatch     = publichistory.EventWorkflowReplayMismatch
+	EventWorkflowTimeRecorded       = publichistory.EventWorkflowTimeRecorded
+	EventWorkflowSideEffectRecorded = publichistory.EventWorkflowSideEffectRecorded
+	EventActivityScheduled          = publichistory.EventActivityScheduled
+	EventActivityCompleted          = publichistory.EventActivityCompleted
+	EventActivityFailed             = publichistory.EventActivityFailed
+	EventActivityRetryScheduled     = publichistory.EventActivityRetryScheduled
+	EventChildWorkflowScheduled     = publichistory.EventChildWorkflowScheduled
+	EventChildWorkflowStarted       = publichistory.EventChildWorkflowStarted
+	EventChildWorkflowCompleted     = publichistory.EventChildWorkflowCompleted
+	EventChildWorkflowFailed        = publichistory.EventChildWorkflowFailed
+	EventChildWorkflowCancelled     = publichistory.EventChildWorkflowCancelled
+	EventChildWorkflowTerminated    = publichistory.EventChildWorkflowTerminated
+	EventChildWorkflowWaitFailed    = publichistory.EventChildWorkflowWaitFailed
+	EventTimerScheduled             = publichistory.EventTimerScheduled
+	EventTimerFired                 = publichistory.EventTimerFired
+	EventSignalReceived             = publichistory.EventSignalReceived
+	EventCancelRequested            = publichistory.EventCancelRequested
+	EventCustomStatusUpdated        = publichistory.EventCustomStatusUpdated
 )
 
 const (
@@ -50,6 +52,8 @@ type WorkflowSuspendedPayload = publichistory.WorkflowSuspendedPayload
 type WorkflowResumedPayload = publichistory.WorkflowResumedPayload
 type WorkflowTerminatedPayload = publichistory.WorkflowTerminatedPayload
 type WorkflowReplayMismatchPayload = publichistory.WorkflowReplayMismatchPayload
+type WorkflowTimeRecordedPayload = publichistory.WorkflowTimeRecordedPayload
+type WorkflowSideEffectRecordedPayload = publichistory.WorkflowSideEffectRecordedPayload
 type ActivityScheduledPayload = publichistory.ActivityScheduledPayload
 type ActivityCompletedPayload = publichistory.ActivityCompletedPayload
 type ActivityFailedPayload = publichistory.ActivityFailedPayload

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -793,6 +793,9 @@ func (r *workflowRunner) SideEffect(key string, fn func() (any, error), out any)
 	if key == "" {
 		return publicworkflow.ErrEmptyKey
 	}
+	if fn == nil {
+		return errors.New("workflow: SideEffect fn must not be nil")
+	}
 	r.advanceState()
 
 	if next, ok := r.peek(); ok {

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -701,6 +701,34 @@ func (r *workflowRunner) skipRecordedActivityRetryEvents(activityKey string) {
 	}
 }
 
+func (r *workflowRunner) Now() time.Time {
+	r.advanceState()
+
+	if next, ok := r.peek(); ok {
+		recorded, ok := next.Payload.(*enginehistory.WorkflowTimeRecordedPayload)
+		if !ok {
+			r.replayMismatch(enginehistory.EventWorkflowTimeRecorded, "", next, "workflow time read did not match recorded history")
+		}
+		r.cursor++
+		return recorded.Now
+	}
+
+	recorded := time.Now().UTC()
+	r.queueEvent(enginehistory.EventWorkflowTimeRecorded, enginehistory.WorkflowTimeRecordedPayload{
+		Now: recorded,
+	})
+	return recorded
+}
+
+func (r *workflowRunner) Sleep(key string, d time.Duration) error {
+	if key == "" {
+		return publicworkflow.ErrEmptyKey
+	}
+
+	base := r.Now()
+	return r.SleepUntil(key, base.Add(d))
+}
+
 func (r *workflowRunner) SleepUntil(key string, at time.Time) error {
 	if key == "" {
 		return publicworkflow.ErrEmptyKey
@@ -759,6 +787,37 @@ func (r *workflowRunner) SleepUntil(key string, at time.Time) error {
 		nil,
 	)
 	return nil
+}
+
+func (r *workflowRunner) SideEffect(key string, fn func() (any, error), out any) error {
+	if key == "" {
+		return publicworkflow.ErrEmptyKey
+	}
+	r.advanceState()
+
+	if next, ok := r.peek(); ok {
+		recorded, ok := next.Payload.(*enginehistory.WorkflowSideEffectRecordedPayload)
+		if !ok || recorded.SideEffectKey != key {
+			r.replayMismatch(enginehistory.EventWorkflowSideEffectRecorded, key, next, "workflow side effect did not match recorded history")
+		}
+		r.cursor++
+		return unmarshalOptional(recorded.Value, out)
+	}
+
+	value, err := fn()
+	if err != nil {
+		return err
+	}
+	valueRaw, err := enginehistory.MarshalPayload(value)
+	if err != nil {
+		return err
+	}
+	recorded := enginehistory.WorkflowSideEffectRecordedPayload{
+		SideEffectKey: key,
+		Value:         cloneRaw(valueRaw),
+	}
+	r.queueEvent(enginehistory.EventWorkflowSideEffectRecorded, recorded)
+	return unmarshalOptional(recorded.Value, out)
 }
 
 func (r *workflowRunner) ReceiveSignal(name string, out any) error {

--- a/engine/internal/workflow/replay_time_test.go
+++ b/engine/internal/workflow/replay_time_test.go
@@ -357,6 +357,7 @@ func TestReplayNowAgainstDifferentRecordedEventFailsAsReplayMismatch(t *testing.
 func TestReplayTimeAPIValidation(t *testing.T) {
 	var sleepErr error
 	var sideEffectKeyErr error
+	var sideEffectNilErr error
 	var sideEffectFnErr error
 	fnFailure := errors.New("side effect exploded")
 
@@ -370,6 +371,8 @@ func TestReplayTimeAPIValidation(t *testing.T) {
 			sideEffectKeyErr = ctx.SideEffect("", func() (any, error) {
 				return "never", nil
 			}, &out)
+
+			sideEffectNilErr = ctx.SideEffect("nil-fn", nil, &out)
 
 			sideEffectFnErr = ctx.SideEffect("failing", func() (any, error) {
 				return nil, fnFailure
@@ -392,6 +395,9 @@ func TestReplayTimeAPIValidation(t *testing.T) {
 	}
 	if !errors.Is(sideEffectKeyErr, publicworkflow.ErrEmptyKey) {
 		t.Fatalf("SideEffect with empty key: want ErrEmptyKey, got %v", sideEffectKeyErr)
+	}
+	if sideEffectNilErr == nil || sideEffectNilErr.Error() != "workflow: SideEffect fn must not be nil" {
+		t.Fatalf("SideEffect with nil fn: want nil fn error, got %v", sideEffectNilErr)
 	}
 	if !errors.Is(sideEffectFnErr, fnFailure) {
 		t.Fatalf("SideEffect fn error must propagate, got %v", sideEffectFnErr)

--- a/engine/internal/workflow/replay_time_test.go
+++ b/engine/internal/workflow/replay_time_test.go
@@ -1,0 +1,408 @@
+package workflow
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+// historyFromDecision materializes the events queued by a prior activation into
+// history rows, simulating the durable write that precedes a crash-recovery
+// replay. startSequence is the sequence number of the first appended row.
+func historyFromDecision(t *testing.T, base []enginedb.EngineHistory, events []queuedHistoryEvent, startSequence int32) []enginedb.EngineHistory {
+	t.Helper()
+
+	rows := append([]enginedb.EngineHistory(nil), base...)
+	for i, event := range events {
+		rows = append(rows, historyRow(t, startSequence+int32(i), event.EventType, event.Payload))
+	}
+	return rows
+}
+
+func startedHistory(t *testing.T, input json.RawMessage) []enginedb.EngineHistory {
+	t.Helper()
+
+	return []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "time-demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-time",
+			Input:             input,
+		}),
+	}
+}
+
+func TestReplayNowRecordsOnFirstExecutionAndReplaysRecordedValue(t *testing.T) {
+	definition := publicworkflow.Definition{
+		Name:    "time-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			first := ctx.Now()
+			second := ctx.Now()
+			return ctx.SetResult(map[string]string{
+				"first":  first.UTC().Format(time.RFC3339Nano),
+				"second": second.UTC().Format(time.RFC3339Nano),
+			})
+		},
+	}
+
+	base := startedHistory(t, nil)
+	before := time.Now().UTC()
+	decision, err := replayDefinition(definition, base, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	after := time.Now().UTC()
+	if decision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision, got %+v", decision)
+	}
+
+	var recordedTimes []time.Time
+	for _, event := range decision.Events {
+		if event.EventType != enginehistory.EventWorkflowTimeRecorded {
+			continue
+		}
+		decoded, err := enginehistory.DecodePayload(event.EventType, event.Payload)
+		if err != nil {
+			t.Fatalf("DecodePayload(%s) error = %v", event.EventType, err)
+		}
+		payload, ok := decoded.(*enginehistory.WorkflowTimeRecordedPayload)
+		if !ok {
+			t.Fatalf("expected WorkflowTimeRecordedPayload, got %T", decoded)
+		}
+		recordedTimes = append(recordedTimes, payload.Now)
+	}
+	if len(recordedTimes) != 2 {
+		t.Fatalf("expected two workflow.time_recorded events, got %d in %+v", len(recordedTimes), decision.Events)
+	}
+	for i, recorded := range recordedTimes {
+		if recorded.Before(before.Add(-time.Second)) || recorded.After(after.Add(time.Second)) {
+			t.Fatalf("recorded time %d = %v outside execution window [%v, %v]", i, recorded, before, after)
+		}
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(decision.Result, &result); err != nil {
+		t.Fatalf("Unmarshal(result) error = %v", err)
+	}
+	if result["first"] != recordedTimes[0].UTC().Format(time.RFC3339Nano) {
+		t.Fatalf("Now() returned %s but recorded %v", result["first"], recordedTimes[0])
+	}
+	if result["second"] != recordedTimes[1].UTC().Format(time.RFC3339Nano) {
+		t.Fatalf("second Now() returned %s but recorded %v", result["second"], recordedTimes[1])
+	}
+
+	// Crash-recovery replay: the recorded events are durable history now.
+	replayRows := historyFromDecision(t, base, decision.Events, 2)
+	replayDecision, err := replayDefinition(definition, replayRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() replay error = %v", err)
+	}
+	if replayDecision.Kind != decisionCompleted {
+		t.Fatalf("expected completed replay decision, got %+v", replayDecision)
+	}
+	if len(replayDecision.Events) != 0 {
+		t.Fatalf("expected no new events on replay, got %+v", replayDecision.Events)
+	}
+	if !equalJSON(replayDecision.Result, decision.Result) {
+		t.Fatalf("replayed result %s differs from first execution %s", replayDecision.Result, decision.Result)
+	}
+}
+
+func TestReplaySideEffectRecordsOnceAndDoesNotReexecuteOnReplay(t *testing.T) {
+	calls := 0
+	definition := publicworkflow.Definition{
+		Name:    "time-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			var token string
+			if err := ctx.SideEffect("token", func() (any, error) {
+				calls++
+				return fmt.Sprintf("token-%d", calls), nil
+			}, &token); err != nil {
+				return err
+			}
+			return ctx.SetResult(map[string]string{"token": token})
+		},
+	}
+
+	base := startedHistory(t, nil)
+	decision, err := replayDefinition(definition, base, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision, got %+v", decision)
+	}
+	if calls != 1 {
+		t.Fatalf("expected side effect fn to run exactly once on first execution, ran %d times", calls)
+	}
+
+	var sideEffects []*enginehistory.WorkflowSideEffectRecordedPayload
+	for _, event := range decision.Events {
+		if event.EventType != enginehistory.EventWorkflowSideEffectRecorded {
+			continue
+		}
+		decoded, err := enginehistory.DecodePayload(event.EventType, event.Payload)
+		if err != nil {
+			t.Fatalf("DecodePayload(%s) error = %v", event.EventType, err)
+		}
+		payload, ok := decoded.(*enginehistory.WorkflowSideEffectRecordedPayload)
+		if !ok {
+			t.Fatalf("expected WorkflowSideEffectRecordedPayload, got %T", decoded)
+		}
+		sideEffects = append(sideEffects, payload)
+	}
+	if len(sideEffects) != 1 {
+		t.Fatalf("expected one workflow.side_effect_recorded event, got %d in %+v", len(sideEffects), decision.Events)
+	}
+	if sideEffects[0].SideEffectKey != "token" {
+		t.Fatalf("expected side effect key %q, got %q", "token", sideEffects[0].SideEffectKey)
+	}
+	if !equalJSON(sideEffects[0].Value, mustRawJSON(t, "token-1")) {
+		t.Fatalf("expected recorded side effect value %q, got %s", "token-1", sideEffects[0].Value)
+	}
+
+	replayRows := historyFromDecision(t, base, decision.Events, 2)
+	replayDecision, err := replayDefinition(definition, replayRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() replay error = %v", err)
+	}
+	if replayDecision.Kind != decisionCompleted {
+		t.Fatalf("expected completed replay decision, got %+v", replayDecision)
+	}
+	if calls != 1 {
+		t.Fatalf("side effect fn must not re-execute on replay, ran %d times total", calls)
+	}
+	if len(replayDecision.Events) != 0 {
+		t.Fatalf("expected no new events on replay, got %+v", replayDecision.Events)
+	}
+	if !equalJSON(replayDecision.Result, mustRawJSON(t, map[string]string{"token": "token-1"})) {
+		t.Fatalf("expected replay to return recorded token-1, got %s", replayDecision.Result)
+	}
+}
+
+func TestReplaySleepDurationSchedulesTimerAndSurvivesReplay(t *testing.T) {
+	const sleepFor = 5 * time.Minute
+
+	definition := publicworkflow.Definition{
+		Name:    "time-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			if err := ctx.Sleep("wait", sleepFor); err != nil {
+				return err
+			}
+			return ctx.SetResult(map[string]string{"status": "woke"})
+		},
+	}
+
+	base := startedHistory(t, nil)
+	before := time.Now().UTC()
+	decision, err := replayDefinition(definition, base, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	after := time.Now().UTC()
+	if decision.Kind != decisionWaiting {
+		t.Fatalf("expected waiting decision, got %+v", decision)
+	}
+	if decision.NewTimer == nil {
+		t.Fatalf("expected Sleep to schedule a new timer, got %+v", decision)
+	}
+	if decision.NewTimer.TimerKey != "wait" {
+		t.Fatalf("expected timer key %q, got %q", "wait", decision.NewTimer.TimerKey)
+	}
+	dueAt := decision.NewTimer.DueAt
+	if dueAt.Before(before.Add(sleepFor-time.Second)) || dueAt.After(after.Add(sleepFor+time.Second)) {
+		t.Fatalf("expected due-at ~now+%v, got %v (executed between %v and %v)", sleepFor, dueAt, before, after)
+	}
+	var wait enginehistory.TimerWait
+	if err := json.Unmarshal(decision.WaitingFor, &wait); err != nil {
+		t.Fatalf("decode waiting state: %v", err)
+	}
+	if wait.Kind != enginehistory.WaitKindTimer || wait.TimerKey != "wait" {
+		t.Fatalf("expected timer wait, got %+v", wait)
+	}
+
+	// Restart mid-sleep: the recorded events replay without recomputing the
+	// deadline, so no mismatch and no duplicate timer.
+	midSleepRows := historyFromDecision(t, base, decision.Events, 2)
+	midSleepDecision, err := replayDefinition(definition, midSleepRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() mid-sleep replay error = %v", err)
+	}
+	if midSleepDecision.Kind != decisionWaiting {
+		t.Fatalf("expected waiting decision on mid-sleep replay, got %+v", midSleepDecision)
+	}
+	if midSleepDecision.NewTimer != nil {
+		t.Fatalf("mid-sleep replay must not schedule a duplicate timer, got %+v", midSleepDecision.NewTimer)
+	}
+	if len(midSleepDecision.Events) != 0 {
+		t.Fatalf("expected no new events on mid-sleep replay, got %+v", midSleepDecision.Events)
+	}
+
+	// Timer fires after the restart: the run completes without mismatch.
+	firedRows := append(midSleepRows, historyRow(
+		t,
+		midSleepRows[len(midSleepRows)-1].SequenceNo+1,
+		enginehistory.EventTimerFired,
+		enginehistory.TimerFiredPayload{TimerKey: "wait"},
+	))
+	firedDecision, err := replayDefinition(definition, firedRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() post-fire replay error = %v", err)
+	}
+	if firedDecision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision after timer fired, got %+v", firedDecision)
+	}
+	if !equalJSON(firedDecision.Result, mustRawJSON(t, map[string]string{"status": "woke"})) {
+		t.Fatalf("unexpected post-sleep result %s", firedDecision.Result)
+	}
+}
+
+func TestReplaySideEffectKeyChangeFailsAsReplayMismatch(t *testing.T) {
+	recordingDefinition := publicworkflow.Definition{
+		Name:    "time-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			var token string
+			if err := ctx.SideEffect("token", func() (any, error) {
+				return "token-1", nil
+			}, &token); err != nil {
+				return err
+			}
+			return ctx.SetResult(map[string]string{"token": token})
+		},
+	}
+
+	base := startedHistory(t, nil)
+	decision, err := replayDefinition(recordingDefinition, base, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision, got %+v", decision)
+	}
+
+	changedDefinition := publicworkflow.Definition{
+		Name:    "time-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			var token string
+			if err := ctx.SideEffect("renamed", func() (any, error) {
+				return "token-1", nil
+			}, &token); err != nil {
+				return err
+			}
+			return ctx.SetResult(map[string]string{"token": token})
+		},
+	}
+
+	replayRows := historyFromDecision(t, base, decision.Events, 2)
+	mismatchDecision, err := replayDefinition(changedDefinition, replayRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() replay error = %v", err)
+	}
+	if mismatchDecision.Kind != decisionFailed {
+		t.Fatalf("expected failed decision for side effect key change, got %+v", mismatchDecision)
+	}
+	if mismatchDecision.FailureCode != "replay_mismatch" {
+		t.Fatalf("expected replay_mismatch failure code, got %q", mismatchDecision.FailureCode)
+	}
+}
+
+func TestReplayNowAgainstDifferentRecordedEventFailsAsReplayMismatch(t *testing.T) {
+	input := mustRawJSON(t, map[string]string{"name": "Ada"})
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "time-demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-time",
+			Input:             input,
+		}),
+		historyRow(t, 2, enginehistory.EventActivityScheduled, enginehistory.ActivityScheduledPayload{
+			ActivityKey:  "fetch",
+			ActivityType: "demo.activity",
+			Input:        input,
+		}),
+	}
+
+	definition := publicworkflow.Definition{
+		Name:    "time-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			now := ctx.Now()
+			return ctx.SetResult(map[string]string{"now": now.UTC().Format(time.RFC3339Nano)})
+		},
+	}
+
+	decision, err := replayDefinition(definition, historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionFailed {
+		t.Fatalf("expected failed decision when Now() faces a foreign recorded event, got %+v", decision)
+	}
+	if decision.FailureCode != "replay_mismatch" {
+		t.Fatalf("expected replay_mismatch failure code, got %q", decision.FailureCode)
+	}
+}
+
+func TestReplayTimeAPIValidation(t *testing.T) {
+	var sleepErr error
+	var sideEffectKeyErr error
+	var sideEffectFnErr error
+	fnFailure := errors.New("side effect exploded")
+
+	definition := publicworkflow.Definition{
+		Name:    "time-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			sleepErr = ctx.Sleep("", time.Second)
+
+			var out string
+			sideEffectKeyErr = ctx.SideEffect("", func() (any, error) {
+				return "never", nil
+			}, &out)
+
+			sideEffectFnErr = ctx.SideEffect("failing", func() (any, error) {
+				return nil, fnFailure
+			}, &out)
+
+			return ctx.SetResult(map[string]string{"status": "done"})
+		},
+	}
+
+	decision, err := replayDefinition(definition, startedHistory(t, nil), nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision, got %+v", decision)
+	}
+
+	if !errors.Is(sleepErr, publicworkflow.ErrEmptyKey) {
+		t.Fatalf("Sleep with empty key: want ErrEmptyKey, got %v", sleepErr)
+	}
+	if !errors.Is(sideEffectKeyErr, publicworkflow.ErrEmptyKey) {
+		t.Fatalf("SideEffect with empty key: want ErrEmptyKey, got %v", sideEffectKeyErr)
+	}
+	if !errors.Is(sideEffectFnErr, fnFailure) {
+		t.Fatalf("SideEffect fn error must propagate, got %v", sideEffectFnErr)
+	}
+
+	for _, event := range decision.Events {
+		if event.EventType == enginehistory.EventWorkflowSideEffectRecorded {
+			t.Fatalf("failed or invalid side effects must not be recorded, got %+v", decision.Events)
+		}
+		if event.EventType == enginehistory.EventTimerScheduled {
+			t.Fatalf("empty-key sleep must not schedule a timer, got %+v", decision.Events)
+		}
+	}
+}

--- a/engine/internal/workflow/replay_time_test.go
+++ b/engine/internal/workflow/replay_time_test.go
@@ -14,18 +14,19 @@ import (
 
 // historyFromDecision materializes the events queued by a prior activation into
 // history rows, simulating the durable write that precedes a crash-recovery
-// replay. startSequence is the sequence number of the first appended row.
-func historyFromDecision(t *testing.T, base []enginedb.EngineHistory, events []queuedHistoryEvent, startSequence int32) []enginedb.EngineHistory {
+// replay. Appended rows continue the base rows' sequence numbering.
+func historyFromDecision(t *testing.T, base []enginedb.EngineHistory, events []queuedHistoryEvent) []enginedb.EngineHistory {
 	t.Helper()
 
 	rows := append([]enginedb.EngineHistory(nil), base...)
+	nextSequence := base[len(base)-1].SequenceNo + 1
 	for i, event := range events {
-		rows = append(rows, historyRow(t, startSequence+int32(i), event.EventType, event.Payload))
+		rows = append(rows, historyRow(t, nextSequence+int32(i), event.EventType, event.Payload))
 	}
 	return rows
 }
 
-func startedHistory(t *testing.T, input json.RawMessage) []enginedb.EngineHistory {
+func startedHistory(t *testing.T) []enginedb.EngineHistory {
 	t.Helper()
 
 	return []enginedb.EngineHistory{
@@ -33,7 +34,6 @@ func startedHistory(t *testing.T, input json.RawMessage) []enginedb.EngineHistor
 			DefinitionName:    "time-demo",
 			DefinitionVersion: "v1",
 			InstanceKey:       "instance-time",
-			Input:             input,
 		}),
 	}
 }
@@ -52,7 +52,7 @@ func TestReplayNowRecordsOnFirstExecutionAndReplaysRecordedValue(t *testing.T) {
 		},
 	}
 
-	base := startedHistory(t, nil)
+	base := startedHistory(t)
 	before := time.Now().UTC()
 	decision, err := replayDefinition(definition, base, nil, nil)
 	if err != nil {
@@ -99,7 +99,7 @@ func TestReplayNowRecordsOnFirstExecutionAndReplaysRecordedValue(t *testing.T) {
 	}
 
 	// Crash-recovery replay: the recorded events are durable history now.
-	replayRows := historyFromDecision(t, base, decision.Events, 2)
+	replayRows := historyFromDecision(t, base, decision.Events)
 	replayDecision, err := replayDefinition(definition, replayRows, nil, nil)
 	if err != nil {
 		t.Fatalf("replayDefinition() replay error = %v", err)
@@ -132,7 +132,7 @@ func TestReplaySideEffectRecordsOnceAndDoesNotReexecuteOnReplay(t *testing.T) {
 		},
 	}
 
-	base := startedHistory(t, nil)
+	base := startedHistory(t)
 	decision, err := replayDefinition(definition, base, nil, nil)
 	if err != nil {
 		t.Fatalf("replayDefinition() error = %v", err)
@@ -169,7 +169,7 @@ func TestReplaySideEffectRecordsOnceAndDoesNotReexecuteOnReplay(t *testing.T) {
 		t.Fatalf("expected recorded side effect value %q, got %s", "token-1", sideEffects[0].Value)
 	}
 
-	replayRows := historyFromDecision(t, base, decision.Events, 2)
+	replayRows := historyFromDecision(t, base, decision.Events)
 	replayDecision, err := replayDefinition(definition, replayRows, nil, nil)
 	if err != nil {
 		t.Fatalf("replayDefinition() replay error = %v", err)
@@ -202,7 +202,7 @@ func TestReplaySleepDurationSchedulesTimerAndSurvivesReplay(t *testing.T) {
 		},
 	}
 
-	base := startedHistory(t, nil)
+	base := startedHistory(t)
 	before := time.Now().UTC()
 	decision, err := replayDefinition(definition, base, nil, nil)
 	if err != nil {
@@ -232,7 +232,7 @@ func TestReplaySleepDurationSchedulesTimerAndSurvivesReplay(t *testing.T) {
 
 	// Restart mid-sleep: the recorded events replay without recomputing the
 	// deadline, so no mismatch and no duplicate timer.
-	midSleepRows := historyFromDecision(t, base, decision.Events, 2)
+	midSleepRows := historyFromDecision(t, base, decision.Events)
 	midSleepDecision, err := replayDefinition(definition, midSleepRows, nil, nil)
 	if err != nil {
 		t.Fatalf("replayDefinition() mid-sleep replay error = %v", err)
@@ -281,7 +281,7 @@ func TestReplaySideEffectKeyChangeFailsAsReplayMismatch(t *testing.T) {
 		},
 	}
 
-	base := startedHistory(t, nil)
+	base := startedHistory(t)
 	decision, err := replayDefinition(recordingDefinition, base, nil, nil)
 	if err != nil {
 		t.Fatalf("replayDefinition() error = %v", err)
@@ -304,7 +304,7 @@ func TestReplaySideEffectKeyChangeFailsAsReplayMismatch(t *testing.T) {
 		},
 	}
 
-	replayRows := historyFromDecision(t, base, decision.Events, 2)
+	replayRows := historyFromDecision(t, base, decision.Events)
 	mismatchDecision, err := replayDefinition(changedDefinition, replayRows, nil, nil)
 	if err != nil {
 		t.Fatalf("replayDefinition() replay error = %v", err)
@@ -379,7 +379,7 @@ func TestReplayTimeAPIValidation(t *testing.T) {
 		},
 	}
 
-	decision, err := replayDefinition(definition, startedHistory(t, nil), nil, nil)
+	decision, err := replayDefinition(definition, startedHistory(t), nil, nil)
 	if err != nil {
 		t.Fatalf("replayDefinition() error = %v", err)
 	}

--- a/engine/pkg/history/history.go
+++ b/engine/pkg/history/history.go
@@ -7,31 +7,33 @@ import (
 )
 
 const (
-	EventWorkflowStarted         = "workflow.started"
-	EventWorkflowCompleted       = "workflow.completed"
-	EventWorkflowFailed          = "workflow.failed"
-	EventWorkflowCancelled       = "workflow.cancelled"
-	EventWorkflowContinuedAsNew  = "workflow.continued_as_new"
-	EventWorkflowSuspended       = "workflow.suspended"
-	EventWorkflowResumed         = "workflow.resumed"
-	EventWorkflowTerminated      = "workflow.terminated"
-	EventWorkflowReplayMismatch  = "workflow.replay_mismatch"
-	EventActivityScheduled       = "activity.scheduled"
-	EventActivityCompleted       = "activity.completed"
-	EventActivityFailed          = "activity.failed"
-	EventActivityRetryScheduled  = "activity.retry_scheduled"
-	EventChildWorkflowScheduled  = "child_workflow.scheduled"
-	EventChildWorkflowStarted    = "child_workflow.started"
-	EventChildWorkflowCompleted  = "child_workflow.completed"
-	EventChildWorkflowFailed     = "child_workflow.failed"
-	EventChildWorkflowCancelled  = "child_workflow.cancelled"
-	EventChildWorkflowTerminated = "child_workflow.terminated"
-	EventChildWorkflowWaitFailed = "child_workflow.wait_failed"
-	EventTimerScheduled          = "timer.scheduled"
-	EventTimerFired              = "timer.fired"
-	EventSignalReceived          = "signal.received"
-	EventCancelRequested         = "cancel.requested"
-	EventCustomStatusUpdated     = "custom_status.updated"
+	EventWorkflowStarted            = "workflow.started"
+	EventWorkflowCompleted          = "workflow.completed"
+	EventWorkflowFailed             = "workflow.failed"
+	EventWorkflowCancelled          = "workflow.cancelled"
+	EventWorkflowContinuedAsNew     = "workflow.continued_as_new"
+	EventWorkflowSuspended          = "workflow.suspended"
+	EventWorkflowResumed            = "workflow.resumed"
+	EventWorkflowTerminated         = "workflow.terminated"
+	EventWorkflowReplayMismatch     = "workflow.replay_mismatch"
+	EventWorkflowTimeRecorded       = "workflow.time_recorded"
+	EventWorkflowSideEffectRecorded = "workflow.side_effect_recorded"
+	EventActivityScheduled          = "activity.scheduled"
+	EventActivityCompleted          = "activity.completed"
+	EventActivityFailed             = "activity.failed"
+	EventActivityRetryScheduled     = "activity.retry_scheduled"
+	EventChildWorkflowScheduled     = "child_workflow.scheduled"
+	EventChildWorkflowStarted       = "child_workflow.started"
+	EventChildWorkflowCompleted     = "child_workflow.completed"
+	EventChildWorkflowFailed        = "child_workflow.failed"
+	EventChildWorkflowCancelled     = "child_workflow.cancelled"
+	EventChildWorkflowTerminated    = "child_workflow.terminated"
+	EventChildWorkflowWaitFailed    = "child_workflow.wait_failed"
+	EventTimerScheduled             = "timer.scheduled"
+	EventTimerFired                 = "timer.fired"
+	EventSignalReceived             = "signal.received"
+	EventCancelRequested            = "cancel.requested"
+	EventCustomStatusUpdated        = "custom_status.updated"
 )
 
 const (
@@ -78,6 +80,15 @@ type WorkflowReplayMismatchPayload struct {
 	ActualType   string `json:"actual_type"`
 	ActualKey    string `json:"actual_key"`
 	Detail       string `json:"detail"`
+}
+
+type WorkflowTimeRecordedPayload struct {
+	Now time.Time `json:"now"`
+}
+
+type WorkflowSideEffectRecordedPayload struct {
+	SideEffectKey string          `json:"side_effect_key"`
+	Value         json.RawMessage `json:"value"`
 }
 
 type ActivityScheduledPayload struct {
@@ -313,6 +324,10 @@ func EventKey(eventType string, payload any) string {
 		return value.SignalName
 	case *SignalReceivedPayload:
 		return value.SignalName
+	case WorkflowSideEffectRecordedPayload:
+		return value.SideEffectKey
+	case *WorkflowSideEffectRecordedPayload:
+		return value.SideEffectKey
 	default:
 		return ""
 	}
@@ -338,6 +353,10 @@ func payloadTarget(eventType string) (any, error) {
 		return &WorkflowTerminatedPayload{}, nil
 	case EventWorkflowReplayMismatch:
 		return &WorkflowReplayMismatchPayload{}, nil
+	case EventWorkflowTimeRecorded:
+		return &WorkflowTimeRecordedPayload{}, nil
+	case EventWorkflowSideEffectRecorded:
+		return &WorkflowSideEffectRecordedPayload{}, nil
 	case EventActivityScheduled:
 		return &ActivityScheduledPayload{}, nil
 	case EventActivityCompleted:

--- a/engine/pkg/workflow/context.go
+++ b/engine/pkg/workflow/context.go
@@ -68,7 +68,10 @@ type Context interface {
 	ActivityWithOptions(key, activityType string, input any, out any, opts ActivityOptions) error
 	ChildWorkflow(childKey, definitionName, definitionVersion string, input any, out any) error
 	ChildWorkflowWithOptions(childKey, definitionName, definitionVersion string, input any, out any, opts ChildWorkflowOptions) error
+	Now() time.Time
+	Sleep(key string, d time.Duration) error
 	SleepUntil(key string, at time.Time) error
+	SideEffect(key string, fn func() (any, error), out any) error
 	ReceiveSignal(name string, out any) error
 	CancellationRequested() bool
 	SetCustomStatus(value any) error


### PR DESCRIPTION
## What / why

The workflow `Context` had no deterministic time source: `ctx.SleepUntil("wait", time.Now().Add(5*time.Minute))` recomputes a different deadline on crash-recovery replay, and replay's `DueAt` comparison then permanently fails the run with `replay_mismatch`. There was also no safe way to branch on time or capture randomness in workflow code. This adds the record-on-first-execution / read-on-replay time APIs from the Phase 1 correctness spine.

## What changed

- New history events `workflow.time_recorded` and `workflow.side_effect_recorded` (`engine/pkg/history` + internal aliases), wired into `DecodePayload`/`EventKey`.
- `Context` gains `Now() time.Time`, `Sleep(key string, d time.Duration) error`, and `SideEffect(key string, fn func() (any, error), out any) error`, implemented in `workflowRunner` with the existing cursor/mismatch replay pattern: values are recorded to history on first execution and returned verbatim on replay; side-effect fns never re-execute; `Sleep` derives its deadline from a recorded base time so replay recomputes an identical `DueAt`. Genuine code changes still fail as `replay_mismatch`.
- New `darklaunch.sleep-demo@v1` definition exercising `Sleep(duration)`.
- Determinism authoring guidance in `docs-site/concepts/engine-foundation.mdx`.

No contract/SQL/migration changes; `make generate` not needed.

## Process

TDD split: orchestrator-authored acceptance tests committed first (red) in `5ea5079` — `engine/internal/workflow/replay_time_test.go` (record/replay identity for Now, single-execution SideEffect, replay-stable Sleep timers mid-wait and post-fire, two genuine-code-change mismatch cases, key/error validation) and `engine/cmd/continua-engine/runtime_time_api_e2e_test.go` (mid-sleep serve restart completes without `replay_mismatch`). Codex implemented against that spec in `00cdfe4`; the test commit was verified untouched.

## Verification

- `go build ./...` and `go vet ./...` clean (engine module)
- `go test ./...` in `engine/`: all 11 packages pass against real Postgres, including the new acceptance tests
- `gofmt -l engine/` clean

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic workflow APIs for reading replay-stable time, sleeping by duration, and recording one-time side effects.
  * Workflows can now survive restarts mid-execution without changing recorded behavior.
  * Added a new demo workflow that waits, receives approval, and returns a greeting plus the approval result.

* **Documentation**
  * Expanded the engine concepts guide with guidance on writing deterministic workflows and using the new time-related APIs correctly.

* **Bug Fixes**
  * Improved replay consistency by preventing duplicate timers and replay mismatches after crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->