### PR TITLE
fix(engine): compute next history sequence with MAX(sequence_no) in activity retry

### DIFF
--- a/engine/db/gen/go/history.sql.go
+++ b/engine/db/gen/go/history.sql.go
@@ -151,6 +151,19 @@ func (q *Queries) GetLatestHistoryIDByRun(ctx context.Context, runID uuid.UUID) 
 	return column_1, err
 }
 
+const getMaxHistorySequenceByRun = `-- name: GetMaxHistorySequenceByRun :one
+SELECT COALESCE(MAX(sequence_no), 0)::int
+FROM engine.history
+WHERE run_id = $1
+`
+
+func (q *Queries) GetMaxHistorySequenceByRun(ctx context.Context, runID uuid.UUID) (int32, error) {
+	row := q.db.QueryRow(ctx, getMaxHistorySequenceByRun, runID)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const listHistoryByRunAfterID = `-- name: ListHistoryByRunAfterID :many
 SELECT id, project_id, instance_id, run_id, sequence_no, event_type, payload, created_at
 FROM engine.history

--- a/engine/db/queries/history.sql
+++ b/engine/db/queries/history.sql
@@ -21,6 +21,11 @@ SELECT COALESCE(MAX(id), 0)::bigint
 FROM engine.history
 WHERE run_id = $1;
 
+-- name: GetMaxHistorySequenceByRun :one
+SELECT COALESCE(MAX(sequence_no), 0)::int
+FROM engine.history
+WHERE run_id = $1;
+
 -- name: ListHistoryByRunAfterID :many
 SELECT *
 FROM engine.history

--- a/engine/internal/activity/worker.go
+++ b/engine/internal/activity/worker.go
@@ -226,14 +226,11 @@ func (w *Worker) shouldRetryTask(task *enginedb.EngineActivityTask, handlerErr e
 }
 
 func nextHistorySequence(ctx context.Context, tx *store.Tx, runID uuid.UUID) (int32, error) {
-	historyRows, err := tx.GetHistoryByRun(ctx, runID)
+	maxSequence, err := tx.GetMaxHistorySequenceByRun(ctx, runID)
 	if err != nil {
 		return 0, err
 	}
-	if len(historyRows) == 0 {
-		return 1, nil
-	}
-	return historyRows[len(historyRows)-1].SequenceNo + 1, nil
+	return maxSequence + 1, nil
 }
 
 func activityErrorCode(err error) string {

--- a/engine/internal/activity/worker_test.go
+++ b/engine/internal/activity/worker_test.go
@@ -471,6 +471,74 @@ func TestWorkerRetryableFailureSchedulesRetryWithoutWakingRun(t *testing.T) {
 	}
 }
 
+func TestWorkerRetryScheduledSequenceContinuesFromMaxHistory(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+
+	initial := int64(333)
+	maxBackoff := int64(1000)
+	multiplier := 1.5
+	instance, run, task := createWaitingRunWithPendingActivity(t, store, pendingActivityConfig{
+		projectID:         enginetest.DefaultPlatformProjectID,
+		instanceKey:       "instance-activity-retry-max-sequence",
+		activityKey:       "compose-greeting",
+		maxAttempts:       3,
+		initialBackoffMS:  &initial,
+		maxBackoffMS:      &maxBackoff,
+		backoffMultiplier: &multiplier,
+	})
+
+	if _, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  run.ProjectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 10,
+		EventType:  "activity.out_of_band_marker",
+		Payload:    []byte(`{"event":"activity.out_of_band_marker"}`),
+	}); err != nil {
+		t.Fatalf("AppendHistory(high sequence marker) error = %v", err)
+	}
+
+	registry, err := NewRegistry(map[string]Handler{
+		testActivityType: func(context.Context, json.RawMessage) (json.RawMessage, error) {
+			return nil, errors.New("boom")
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	worker := NewWorker(store, registry, time.Minute)
+	if err := worker.PollOnce(ctx, "activity-worker"); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+
+	retriedTask, err := store.GetActivityTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask() error = %v", err)
+	}
+	if retriedTask.Status != enginedb.EngineActivityTaskStatusQueued {
+		t.Fatalf("expected queued retry task, got %+v", retriedTask)
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	if len(historyRows) != 4 {
+		t.Fatalf("expected started + activity.scheduled + marker + retry history, got %+v", historyRows)
+	}
+
+	retryHistory := historyRows[len(historyRows)-1]
+	if retryHistory.EventType != enginehistory.EventActivityRetryScheduled {
+		t.Fatalf("expected final history row to be activity.retry_scheduled, got %+v", retryHistory)
+	}
+	if retryHistory.SequenceNo != 11 {
+		t.Fatalf("expected retry_scheduled sequence_no 11 after max sequence 10, got %+v", retryHistory)
+	}
+}
+
 func TestWorkerSingleAttemptFailureWakesWaitingRun(t *testing.T) {
 	db := enginetest.NewTestDatabase(t)
 	store := enginestore.New(db.Pool)

--- a/engine/internal/store/history.go
+++ b/engine/internal/store/history.go
@@ -21,6 +21,10 @@ func (o *storeOps) GetLatestHistoryIDByRun(ctx context.Context, runID uuid.UUID)
 	return o.q.GetLatestHistoryIDByRun(ctx, runID)
 }
 
+func (o *storeOps) GetMaxHistorySequenceByRun(ctx context.Context, runID uuid.UUID) (int32, error) {
+	return o.q.GetMaxHistorySequenceByRun(ctx, runID)
+}
+
 func (o *storeOps) ListHistoryByRunAfterID(
 	ctx context.Context,
 	arg enginedb.ListHistoryByRunAfterIDParams,

--- a/engine/internal/store/history_test.go
+++ b/engine/internal/store/history_test.go
@@ -1,6 +1,12 @@
 package store
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+)
 
 func TestHistoryOrdering(t *testing.T) {
 	ts := newTestStore(t)
@@ -23,5 +29,81 @@ func TestHistoryOrdering(t *testing.T) {
 	}
 	if len(runOneHistory) != 2 || runOneHistory[0].SequenceNo != 1 || runOneHistory[1].SequenceNo != 2 {
 		t.Fatalf("expected stable per-run ordering by sequence_no, got %+v", runOneHistory)
+	}
+}
+
+func TestGetMaxHistorySequenceByRunEmptyRunReturnsZero(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	instance := ts.createInstance(t, projectID, "instance-history-max-empty")
+	run := ts.createRun(t, instance, 1)
+
+	maxSequence, err := ts.store.GetMaxHistorySequenceByRun(ts.ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetMaxHistorySequenceByRun() error = %v", err)
+	}
+	if maxSequence != 0 {
+		t.Fatalf("expected empty run max sequence 0, got %d", maxSequence)
+	}
+}
+
+func TestGetMaxHistorySequenceByRunReturnsPerRunMax(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	instance := ts.createInstance(t, projectID, "instance-history-max-per-run")
+	runA := ts.createRun(t, instance, 1)
+	runB := ts.createRun(t, instance, 2)
+
+	ts.createHistory(t, projectID, instance.ID, runA.ID, 1, "run-a.started")
+	ts.createHistory(t, projectID, instance.ID, runA.ID, 2, "run-a.progressed")
+	ts.createHistory(t, projectID, instance.ID, runA.ID, 7, "run-a.completed")
+	ts.createHistory(t, projectID, instance.ID, runB.ID, 9, "run-b.started")
+
+	maxRunA, err := ts.store.GetMaxHistorySequenceByRun(ts.ctx, runA.ID)
+	if err != nil {
+		t.Fatalf("GetMaxHistorySequenceByRun(runA) error = %v", err)
+	}
+	if maxRunA != 7 {
+		t.Fatalf("expected run A max sequence 7, got %d", maxRunA)
+	}
+
+	maxRunB, err := ts.store.GetMaxHistorySequenceByRun(ts.ctx, runB.ID)
+	if err != nil {
+		t.Fatalf("GetMaxHistorySequenceByRun(runB) error = %v", err)
+	}
+	if maxRunB != 9 {
+		t.Fatalf("expected run B max sequence 9, got %d", maxRunB)
+	}
+}
+
+func TestGetMaxHistorySequenceByRunInsideTx(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	instance := ts.createInstance(t, projectID, "instance-history-max-tx")
+	run := ts.createRun(t, instance, 1)
+
+	tx, err := ts.store.BeginTx(ts.ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback(ts.ctx) }()
+
+	if _, err := tx.AppendHistory(ts.ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 3,
+		EventType:  "run.tx_event",
+		Payload:    []byte(`{"event":"run.tx_event"}`),
+	}); err != nil {
+		t.Fatalf("AppendHistory(tx) error = %v", err)
+	}
+
+	maxSequence, err := tx.GetMaxHistorySequenceByRun(ts.ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetMaxHistorySequenceByRun(tx) error = %v", err)
+	}
+	if maxSequence != 3 {
+		t.Fatalf("expected tx-visible max sequence 3, got %d", maxSequence)
 	}
 }


### PR DESCRIPTION
## What / why

`nextHistorySequence` in the activity worker's retry path loaded and decoded the **entire** run history (`GetHistoryByRun`) just to read the last `sequence_no` and add 1. The cost grew linearly with history length and was paid on every activity retry — long agent runs with many retries paid it repeatedly. Computing the next sequence number is now O(1) at the database.

## Changes

- New sqlc query `GetMaxHistorySequenceByRun` (`SELECT COALESCE(MAX(sequence_no), 0)::int FROM engine.history WHERE run_id = $1`) in `engine/db/queries/history.sql`, served by the existing `UNIQUE (run_id, sequence_no)` index — no new migration needed.
- Regenerated engine sqlc output with the pinned sqlc v1.27.0 (no hand edits to generated files).
- Thin `storeOps` wrapper in `engine/internal/store/history.go`, available on both `Store` and `Tx` via the embedded ops.
- `nextHistorySequence` in `engine/internal/activity/worker.go` now returns `MAX(sequence_no) + 1`; the empty-history case falls out of the `COALESCE` (0 → 1).
- Other `GetHistoryByRun` callers audited: workflow replay activation (`engine/internal/workflow/activation.go`) and the CLI `inspect` command (`engine/cmd/continua-engine/runtime_commands.go`) legitimately need the full history and are unchanged.

## Tests

Acceptance tests were authored first and committed red (the store package failed to compile on the missing method), then implemented against by an independent session:

- `TestGetMaxHistorySequenceByRunEmptyRunReturnsZero` — a run with no history returns 0 (so the retry path yields sequence 1).
- `TestGetMaxHistorySequenceByRunReturnsPerRunMax` — per-run scoping and MAX semantics across intentional sequence gaps (run A {1,2,7} → 7; run B {9} → 9).
- `TestGetMaxHistorySequenceByRunInsideTx` — the method exists on the `Tx` path the activity worker uses and sees uncommitted rows.
- `TestWorkerRetryScheduledSequenceContinuesFromMaxHistory` — with the run's max sequence decoupled from row count, the `activity.retry_scheduled` event lands at max+1 with no unique-constraint violation.

Verification: `go test ./engine/internal/store/... ./engine/internal/activity/...` green against real Postgres; engine `sqlc generate` (pinned v1.27.0) reproduces the committed generated code with zero drift.

Closes #160


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * History tracking now uses the latest recorded sequence to determine the next event number.
  * Runs with no history now correctly start from sequence `1`.

* **Bug Fixes**
  * Retry scheduling now continues from the highest existing history sequence, even if additional entries were added out of band.
  * Improved consistency when history is read inside a transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->