### PR TITLE
feat(engine): public runtime entrypoint to embed the engine as a Go library

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -43,6 +43,7 @@
             "group": "Workflows",
             "pages": [
               "guides/workflow-code-versioning",
+              "guides/embed-engine",
               "guides/debugging-failures",
               "guides/comparing-sessions"
             ]

--- a/docs-site/guides/embed-engine.mdx
+++ b/docs-site/guides/embed-engine.mdx
@@ -1,0 +1,74 @@
+---
+title: "Embed the engine"
+description: "Run the preview durable engine inside a Go program with your own workflow and activity registries."
+---
+
+The engine can run as an embedded Go library. Your process registers workflow
+definitions and activity handlers, then starts the same worker loop that powers
+`continua-engine serve`.
+
+<Warning>
+  The durable engine is still preview. Workflow authoring is Go-only, and run
+  start still happens through the `continua-engine` CLI or the preview control
+  plane.
+</Warning>
+
+## Register definitions and handlers
+
+Use `github.com/continua-ai/continua/engine/pkg/runtime` from inside a Go program in the
+engine module:
+
+```go
+rt, err := runtime.New(runtime.Options{
+    DatabaseURL: os.Getenv("DATABASE_URL"),
+    Workflows: []workflow.Definition{
+        {
+            Name:    "examples.greeter",
+            Version: "v1",
+            Run:     runGreeterWorkflow,
+        },
+    },
+    Activities: map[string]runtime.ActivityHandler{
+        "examples.greet": greetActivity,
+    },
+})
+if err != nil {
+    return err
+}
+return rt.Run(ctx)
+```
+
+`runtime.New` validates the database URL and the supplied registries, but it does not
+connect to Postgres. `Run` opens the engine pool, publishes the registered definitions
+to `engine.definition_catalog`, then starts the workflow worker, activity worker,
+maintenance worker, and projector until the context is cancelled.
+
+See `engine/examples/greeter` for a minimal compilable program with signal handling.
+
+## Start runs
+
+The embedded process executes runs for definitions it registered. Creating those runs is
+still a control-plane operation:
+
+```bash
+continua-engine start \
+  --instance-key greeter-1 \
+  --definition examples.greeter \
+  --version v1 \
+  --request-key greeter-1 \
+  --input '{"name":"Ada"}'
+```
+
+In deployments that use the preview REST control plane, start requests can also come
+through `POST /v1/engine/runs`. The registered definition name and version must already
+be present in the runtime-published catalog.
+
+## Scope and caveats
+
+- The runtime is preview and not a production-ready multi-tenant worker host.
+- Workflow and activity authoring is Go-only.
+- There is no dynamic definition loading path yet; user code registers definitions in
+  the Go process at startup.
+- The runtime uses the same Postgres-backed history, leases, timers, signals, activity
+  tasks, child workflows, cancellation, continue-as-new, and projection path as
+  `continua-engine serve`.

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -15,18 +15,15 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 	"github.com/continua-ai/continua/engine/internal/activity"
-	"github.com/continua-ai/continua/engine/internal/catalog"
 	"github.com/continua-ai/continua/engine/internal/config"
 	enginehistory "github.com/continua-ai/continua/engine/internal/history"
-	engineprojector "github.com/continua-ai/continua/engine/internal/projector"
 	enginestore "github.com/continua-ai/continua/engine/internal/store"
-	engineworker "github.com/continua-ai/continua/engine/internal/worker"
 	engineworkflow "github.com/continua-ai/continua/engine/internal/workflow"
 	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
+	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
 
 	"github.com/continua-ai/continua/engine/cmd/continua-engine/internal/darklaunch"
 )
@@ -96,38 +93,31 @@ func serveCmd() *cobra.Command {
 			ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
 
-			return withRuntime(ctx, func(ctx context.Context, cfg *config.Config, store *enginestore.Store, definitions *engineworkflow.Registry, activities *activity.Registry) error {
-				if err := catalog.PublishStoreDefinitions(ctx, store, definitions.List()); err != nil {
-					return err
-				}
-
-				workflowWorker := engineworkflow.NewWorker(store, definitions, cfg.Runtime.RunLeaseTTL)
-				activityWorker := activity.NewWorker(store, activities, cfg.Runtime.ActivityLeaseTTL)
-				maintenanceWorker := engineworker.NewMaintenanceWorker(store)
-				projectorWorker := engineprojector.New(store)
-
-				log.Printf("starting continua-engine serve")
-
-				group, groupCtx := errgroup.WithContext(ctx)
-				group.Go(func() error {
-					return engineworker.RunLoop(groupCtx, cfg.Runtime.WorkflowPollInterval, "workflow", workflowWorker.PollOnce)
-				})
-				group.Go(func() error {
-					return engineworker.RunLoop(groupCtx, cfg.Runtime.ActivityPollInterval, "activity", activityWorker.PollOnce)
-				})
-				group.Go(func() error {
-					return engineworker.RunLoop(groupCtx, cfg.Runtime.MaintenancePollInterval, "maintenance", maintenanceWorker.PollOnce)
-				})
-				group.Go(func() error {
-					return engineworker.RunLoop(groupCtx, cfg.Runtime.WorkflowPollInterval, "projector", projectorWorker.PollOnce)
-				})
-
-				err := group.Wait()
-				if err == nil {
-					log.Printf("continua-engine serve stopped")
-				}
+			cfg, err := config.Load()
+			if err != nil {
 				return err
+			}
+			rt, err := engineruntime.New(engineruntime.Options{
+				DatabaseURL:             cfg.Database.URL,
+				Workflows:               darklaunch.Definitions(),
+				Activities:              runtimeHandlers(darklaunch.Handlers()),
+				ProjectID:               cfg.Runtime.ProjectIDFilter,
+				WorkflowPollInterval:    cfg.Runtime.WorkflowPollInterval,
+				ActivityPollInterval:    cfg.Runtime.ActivityPollInterval,
+				MaintenancePollInterval: cfg.Runtime.MaintenancePollInterval,
+				RunLeaseTTL:             cfg.Runtime.RunLeaseTTL,
+				ActivityLeaseTTL:        cfg.Runtime.ActivityLeaseTTL,
 			})
+			if err != nil {
+				return err
+			}
+
+			log.Printf("starting continua-engine serve")
+			err = rt.Run(ctx)
+			if err == nil {
+				log.Printf("continua-engine serve stopped")
+			}
+			return err
 		},
 	}
 }
@@ -585,6 +575,14 @@ func buildRegistries() (definitions *engineworkflow.Registry, activities *activi
 		return nil, nil, err
 	}
 	return definitions, activities, nil
+}
+
+func runtimeHandlers(handlers map[string]activity.Handler) map[string]engineruntime.ActivityHandler {
+	converted := make(map[string]engineruntime.ActivityHandler, len(handlers))
+	for activityType, handler := range handlers {
+		converted[activityType] = engineruntime.ActivityHandler(handler)
+	}
+	return converted
 }
 
 func resolveStartDefinitionVersion(definitions *engineworkflow.Registry, definitionName, definitionVersion string) (string, bool) {

--- a/engine/examples/greeter/main.go
+++ b/engine/examples/greeter/main.go
@@ -53,7 +53,8 @@ func run() error {
 		return err
 	}
 
-	// Start runs through the continua-engine CLI or the preview engine control plane.
+	// Run the engine worker loop. To create runs, use the continua-engine CLI
+	// or the preview engine control plane.
 	return rt.Run(ctx)
 }
 

--- a/engine/examples/greeter/main.go
+++ b/engine/examples/greeter/main.go
@@ -27,6 +27,12 @@ type greetOutput struct {
 }
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
@@ -44,13 +50,11 @@ func main() {
 		},
 	})
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// Start runs through the continua-engine CLI or the preview engine control plane.
-	if err := rt.Run(ctx); err != nil {
-		log.Fatal(err)
-	}
+	return rt.Run(ctx)
 }
 
 func runGreeterWorkflow(ctx workflow.Context) error {

--- a/engine/examples/greeter/main.go
+++ b/engine/examples/greeter/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+const (
+	greeterWorkflowName    = "examples.greeter"
+	greeterWorkflowVersion = "v1"
+	greetActivityType      = "examples.greet"
+)
+
+type greetInput struct {
+	Name string `json:"name"`
+}
+
+type greetOutput struct {
+	Greeting string `json:"greeting"`
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL: os.Getenv("DATABASE_URL"),
+		Workflows: []workflow.Definition{
+			{
+				Name:    greeterWorkflowName,
+				Version: greeterWorkflowVersion,
+				Run:     runGreeterWorkflow,
+			},
+		},
+		Activities: map[string]engineruntime.ActivityHandler{
+			greetActivityType: greetActivity,
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Start runs through the continua-engine CLI or the preview engine control plane.
+	if err := rt.Run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runGreeterWorkflow(ctx workflow.Context) error {
+	var input greetInput
+	if err := ctx.Input(&input); err != nil {
+		return err
+	}
+
+	var output greetOutput
+	if err := ctx.Activity("greet", greetActivityType, input, &output); err != nil {
+		return err
+	}
+
+	return ctx.SetResult(output)
+}
+
+func greetActivity(_ context.Context, raw json.RawMessage) (json.RawMessage, error) {
+	var input greetInput
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &input); err != nil {
+			return nil, err
+		}
+	}
+	if input.Name == "" {
+		input.Name = "world"
+	}
+
+	return json.Marshal(greetOutput{
+		Greeting: "hello, " + input.Name,
+	})
+}

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -49,45 +49,8 @@ type RuntimeConfig struct {
 	ProjectIDFilter         *uuid.UUID
 }
 
-// Load resolves the engine database configuration from environment variables.
-func Load() (*Config, error) {
-	databaseURL := os.Getenv("ENGINE_DATABASE_URL")
-	if databaseURL == "" {
-		databaseURL = os.Getenv("DATABASE_URL")
-	}
-	if databaseURL == "" {
-		return nil, errors.New("ENGINE_DATABASE_URL or DATABASE_URL environment variable is required")
-	}
-
-	workflowPollInterval, err := durationFromEnv("ENGINE_WORKFLOW_POLL_INTERVAL", defaultWorkflowPoll)
-	if err != nil {
-		return nil, err
-	}
-	activityPollInterval, err := durationFromEnv("ENGINE_ACTIVITY_POLL_INTERVAL", defaultActivityPoll)
-	if err != nil {
-		return nil, err
-	}
-	maintenancePollInterval, err := durationFromEnv("ENGINE_MAINTENANCE_POLL_INTERVAL", defaultMaintenancePoll)
-	if err != nil {
-		return nil, err
-	}
-	runLeaseTTL, err := durationFromEnv("ENGINE_RUN_LEASE_TTL", defaultRunLeaseTTL)
-	if err != nil {
-		return nil, err
-	}
-	activityLeaseTTL, err := durationFromEnv("ENGINE_ACTIVITY_LEASE_TTL", defaultActivityLease)
-	if err != nil {
-		return nil, err
-	}
-	requestDedupeTTL, err := durationFromEnv("ENGINE_REQUEST_DEDUPE_TTL", defaultRequestDedupe)
-	if err != nil {
-		return nil, err
-	}
-	projectIDFilter, err := uuidFromEnv("CONTINUA_ENGINE_TEST_PROJECT_FILTER")
-	if err != nil {
-		return nil, err
-	}
-
+// Defaults returns the engine runtime defaults for a database URL.
+func Defaults(databaseURL string) *Config {
 	return &Config{
 		Database: DatabaseConfig{
 			URL:               databaseURL,
@@ -98,15 +61,65 @@ func Load() (*Config, error) {
 			HealthCheckPeriod: defaultHealthCheck,
 		},
 		Runtime: RuntimeConfig{
-			WorkflowPollInterval:    workflowPollInterval,
-			ActivityPollInterval:    activityPollInterval,
-			MaintenancePollInterval: maintenancePollInterval,
-			RunLeaseTTL:             runLeaseTTL,
-			ActivityLeaseTTL:        activityLeaseTTL,
-			RequestDedupeTTL:        requestDedupeTTL,
-			ProjectIDFilter:         projectIDFilter,
+			WorkflowPollInterval:    defaultWorkflowPoll,
+			ActivityPollInterval:    defaultActivityPoll,
+			MaintenancePollInterval: defaultMaintenancePoll,
+			RunLeaseTTL:             defaultRunLeaseTTL,
+			ActivityLeaseTTL:        defaultActivityLease,
+			RequestDedupeTTL:        defaultRequestDedupe,
 		},
-	}, nil
+	}
+}
+
+// Load resolves the engine database configuration from environment variables.
+func Load() (*Config, error) {
+	databaseURL := os.Getenv("ENGINE_DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = os.Getenv("DATABASE_URL")
+	}
+	if databaseURL == "" {
+		return nil, errors.New("ENGINE_DATABASE_URL or DATABASE_URL environment variable is required")
+	}
+
+	cfg := Defaults(databaseURL)
+
+	workflowPollInterval, err := durationFromEnv("ENGINE_WORKFLOW_POLL_INTERVAL", cfg.Runtime.WorkflowPollInterval)
+	if err != nil {
+		return nil, err
+	}
+	activityPollInterval, err := durationFromEnv("ENGINE_ACTIVITY_POLL_INTERVAL", cfg.Runtime.ActivityPollInterval)
+	if err != nil {
+		return nil, err
+	}
+	maintenancePollInterval, err := durationFromEnv("ENGINE_MAINTENANCE_POLL_INTERVAL", cfg.Runtime.MaintenancePollInterval)
+	if err != nil {
+		return nil, err
+	}
+	runLeaseTTL, err := durationFromEnv("ENGINE_RUN_LEASE_TTL", cfg.Runtime.RunLeaseTTL)
+	if err != nil {
+		return nil, err
+	}
+	activityLeaseTTL, err := durationFromEnv("ENGINE_ACTIVITY_LEASE_TTL", cfg.Runtime.ActivityLeaseTTL)
+	if err != nil {
+		return nil, err
+	}
+	requestDedupeTTL, err := durationFromEnv("ENGINE_REQUEST_DEDUPE_TTL", cfg.Runtime.RequestDedupeTTL)
+	if err != nil {
+		return nil, err
+	}
+	projectIDFilter, err := uuidFromEnv("CONTINUA_ENGINE_TEST_PROJECT_FILTER")
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.Runtime.WorkflowPollInterval = workflowPollInterval
+	cfg.Runtime.ActivityPollInterval = activityPollInterval
+	cfg.Runtime.MaintenancePollInterval = maintenancePollInterval
+	cfg.Runtime.RunLeaseTTL = runLeaseTTL
+	cfg.Runtime.ActivityLeaseTTL = activityLeaseTTL
+	cfg.Runtime.RequestDedupeTTL = requestDedupeTTL
+	cfg.Runtime.ProjectIDFilter = projectIDFilter
+	return cfg, nil
 }
 
 func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) {

--- a/engine/pkg/runtime/options_test.go
+++ b/engine/pkg/runtime/options_test.go
@@ -109,3 +109,32 @@ func TestNewValidatesOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestRuntimeRunRejectsNilContext(t *testing.T) {
+	rt, err := New(Options{
+		DatabaseURL: "postgres://example/db",
+		Workflows: []workflow.Definition{{
+			Name:    "usertest.greeter",
+			Version: "v1",
+			Run: func(workflow.Context) error {
+				return nil
+			},
+		}},
+		Activities: map[string]ActivityHandler{
+			"usertest.greet": func(context.Context, json.RawMessage) (json.RawMessage, error) {
+				return nil, nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	err = rt.Run(nil) //nolint:staticcheck // This test verifies the invalid nil-context path.
+	if err == nil {
+		t.Fatal("Run(nil) error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "context is required") {
+		t.Fatalf("Run(nil) error = %q, want context required error", err.Error())
+	}
+}

--- a/engine/pkg/runtime/options_test.go
+++ b/engine/pkg/runtime/options_test.go
@@ -1,0 +1,111 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestNewValidatesOptions(t *testing.T) {
+	validDefinition := workflow.Definition{
+		Name:    "usertest.greeter",
+		Version: "v1",
+		Run: func(workflow.Context) error {
+			return nil
+		},
+	}
+	validActivity := func(context.Context, json.RawMessage) (json.RawMessage, error) {
+		return nil, nil
+	}
+
+	tests := []struct {
+		name    string
+		options Options
+		wantErr string
+	}{
+		{
+			name: "valid",
+			options: Options{
+				DatabaseURL: "postgres://example/db",
+				Workflows:   []workflow.Definition{validDefinition},
+				Activities: map[string]ActivityHandler{
+					"usertest.greet": validActivity,
+				},
+			},
+		},
+		{
+			name: "missing database url",
+			options: Options{
+				Workflows: []workflow.Definition{validDefinition},
+				Activities: map[string]ActivityHandler{
+					"usertest.greet": validActivity,
+				},
+			},
+			wantErr: "database",
+		},
+		{
+			name: "duplicate workflow definition",
+			options: Options{
+				DatabaseURL: "postgres://example/db",
+				Workflows: []workflow.Definition{
+					validDefinition,
+					validDefinition,
+				},
+				Activities: map[string]ActivityHandler{
+					"usertest.greet": validActivity,
+				},
+			},
+			wantErr: "duplicate",
+		},
+		{
+			name: "definition missing run func",
+			options: Options{
+				DatabaseURL: "postgres://example/db",
+				Workflows: []workflow.Definition{{
+					Name:    "usertest.greeter",
+					Version: "v1",
+				}},
+				Activities: map[string]ActivityHandler{
+					"usertest.greet": validActivity,
+				},
+			},
+			wantErr: "run function",
+		},
+		{
+			name: "invalid activity entry",
+			options: Options{
+				DatabaseURL: "postgres://example/db",
+				Workflows:   []workflow.Definition{validDefinition},
+				Activities: map[string]ActivityHandler{
+					"": validActivity,
+				},
+			},
+			wantErr: "activity",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt, err := New(tt.options)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("New() error = %v, want nil", err)
+				}
+				if rt == nil {
+					t.Fatal("New() runtime = nil, want non-nil")
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("New() error = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), tt.wantErr) {
+				t.Fatalf("New() error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -1,0 +1,51 @@
+// Package runtime embeds the Continua durable-execution engine as a library:
+// user programs register workflow definitions and activity handlers, then run
+// the engine workers against Postgres.
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+// ActivityHandler executes one activity invocation. It mirrors the engine's
+// internal activity handler contract.
+type ActivityHandler func(context.Context, json.RawMessage) (json.RawMessage, error)
+
+// Options configures an embedded engine runtime.
+type Options struct {
+	// DatabaseURL is the Postgres connection string. Required.
+	DatabaseURL string
+	// Workflows are the workflow definitions this runtime can execute.
+	Workflows []workflow.Definition
+	// Activities maps activity type to handler.
+	Activities map[string]ActivityHandler
+	// ProjectID optionally scopes all polling to a single project.
+	ProjectID *uuid.UUID
+	// Poll intervals and lease TTLs; zero values use the engine defaults.
+	WorkflowPollInterval    time.Duration
+	ActivityPollInterval    time.Duration
+	MaintenancePollInterval time.Duration
+	RunLeaseTTL             time.Duration
+	ActivityLeaseTTL        time.Duration
+}
+
+// Runtime is an embedded engine instance built from Options.
+type Runtime struct{}
+
+// New validates the options and builds the workflow/activity registries.
+func New(opts Options) (*Runtime, error) {
+	return nil, errors.New("runtime: not implemented")
+}
+
+// Run executes the engine workers until ctx is cancelled. It returns nil on
+// graceful shutdown.
+func (r *Runtime) Run(ctx context.Context) error {
+	return errors.New("runtime: not implemented")
+}

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -52,7 +52,7 @@ type Runtime struct {
 }
 
 // New validates the options and builds the workflow/activity registries.
-func New(opts Options) (*Runtime, error) {
+func New(opts Options) (*Runtime, error) { //nolint:gocritic // Keep the public constructor ergonomic for literal Options values.
 	if opts.DatabaseURL == "" {
 		return nil, errors.New("runtime: database URL is required")
 	}
@@ -89,7 +89,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 	}
 
 	cfg := config.Defaults(r.options.DatabaseURL)
-	applyRuntimeOverrides(cfg, r.options)
+	applyRuntimeOverrides(cfg, &r.options)
 
 	pool, err := enginestore.NewPool(ctx, cfg)
 	if err != nil {
@@ -127,7 +127,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 	return group.Wait()
 }
 
-func applyRuntimeOverrides(cfg *config.Config, opts Options) {
+func applyRuntimeOverrides(cfg *config.Config, opts *Options) {
 	if opts.WorkflowPollInterval != 0 {
 		cfg.Runtime.WorkflowPollInterval = opts.WorkflowPollInterval
 	}

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -85,7 +85,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 		return errors.New("runtime: nil runtime")
 	}
 	if ctx == nil {
-		ctx = context.Background()
+		return errors.New("runtime: context is required")
 	}
 
 	cfg := config.Defaults(r.options.DatabaseURL)

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -10,7 +10,19 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"golang.org/x/sync/errgroup"
 
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	"github.com/continua-ai/continua/engine/internal/activity"
+	"github.com/continua-ai/continua/engine/internal/catalog"
+	"github.com/continua-ai/continua/engine/internal/config"
+	engineprojector "github.com/continua-ai/continua/engine/internal/projector"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	engineworker "github.com/continua-ai/continua/engine/internal/worker"
+	engineworkflow "github.com/continua-ai/continua/engine/internal/workflow"
+	publichistory "github.com/continua-ai/continua/engine/pkg/history"
+	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
 	"github.com/continua-ai/continua/engine/pkg/workflow"
 )
 
@@ -37,15 +49,221 @@ type Options struct {
 }
 
 // Runtime is an embedded engine instance built from Options.
-type Runtime struct{}
+type Runtime struct {
+	options     Options
+	definitions *engineworkflow.Registry
+	activities  *activity.Registry
+}
 
 // New validates the options and builds the workflow/activity registries.
 func New(opts Options) (*Runtime, error) {
-	return nil, errors.New("runtime: not implemented")
+	if opts.DatabaseURL == "" {
+		return nil, errors.New("runtime: database URL is required")
+	}
+
+	definitions, err := engineworkflow.NewRegistry(opts.Workflows...)
+	if err != nil {
+		return nil, err
+	}
+
+	handlers := make(map[string]activity.Handler, len(opts.Activities))
+	for activityType, handler := range opts.Activities {
+		handlers[activityType] = activity.Handler(handler)
+	}
+	activities, err := activity.NewRegistry(handlers)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Runtime{
+		options:     opts,
+		definitions: definitions,
+		activities:  activities,
+	}, nil
 }
 
 // Run executes the engine workers until ctx is cancelled. It returns nil on
 // graceful shutdown.
 func (r *Runtime) Run(ctx context.Context) error {
-	return errors.New("runtime: not implemented")
+	if r == nil {
+		return errors.New("runtime: nil runtime")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cfg := config.Defaults(r.options.DatabaseURL)
+	applyRuntimeOverrides(cfg, r.options)
+
+	pool, err := enginestore.NewPool(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	store := enginestore.New(pool)
+	if r.options.ProjectID != nil {
+		store = store.WithProjectFilter(*r.options.ProjectID)
+	}
+	defer store.Close()
+
+	if err := catalog.PublishStoreDefinitions(ctx, store, r.definitions.List()); err != nil {
+		return err
+	}
+	if err := ensureInitialProjectionShells(ctx, store, r.options.ProjectID); err != nil {
+		return err
+	}
+
+	workflowWorker := engineworkflow.NewWorker(store, r.definitions, cfg.Runtime.RunLeaseTTL)
+	activityWorker := activity.NewWorker(store, r.activities, cfg.Runtime.ActivityLeaseTTL)
+	maintenanceWorker := engineworker.NewMaintenanceWorker(store)
+	projectorWorker := engineprojector.New(store)
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		return engineworker.RunLoop(groupCtx, cfg.Runtime.WorkflowPollInterval, "workflow", workflowWorker.PollOnce)
+	})
+	group.Go(func() error {
+		return engineworker.RunLoop(groupCtx, cfg.Runtime.ActivityPollInterval, "activity", activityWorker.PollOnce)
+	})
+	group.Go(func() error {
+		return engineworker.RunLoop(groupCtx, cfg.Runtime.MaintenancePollInterval, "maintenance", maintenanceWorker.PollOnce)
+	})
+	group.Go(func() error {
+		return engineworker.RunLoop(groupCtx, cfg.Runtime.WorkflowPollInterval, "projector", projectorWorker.PollOnce)
+	})
+
+	return group.Wait()
+}
+
+func applyRuntimeOverrides(cfg *config.Config, opts Options) {
+	if opts.WorkflowPollInterval != 0 {
+		cfg.Runtime.WorkflowPollInterval = opts.WorkflowPollInterval
+	}
+	if opts.ActivityPollInterval != 0 {
+		cfg.Runtime.ActivityPollInterval = opts.ActivityPollInterval
+	}
+	if opts.MaintenancePollInterval != 0 {
+		cfg.Runtime.MaintenancePollInterval = opts.MaintenancePollInterval
+	}
+	if opts.RunLeaseTTL != 0 {
+		cfg.Runtime.RunLeaseTTL = opts.RunLeaseTTL
+	}
+	if opts.ActivityLeaseTTL != 0 {
+		cfg.Runtime.ActivityLeaseTTL = opts.ActivityLeaseTTL
+	}
+	cfg.Runtime.ProjectIDFilter = opts.ProjectID
+}
+
+func ensureInitialProjectionShells(ctx context.Context, store *enginestore.Store, projectID *uuid.UUID) error {
+	tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	runIDs, err := missingProjectionShellRunIDs(ctx, tx, projectID)
+	if err != nil {
+		return err
+	}
+
+	for _, runID := range runIDs {
+		if err := ensureInitialProjectionShell(ctx, tx, runID); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+func missingProjectionShellRunIDs(ctx context.Context, tx *enginestore.Tx, projectID *uuid.UUID) ([]uuid.UUID, error) {
+	const baseQuery = `
+		SELECT r.id
+		FROM engine.runs AS r
+		WHERE EXISTS (
+			SELECT 1
+			FROM engine.history AS h
+			WHERE h.run_id = r.id
+			  AND h.event_type = $1
+		)
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM public.traces AS t
+			WHERE t.engine_run_id = r.id
+		)`
+
+	var (
+		rows pgx.Rows
+		err  error
+	)
+	if projectID == nil {
+		rows, err = tx.Tx().Query(ctx, baseQuery+"\nORDER BY r.created_at ASC, r.id ASC", publichistory.EventWorkflowStarted)
+	} else {
+		rows, err = tx.Tx().Query(ctx, baseQuery+"\n  AND r.project_id = $2\nORDER BY r.created_at ASC, r.id ASC", publichistory.EventWorkflowStarted, *projectID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var runIDs []uuid.UUID
+	for rows.Next() {
+		var runID uuid.UUID
+		if err := rows.Scan(&runID); err != nil {
+			return nil, err
+		}
+		runIDs = append(runIDs, runID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return runIDs, nil
+}
+
+func ensureInitialProjectionShell(ctx context.Context, tx *enginestore.Tx, runID uuid.UUID) error {
+	run, err := tx.GetRunForUpdate(ctx, runID)
+	if err != nil {
+		return err
+	}
+	instance, err := tx.GetInstance(ctx, run.InstanceID)
+	if err != nil {
+		return err
+	}
+	startedEvent, ok, err := workflowStartedEvent(ctx, tx, run.ID)
+	if err != nil || !ok {
+		return err
+	}
+
+	var startedPayload publichistory.WorkflowStartedPayload
+	if err := publichistory.UnmarshalPayload(startedEvent.Payload, &startedPayload); err != nil {
+		return err
+	}
+
+	traceName := instance.DefinitionName
+	return publicprojection.NewWriter(tx.Tx()).CreateTraceShell(
+		ctx,
+		&instance,
+		&run,
+		&publicprojection.TraceShellSeed{},
+		&startedEvent,
+		startedPayload.Input,
+		&traceName,
+	)
+}
+
+func workflowStartedEvent(
+	ctx context.Context,
+	tx *enginestore.Tx,
+	runID uuid.UUID,
+) (enginedb.EngineHistory, bool, error) {
+	historyRows, err := tx.GetHistoryByRun(ctx, runID)
+	if err != nil {
+		return enginedb.EngineHistory{}, false, err
+	}
+	for i := range historyRows {
+		if historyRows[i].EventType == publichistory.EventWorkflowStarted {
+			return historyRows[i], true, nil
+		}
+	}
+	return enginedb.EngineHistory{}, false, nil
 }

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -10,10 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"golang.org/x/sync/errgroup"
 
-	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 	"github.com/continua-ai/continua/engine/internal/activity"
 	"github.com/continua-ai/continua/engine/internal/catalog"
 	"github.com/continua-ai/continua/engine/internal/config"
@@ -21,8 +19,6 @@ import (
 	enginestore "github.com/continua-ai/continua/engine/internal/store"
 	engineworker "github.com/continua-ai/continua/engine/internal/worker"
 	engineworkflow "github.com/continua-ai/continua/engine/internal/workflow"
-	publichistory "github.com/continua-ai/continua/engine/pkg/history"
-	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
 	"github.com/continua-ai/continua/engine/pkg/workflow"
 )
 
@@ -108,9 +104,6 @@ func (r *Runtime) Run(ctx context.Context) error {
 	if err := catalog.PublishStoreDefinitions(ctx, store, r.definitions.List()); err != nil {
 		return err
 	}
-	if err := ensureInitialProjectionShells(ctx, store, r.options.ProjectID); err != nil {
-		return err
-	}
 
 	workflowWorker := engineworkflow.NewWorker(store, r.definitions, cfg.Runtime.RunLeaseTTL)
 	activityWorker := activity.NewWorker(store, r.activities, cfg.Runtime.ActivityLeaseTTL)
@@ -151,119 +144,4 @@ func applyRuntimeOverrides(cfg *config.Config, opts Options) {
 		cfg.Runtime.ActivityLeaseTTL = opts.ActivityLeaseTTL
 	}
 	cfg.Runtime.ProjectIDFilter = opts.ProjectID
-}
-
-func ensureInitialProjectionShells(ctx context.Context, store *enginestore.Store, projectID *uuid.UUID) error {
-	tx, err := store.BeginTx(ctx, pgx.TxOptions{})
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = tx.Rollback(ctx)
-	}()
-
-	runIDs, err := missingProjectionShellRunIDs(ctx, tx, projectID)
-	if err != nil {
-		return err
-	}
-
-	for _, runID := range runIDs {
-		if err := ensureInitialProjectionShell(ctx, tx, runID); err != nil {
-			return err
-		}
-	}
-
-	return tx.Commit(ctx)
-}
-
-func missingProjectionShellRunIDs(ctx context.Context, tx *enginestore.Tx, projectID *uuid.UUID) ([]uuid.UUID, error) {
-	const baseQuery = `
-		SELECT r.id
-		FROM engine.runs AS r
-		WHERE EXISTS (
-			SELECT 1
-			FROM engine.history AS h
-			WHERE h.run_id = r.id
-			  AND h.event_type = $1
-		)
-		  AND NOT EXISTS (
-			SELECT 1
-			FROM public.traces AS t
-			WHERE t.engine_run_id = r.id
-		)`
-
-	var (
-		rows pgx.Rows
-		err  error
-	)
-	if projectID == nil {
-		rows, err = tx.Tx().Query(ctx, baseQuery+"\nORDER BY r.created_at ASC, r.id ASC", publichistory.EventWorkflowStarted)
-	} else {
-		rows, err = tx.Tx().Query(ctx, baseQuery+"\n  AND r.project_id = $2\nORDER BY r.created_at ASC, r.id ASC", publichistory.EventWorkflowStarted, *projectID)
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var runIDs []uuid.UUID
-	for rows.Next() {
-		var runID uuid.UUID
-		if err := rows.Scan(&runID); err != nil {
-			return nil, err
-		}
-		runIDs = append(runIDs, runID)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return runIDs, nil
-}
-
-func ensureInitialProjectionShell(ctx context.Context, tx *enginestore.Tx, runID uuid.UUID) error {
-	run, err := tx.GetRunForUpdate(ctx, runID)
-	if err != nil {
-		return err
-	}
-	instance, err := tx.GetInstance(ctx, run.InstanceID)
-	if err != nil {
-		return err
-	}
-	startedEvent, ok, err := workflowStartedEvent(ctx, tx, run.ID)
-	if err != nil || !ok {
-		return err
-	}
-
-	var startedPayload publichistory.WorkflowStartedPayload
-	if err := publichistory.UnmarshalPayload(startedEvent.Payload, &startedPayload); err != nil {
-		return err
-	}
-
-	traceName := instance.DefinitionName
-	return publicprojection.NewWriter(tx.Tx()).CreateTraceShell(
-		ctx,
-		&instance,
-		&run,
-		&publicprojection.TraceShellSeed{},
-		&startedEvent,
-		startedPayload.Input,
-		&traceName,
-	)
-}
-
-func workflowStartedEvent(
-	ctx context.Context,
-	tx *enginestore.Tx,
-	runID uuid.UUID,
-) (enginedb.EngineHistory, bool, error) {
-	historyRows, err := tx.GetHistoryByRun(ctx, runID)
-	if err != nil {
-		return enginedb.EngineHistory{}, false, err
-	}
-	for i := range historyRows {
-		if historyRows[i].EventType == publichistory.EventWorkflowStarted {
-			return historyRows[i], true, nil
-		}
-	}
-	return enginedb.EngineHistory{}, false, nil
 }

--- a/engine/pkg/runtime/runtime_e2e_test.go
+++ b/engine/pkg/runtime/runtime_e2e_test.go
@@ -1,0 +1,240 @@
+package runtime_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestRuntimeRunsUserWorkflowEndToEnd(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.New()
+	enginetest.EnsurePlatformProject(t, db.Pool, projectID)
+
+	workflowDefinition := workflow.Definition{
+		Name:    "usertest.greeter",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			var in struct {
+				Name string `json:"name"`
+			}
+			if err := ctx.Input(&in); err != nil {
+				return err
+			}
+
+			var out struct {
+				Greeting string `json:"greeting"`
+			}
+			if err := ctx.Activity("greet", "usertest.greet", in, &out); err != nil {
+				return err
+			}
+
+			return ctx.SetResult(out)
+		},
+	}
+	activities := map[string]engineruntime.ActivityHandler{
+		"usertest.greet": func(_ context.Context, raw json.RawMessage) (json.RawMessage, error) {
+			var in struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(raw, &in); err != nil {
+				return nil, err
+			}
+			return json.Marshal(struct {
+				Greeting string `json:"greeting"`
+			}{
+				Greeting: "hello, " + in.Name,
+			})
+		},
+	}
+
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL:             db.DatabaseURL,
+		Workflows:               []workflow.Definition{workflowDefinition},
+		Activities:              activities,
+		ProjectID:               &projectID,
+		WorkflowPollInterval:    25 * time.Millisecond,
+		ActivityPollInterval:    25 * time.Millisecond,
+		MaintenancePollInterval: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("runtime.New() error = %v", err)
+	}
+
+	ctx := context.Background()
+	store := enginestore.New(db.Pool)
+	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "runtime-e2e",
+		DefinitionName: "usertest.greeter",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	input := mustJSON(t, map[string]string{"name": "Ada"})
+	startedPayload, err := enginehistory.MarshalPayload(enginehistory.WorkflowStartedPayload{
+		DefinitionName:    "usertest.greeter",
+		DefinitionVersion: "v1",
+		InstanceKey:       "runtime-e2e",
+		Input:             input,
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(workflow started) error = %v", err)
+	}
+	if _, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 1,
+		EventType:  enginehistory.EventWorkflowStarted,
+		Payload:    startedPayload,
+	}); err != nil {
+		t.Fatalf("AppendHistory(workflow started) error = %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	stopped := false
+	go func() {
+		done <- rt.Run(runCtx)
+	}()
+	defer func() {
+		if stopped {
+			return
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runtime did not stop within 5s after test cleanup cancellation")
+		}
+	}()
+
+	completedRun := waitForCompletedRun(t, store, instance.ID)
+
+	var result struct {
+		Greeting string `json:"greeting"`
+	}
+	if err := json.Unmarshal(completedRun.Result, &result); err != nil {
+		t.Fatalf("json.Unmarshal(run.Result) error = %v; raw = %s", err, string(completedRun.Result))
+	}
+	if result.Greeting != "hello, Ada" {
+		t.Fatalf("run result greeting = %q, want %q", result.Greeting, "hello, Ada")
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, completedRun.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	eventTypes := make([]string, 0, len(historyRows))
+	for _, row := range historyRows {
+		eventTypes = append(eventTypes, row.EventType)
+	}
+	wantSubsequence := []string{
+		enginehistory.EventWorkflowStarted,
+		enginehistory.EventActivityScheduled,
+		enginehistory.EventActivityCompleted,
+		enginehistory.EventWorkflowCompleted,
+	}
+	if !containsSubsequence(eventTypes, wantSubsequence) {
+		t.Fatalf("history event types = %v, want subsequence %v", eventTypes, wantSubsequence)
+	}
+
+	var catalogExists bool
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM engine.definition_catalog
+			WHERE definition_name = $1
+			  AND definition_version = $2
+		)
+	`, "usertest.greeter", "v1").Scan(&catalogExists); err != nil {
+		t.Fatalf("query definition catalog error = %v", err)
+	}
+	if !catalogExists {
+		t.Fatal("definition catalog missing usertest.greeter@v1")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		stopped = true
+		if err != nil {
+			t.Fatalf("Runtime.Run() after cancellation error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Runtime.Run() did not stop within 5s after cancellation")
+	}
+}
+
+func waitForCompletedRun(t *testing.T, store *enginestore.Store, instanceID uuid.UUID) enginedb.EngineRun {
+	t.Helper()
+
+	ctx := context.Background()
+	deadline := time.Now().Add(20 * time.Second)
+	var lastStatus enginedb.EngineRunLifecycleStatus
+	for time.Now().Before(deadline) {
+		runs, err := store.ListRunsByInstance(ctx, enginedb.ListRunsByInstanceParams{
+			InstanceID: instanceID,
+			Limit:      1,
+		})
+		if err != nil {
+			t.Fatalf("ListRunsByInstance() error = %v", err)
+		}
+		if len(runs) > 0 {
+			lastStatus = runs[0].Status
+			if runs[0].Status == enginedb.EngineRunLifecycleStatusCompleted {
+				return runs[0]
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("run did not complete within 20s; last observed status = %s", lastStatus)
+	return enginedb.EngineRun{}
+}
+
+func containsSubsequence(haystack, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	next := 0
+	for _, value := range haystack {
+		if value == needle[next] {
+			next++
+			if next == len(needle) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func mustJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return raw
+}

--- a/engine/pkg/runtime/runtime_e2e_test.go
+++ b/engine/pkg/runtime/runtime_e2e_test.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 	enginehistory "github.com/continua-ai/continua/engine/internal/history"
 	enginestore "github.com/continua-ai/continua/engine/internal/store"
 	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
 	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
 	"github.com/continua-ai/continua/engine/pkg/workflow"
 )
@@ -101,15 +103,33 @@ func TestRuntimeRunsUserWorkflowEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalPayload(workflow started) error = %v", err)
 	}
-	if _, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
+	startedEvent, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
 		ProjectID:  projectID,
 		InstanceID: instance.ID,
 		RunID:      run.ID,
 		SequenceNo: 1,
 		EventType:  enginehistory.EventWorkflowStarted,
 		Payload:    startedPayload,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("AppendHistory(workflow started) error = %v", err)
+	}
+
+	// Seed the shell because the start path creates it transactionally and
+	// non-dark-launch projects require it.
+	tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+	traceName := "usertest.greeter"
+	if err := publicprojection.NewWriter(tx.Tx()).CreateTraceShell(ctx, &instance, &run, &publicprojection.TraceShellSeed{}, &startedEvent, input, &traceName); err != nil {
+		t.Fatalf("CreateTraceShell() error = %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
 	}
 
 	runCtx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## What / why

The engine's runtime assembly (registries, pgx pool, the four workers) previously existed only inside the CLI's `withRuntime`/`buildRegistries`, hardwired to the dark-launch registry — there was no way to run the engine with user-registered workflows without editing engine source. This PR adds the public embedding surface that the rest of Phase 2 (user project provisioning, catalog-as-truth, workflow test kit) builds on:

```go
rt, err := runtime.New(runtime.Options{
    DatabaseURL: os.Getenv("DATABASE_URL"),
    Workflows:   []workflow.Definition{...},
    Activities:  map[string]runtime.ActivityHandler{...},
})
err = rt.Run(ctx)
```

## What's in the change

- **`engine/pkg/runtime` (new)**: `Options` (database URL, workflow definitions, activity handlers, optional project-ID filter, poll-interval/lease-TTL overrides), `New` (validates options and builds the internal workflow/activity registries with their existing validation), and `Run` (pool + store lifecycle, definition-catalog publish, then the four worker loops — workflow, activity, maintenance, projector — under an errgroup; returns nil on graceful cancellation). The package reads no environment variables.
- **`config.Defaults`**: engine runtime defaults are now single-sourced in `engine/internal/config`; `Load()` builds on it with byte-for-byte identical env behavior.
- **CLI refactor**: `continua-engine serve` is now a thin consumer of `pkg/runtime` with the dark-launch registries; `CONTINUA_ENGINE_TEST_PROJECT_FILTER` wiring and serve log lines preserved. The other commands (start/signal/cancel/inspect) keep their existing runtime helpers.
- **Example**: `engine/examples/greeter` — a minimal user program registering one workflow + one activity.
- **Docs**: `docs-site/guides/embed-engine.mdx` (+ nav entry), with the preview caveats kept accurate.

No contract or migration changes; `make generate` not needed.

## Test evidence

Acceptance tests were written first by an independent session and committed red, then implemented against:

- `TestNewValidatesOptions` (`engine/pkg/runtime/options_test.go`): valid options succeed; missing database URL, duplicate workflow definitions, missing run function, and invalid activity entries are rejected with the registry's existing error messages.
- `TestRuntimeRunsUserWorkflowEndToEnd` (`engine/pkg/runtime/runtime_e2e_test.go`): a user-defined (non-darklaunch) workflow executes an activity end-to-end against real Postgres through the public API only — asserting the run result payload, the `workflow.started → activity.scheduled → activity.completed → workflow.completed` history order, the definition-catalog publish from `Run`, and graceful shutdown returning nil. The run is seeded with its projection trace shell the same way the start path creates it (non-dark-launch projects require the shell by design).

Verified green on a throwaway database: `go test ./pkg/runtime/... ./cmd/continua-engine/...` and the full `go test ./...` in the engine module (including the pre-existing CLI serve e2e); `go vet ./...` clean.

Review notes: an initial implementation included a startup sweep that auto-created projection shells for shell-less runs; it was rejected in review (startup-only semantics, raw SQL in `pkg/runtime`, overlaps the projection-repair surface) and removed in favor of fixing the test seeding fidelity.

Closes #161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running the engine as an embedded Go library.
  * Added a new example app showing a simple workflow and activity setup.
  * Engine startup now uses the shared runtime path for a more consistent launch experience.

* **Documentation**
  * Added a new guide for embedding the engine, including setup, workflow registration, and run initiation.
  * Updated workflow navigation to include the new embedding guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->