### PR TITLE
fix(engine): quarantine history decode failures as history_corrupt instead of replay_mismatch

### DIFF
--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -335,7 +335,7 @@ func TestActivatorQuarantinedRunRecoversAfterDefinitionRestore(t *testing.T) {
 	if completedRun.Status != enginedb.EngineRunLifecycleStatusCompleted {
 		t.Fatalf("expected completed run after restored definition, got %+v", completedRun)
 	}
-	if !equalJSON(completedRun.Result, wantResult) {
+	if !equalJSONForTest(t, completedRun.Result, wantResult) {
 		t.Fatalf("expected result %s, got %s", wantResult, completedRun.Result)
 	}
 	historyRows, err = store.GetHistoryByRun(ctx, run.ID)

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -123,7 +123,8 @@ type pendingInboxItem struct {
 type blockedPanic struct{}
 
 type replayMismatchPanic struct {
-	payload enginehistory.WorkflowReplayMismatchPayload
+	payload     enginehistory.WorkflowReplayMismatchPayload
+	failureCode string
 }
 
 type controlledFailurePanic struct {
@@ -350,7 +351,8 @@ func (r *workflowRunner) execute(definition publicworkflow.Definition) (decision
 			decision = r.waitingDecision()
 			err = nil
 		case replayMismatchPanic:
-			decision = r.quarantinedDecision(&value.payload)
+			mismatch := value
+			decision = r.quarantinedDecision(&mismatch)
 			err = nil
 		case controlledFailurePanic:
 			decision = r.recordWorkflowFailure(value.failure)
@@ -392,7 +394,14 @@ func (r *workflowRunner) execute(definition publicworkflow.Definition) (decision
 			continuedAsNew := enginehistory.WorkflowContinuedAsNewPayload{Input: cloneRaw(continuationInput)}
 			if next, ok := r.peek(); ok {
 				recorded, ok := next.Payload.(*enginehistory.WorkflowContinuedAsNewPayload)
-				if !ok || !equalJSON(recorded.Input, continuedAsNew.Input) {
+				if !ok {
+					r.replayMismatch(enginehistory.EventWorkflowContinuedAsNew, "", next, "workflow continuation did not match recorded history")
+				}
+				equal, err := equalJSON(recorded.Input, continuedAsNew.Input)
+				if err != nil {
+					r.historyCorrupt(enginehistory.EventWorkflowContinuedAsNew, "", next, err)
+				}
+				if !equal {
 					r.replayMismatch(enginehistory.EventWorkflowContinuedAsNew, "", next, "workflow continuation did not match recorded history")
 				}
 				r.cursor++
@@ -439,7 +448,14 @@ func (r *workflowRunner) execute(definition publicworkflow.Definition) (decision
 	completed := enginehistory.WorkflowCompletedPayload{Result: cloneRaw(r.result)}
 	if next, ok := r.peek(); ok {
 		recorded, ok := next.Payload.(*enginehistory.WorkflowCompletedPayload)
-		if !ok || !equalJSON(recorded.Result, completed.Result) {
+		if !ok {
+			r.replayMismatch(enginehistory.EventWorkflowCompleted, "", next, "workflow completion did not match recorded history")
+		}
+		equal, err := equalJSON(recorded.Result, completed.Result)
+		if err != nil {
+			r.historyCorrupt(enginehistory.EventWorkflowCompleted, "", next, err)
+		}
+		if !equal {
 			r.replayMismatch(enginehistory.EventWorkflowCompleted, "", next, "workflow completion did not match recorded history")
 		}
 		r.cursor++
@@ -487,7 +503,14 @@ func (r *workflowRunner) ActivityWithOptions(
 
 	if next, ok := r.peek(); ok {
 		scheduled, ok := next.Payload.(*enginehistory.ActivityScheduledPayload)
-		if !ok || !matchActivityScheduled(scheduled, key, activityType, inputRaw) {
+		if !ok {
+			r.replayMismatch(enginehistory.EventActivityScheduled, key, next, "activity scheduling did not match recorded history")
+		}
+		match, err := matchActivityScheduled(scheduled, key, activityType, inputRaw)
+		if err != nil {
+			r.historyCorrupt(enginehistory.EventActivityScheduled, key, next, err)
+		}
+		if !match {
 			r.replayMismatch(enginehistory.EventActivityScheduled, key, next, "activity scheduling did not match recorded history")
 		}
 		r.cursor++
@@ -598,7 +621,14 @@ func (r *workflowRunner) ChildWorkflowWithOptions(
 
 	if next, ok := r.peek(); ok {
 		scheduled, ok := next.Payload.(*enginehistory.ChildWorkflowScheduledPayload)
-		if !ok || !matchChildWorkflowScheduled(scheduled, childKey, definitionName, definitionVersion, inputRaw, instanceKey) {
+		if !ok {
+			r.replayMismatch(enginehistory.EventChildWorkflowScheduled, childKey, next, "child workflow scheduling did not match recorded history")
+		}
+		match, err := matchChildWorkflowScheduled(scheduled, childKey, definitionName, definitionVersion, inputRaw, instanceKey)
+		if err != nil {
+			r.historyCorrupt(enginehistory.EventChildWorkflowScheduled, childKey, next, err)
+		}
+		if !match {
 			r.replayMismatch(enginehistory.EventChildWorkflowScheduled, childKey, next, "child workflow scheduling did not match recorded history")
 		}
 		r.cursor++
@@ -905,7 +935,14 @@ func (r *workflowRunner) SetCustomStatus(value any) error {
 
 	if next, ok := r.peek(); ok {
 		recorded, ok := next.Payload.(*enginehistory.CustomStatusUpdatedPayload)
-		if !ok || !equalJSON(recorded.Status, statusRaw) {
+		if !ok {
+			r.replayMismatch(enginehistory.EventCustomStatusUpdated, "", next, "custom status update did not match recorded history")
+		}
+		equal, err := equalJSON(recorded.Status, statusRaw)
+		if err != nil {
+			r.historyCorrupt(enginehistory.EventCustomStatusUpdated, "", next, err)
+		}
+		if !equal {
 			r.replayMismatch(enginehistory.EventCustomStatusUpdated, "", next, "custom status update did not match recorded history")
 		}
 		r.customStatus = cloneRaw(statusRaw)
@@ -1005,6 +1042,14 @@ func (r *workflowRunner) replayMismatch(expectedType, expectedKey string, actual
 	})
 }
 
+func (r *workflowRunner) historyCorrupt(expectedType, expectedKey string, actual decodedEvent, decodeErr error) {
+	detail := fmt.Sprintf("history payload decode failed: %v", decodeErr)
+	panic(replayMismatchPanic{
+		payload:     replayMismatchPayload(expectedType, expectedKey, actual, detail),
+		failureCode: "history_corrupt",
+	})
+}
+
 func replayMismatchPayload(
 	expectedType, expectedKey string,
 	actual decodedEvent,
@@ -1084,22 +1129,27 @@ func (r *workflowRunner) failedDecision(failure enginehistory.WorkflowFailedPayl
 	}
 }
 
-func (r *workflowRunner) quarantinedDecision(mismatch *enginehistory.WorkflowReplayMismatchPayload) activationDecision {
+func (r *workflowRunner) quarantinedDecision(mismatch *replayMismatchPanic) activationDecision {
+	payload := mismatch.payload
+	failureCode := mismatch.failureCode
+	if failureCode == "" {
+		failureCode = "replay_mismatch"
+	}
 	waitingFor := mustMarshalPayload(enginehistory.ReplayMismatchWait{
 		Kind:         enginehistory.WaitKindReplayMismatch,
-		ExpectedType: mismatch.ExpectedType,
-		ExpectedKey:  mismatch.ExpectedKey,
-		ActualType:   mismatch.ActualType,
-		ActualKey:    mismatch.ActualKey,
-		Detail:       mismatch.Detail,
+		ExpectedType: payload.ExpectedType,
+		ExpectedKey:  payload.ExpectedKey,
+		ActualType:   payload.ActualType,
+		ActualKey:    payload.ActualKey,
+		Detail:       payload.Detail,
 	})
 	return activationDecision{
 		Kind:           decisionQuarantined,
 		NextSequence:   r.nextSequence,
 		WaitingFor:     cloneRaw(waitingFor),
 		CustomStatus:   cloneRaw(r.customStatus),
-		FailureCode:    "replay_mismatch",
-		FailureMessage: mismatch.Detail,
+		FailureCode:    failureCode,
+		FailureMessage: payload.Detail,
 	}
 }
 
@@ -1132,10 +1182,11 @@ func matchActivityScheduled(
 	recorded *enginehistory.ActivityScheduledPayload,
 	key, activityType string,
 	input json.RawMessage,
-) bool {
-	return recorded.ActivityKey == key &&
-		recorded.ActivityType == activityType &&
-		equalJSON(recorded.Input, input)
+) (bool, error) {
+	if recorded.ActivityKey != key || recorded.ActivityType != activityType {
+		return false, nil
+	}
+	return equalJSON(recorded.Input, input)
 }
 
 func matchChildWorkflowScheduled(
@@ -1143,12 +1194,14 @@ func matchChildWorkflowScheduled(
 	childKey, definitionName, definitionVersion string,
 	input json.RawMessage,
 	instanceKey string,
-) bool {
-	return recorded.ChildKey == childKey &&
-		recorded.DefinitionName == definitionName &&
-		recorded.DefinitionVersion == definitionVersion &&
-		recorded.ChildInstanceKey == instanceKey &&
-		equalJSON(recorded.Input, input)
+) (bool, error) {
+	if recorded.ChildKey != childKey ||
+		recorded.DefinitionName != definitionName ||
+		recorded.DefinitionVersion != definitionVersion ||
+		recorded.ChildInstanceKey != instanceKey {
+		return false, nil
+	}
+	return equalJSON(recorded.Input, input)
 }
 
 func defaultChildInstanceKey(projectID, parentRunID uuid.UUID, childKey string) string {
@@ -1357,23 +1410,26 @@ func unmarshalOptional(raw []byte, out any) error {
 	return json.Unmarshal(raw, out)
 }
 
-func equalJSON(left, right json.RawMessage) bool {
+func equalJSON(left, right json.RawMessage) (bool, error) {
 	if bytes.Equal(bytes.TrimSpace(left), bytes.TrimSpace(right)) {
-		return true
+		return true, nil
 	}
 	if len(left) == 0 && len(right) == 0 {
-		return true
+		return true, nil
+	}
+	if len(left) == 0 || len(right) == 0 {
+		return false, nil
 	}
 
 	var leftValue any
 	var rightValue any
 	if err := json.Unmarshal(left, &leftValue); err != nil {
-		return false
+		return false, fmt.Errorf("decode recorded payload: %w", err)
 	}
 	if err := json.Unmarshal(right, &rightValue); err != nil {
-		return false
+		return false, fmt.Errorf("decode replayed payload: %w", err)
 	}
-	return reflect.DeepEqual(leftValue, rightValue)
+	return reflect.DeepEqual(leftValue, rightValue), nil
 }
 
 func cloneRaw(raw json.RawMessage) json.RawMessage {

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 	"time"
 
@@ -1421,15 +1422,33 @@ func equalJSON(left, right json.RawMessage) (bool, error) {
 		return false, nil
 	}
 
-	var leftValue any
-	var rightValue any
-	if err := json.Unmarshal(left, &leftValue); err != nil {
+	leftValue, err := decodeJSONValue(left)
+	if err != nil {
 		return false, fmt.Errorf("decode recorded payload: %w", err)
 	}
-	if err := json.Unmarshal(right, &rightValue); err != nil {
+	rightValue, err := decodeJSONValue(right)
+	if err != nil {
 		return false, fmt.Errorf("decode replayed payload: %w", err)
 	}
 	return reflect.DeepEqual(leftValue, rightValue), nil
+}
+
+func decodeJSONValue(raw json.RawMessage) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("multiple JSON values")
+		}
+		return nil, err
+	}
+	return value, nil
 }
 
 func cloneRaw(raw json.RawMessage) json.RawMessage {

--- a/engine/internal/workflow/replay_corrupt_test.go
+++ b/engine/internal/workflow/replay_corrupt_test.go
@@ -1,0 +1,204 @@
+package workflow
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+var corruptRecordedJSON = json.RawMessage("{corrupt")
+
+func TestCorruptRecordedCustomStatusQuarantinesAsHistoryCorrupt(t *testing.T) {
+	decision, err := newCorruptReplayRunner(decodedEvent{
+		EventType: enginehistory.EventCustomStatusUpdated,
+		Payload: &enginehistory.CustomStatusUpdatedPayload{
+			Status: corruptRecordedJSON,
+		},
+	}).execute(testCorruptReplayDefinition(func(ctx publicworkflow.Context) error {
+		if err := ctx.SetCustomStatus(map[string]string{"phase": "x"}); err != nil {
+			return err
+		}
+		return nil
+	}))
+
+	assertHistoryCorruptQuarantine(t, decision, err)
+}
+
+func TestCorruptRecordedContinueAsNewInputQuarantinesAsHistoryCorrupt(t *testing.T) {
+	decision, err := newCorruptReplayRunner(decodedEvent{
+		EventType: enginehistory.EventWorkflowContinuedAsNew,
+		Payload: &enginehistory.WorkflowContinuedAsNewPayload{
+			Input: corruptRecordedJSON,
+		},
+	}).execute(testCorruptReplayDefinition(func(publicworkflow.Context) error {
+		return publicworkflow.ContinueAsNew(map[string]int{"cursor": 1})
+	}))
+
+	assertHistoryCorruptQuarantine(t, decision, err)
+}
+
+func TestCorruptRecordedWorkflowResultQuarantinesAsHistoryCorrupt(t *testing.T) {
+	decision, err := newCorruptReplayRunner(decodedEvent{
+		EventType: enginehistory.EventWorkflowCompleted,
+		Payload: &enginehistory.WorkflowCompletedPayload{
+			Result: corruptRecordedJSON,
+		},
+	}).execute(testCorruptReplayDefinition(func(ctx publicworkflow.Context) error {
+		return ctx.SetResult(map[string]string{"greeting": "hi"})
+	}))
+
+	assertHistoryCorruptQuarantine(t, decision, err)
+}
+
+func TestCorruptRecordedActivityInputQuarantinesAsHistoryCorrupt(t *testing.T) {
+	decision, err := newCorruptReplayRunner(decodedEvent{
+		EventType: enginehistory.EventActivityScheduled,
+		Payload: &enginehistory.ActivityScheduledPayload{
+			ActivityKey:  "step-1",
+			ActivityType: "demo.activity",
+			Input:        corruptRecordedJSON,
+		},
+	}).execute(testCorruptReplayDefinition(func(ctx publicworkflow.Context) error {
+		return ctx.Activity("step-1", "demo.activity", map[string]string{"name": "Ada"}, nil)
+	}))
+
+	assertHistoryCorruptQuarantine(t, decision, err)
+}
+
+func TestCorruptRecordedChildWorkflowInputQuarantinesAsHistoryCorrupt(t *testing.T) {
+	childInstanceKey := defaultChildInstanceKey(uuid.Nil, uuid.Nil, "child-1")
+
+	decision, err := newCorruptReplayRunner(decodedEvent{
+		EventType: enginehistory.EventChildWorkflowScheduled,
+		Payload: &enginehistory.ChildWorkflowScheduledPayload{
+			ChildKey:          "child-1",
+			DefinitionName:    "child-def",
+			DefinitionVersion: "v1",
+			ChildInstanceKey:  childInstanceKey,
+			Input:             corruptRecordedJSON,
+		},
+	}).execute(testCorruptReplayDefinition(func(ctx publicworkflow.Context) error {
+		return ctx.ChildWorkflowWithOptions(
+			"child-1",
+			"child-def",
+			"v1",
+			map[string]string{"name": "Ada"},
+			nil,
+			publicworkflow.ChildWorkflowOptions{InstanceKey: childInstanceKey},
+		)
+	}))
+
+	assertHistoryCorruptQuarantine(t, decision, err)
+}
+
+func TestDifferentCustomStatusStillQuarantinesAsReplayMismatch(t *testing.T) {
+	decision, err := newCorruptReplayRunner(decodedEvent{
+		EventType: enginehistory.EventCustomStatusUpdated,
+		Payload: &enginehistory.CustomStatusUpdatedPayload{
+			Status: json.RawMessage(`{"phase":"other"}`),
+		},
+	}).execute(testCorruptReplayDefinition(func(ctx publicworkflow.Context) error {
+		if err := ctx.SetCustomStatus(map[string]string{"phase": "x"}); err != nil {
+			return err
+		}
+		return nil
+	}))
+
+	assertReplayMismatchQuarantine(t, decision, err)
+}
+
+func TestDifferentContinueAsNewInputStillQuarantinesAsReplayMismatch(t *testing.T) {
+	decision, err := newCorruptReplayRunner(decodedEvent{
+		EventType: enginehistory.EventWorkflowContinuedAsNew,
+		Payload: &enginehistory.WorkflowContinuedAsNewPayload{
+			Input: json.RawMessage(`{"cursor":999}`),
+		},
+	}).execute(testCorruptReplayDefinition(func(publicworkflow.Context) error {
+		return publicworkflow.ContinueAsNew(map[string]int{"cursor": 1})
+	}))
+
+	assertReplayMismatchQuarantine(t, decision, err)
+}
+
+func TestEmptyRecordedResultVsPresentResultIsReplayMismatchNotCorrupt(t *testing.T) {
+	decision, err := newCorruptReplayRunner(decodedEvent{
+		EventType: enginehistory.EventWorkflowCompleted,
+		Payload: &enginehistory.WorkflowCompletedPayload{
+			Result: nil,
+		},
+	}).execute(testCorruptReplayDefinition(func(ctx publicworkflow.Context) error {
+		return ctx.SetResult(map[string]string{"greeting": "hi"})
+	}))
+
+	assertReplayMismatchQuarantine(t, decision, err)
+	if decision.FailureCode == "history_corrupt" {
+		t.Fatalf("FailureCode = %q, want replay_mismatch for absent recorded result", decision.FailureCode)
+	}
+}
+
+func newCorruptReplayRunner(events ...decodedEvent) *workflowRunner {
+	return &workflowRunner{
+		input:             json.RawMessage(`{}`),
+		nextSequence:      int32(len(events) + 2),
+		pendingActivities: make(map[string]activityOutcome),
+		pendingChildren:   make(map[string]childWorkflowOutcome),
+		pendingSignals:    make(map[string][]pendingSignal),
+		pendingTimers:     make(map[string]pendingTimer),
+		replayEvents:      events,
+	}
+}
+
+func testCorruptReplayDefinition(run func(publicworkflow.Context) error) publicworkflow.Definition {
+	return publicworkflow.Definition{
+		Name:    "demo",
+		Version: "v1",
+		Run:     run,
+	}
+}
+
+func assertHistoryCorruptQuarantine(t *testing.T, decision activationDecision, err error) {
+	t.Helper()
+	assertQuarantineDecision(t, decision, err)
+	if decision.FailureCode != "history_corrupt" {
+		t.Fatalf("FailureCode = %q, want history_corrupt", decision.FailureCode)
+	}
+}
+
+func assertReplayMismatchQuarantine(t *testing.T, decision activationDecision, err error) {
+	t.Helper()
+	assertQuarantineDecision(t, decision, err)
+	if decision.FailureCode != "replay_mismatch" {
+		t.Fatalf("FailureCode = %q, want replay_mismatch", decision.FailureCode)
+	}
+}
+
+func assertQuarantineDecision(t *testing.T, decision activationDecision, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if decision.Kind != decisionQuarantined {
+		t.Fatalf("decision.Kind = %q, want %q", decision.Kind, decisionQuarantined)
+	}
+	if decision.FailureMessage == "" {
+		t.Fatal("FailureMessage is empty")
+	}
+	if len(decision.Events) != 0 {
+		t.Fatalf("len(decision.Events) = %d, want 0", len(decision.Events))
+	}
+
+	var wait enginehistory.ReplayMismatchWait
+	if err := json.Unmarshal(decision.WaitingFor, &wait); err != nil {
+		t.Fatalf("WaitingFor did not decode as ReplayMismatchWait: %v", err)
+	}
+	if wait.Kind != enginehistory.WaitKindReplayMismatch {
+		t.Fatalf("WaitingFor.kind = %q, want %q", wait.Kind, enginehistory.WaitKindReplayMismatch)
+	}
+	if wait.Detail == "" {
+		t.Fatal("WaitingFor.detail is empty")
+	}
+}

--- a/engine/internal/workflow/replay_demo_test.go
+++ b/engine/internal/workflow/replay_demo_test.go
@@ -117,7 +117,7 @@ func TestReplayDefinitionDemoProgression(t *testing.T) {
 		if len(decision.ConsumedInboxIDs) != 1 || decision.ConsumedInboxIDs[0] != inboxRows[0].ID {
 			t.Fatalf("expected queued signal inbox item to be consumed, got %+v", decision.ConsumedInboxIDs)
 		}
-		if !equalJSON(decision.Result, mustRawJSON(t, map[string]string{"approval": "granted"})) {
+		if !equalJSONForTest(t, decision.Result, mustRawJSON(t, map[string]string{"approval": "granted"})) {
 			t.Fatalf("expected completed result to reflect signal payload, got %s", decision.Result)
 		}
 	})
@@ -204,7 +204,7 @@ func TestReplayDefinitionDemoProgression(t *testing.T) {
 		if decision.Events[1].EventType != enginehistory.EventWorkflowCompleted {
 			t.Fatalf("expected second event to be workflow.completed, got %+v", decision.Events)
 		}
-		if !equalJSON(decision.Result, result) {
+		if !equalJSONForTest(t, decision.Result, result) {
 			t.Fatalf("expected completed result %s, got %s", result, decision.Result)
 		}
 	})

--- a/engine/internal/workflow/replay_test.go
+++ b/engine/internal/workflow/replay_test.go
@@ -1385,6 +1385,19 @@ func equalJSONForTest(t *testing.T, left, right json.RawMessage) bool {
 	return equal
 }
 
+func TestEqualJSONPreservesNumberPrecision(t *testing.T) {
+	equal, err := equalJSON(
+		json.RawMessage(`{"value":9007199254740992}`),
+		json.RawMessage(`{"value":9007199254740993}`),
+	)
+	if err != nil {
+		t.Fatalf("equalJSON() error = %v", err)
+	}
+	if equal {
+		t.Fatal("equalJSON() = true, want false for distinct large integers")
+	}
+}
+
 func testDefinition(timerAt time.Time) publicworkflow.Definition {
 	return publicworkflow.Definition{
 		Name:    "demo",

--- a/engine/internal/workflow/replay_test.go
+++ b/engine/internal/workflow/replay_test.go
@@ -64,7 +64,7 @@ func TestReplayDefinitionHappyPath(t *testing.T) {
 	if len(decision.Events) != 0 {
 		t.Fatalf("expected no new history events during replay, got %+v", decision.Events)
 	}
-	if !equalJSON(decision.Result, result) {
+	if !equalJSONForTest(t, decision.Result, result) {
 		t.Fatalf("expected replayed result %s, got %s", result, decision.Result)
 	}
 }
@@ -140,7 +140,7 @@ func TestReplayDefinitionChildWorkflowRoundTrip(t *testing.T) {
 	if len(decision.Events) != 0 {
 		t.Fatalf("expected no new history events during child workflow replay, got %+v", decision.Events)
 	}
-	if !equalJSON(decision.Result, result) {
+	if !equalJSONForTest(t, decision.Result, result) {
 		t.Fatalf("expected replayed result %s, got %s", result, decision.Result)
 	}
 }
@@ -646,7 +646,7 @@ func TestReplayDefinitionContinueAsNewFirstExecution(t *testing.T) {
 	if decision.Events[0].EventType != enginehistory.EventWorkflowContinuedAsNew {
 		t.Fatalf("expected workflow.continued_as_new event, got %+v", decision.Events[0])
 	}
-	if !equalJSON(decision.ContinuationInput, continuationInput) {
+	if !equalJSONForTest(t, decision.ContinuationInput, continuationInput) {
 		t.Fatalf("expected continuation input %s, got %s", continuationInput, decision.ContinuationInput)
 	}
 }
@@ -704,7 +704,7 @@ func TestReplayDefinitionContinueAsNewMatchesSemanticallyEquivalentJSON(t *testi
 	if len(decision.Events) != 0 {
 		t.Fatalf("expected semantic JSON replay equality to avoid new events, got %+v", decision.Events)
 	}
-	if !equalJSON(decision.ContinuationInput, recordedInput) {
+	if !equalJSONForTest(t, decision.ContinuationInput, recordedInput) {
 		t.Fatalf("expected continuation input to match recorded JSON, got %s", decision.ContinuationInput)
 	}
 }
@@ -793,7 +793,7 @@ func TestReplayDefinitionSkipsRecordedActivityRetryEvents(t *testing.T) {
 	if len(decision.Events) != 0 {
 		t.Fatalf("expected no new events while replaying recorded retries, got %+v", decision.Events)
 	}
-	if !equalJSON(decision.Result, output) {
+	if !equalJSONForTest(t, decision.Result, output) {
 		t.Fatalf("expected replayed result %s, got %s", output, decision.Result)
 	}
 }
@@ -842,7 +842,7 @@ func TestReplayDefinitionSkipsSingleRecordedActivityRetryEvent(t *testing.T) {
 	if len(decision.Events) != 0 {
 		t.Fatalf("expected single recorded retry replay to avoid new events, got %+v", decision.Events)
 	}
-	if !equalJSON(decision.Result, output) {
+	if !equalJSONForTest(t, decision.Result, output) {
 		t.Fatalf("expected replayed result %s, got %s", output, decision.Result)
 	}
 }
@@ -961,7 +961,7 @@ func TestReplayDefinitionIgnoresSuspendResumeControlEvents(t *testing.T) {
 	if len(decision.Events) != 0 {
 		t.Fatalf("expected suspend/resume control events to be ignored during replay, got %+v", decision.Events)
 	}
-	if !equalJSON(decision.Result, output) {
+	if !equalJSONForTest(t, decision.Result, output) {
 		t.Fatalf("expected replayed result %s, got %s", output, decision.Result)
 	}
 }
@@ -1009,7 +1009,7 @@ func TestReplayDefinitionCancellationRequestedRespectsHistoryOrder(t *testing.T)
 	if len(decision.Events) != 0 {
 		t.Fatalf("expected no new history events during replay, got %+v", decision.Events)
 	}
-	if !equalJSON(decision.Result, result) {
+	if !equalJSONForTest(t, decision.Result, result) {
 		t.Fatalf("expected replayed result %s, got %s", result, decision.Result)
 	}
 }
@@ -1089,7 +1089,7 @@ func TestReplayDefinitionCancellationRequestedFoldsPendingCancelAtFrontier(t *te
 	if len(decision.ConsumedInboxIDs) != 1 || decision.ConsumedInboxIDs[0] != cancelInboxID {
 		t.Fatalf("expected pending cancel inbox to be consumed, got %+v", decision.ConsumedInboxIDs)
 	}
-	if !equalJSON(decision.Result, result) {
+	if !equalJSONForTest(t, decision.Result, result) {
 		t.Fatalf("expected completed result %s, got %s", result, decision.Result)
 	}
 }
@@ -1224,7 +1224,7 @@ func TestReplayDefinitionPendingSignalBeforeCancelPreservesFrontierOrder(t *test
 	if len(decision.ConsumedInboxIDs) != 2 || decision.ConsumedInboxIDs[0] != signalInboxID || decision.ConsumedInboxIDs[1] != cancelInboxID {
 		t.Fatalf("expected signal then cancel inbox consumption, got %+v", decision.ConsumedInboxIDs)
 	}
-	if !equalJSON(decision.Result, result) {
+	if !equalJSONForTest(t, decision.Result, result) {
 		t.Fatalf("expected completed result %s, got %s", result, decision.Result)
 	}
 }
@@ -1306,7 +1306,7 @@ func TestReplayDefinitionPendingTimerBeforeCancelPreservesFrontierOrder(t *testi
 	if len(decision.ConsumedInboxIDs) != 2 || decision.ConsumedInboxIDs[0] != timerInboxID || decision.ConsumedInboxIDs[1] != cancelInboxID {
 		t.Fatalf("expected timer then cancel inbox consumption, got %+v", decision.ConsumedInboxIDs)
 	}
-	if !equalJSON(decision.Result, result) {
+	if !equalJSONForTest(t, decision.Result, result) {
 		t.Fatalf("expected completed result %s, got %s", result, decision.Result)
 	}
 }
@@ -1373,6 +1373,16 @@ func mustRawJSON(t *testing.T, value any) json.RawMessage {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 	return raw
+}
+
+func equalJSONForTest(t *testing.T, left, right json.RawMessage) bool {
+	t.Helper()
+
+	equal, err := equalJSON(left, right)
+	if err != nil {
+		t.Fatalf("equalJSON() error = %v", err)
+	}
+	return equal
 }
 
 func testDefinition(timerAt time.Time) publicworkflow.Definition {

--- a/engine/internal/workflow/replay_time_test.go
+++ b/engine/internal/workflow/replay_time_test.go
@@ -110,7 +110,7 @@ func TestReplayNowRecordsOnFirstExecutionAndReplaysRecordedValue(t *testing.T) {
 	if len(replayDecision.Events) != 0 {
 		t.Fatalf("expected no new events on replay, got %+v", replayDecision.Events)
 	}
-	if !equalJSON(replayDecision.Result, decision.Result) {
+	if !equalJSONForTest(t, replayDecision.Result, decision.Result) {
 		t.Fatalf("replayed result %s differs from first execution %s", replayDecision.Result, decision.Result)
 	}
 }
@@ -165,7 +165,7 @@ func TestReplaySideEffectRecordsOnceAndDoesNotReexecuteOnReplay(t *testing.T) {
 	if sideEffects[0].SideEffectKey != "token" {
 		t.Fatalf("expected side effect key %q, got %q", "token", sideEffects[0].SideEffectKey)
 	}
-	if !equalJSON(sideEffects[0].Value, mustRawJSON(t, "token-1")) {
+	if !equalJSONForTest(t, sideEffects[0].Value, mustRawJSON(t, "token-1")) {
 		t.Fatalf("expected recorded side effect value %q, got %s", "token-1", sideEffects[0].Value)
 	}
 
@@ -183,7 +183,7 @@ func TestReplaySideEffectRecordsOnceAndDoesNotReexecuteOnReplay(t *testing.T) {
 	if len(replayDecision.Events) != 0 {
 		t.Fatalf("expected no new events on replay, got %+v", replayDecision.Events)
 	}
-	if !equalJSON(replayDecision.Result, mustRawJSON(t, map[string]string{"token": "token-1"})) {
+	if !equalJSONForTest(t, replayDecision.Result, mustRawJSON(t, map[string]string{"token": "token-1"})) {
 		t.Fatalf("expected replay to return recorded token-1, got %s", replayDecision.Result)
 	}
 }
@@ -261,7 +261,7 @@ func TestReplaySleepDurationSchedulesTimerAndSurvivesReplay(t *testing.T) {
 	if firedDecision.Kind != decisionCompleted {
 		t.Fatalf("expected completed decision after timer fired, got %+v", firedDecision)
 	}
-	if !equalJSON(firedDecision.Result, mustRawJSON(t, map[string]string{"status": "woke"})) {
+	if !equalJSONForTest(t, firedDecision.Result, mustRawJSON(t, map[string]string{"status": "woke"})) {
 		t.Fatalf("unexpected post-sleep result %s", firedDecision.Result)
 	}
 }

--- a/engine/internal/workflow/replay_version_test.go
+++ b/engine/internal/workflow/replay_version_test.go
@@ -116,7 +116,7 @@ func TestReplayGetVersionRecordsMaxSupportedOnFirstExecutionAndReplaysRecordedVa
 	if markers[0].Version != 2 {
 		t.Fatalf("first execution must record maxSupported (2), got %d", markers[0].Version)
 	}
-	if !equalJSON(decision.Result, mustRawJSON(t, map[string]int{"version": 2})) {
+	if !equalJSONForTest(t, decision.Result, mustRawJSON(t, map[string]int{"version": 2})) {
 		t.Fatalf("expected GetVersion to return maxSupported on first execution, result = %s", decision.Result)
 	}
 
@@ -133,7 +133,7 @@ func TestReplayGetVersionRecordsMaxSupportedOnFirstExecutionAndReplaysRecordedVa
 	if len(replayDecision.Events) != 0 {
 		t.Fatalf("expected no new events on replay, got %+v", replayDecision.Events)
 	}
-	if !equalJSON(replayDecision.Result, decision.Result) {
+	if !equalJSONForTest(t, replayDecision.Result, decision.Result) {
 		t.Fatalf("replayed result %s differs from first execution %s", replayDecision.Result, decision.Result)
 	}
 }
@@ -178,7 +178,7 @@ func TestReplayGetVersionMarkerlessOldRunTakesOldBranchUnderNewCode(t *testing.T
 		t.Fatalf("expected no failure completing the in-flight run, got %q: %q", inFlightDecision.FailureCode, inFlightDecision.FailureMessage)
 	}
 	wantOldResult := mustRawJSON(t, map[string]string{"branch": "old", "greeting": "hello, Ada"})
-	if !equalJSON(inFlightDecision.Result, wantOldResult) {
+	if !equalJSONForTest(t, inFlightDecision.Result, wantOldResult) {
 		t.Fatalf("expected old-branch result %s, got %s", wantOldResult, inFlightDecision.Result)
 	}
 	if markers := collectVersionMarkers(t, inFlightDecision.Events); len(markers) != 0 {
@@ -203,7 +203,7 @@ func TestReplayGetVersionMarkerlessOldRunTakesOldBranchUnderNewCode(t *testing.T
 	if len(replayDecision.Events) != 0 {
 		t.Fatalf("expected no new events on full replay, got %+v", replayDecision.Events)
 	}
-	if !equalJSON(replayDecision.Result, wantOldResult) {
+	if !equalJSONForTest(t, replayDecision.Result, wantOldResult) {
 		t.Fatalf("full replay under new code returned %s, want %s", replayDecision.Result, wantOldResult)
 	}
 }
@@ -221,7 +221,7 @@ func TestReplayGetVersionNewRunTakesNewBranch(t *testing.T) {
 	if decision.NewActivity != nil {
 		t.Fatalf("new branch must not schedule the old activity, got %+v", decision.NewActivity)
 	}
-	if !equalJSON(decision.Result, mustRawJSON(t, map[string]string{"branch": "new"})) {
+	if !equalJSONForTest(t, decision.Result, mustRawJSON(t, map[string]string{"branch": "new"})) {
 		t.Fatalf("expected new-branch result, got %s", decision.Result)
 	}
 


### PR DESCRIPTION
## What / why

`equalJSON` in `engine/internal/workflow/replay.go` returned `false` whenever
`json.Unmarshal` failed on either side, so a corrupt/truncated payload field in stored history
surfaced as a `replay_mismatch` quarantine — a "your workflow code changed" signal — steering
operators toward the wrong diagnosis. Decode failures are a storage-corruption problem and need
a distinct failure code.

## What changed

- `equalJSON` now returns `(bool, error)`: byte-equal and both-empty inputs stay equal; an
  input that is empty on exactly one side stays a **semantic mismatch** (absent vs present is
  not corruption); a JSON decode failure on either side returns a wrapped error naming which
  side failed.
- New `historyCorrupt` panic path: decode errors quarantine the run (same #155 machinery)
  with `FailureCode: history_corrupt` and a "history payload decode failed: …" detail, while
  genuine mismatches keep `replay_mismatch`. The `waiting_for` payload keeps the existing
  `ReplayMismatchWait` shape/kind for console compatibility.
- All five comparison sites thread the error: continue-as-new input, workflow completion
  result, custom status, activity scheduling (`matchActivityScheduled`), and child-workflow
  scheduling (`matchChildWorkflowScheduled`). The match helpers return plain-field mismatches
  as mismatch (no error) and only propagate JSON decode errors.
- Existing test helper call sites updated mechanically via `equalJSONForTest`; no assertion
  changes.

## Test evidence

Acceptance tests (`engine/internal/workflow/replay_corrupt_test.go`, committed red first,
authored by an independent session): five corrupt-payload paths (custom status,
continue-as-new, workflow result, activity input, child-workflow input) now quarantine as
`history_corrupt`; regression guards prove valid-but-different payloads and absent-vs-present
results still quarantine as `replay_mismatch`.

- `go test ./engine/internal/workflow/...` — green
- `golangci-lint run ./engine/internal/workflow/...` — 0 issues
- No contract/SQL changes; `make generate` not needed

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow replay handling so corrupted or invalid recorded data is detected more reliably.
  * Replay mismatches now surface clearer quarantine details, including a more specific failure reason and message.
  * Matching behavior for workflow results, custom status, activities, child workflows, and continue-as-new inputs is now more consistent during replay.

* **Tests**
  * Added coverage for corrupt-history and replay-mismatch scenarios to verify quarantine behavior and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->