### PR TITLE
feat(engine): workflow code versioning (GetVersion) for in-flight runs

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -42,6 +42,7 @@
           {
             "group": "Workflows",
             "pages": [
+              "guides/workflow-code-versioning",
               "guides/debugging-failures",
               "guides/comparing-sessions"
             ]

--- a/docs-site/guides/workflow-code-versioning.mdx
+++ b/docs-site/guides/workflow-code-versioning.mdx
@@ -1,0 +1,101 @@
+---
+title: "Workflow code versioning"
+description: "Safely deploy durable workflow code changes while runs are still in flight."
+---
+
+The durable engine replays workflow code against recorded history. If deployed code
+changes which commands a run emits, old in-flight runs can fail replay unless the change
+is versioned.
+
+Use this guide for single-node preview deployments of Go workflow definitions.
+
+<Warning>
+  The durable engine is still preview. These rules describe the current Go-defined
+  runtime and dark-launch CLI behavior, not a production multi-node rollout protocol.
+</Warning>
+
+## Safe deploy rule
+
+Before deploying a workflow code change, decide whether existing runs for the same
+definition name and version might still be active.
+
+- If no runs are in flight, deploy normally.
+- If runs are in flight and the command sequence changes, guard the change with
+  `ctx.GetVersion`.
+- If the change is a new definition contract, register a new `definition_version`
+  instead.
+
+The run row stores `definition_version` when the run starts. Existing runs continue to
+load that exact definition version during activation, while new runs can bind to a newer
+registered version.
+
+## Use GetVersion for in-place behavior changes
+
+Use `ctx.GetVersion(changeID, minSupported, maxSupported)` when you need to change the
+behavior of an existing definition version without breaking runs that already started.
+
+Example:
+
+```go
+version := ctx.GetVersion("approval-gate", 1, 2)
+
+if version >= 2 {
+    // New runs record version 2 and take the new branch.
+    return ctx.SetResult(newResult)
+}
+
+// Marker-less old runs return minSupported, so they keep the old command sequence.
+if err := ctx.ReceiveSignal("approval", &approval); err != nil {
+    return err
+}
+return ctx.SetResult(oldResult)
+```
+
+On first execution, `GetVersion` records a `workflow.version_marker` event with
+`maxSupported` and returns that value. On replay, the recorded marker controls the branch.
+If a run started before the `GetVersion` call existed, the next history event is not a
+version marker, so `GetVersion` returns `minSupported` without recording anything. The old
+run keeps following the old branch.
+
+## Use definition versions for contract changes
+
+Bump `definition_version` when the new code should be a distinct workflow definition
+contract:
+
+- Input or result schema changes.
+- Activity or child workflow contracts change.
+- Operators should be able to start old and new definitions explicitly.
+- Old runs should stay pinned to the old registered definition implementation.
+
+When the dark-launch `continua-engine start` command omits `--version`, the runtime
+resolves the latest registered version for `--definition` and pins that version into the
+new run. Latest is numeric-aware: versions with trailing integers sort by that integer,
+so `v10` is newer than `v2`; non-numeric versions fall back to lexicographic ordering.
+
+Explicit `--version` keeps exact-match behavior. If the requested definition name or
+version is not registered, the command returns `definition_not_registered`.
+
+## Dropping old branches
+
+Do not raise `minSupported` until all runs that recorded or imply the older branch are
+terminal.
+
+If a replay sees a recorded `workflow.version_marker` whose version is below
+`minSupported`, the workflow fails in a controlled way with failure code
+`version_unsupported`. This is not a replay mismatch: it means the deployed code
+intentionally no longer supports that in-flight branch.
+
+## Single-node upgrade playbook
+
+1. Check whether the definition version has non-terminal runs.
+2. For in-place behavior changes, add `GetVersion` before the first changed command and
+   keep the old branch byte-for-byte compatible with existing history.
+3. For new contracts, register a higher `definition_version` and start new runs on that
+   version.
+4. Deploy the new binary.
+5. Let old runs drain. Keep old `GetVersion` branches until every affected run is
+   terminal.
+6. After old runs drain, raise `minSupported` or remove the old branch in a later deploy.
+
+For long waits on human signals, prefer keeping compatibility branches longer than the
+expected maximum wait time.

--- a/engine/cmd/continua-engine/internal/darklaunch/workflow.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/workflow.go
@@ -1,6 +1,7 @@
 package darklaunch
 
 import (
+	"os"
 	"time"
 
 	"github.com/continua-ai/continua/engine/pkg/workflow"
@@ -21,6 +22,12 @@ const (
 	InvalidRetryDefinitionVersion    = "v1"
 	SleepDemoDefinitionName          = "darklaunch.sleep-demo"
 	SleepDemoDefinitionVersion       = "v1"
+	VersionDemoDefinitionName        = "darklaunch.version-demo"
+	VersionDemoDefinitionVersion     = "v1"
+	VersionDemoChangeID              = "approval-gate"
+	TestVersionDemoCodeEnv           = "CONTINUA_ENGINE_TEST_VERSION_DEMO_CODE"
+	VersionDemoCodeOld               = "old"
+	VersionDemoCodeNew               = "new"
 )
 
 type WorkflowInput struct {
@@ -79,6 +86,11 @@ func Definitions() []workflow.Definition {
 			Version: SleepDemoDefinitionVersion,
 			Run:     runSleepDemoWorkflow,
 		},
+		{
+			Name:    VersionDemoDefinitionName,
+			Version: VersionDemoDefinitionVersion,
+			Run:     runVersionDemoWorkflow,
+		},
 	}
 }
 
@@ -134,6 +146,74 @@ func runSleepDemoWorkflow(ctx workflow.Context) error {
 	return ctx.SetResult(WorkflowResult{
 		Greeting: "hello, " + input.Name,
 		Approval: signal.Approval,
+	})
+}
+
+func runVersionDemoWorkflow(ctx workflow.Context) error {
+	if os.Getenv(TestVersionDemoCodeEnv) == VersionDemoCodeNew {
+		return runVersionDemoNewWorkflow(ctx)
+	}
+	return runVersionDemoOldWorkflow(ctx)
+}
+
+func runVersionDemoOldWorkflow(ctx workflow.Context) error {
+	var input WorkflowInput
+	if err := ctx.Input(&input); err != nil {
+		return err
+	}
+	if input.Name == "" {
+		input.Name = "world"
+	}
+
+	var activityOutput ActivityOutput
+	if err := ctx.Activity("greet", DemoActivityType, ActivityInput{Name: input.Name}, &activityOutput); err != nil {
+		return err
+	}
+
+	var signal SignalPayload
+	if err := ctx.ReceiveSignal("approval", &signal); err != nil {
+		return err
+	}
+
+	return ctx.SetResult(map[string]string{
+		"branch":   "old",
+		"greeting": activityOutput.Greeting,
+		"approval": signal.Approval,
+	})
+}
+
+func runVersionDemoNewWorkflow(ctx workflow.Context) error {
+	version := ctx.GetVersion(VersionDemoChangeID, 1, 2)
+
+	var input WorkflowInput
+	if err := ctx.Input(&input); err != nil {
+		return err
+	}
+	if input.Name == "" {
+		input.Name = "world"
+	}
+
+	var activityOutput ActivityOutput
+	if err := ctx.Activity("greet", DemoActivityType, ActivityInput{Name: input.Name}, &activityOutput); err != nil {
+		return err
+	}
+
+	if version >= 2 {
+		return ctx.SetResult(map[string]string{
+			"branch":   "new",
+			"greeting": activityOutput.Greeting,
+		})
+	}
+
+	var signal SignalPayload
+	if err := ctx.ReceiveSignal("approval", &signal); err != nil {
+		return err
+	}
+
+	return ctx.SetResult(map[string]string{
+		"branch":   "old",
+		"greeting": activityOutput.Greeting,
+		"approval": signal.Approval,
 	})
 }
 

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -143,8 +143,8 @@ func startCmd() *cobra.Command {
 		Use:   "start",
 		Short: "Start a dark-launch workflow instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if instanceKey == "" || definitionName == "" || definitionVersion == "" || requestKey == "" {
-				return writeJSONError(cmd.OutOrStdout(), "internal_error", "start requires --instance-key, --definition, --version, and --request-key")
+			if instanceKey == "" || definitionName == "" || requestKey == "" {
+				return writeJSONError(cmd.OutOrStdout(), "internal_error", "start requires --instance-key, --definition, and --request-key")
 			}
 
 			inputPayload, err := parseOptionalJSON(input)
@@ -153,9 +153,14 @@ func startCmd() *cobra.Command {
 			}
 
 			err = withRuntime(cmd.Context(), func(ctx context.Context, cfg *config.Config, store *enginestore.Store, definitions *engineworkflow.Registry, _ *activity.Registry) error {
-				if _, ok := definitions.Get(definitionName, definitionVersion); !ok {
+				resolvedVersion, ok := resolveStartDefinitionVersion(definitions, definitionName, definitionVersion)
+				if !ok {
+					if definitionVersion == "" {
+						return writeJSONError(cmd.OutOrStdout(), "definition_not_registered", fmt.Sprintf("definition %s is not registered", definitionName))
+					}
 					return writeJSONError(cmd.OutOrStdout(), "definition_not_registered", fmt.Sprintf("definition %s@%s is not registered", definitionName, definitionVersion))
 				}
+				definitionVersion = resolvedVersion
 
 				tx, err := store.BeginTx(ctx, pgx.TxOptions{})
 				if err != nil {
@@ -580,6 +585,21 @@ func buildRegistries() (definitions *engineworkflow.Registry, activities *activi
 		return nil, nil, err
 	}
 	return definitions, activities, nil
+}
+
+func resolveStartDefinitionVersion(definitions *engineworkflow.Registry, definitionName, definitionVersion string) (string, bool) {
+	if definitionVersion != "" {
+		if _, ok := definitions.Get(definitionName, definitionVersion); !ok {
+			return "", false
+		}
+		return definitionVersion, true
+	}
+
+	definition, ok := definitions.Latest(definitionName)
+	if !ok {
+		return "", false
+	}
+	return definition.Version, true
 }
 
 func loadInstanceState(

--- a/engine/cmd/continua-engine/runtime_commands_unit_test.go
+++ b/engine/cmd/continua-engine/runtime_commands_unit_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+
+	engineworkflow "github.com/continua-ai/continua/engine/internal/workflow"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestResolveStartDefinitionVersionOmittedUsesLatestRegisteredVersion(t *testing.T) {
+	run := func(publicworkflow.Context) error { return nil }
+	registry, err := engineworkflow.NewRegistry(
+		publicworkflow.Definition{Name: "demo", Version: "v1", Run: run},
+		publicworkflow.Definition{Name: "demo", Version: "v10", Run: run},
+		publicworkflow.Definition{Name: "demo", Version: "v2", Run: run},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	version, ok := resolveStartDefinitionVersion(registry, "demo", "")
+	if !ok {
+		t.Fatalf("resolveStartDefinitionVersion() returned ok=false")
+	}
+	if version != "v10" {
+		t.Fatalf("resolved version = %q, want v10", version)
+	}
+}
+
+func TestResolveStartDefinitionVersionExplicitUsesExactMatch(t *testing.T) {
+	run := func(publicworkflow.Context) error { return nil }
+	registry, err := engineworkflow.NewRegistry(
+		publicworkflow.Definition{Name: "demo", Version: "v1", Run: run},
+		publicworkflow.Definition{Name: "demo", Version: "v2", Run: run},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	version, ok := resolveStartDefinitionVersion(registry, "demo", "v1")
+	if !ok {
+		t.Fatalf("resolveStartDefinitionVersion() returned ok=false")
+	}
+	if version != "v1" {
+		t.Fatalf("resolved version = %q, want v1", version)
+	}
+
+	if _, ok := resolveStartDefinitionVersion(registry, "demo", "v10"); ok {
+		t.Fatalf("resolveStartDefinitionVersion() returned ok=true for unregistered explicit version")
+	}
+}

--- a/engine/cmd/continua-engine/runtime_version_swap_e2e_test.go
+++ b/engine/cmd/continua-engine/runtime_version_swap_e2e_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+
+	"github.com/continua-ai/continua/engine/cmd/continua-engine/internal/darklaunch"
+)
+
+// A definition swap between restarts must not fail in-flight runs: the run
+// started under the old code completes its old branch under the new
+// GetVersion-guarded code, while a fresh run takes the new branch and records
+// a workflow.version_marker in history.
+func TestEngineRuntimeDefinitionSwapKeepsInFlightRunOnOldBranch(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+	t.Setenv(darklaunch.TestVersionDemoCodeEnv, darklaunch.VersionDemoCodeOld)
+
+	serve := startServe(t)
+
+	inFlightKey := "runtime-version-swap-inflight"
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", inFlightKey,
+		"--definition", darklaunch.VersionDemoDefinitionName,
+		"--version", darklaunch.VersionDemoDefinitionVersion,
+		"--request-key", "req-version-swap-inflight",
+		"--input", `{"name":"Ada"}`,
+	); err != nil {
+		t.Fatalf("start version demo workflow under old code: %v", err)
+	}
+
+	waitForInspect(t, inFlightKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusWaiting) &&
+			jsonContainsKind(state.WaitingFor, "signal")
+	})
+	serve.stop(t)
+
+	// Deploy the new code while the run is waiting on its approval signal.
+	t.Setenv(darklaunch.TestVersionDemoCodeEnv, darklaunch.VersionDemoCodeNew)
+	serve = startServe(t)
+	defer serve.stop(t)
+
+	if _, _, err := executeCommand(t,
+		"signal",
+		"--instance-key", inFlightKey,
+		"--signal-name", "approval",
+		"--payload", `{"approval":"swap-approved"}`,
+	); err != nil {
+		t.Fatalf("signal in-flight run after definition swap: %v", err)
+	}
+
+	inFlightState := waitForInspect(t, inFlightKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusCompleted)
+	})
+
+	var inFlightResult map[string]string
+	if err := json.Unmarshal(inFlightState.Result, &inFlightResult); err != nil {
+		t.Fatalf("Unmarshal(in-flight result) error = %v", err)
+	}
+	if inFlightResult["branch"] != "old" {
+		t.Fatalf("in-flight run must complete its old branch under new code, got %+v", inFlightResult)
+	}
+	if inFlightResult["greeting"] != "hello, Ada" || inFlightResult["approval"] != "swap-approved" {
+		t.Fatalf("unexpected in-flight old-branch result: %+v", inFlightResult)
+	}
+	for _, event := range inFlightState.History {
+		if event.EventType == enginehistory.EventWorkflowReplayMismatch {
+			t.Fatalf("in-flight run hit replay_mismatch after definition swap: %+v", event)
+		}
+		if event.EventType == enginehistory.EventWorkflowVersionMarker {
+			t.Fatalf("marker-less old run must not gain a version marker, got %+v", event)
+		}
+	}
+
+	// A fresh run under the new code takes the new branch and records the
+	// version marker.
+	newRunKey := "runtime-version-swap-new"
+	if _, _, err := executeCommand(t,
+		"start",
+		"--instance-key", newRunKey,
+		"--definition", darklaunch.VersionDemoDefinitionName,
+		"--version", darklaunch.VersionDemoDefinitionVersion,
+		"--request-key", "req-version-swap-new",
+		"--input", `{"name":"Grace"}`,
+	); err != nil {
+		t.Fatalf("start version demo workflow under new code: %v", err)
+	}
+
+	newRunState := waitForInspect(t, newRunKey, func(state inspectResponse) bool {
+		return state.Status == string(enginedb.EngineRunLifecycleStatusCompleted)
+	})
+
+	var newRunResult map[string]string
+	if err := json.Unmarshal(newRunState.Result, &newRunResult); err != nil {
+		t.Fatalf("Unmarshal(new run result) error = %v", err)
+	}
+	if newRunResult["branch"] != "new" {
+		t.Fatalf("new run must take the new branch, got %+v", newRunResult)
+	}
+	if newRunResult["greeting"] != "hello, Grace" {
+		t.Fatalf("unexpected new-branch result: %+v", newRunResult)
+	}
+
+	var markers []enginehistory.WorkflowVersionMarkerPayload
+	for _, event := range newRunState.History {
+		if event.EventType == enginehistory.EventWorkflowReplayMismatch {
+			t.Fatalf("new run hit replay_mismatch: %+v", event)
+		}
+		if event.EventType != enginehistory.EventWorkflowVersionMarker {
+			continue
+		}
+		var payload enginehistory.WorkflowVersionMarkerPayload
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("Unmarshal(version marker payload) error = %v", err)
+		}
+		markers = append(markers, payload)
+	}
+	if len(markers) != 1 {
+		t.Fatalf("expected exactly one workflow.version_marker in new run history, got %d in %+v", len(markers), newRunState.History)
+	}
+	if markers[0].ChangeID != darklaunch.VersionDemoChangeID || markers[0].Version != 2 {
+		t.Fatalf("expected version marker {%s, 2}, got %+v", darklaunch.VersionDemoChangeID, markers[0])
+	}
+}

--- a/engine/internal/history/events.go
+++ b/engine/internal/history/events.go
@@ -18,6 +18,7 @@ const (
 	EventWorkflowReplayMismatch     = publichistory.EventWorkflowReplayMismatch
 	EventWorkflowTimeRecorded       = publichistory.EventWorkflowTimeRecorded
 	EventWorkflowSideEffectRecorded = publichistory.EventWorkflowSideEffectRecorded
+	EventWorkflowVersionMarker      = publichistory.EventWorkflowVersionMarker
 	EventActivityScheduled          = publichistory.EventActivityScheduled
 	EventActivityCompleted          = publichistory.EventActivityCompleted
 	EventActivityFailed             = publichistory.EventActivityFailed
@@ -54,6 +55,7 @@ type WorkflowTerminatedPayload = publichistory.WorkflowTerminatedPayload
 type WorkflowReplayMismatchPayload = publichistory.WorkflowReplayMismatchPayload
 type WorkflowTimeRecordedPayload = publichistory.WorkflowTimeRecordedPayload
 type WorkflowSideEffectRecordedPayload = publichistory.WorkflowSideEffectRecordedPayload
+type WorkflowVersionMarkerPayload = publichistory.WorkflowVersionMarkerPayload
 type ActivityScheduledPayload = publichistory.ActivityScheduledPayload
 type ActivityCompletedPayload = publichistory.ActivityCompletedPayload
 type ActivityFailedPayload = publichistory.ActivityFailedPayload

--- a/engine/internal/workflow/registry.go
+++ b/engine/internal/workflow/registry.go
@@ -101,7 +101,7 @@ func trailingVersionNumber(version string) (int64, bool) {
 	end := len(version)
 	start := end
 	for start > 0 {
-		r, size := utf8LastRuneInString(version[:start])
+		r, size := utf8.DecodeLastRuneInString(version[:start])
 		if !unicode.IsDigit(r) {
 			break
 		}
@@ -116,8 +116,4 @@ func trailingVersionNumber(version string) (int64, bool) {
 		return 0, false
 	}
 	return number, true
-}
-
-func utf8LastRuneInString(value string) (rune, int) {
-	return utf8.DecodeLastRuneInString(value)
 }

--- a/engine/internal/workflow/registry.go
+++ b/engine/internal/workflow/registry.go
@@ -2,6 +2,10 @@ package workflow
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
 )
@@ -44,6 +48,29 @@ func (r *Registry) Get(name, version string) (publicworkflow.Definition, bool) {
 	return definition, ok
 }
 
+// Latest returns the highest registered version for name. Version comparison is
+// numeric-aware: if both versions end in digits, the trailing integers are
+// compared first so v10 sorts after v2; ties and non-numeric versions fall back
+// to lexicographic ordering.
+func (r *Registry) Latest(name string) (publicworkflow.Definition, bool) {
+	if r == nil {
+		return publicworkflow.Definition{}, false
+	}
+
+	var latest publicworkflow.Definition
+	found := false
+	for key, definition := range r.definitions {
+		if key.name != name {
+			continue
+		}
+		if !found || compareDefinitionVersions(definition.Version, latest.Version) > 0 {
+			latest = definition
+			found = true
+		}
+	}
+	return latest, found
+}
+
 func (r *Registry) List() []publicworkflow.Definition {
 	if r == nil {
 		return nil
@@ -55,4 +82,42 @@ func (r *Registry) List() []publicworkflow.Definition {
 	}
 
 	return definitions
+}
+
+func compareDefinitionVersions(left, right string) int {
+	leftNumber, leftOK := trailingVersionNumber(left)
+	rightNumber, rightOK := trailingVersionNumber(right)
+	if leftOK && rightOK && leftNumber != rightNumber {
+		if leftNumber > rightNumber {
+			return 1
+		}
+		return -1
+	}
+
+	return strings.Compare(left, right)
+}
+
+func trailingVersionNumber(version string) (int64, bool) {
+	end := len(version)
+	start := end
+	for start > 0 {
+		r, size := utf8LastRuneInString(version[:start])
+		if !unicode.IsDigit(r) {
+			break
+		}
+		start -= size
+	}
+	if start == end {
+		return 0, false
+	}
+
+	number, err := strconv.ParseInt(version[start:end], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return number, true
+}
+
+func utf8LastRuneInString(value string) (rune, int) {
+	return utf8.DecodeLastRuneInString(value)
 }

--- a/engine/internal/workflow/registry_test.go
+++ b/engine/internal/workflow/registry_test.go
@@ -1,0 +1,58 @@
+package workflow
+
+import (
+	"testing"
+
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestRegistryLatestUsesNumericAwareVersionOrdering(t *testing.T) {
+	run := func(publicworkflow.Context) error { return nil }
+	registry, err := NewRegistry(
+		publicworkflow.Definition{Name: "demo", Version: "v2", Run: run},
+		publicworkflow.Definition{Name: "demo", Version: "v10", Run: run},
+		publicworkflow.Definition{Name: "demo", Version: "v3", Run: run},
+		publicworkflow.Definition{Name: "other", Version: "v99", Run: run},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	definition, ok := registry.Latest("demo")
+	if !ok {
+		t.Fatalf("Latest(demo) returned ok=false")
+	}
+	if definition.Version != "v10" {
+		t.Fatalf("Latest(demo) version = %q, want v10", definition.Version)
+	}
+}
+
+func TestRegistryLatestFallsBackToLexicographicForNonNumericVersions(t *testing.T) {
+	run := func(publicworkflow.Context) error { return nil }
+	registry, err := NewRegistry(
+		publicworkflow.Definition{Name: "demo", Version: "beta", Run: run},
+		publicworkflow.Definition{Name: "demo", Version: "alpha", Run: run},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	definition, ok := registry.Latest("demo")
+	if !ok {
+		t.Fatalf("Latest(demo) returned ok=false")
+	}
+	if definition.Version != "beta" {
+		t.Fatalf("Latest(demo) version = %q, want beta", definition.Version)
+	}
+}
+
+func TestRegistryLatestMissingDefinition(t *testing.T) {
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	if _, ok := registry.Latest("missing"); ok {
+		t.Fatalf("Latest(missing) returned ok=true")
+	}
+}

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -125,6 +125,10 @@ type replayMismatchPanic struct {
 	payload enginehistory.WorkflowReplayMismatchPayload
 }
 
+type controlledFailurePanic struct {
+	failure enginehistory.WorkflowFailedPayload
+}
+
 type codedWorkflowError struct {
 	code    string
 	message string
@@ -352,6 +356,9 @@ func (r *workflowRunner) execute(definition publicworkflow.Definition) (decision
 			}
 			r.queueEvent(enginehistory.EventWorkflowFailed, failure)
 			decision = r.failedDecision(failure)
+			err = nil
+		case controlledFailurePanic:
+			decision = r.recordWorkflowFailure(value.failure)
 			err = nil
 		default:
 			panicMessage := fmt.Sprintf("workflow panic: %v", value)
@@ -823,6 +830,44 @@ func (r *workflowRunner) SideEffect(key string, fn func() (any, error), out any)
 	return unmarshalOptional(recorded.Value, out)
 }
 
+func (r *workflowRunner) GetVersion(changeID string, minSupported, maxSupported int) int {
+	r.advanceState()
+	if changeID == "" {
+		r.failControlled("version_invalid", "workflow version change_id is required")
+	}
+	if minSupported < 1 {
+		r.failControlled("version_invalid", "workflow version min_supported must be at least 1")
+	}
+	if minSupported > maxSupported {
+		r.failControlled("version_invalid", "workflow version min_supported must be less than or equal to max_supported")
+	}
+	if maxSupported > int(^uint32(0)>>1) {
+		r.failControlled("version_invalid", "workflow version max_supported exceeds int32")
+	}
+
+	if next, ok := r.peek(); ok {
+		recorded, ok := next.Payload.(*enginehistory.WorkflowVersionMarkerPayload)
+		if !ok {
+			return minSupported
+		}
+		if recorded.ChangeID != changeID {
+			r.replayMismatch(enginehistory.EventWorkflowVersionMarker, changeID, next, "workflow version marker did not match recorded history")
+		}
+		r.cursor++
+		if recorded.Version < int32(minSupported) {
+			r.failControlled("version_unsupported", fmt.Sprintf("workflow version %d for change %q is below min_supported %d", recorded.Version, changeID, minSupported))
+		}
+		return int(recorded.Version)
+	}
+
+	recorded := enginehistory.WorkflowVersionMarkerPayload{
+		ChangeID: changeID,
+		Version:  int32(maxSupported),
+	}
+	r.queueEvent(enginehistory.EventWorkflowVersionMarker, recorded)
+	return maxSupported
+}
+
 func (r *workflowRunner) ReceiveSignal(name string, out any) error {
 	r.advanceState()
 	if next, ok := r.peek(); ok {
@@ -969,6 +1014,31 @@ func (r *workflowRunner) replayMismatch(expectedType, expectedKey string, actual
 			Detail:       detail,
 		},
 	})
+}
+
+func (r *workflowRunner) failControlled(code, message string) {
+	panic(controlledFailurePanic{
+		failure: enginehistory.WorkflowFailedPayload{
+			ErrorCode:    code,
+			ErrorMessage: message,
+		},
+	})
+}
+
+func (r *workflowRunner) recordWorkflowFailure(failure enginehistory.WorkflowFailedPayload) activationDecision {
+	if next, ok := r.peek(); ok {
+		recorded, ok := next.Payload.(*enginehistory.WorkflowFailedPayload)
+		if !ok || recorded.ErrorCode != failure.ErrorCode || recorded.ErrorMessage != failure.ErrorMessage {
+			r.replayMismatch(enginehistory.EventWorkflowFailed, "", next, "workflow failure did not match recorded history")
+		}
+		r.cursor++
+	} else {
+		r.queueEvent(enginehistory.EventWorkflowFailed, failure)
+	}
+	if next, ok := r.peek(); ok {
+		r.replayMismatch("", "", next, "recorded history contains events after workflow failure")
+	}
+	return r.failedDecision(failure)
 }
 
 func (r *workflowRunner) waitingDecision() activationDecision {

--- a/engine/internal/workflow/replay_version_test.go
+++ b/engine/internal/workflow/replay_version_test.go
@@ -1,0 +1,270 @@
+package workflow
+
+import (
+	"testing"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+const (
+	versionDemoChangeID     = "greeting-upgrade"
+	versionDemoActivityType = "demo.compose"
+)
+
+func versionStartedHistory(t *testing.T) []enginedb.EngineHistory {
+	t.Helper()
+
+	return []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "version-demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-version",
+		}),
+	}
+}
+
+// oldVersionDemoDefinition is the pre-GetVersion code: it never calls
+// GetVersion, so runs it produces carry no version marker in history.
+func oldVersionDemoDefinition() publicworkflow.Definition {
+	return publicworkflow.Definition{
+		Name:    "version-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			var output struct {
+				Greeting string `json:"greeting"`
+			}
+			if err := ctx.Activity("greet", versionDemoActivityType, map[string]string{"name": "Ada"}, &output); err != nil {
+				return err
+			}
+			return ctx.SetResult(map[string]string{"branch": "old", "greeting": output.Greeting})
+		},
+	}
+}
+
+// newVersionDemoDefinition is the same workflow after a code change guarded by
+// GetVersion: version 1 preserves the old branch byte-for-byte, version 2 skips
+// the activity and returns a different result.
+func newVersionDemoDefinition() publicworkflow.Definition {
+	return publicworkflow.Definition{
+		Name:    "version-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			version := ctx.GetVersion(versionDemoChangeID, 1, 2)
+			if version >= 2 {
+				return ctx.SetResult(map[string]string{"branch": "new"})
+			}
+			var output struct {
+				Greeting string `json:"greeting"`
+			}
+			if err := ctx.Activity("greet", versionDemoActivityType, map[string]string{"name": "Ada"}, &output); err != nil {
+				return err
+			}
+			return ctx.SetResult(map[string]string{"branch": "old", "greeting": output.Greeting})
+		},
+	}
+}
+
+func collectVersionMarkers(t *testing.T, events []queuedHistoryEvent) []*enginehistory.WorkflowVersionMarkerPayload {
+	t.Helper()
+
+	var markers []*enginehistory.WorkflowVersionMarkerPayload
+	for _, event := range events {
+		if event.EventType != enginehistory.EventWorkflowVersionMarker {
+			continue
+		}
+		decoded, err := enginehistory.DecodePayload(event.EventType, event.Payload)
+		if err != nil {
+			t.Fatalf("DecodePayload(%s) error = %v", event.EventType, err)
+		}
+		payload, ok := decoded.(*enginehistory.WorkflowVersionMarkerPayload)
+		if !ok {
+			t.Fatalf("expected WorkflowVersionMarkerPayload, got %T", decoded)
+		}
+		markers = append(markers, payload)
+	}
+	return markers
+}
+
+func TestReplayGetVersionRecordsMaxSupportedOnFirstExecutionAndReplaysRecordedValue(t *testing.T) {
+	definition := publicworkflow.Definition{
+		Name:    "version-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			version := ctx.GetVersion(versionDemoChangeID, 1, 2)
+			return ctx.SetResult(map[string]int{"version": version})
+		},
+	}
+
+	base := versionStartedHistory(t)
+	decision, err := replayDefinition(definition, base, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision, got %+v", decision)
+	}
+
+	markers := collectVersionMarkers(t, decision.Events)
+	if len(markers) != 1 {
+		t.Fatalf("expected exactly one workflow.version_marker event, got %d in %+v", len(markers), decision.Events)
+	}
+	if markers[0].ChangeID != versionDemoChangeID {
+		t.Fatalf("expected marker change_id %q, got %q", versionDemoChangeID, markers[0].ChangeID)
+	}
+	if markers[0].Version != 2 {
+		t.Fatalf("first execution must record maxSupported (2), got %d", markers[0].Version)
+	}
+	if !equalJSON(decision.Result, mustRawJSON(t, map[string]int{"version": 2})) {
+		t.Fatalf("expected GetVersion to return maxSupported on first execution, result = %s", decision.Result)
+	}
+
+	// Crash-recovery replay: the marker is durable history now; GetVersion must
+	// return the recorded value without recording again.
+	replayRows := historyFromDecision(t, base, decision.Events)
+	replayDecision, err := replayDefinition(definition, replayRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() replay error = %v", err)
+	}
+	if replayDecision.Kind != decisionCompleted {
+		t.Fatalf("expected completed replay decision, got %+v", replayDecision)
+	}
+	if len(replayDecision.Events) != 0 {
+		t.Fatalf("expected no new events on replay, got %+v", replayDecision.Events)
+	}
+	if !equalJSON(replayDecision.Result, decision.Result) {
+		t.Fatalf("replayed result %s differs from first execution %s", replayDecision.Result, decision.Result)
+	}
+}
+
+func TestReplayGetVersionMarkerlessOldRunTakesOldBranchUnderNewCode(t *testing.T) {
+	oldDefinition := oldVersionDemoDefinition()
+	newDefinition := newVersionDemoDefinition()
+
+	// Execute the old code up to its activity wait, then record the activity
+	// outcome, simulating a run that lived under the old deployment.
+	base := versionStartedHistory(t)
+	scheduleDecision, err := replayDefinition(oldDefinition, base, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() old schedule error = %v", err)
+	}
+	if scheduleDecision.Kind != decisionWaiting || scheduleDecision.NewActivity == nil {
+		t.Fatalf("expected old code to wait on a new activity, got %+v", scheduleDecision)
+	}
+	scheduledRows := historyFromDecision(t, base, scheduleDecision.Events)
+	inFlightRows := append(scheduledRows, historyRow(
+		t,
+		scheduledRows[len(scheduledRows)-1].SequenceNo+1,
+		enginehistory.EventActivityCompleted,
+		enginehistory.ActivityCompletedPayload{
+			ActivityKey:  "greet",
+			ActivityType: versionDemoActivityType,
+			Output:       mustRawJSON(t, map[string]string{"greeting": "hello, Ada"}),
+		},
+	))
+
+	// The deployment swaps to the new code while the run is in flight. The
+	// remainder of the run must complete on the old branch: no version marker
+	// exists in history, so GetVersion returns minSupported.
+	inFlightDecision, err := replayDefinition(newDefinition, inFlightRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() in-flight under new code error = %v", err)
+	}
+	if inFlightDecision.Kind != decisionCompleted {
+		t.Fatalf("expected in-flight run to complete under new code, got %+v", inFlightDecision)
+	}
+	if inFlightDecision.FailureCode != "" {
+		t.Fatalf("expected no failure completing the in-flight run, got %q: %q", inFlightDecision.FailureCode, inFlightDecision.FailureMessage)
+	}
+	wantOldResult := mustRawJSON(t, map[string]string{"branch": "old", "greeting": "hello, Ada"})
+	if !equalJSON(inFlightDecision.Result, wantOldResult) {
+		t.Fatalf("expected old-branch result %s, got %s", wantOldResult, inFlightDecision.Result)
+	}
+	if markers := collectVersionMarkers(t, inFlightDecision.Events); len(markers) != 0 {
+		t.Fatalf("a marker-less old run must not gain version markers under new code, got %+v", markers)
+	}
+	for _, event := range inFlightDecision.Events {
+		if event.EventType == enginehistory.EventWorkflowReplayMismatch {
+			t.Fatalf("in-flight run hit replay mismatch under new code: %+v", inFlightDecision.Events)
+		}
+	}
+
+	// Full-history crash-recovery replay under the new code: the terminal
+	// events are durable now and must replay cleanly with zero new events.
+	fullRows := historyFromDecision(t, inFlightRows, inFlightDecision.Events)
+	replayDecision, err := replayDefinition(newDefinition, fullRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() full replay under new code error = %v", err)
+	}
+	if replayDecision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision on full replay, got %+v", replayDecision)
+	}
+	if len(replayDecision.Events) != 0 {
+		t.Fatalf("expected no new events on full replay, got %+v", replayDecision.Events)
+	}
+	if !equalJSON(replayDecision.Result, wantOldResult) {
+		t.Fatalf("full replay under new code returned %s, want %s", replayDecision.Result, wantOldResult)
+	}
+}
+
+func TestReplayGetVersionNewRunTakesNewBranch(t *testing.T) {
+	newDefinition := newVersionDemoDefinition()
+
+	decision, err := replayDefinition(newDefinition, versionStartedHistory(t), nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionCompleted {
+		t.Fatalf("expected new run to complete on the new branch, got %+v", decision)
+	}
+	if decision.NewActivity != nil {
+		t.Fatalf("new branch must not schedule the old activity, got %+v", decision.NewActivity)
+	}
+	if !equalJSON(decision.Result, mustRawJSON(t, map[string]string{"branch": "new"})) {
+		t.Fatalf("expected new-branch result, got %s", decision.Result)
+	}
+
+	markers := collectVersionMarkers(t, decision.Events)
+	if len(markers) != 1 {
+		t.Fatalf("expected exactly one version marker for the new run, got %d in %+v", len(markers), decision.Events)
+	}
+	if markers[0].ChangeID != versionDemoChangeID || markers[0].Version != 2 {
+		t.Fatalf("expected marker {%s, 2}, got %+v", versionDemoChangeID, markers[0])
+	}
+}
+
+func TestReplayGetVersionRecordedBelowMinSupportedFailsControlled(t *testing.T) {
+	definition := publicworkflow.Definition{
+		Name:    "version-demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			version := ctx.GetVersion(versionDemoChangeID, 2, 3)
+			return ctx.SetResult(map[string]int{"version": version})
+		},
+	}
+
+	rows := append(versionStartedHistory(t), historyRow(
+		t,
+		2,
+		enginehistory.EventWorkflowVersionMarker,
+		enginehistory.WorkflowVersionMarkerPayload{
+			ChangeID: versionDemoChangeID,
+			Version:  1,
+		},
+	))
+
+	decision, err := replayDefinition(definition, rows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionFailed {
+		t.Fatalf("expected controlled failure when recorded version is below minSupported, got %+v", decision)
+	}
+	if decision.FailureCode == "replay_mismatch" {
+		t.Fatalf("dropping support for an old version must be a controlled failure, not replay_mismatch: %+v", decision)
+	}
+	if decision.FailureCode != "version_unsupported" {
+		t.Fatalf("expected failure code %q, got %q (%q)", "version_unsupported", decision.FailureCode, decision.FailureMessage)
+	}
+}

--- a/engine/internal/workflow/replay_version_validation_test.go
+++ b/engine/internal/workflow/replay_version_validation_test.go
@@ -1,0 +1,59 @@
+package workflow
+
+import (
+	"testing"
+
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestReplayGetVersionInvalidArgumentsFailControlled(t *testing.T) {
+	tests := []struct {
+		name         string
+		changeID     string
+		minSupported int
+		maxSupported int
+	}{
+		{
+			name:         "empty change id",
+			changeID:     "",
+			minSupported: 1,
+			maxSupported: 2,
+		},
+		{
+			name:         "min below one",
+			changeID:     versionDemoChangeID,
+			minSupported: 0,
+			maxSupported: 2,
+		},
+		{
+			name:         "min greater than max",
+			changeID:     versionDemoChangeID,
+			minSupported: 3,
+			maxSupported: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			definition := publicworkflow.Definition{
+				Name:    "version-demo",
+				Version: "v1",
+				Run: func(ctx publicworkflow.Context) error {
+					version := ctx.GetVersion(tt.changeID, tt.minSupported, tt.maxSupported)
+					return ctx.SetResult(map[string]int{"version": version})
+				},
+			}
+
+			decision, err := replayDefinition(definition, versionStartedHistory(t), nil, nil)
+			if err != nil {
+				t.Fatalf("replayDefinition() error = %v", err)
+			}
+			if decision.Kind != decisionFailed {
+				t.Fatalf("expected failed decision, got %+v", decision)
+			}
+			if decision.FailureCode != "version_invalid" {
+				t.Fatalf("FailureCode = %q, want version_invalid", decision.FailureCode)
+			}
+		})
+	}
+}

--- a/engine/pkg/history/history.go
+++ b/engine/pkg/history/history.go
@@ -18,6 +18,7 @@ const (
 	EventWorkflowReplayMismatch     = "workflow.replay_mismatch"
 	EventWorkflowTimeRecorded       = "workflow.time_recorded"
 	EventWorkflowSideEffectRecorded = "workflow.side_effect_recorded"
+	EventWorkflowVersionMarker      = "workflow.version_marker"
 	EventActivityScheduled          = "activity.scheduled"
 	EventActivityCompleted          = "activity.completed"
 	EventActivityFailed             = "activity.failed"
@@ -89,6 +90,11 @@ type WorkflowTimeRecordedPayload struct {
 type WorkflowSideEffectRecordedPayload struct {
 	SideEffectKey string          `json:"side_effect_key"`
 	Value         json.RawMessage `json:"value"`
+}
+
+type WorkflowVersionMarkerPayload struct {
+	ChangeID string `json:"change_id"`
+	Version  int32  `json:"version"`
 }
 
 type ActivityScheduledPayload struct {
@@ -328,6 +334,10 @@ func EventKey(eventType string, payload any) string {
 		return value.SideEffectKey
 	case *WorkflowSideEffectRecordedPayload:
 		return value.SideEffectKey
+	case WorkflowVersionMarkerPayload:
+		return value.ChangeID
+	case *WorkflowVersionMarkerPayload:
+		return value.ChangeID
 	default:
 		return ""
 	}
@@ -357,6 +367,8 @@ func payloadTarget(eventType string) (any, error) {
 		return &WorkflowTimeRecordedPayload{}, nil
 	case EventWorkflowSideEffectRecorded:
 		return &WorkflowSideEffectRecordedPayload{}, nil
+	case EventWorkflowVersionMarker:
+		return &WorkflowVersionMarkerPayload{}, nil
 	case EventActivityScheduled:
 		return &ActivityScheduledPayload{}, nil
 	case EventActivityCompleted:

--- a/engine/pkg/workflow/context.go
+++ b/engine/pkg/workflow/context.go
@@ -72,6 +72,7 @@ type Context interface {
 	Sleep(key string, d time.Duration) error
 	SleepUntil(key string, at time.Time) error
 	SideEffect(key string, fn func() (any, error), out any) error
+	GetVersion(changeID string, minSupported, maxSupported int) int
 	ReceiveSignal(name string, out any) error
 	CancellationRequested() bool
 	SetCustomStatus(value any) error


### PR DESCRIPTION
## What / why

Adds a GetVersion-style workflow code versioning API so in-flight runs survive code evolution. Previously any behavioral change to a deployed definition failed in-flight runs with `replay_mismatch`, making "no in-flight runs" the only safe deploy — unacceptable for long-running AI-agent workflows waiting days on human signals.

## Semantics

`Context.GetVersion(changeID string, minSupported, maxSupported int) int`:

- **First execution** (past recorded history): records a `workflow.version_marker` history event with `maxSupported` and returns it — new runs take the new branch.
- **Replay with a matching recorded marker**: returns the recorded version; a recorded version below `minSupported` fails controlled with `version_unsupported` (never `replay_mismatch`).
- **Replay where no marker exists at that point** (run started on code that predates the GetVersion call): returns `minSupported` without consuming or recording — marker-less old runs deterministically take the old branch under new code.
- Invalid arguments (empty change id, min < 1, min > max) fail controlled with `version_invalid`; controlled failures replay their `workflow.failed` event deterministically.

Also:
- Registry `Latest(name)` with numeric-aware version ordering (`v10` > `v2`); `continua-engine start --version` is now optional — new runs resolve and pin the latest registered version, in-flight runs stay pinned to `runs.definition_version`.
- Dark-launch `darklaunch.version-demo` definition with an env-swapped body to exercise a definition swap between restarts.
- Docs-site guide: `docs-site/guides/workflow-code-versioning.mdx` (single-node upgrade playbook: GetVersion vs bumping definition_version, `version_unsupported` failure mode).

## How this was built

TDD orchestrator/minion pipeline: the acceptance tests were authored first and committed red (88d7136), then Codex implemented against them without touching the test commit (verified by empty diff). One review iteration fixed a `gocritic` lint finding.

## Test evidence

- `engine/internal/workflow/replay_version_test.go`: first execution records `maxSupported` + crash-recovery replay returns the recorded value; a marker-less old run completes its old branch under new code (mid-flight and full-history, zero new events, no mismatch); a new run takes the new branch with exactly one marker; recorded version below `minSupported` → `version_unsupported`.
- `engine/cmd/continua-engine/runtime_version_swap_e2e_test.go`: definition swap between serve restarts — the in-flight run waiting on a signal completes its old branch with no `replay_mismatch` and no marker; a fresh run takes the new branch and records the marker.
- Full engine suite (`go test -count=1 ./...`), `go build`, `go vet`, and `make lint-go` (both modules, 0 issues) pass locally.

Closes #154