### PR TITLE
refactor(engine): quarantine typed engine-invariant panics as engine_invariant

### DIFF
--- a/engine/internal/history/events.go
+++ b/engine/internal/history/events.go
@@ -38,11 +38,12 @@ const (
 )
 
 const (
-	WaitKindActivity       = publichistory.WaitKindActivity
-	WaitKindTimer          = publichistory.WaitKindTimer
-	WaitKindSignal         = publichistory.WaitKindSignal
-	WaitKindChildWorkflow  = publichistory.WaitKindChildWorkflow
-	WaitKindReplayMismatch = publichistory.WaitKindReplayMismatch
+	WaitKindActivity        = publichistory.WaitKindActivity
+	WaitKindTimer           = publichistory.WaitKindTimer
+	WaitKindSignal          = publichistory.WaitKindSignal
+	WaitKindChildWorkflow   = publichistory.WaitKindChildWorkflow
+	WaitKindReplayMismatch  = publichistory.WaitKindReplayMismatch
+	WaitKindEngineInvariant = publichistory.WaitKindEngineInvariant
 )
 
 type WorkflowStartedPayload = publichistory.WorkflowStartedPayload
@@ -55,6 +56,7 @@ type WorkflowResumedPayload = publichistory.WorkflowResumedPayload
 type WorkflowTerminatedPayload = publichistory.WorkflowTerminatedPayload
 type WorkflowReplayMismatchPayload = publichistory.WorkflowReplayMismatchPayload
 type ReplayMismatchWait = publichistory.ReplayMismatchWait
+type EngineInvariantWait = publichistory.EngineInvariantWait
 type WorkflowTimeRecordedPayload = publichistory.WorkflowTimeRecordedPayload
 type WorkflowSideEffectRecordedPayload = publichistory.WorkflowSideEffectRecordedPayload
 type WorkflowVersionMarkerPayload = publichistory.WorkflowVersionMarkerPayload

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -128,6 +128,11 @@ type replayMismatchPanic struct {
 	failureCode string
 }
 
+// internalInvariantPanic marks engine-side invariant violations. These quarantine
+// the run with engine_invariant instead of failing it as a user workflow panic:
+// like replay_mismatch and history_corrupt, the run may be recoverable once a
+// fixed engine binary is deployed, and the existing quarantine resume path is
+// wait-kind-agnostic.
 type internalInvariantPanic struct {
 	detail string
 }
@@ -358,6 +363,9 @@ func (r *workflowRunner) execute(definition publicworkflow.Definition) (decision
 		case replayMismatchPanic:
 			mismatch := value
 			decision = r.quarantinedDecision(&mismatch)
+			err = nil
+		case internalInvariantPanic:
+			decision = r.invariantQuarantinedDecision(value.detail)
 			err = nil
 		case controlledFailurePanic:
 			decision = r.recordWorkflowFailure(value.failure)
@@ -1026,7 +1034,7 @@ func (r *workflowRunner) removePendingFrontier(inboxID uuid.UUID) {
 		return
 	}
 
-	panic(fmt.Sprintf("frontier inbox %s missing from pending frontier", inboxID))
+	panic(internalInvariantPanic{detail: fmt.Sprintf("frontier inbox %s missing from pending frontier", inboxID)})
 }
 
 func (r *workflowRunner) blockOnWait(wait any, scheduledEvent *queuedHistoryEvent, _ any) {
@@ -1035,7 +1043,7 @@ func (r *workflowRunner) blockOnWait(wait any, scheduledEvent *queuedHistoryEven
 	}
 	waitingFor, err := enginehistory.MarshalPayload(wait)
 	if err != nil {
-		panic(fmt.Sprintf("marshal waiting state: %v", err))
+		panic(internalInvariantPanic{detail: fmt.Sprintf("marshal waiting state: %v", err)})
 	}
 	r.waitingFor = waitingFor
 	panic(blockedPanic{})
@@ -1155,6 +1163,21 @@ func (r *workflowRunner) quarantinedDecision(mismatch *replayMismatchPanic) acti
 		CustomStatus:   cloneRaw(r.customStatus),
 		FailureCode:    failureCode,
 		FailureMessage: payload.Detail,
+	}
+}
+
+func (r *workflowRunner) invariantQuarantinedDecision(detail string) activationDecision {
+	waitingFor := mustMarshalPayload(enginehistory.EngineInvariantWait{
+		Kind:   enginehistory.WaitKindEngineInvariant,
+		Detail: detail,
+	})
+	return activationDecision{
+		Kind:           decisionQuarantined,
+		NextSequence:   r.nextSequence,
+		WaitingFor:     cloneRaw(waitingFor),
+		CustomStatus:   cloneRaw(r.customStatus),
+		FailureCode:    "engine_invariant",
+		FailureMessage: detail,
 	}
 }
 
@@ -1403,7 +1426,7 @@ func normalizedChildTerminatedError(code, message string) (normalizedCode, norma
 func mustMarshalPayload(payload any) json.RawMessage {
 	raw, err := enginehistory.MarshalPayload(payload)
 	if err != nil {
-		panic(fmt.Sprintf("marshal history payload: %v", err))
+		panic(internalInvariantPanic{detail: fmt.Sprintf("marshal history payload: %v", err)})
 	}
 	return raw
 }

--- a/engine/internal/workflow/replay.go
+++ b/engine/internal/workflow/replay.go
@@ -128,6 +128,10 @@ type replayMismatchPanic struct {
 	failureCode string
 }
 
+type internalInvariantPanic struct {
+	detail string
+}
+
 type controlledFailurePanic struct {
 	failure enginehistory.WorkflowFailedPayload
 }

--- a/engine/internal/workflow/replay_test.go
+++ b/engine/internal/workflow/replay_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -1383,6 +1384,118 @@ func equalJSONForTest(t *testing.T, left, right json.RawMessage) bool {
 		t.Fatalf("equalJSON() error = %v", err)
 	}
 	return equal
+}
+
+func TestReplayDefinitionEngineInvariantViolationQuarantines(t *testing.T) {
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-1",
+		}),
+	}
+	definition := publicworkflow.Definition{
+		Name:    "demo",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			ctx.(*workflowRunner).removePendingFrontier(uuid.New())
+			return nil
+		},
+	}
+
+	decision, err := replayDefinition(definition, historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionQuarantined {
+		t.Fatalf("expected quarantined decision, got %+v", decision)
+	}
+	if decision.FailureCode != "engine_invariant" {
+		t.Fatalf("expected engine_invariant failure code, got %q", decision.FailureCode)
+	}
+	if !strings.Contains(decision.FailureMessage, "missing from pending frontier") {
+		t.Fatalf("expected invariant detail in failure message, got %q", decision.FailureMessage)
+	}
+	if len(decision.Events) != 0 {
+		t.Fatalf("expected no events for quarantined invariant violation, got %+v", decision.Events)
+	}
+	if len(decision.ConsumedInboxIDs) != 0 {
+		t.Fatalf("expected no consumed inbox IDs, got %+v", decision.ConsumedInboxIDs)
+	}
+	if len(decision.WaitingFor) == 0 {
+		t.Fatalf("expected waiting state for quarantined invariant violation")
+	}
+	var waitingFor struct {
+		Kind   string `json:"kind"`
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(decision.WaitingFor, &waitingFor); err != nil {
+		t.Fatalf("decode waiting state: %v", err)
+	}
+	if waitingFor.Kind != "engine_invariant" {
+		t.Fatalf("expected engine_invariant waiting kind, got %q", waitingFor.Kind)
+	}
+	if waitingFor.Detail == "" {
+		t.Fatalf("expected non-empty invariant waiting detail")
+	}
+}
+
+func TestReplayDefinitionUserPanicKeepsWorkflowPanicCode(t *testing.T) {
+	historyRows := []enginedb.EngineHistory{
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "demo",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-1",
+		}),
+	}
+	definition := publicworkflow.Definition{
+		Name:    "demo",
+		Version: "v1",
+		Run: func(publicworkflow.Context) error {
+			panic("user boom")
+		},
+	}
+
+	decision, err := replayDefinition(definition, historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("replayDefinition() error = %v", err)
+	}
+	if decision.Kind != decisionFailed {
+		t.Fatalf("expected failed decision, got %+v", decision)
+	}
+	if decision.FailureCode != "workflow_panic" {
+		t.Fatalf("expected workflow_panic failure code, got %q", decision.FailureCode)
+	}
+	if !strings.Contains(decision.FailureMessage, "user boom") {
+		t.Fatalf("expected user panic detail in failure message, got %q", decision.FailureMessage)
+	}
+	if len(decision.Events) != 1 {
+		t.Fatalf("expected one workflow failed event, got %+v", decision.Events)
+	}
+	if decision.Events[0].EventType != enginehistory.EventWorkflowFailed {
+		t.Fatalf("expected workflow failed event, got %+v", decision.Events[0])
+	}
+}
+
+func TestRemovePendingFrontierMissingInboxPanicsTyped(t *testing.T) {
+	r := &workflowRunner{}
+	id := uuid.New()
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatalf("expected removePendingFrontier to panic")
+		}
+		invariant, ok := recovered.(internalInvariantPanic)
+		if !ok {
+			t.Fatalf("expected internalInvariantPanic, got %T: %[1]v", recovered)
+		}
+		if !strings.Contains(invariant.detail, id.String()) {
+			t.Fatalf("expected invariant detail to contain inbox ID %s, got %q", id, invariant.detail)
+		}
+	}()
+
+	r.removePendingFrontier(id)
 }
 
 func TestEqualJSONPreservesNumberPrecision(t *testing.T) {

--- a/engine/pkg/history/history.go
+++ b/engine/pkg/history/history.go
@@ -38,11 +38,12 @@ const (
 )
 
 const (
-	WaitKindActivity       = "activity"
-	WaitKindTimer          = "timer"
-	WaitKindSignal         = "signal"
-	WaitKindChildWorkflow  = "child_workflow"
-	WaitKindReplayMismatch = "replay_mismatch"
+	WaitKindActivity        = "activity"
+	WaitKindTimer           = "timer"
+	WaitKindSignal          = "signal"
+	WaitKindChildWorkflow   = "child_workflow"
+	WaitKindReplayMismatch  = "replay_mismatch"
+	WaitKindEngineInvariant = "engine_invariant"
 )
 
 type WorkflowStartedPayload struct {
@@ -91,6 +92,11 @@ type ReplayMismatchWait struct {
 	ActualType   string `json:"actual_type"`
 	ActualKey    string `json:"actual_key"`
 	Detail       string `json:"detail"`
+}
+
+type EngineInvariantWait struct {
+	Kind   string `json:"kind"`
+	Detail string `json:"detail"`
 }
 
 type WorkflowTimeRecordedPayload struct {


### PR DESCRIPTION
## What / why

Engine-internal invariant violations were indistinguishable from user workflow panics: `removePendingFrontier` panicked with a bare string, `execute()`'s generic recover caught it in the `default` branch, and the run terminally failed with the user-code `workflow_panic` code. Operators could not tell engine bugs from workflow bugs, and both were unrecoverable.

This change introduces a typed `internalInvariantPanic` for engine-side defensive panics and maps it to a **quarantined** decision with the distinct failure code `engine_invariant`, while genuine user panics keep the terminal `workflow_panic` failure.

**Decision (aligned with #155):** invariant violations quarantine rather than terminally fail. Like `replay_mismatch` and `history_corrupt`, they are engine-side defects — the run may be recoverable once a fixed engine binary is deployed, and the existing quarantine resume path is wait-kind-agnostic, so operators can resume such runs with zero API changes. User panics stay terminal because retrying a deterministic user bug just replays the same panic. The decision is documented on the type in `replay.go`.

## Implementation

- `engine/pkg/history`: new `WaitKindEngineInvariant` const and `EngineInvariantWait{kind, detail}` wait payload; mirrored via the existing alias pattern in `engine/internal/history`.
- `engine/internal/workflow/replay.go`:
  - `internalInvariantPanic{detail}` now carries all defensive engine-invariant panics: `removePendingFrontier` (missing frontier inbox), `blockOnWait` (waiting-state marshal failure), and `mustMarshalPayload` (history payload marshal failure).
  - `execute()`'s recover gains a `case internalInvariantPanic` that produces a quarantined decision (failure code `engine_invariant`, `waiting_for` = `EngineInvariantWait`) without queuing history events or advancing runner state — the state is untrustworthy after an invariant violation.
  - `invariantQuarantinedDecision` mirrors the existing `quarantinedDecision`.

No contract, schema, or generated-code changes (`make generate` not needed); the `quarantined` run status and its resume path already exist from #155. `activation.go` commits `decisionQuarantined` generically and is untouched.

## Tests (written first, committed red by an independent session)

`engine/internal/workflow/replay_test.go`:
- `TestReplayDefinitionEngineInvariantViolationQuarantines` — drives a real inconsistent-frontier invariant violation through `replayDefinition` and asserts the quarantined decision, `engine_invariant` failure code, `engine_invariant` waiting kind with detail, and that no history events are queued or inbox rows consumed. (Red before: failed with `workflow_panic`.)
- `TestReplayDefinitionUserPanicKeepsWorkflowPanicCode` — pins the contrast: user panics still terminally fail with `workflow_panic` and record `workflow.failed`.
- `TestRemovePendingFrontierMissingInboxPanicsTyped` — asserts the panic value is the typed `internalInvariantPanic` carrying the missing inbox ID. (Red before: bare string.)

Verified: `cd engine && go build ./... && go test ./internal/workflow/... ./pkg/history/...` all green; tests reviewed against the spec and confirmed unmodified by the implementation session.

Closes #159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new engine invariant wait state for workflows, with a detail message that explains what went wrong.
  - Replay now distinguishes engine-internal invariant issues from user panics and surfaces them as a quarantined state.

- **Bug Fixes**
  - Improved handling of unexpected internal failures so they no longer look like normal workflow errors.
  - Added coverage to verify invariant violations, user panics, and missing frontier entries are reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->