### PR TITLE
feat(engine): user project provisioning; retire the DarkLaunchProjectID sentinel

### DIFF
--- a/docs-site/concepts/engine-foundation.mdx
+++ b/docs-site/concepts/engine-foundation.mdx
@@ -115,10 +115,13 @@ the control bar. Polling-based.
   with the runtime. There is no TypeScript/Python SDK for *authoring* workflows yet (the
   Python SDK's `ActivityWorker` / `@activity` / `EngineControlClient` target this surface
   but aren't a full authoring runtime).
-- **No production definition loading.** The runtime today registers definitions through a
-  built-in "dark-launch" harness against a fixed demo project. There's no supported path
-  yet to register and version arbitrary user workflow definitions in a multi-tenant
-  deployment.
+- **No production definition loading.** The runtime today registers definitions from the
+  Go process that starts workers; the bundled dark-launch CLI is still only a demo
+  consumer. There's no supported path yet to dynamically register and version arbitrary
+  user workflow definitions in a multi-tenant deployment.
+- **Explicit project provisioning.** Scoped workers must point at an existing platform
+  project with `ENGINE_PROJECT_ID` or `runtime.Options.ProjectID`; missing projects fail
+  startup. See [Engine project provisioning](/guides/engine-project-provisioning).
 - **Preview-gated REST control plane.** The `/v1/engine/*` endpoints require
   `X-Continua-Engine-Preview` + `ENGINE_PUBLIC_API_ENABLED`, and shapes may change
   before GA.
@@ -127,10 +130,10 @@ the control bar. Polling-based.
 
 - **Durable Go workflows (preview).** Go-defined workflows and activities registered with
   the runtime execute end-to-end with retries, timers, signals, child workflows, and
-  crash-recovery. Today they register through the built-in dark-launch harness
-  (`continua-engine serve`); running your *own* workflow means adding it to that registry
-  and rebuilding, as there's no dynamic definition loading yet. Don't put it on a
-  production-critical path yet, it's preview.
+  crash-recovery. Running your *own* workflow means registering it in the Go runtime that
+  starts workers and provisioning a platform project for its projections, as there's no
+  dynamic definition loading yet. Don't put it on a production-critical path yet, it's
+  preview.
 - **Operator tooling & inspection.** The control endpoints + runs console are useful for
   driving and observing run state, pending work, and history.
 

--- a/docs-site/debugger/engine-runs.mdx
+++ b/docs-site/debugger/engine-runs.mdx
@@ -76,9 +76,9 @@ The page calls `POST /v1/engine/projections/backfill` and reports per-run progre
 
 **Not yet:**
 
-- Non-Go workflow authoring, and a production path to register arbitrary workflow
-  definitions (the runtime registers a fixed dark-launch set today)
+- Non-Go workflow authoring, and a production path to dynamically register arbitrary
+  workflow definitions
 - A GA, non-preview `/v1/engine/*` control plane
 
 For the full status breakdown, see [Engine foundation](/concepts/engine-foundation) and
-[Roadmap](/roadmap).
+[Engine project provisioning](/guides/engine-project-provisioning).

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -43,6 +43,7 @@
             "group": "Workflows",
             "pages": [
               "guides/workflow-code-versioning",
+              "guides/engine-project-provisioning",
               "guides/embed-engine",
               "guides/debugging-failures",
               "guides/comparing-sessions"

--- a/docs-site/guides/embed-engine.mdx
+++ b/docs-site/guides/embed-engine.mdx
@@ -19,7 +19,10 @@ Use `github.com/continua-ai/continua/engine/pkg/runtime` from inside a Go progra
 engine module:
 
 ```go
-projectID := uuid.MustParse(os.Getenv("ENGINE_PROJECT_ID"))
+projectID, err := uuid.Parse(os.Getenv("ENGINE_PROJECT_ID"))
+if err != nil {
+    return fmt.Errorf("parse ENGINE_PROJECT_ID: %w", err)
+}
 rt, err := runtime.New(runtime.Options{
     DatabaseURL: os.Getenv("ENGINE_DATABASE_URL"),
     ProjectID:   &projectID,

--- a/docs-site/guides/embed-engine.mdx
+++ b/docs-site/guides/embed-engine.mdx
@@ -19,8 +19,10 @@ Use `github.com/continua-ai/continua/engine/pkg/runtime` from inside a Go progra
 engine module:
 
 ```go
+projectID := uuid.MustParse(os.Getenv("ENGINE_PROJECT_ID"))
 rt, err := runtime.New(runtime.Options{
-    DatabaseURL: os.Getenv("DATABASE_URL"),
+    DatabaseURL: os.Getenv("ENGINE_DATABASE_URL"),
+    ProjectID:   &projectID,
     Workflows: []workflow.Definition{
         {
             Name:    "examples.greeter",
@@ -42,6 +44,10 @@ return rt.Run(ctx)
 connect to Postgres. `Run` opens the engine pool, publishes the registered definitions
 to `engine.definition_catalog`, then starts the workflow worker, activity worker,
 maintenance worker, and projector until the context is cancelled.
+
+If `ProjectID` is set, `Run` verifies that the platform project exists before workers
+start. Create the project first and set `ENGINE_PROJECT_ID`; see
+[Engine project provisioning](/guides/engine-project-provisioning).
 
 See `engine/examples/greeter` for a minimal compilable program with signal handling.
 
@@ -69,6 +75,8 @@ be present in the runtime-published catalog.
 - Workflow and activity authoring is Go-only.
 - There is no dynamic definition loading path yet; user code registers definitions in
   the Go process at startup.
+- A scoped runtime requires a pre-created platform project. Missing projects fail startup
+  instead of creating implicit projection rows.
 - The runtime uses the same Postgres-backed history, leases, timers, signals, activity
   tasks, child workflows, cancellation, continue-as-new, and projection path as
   `continua-engine serve`.

--- a/docs-site/guides/engine-project-provisioning.mdx
+++ b/docs-site/guides/engine-project-provisioning.mdx
@@ -1,0 +1,59 @@
+---
+title: "Engine project provisioning"
+description: "Create a platform project and point the preview engine runtime at it."
+---
+
+Engine runs are projected into the same platform tables as traces and spans. Before an
+engine runtime starts with a project filter, that project must already exist in the
+platform.
+
+## Create a platform project
+
+Create a project from the debugger Projects page or the projects API:
+
+```bash
+curl -X POST http://localhost:8080/api/projects \
+  -H "X-API-Key: <admin-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"engine-prod","description":"Durable engine runs"}'
+```
+
+Save the returned `id` and the plaintext `api_key`. The API key is shown only once. See
+[Managing projects](/guides/managing-projects) for rotation and deletion workflows.
+
+## Configure the engine runtime
+
+Point the engine at the same Postgres database as the platform when you want runs to show
+up in the debugger:
+
+```bash
+export ENGINE_DATABASE_URL="postgres://continua:continua@localhost:5432/continua?sslmode=disable"
+export ENGINE_PROJECT_ID="<project-id>"
+
+continua-engine migrate up
+continua-engine serve
+```
+
+`ENGINE_PROJECT_ID` scopes the worker runtime to that project. Startup fails fast if the
+project row is missing, so create the project before starting workers.
+
+When embedding the Go runtime directly, pass the same project id through
+`runtime.Options.ProjectID`:
+
+```go
+projectID := uuid.MustParse(os.Getenv("ENGINE_PROJECT_ID"))
+rt, err := runtime.New(runtime.Options{
+    DatabaseURL: os.Getenv("ENGINE_DATABASE_URL"),
+    ProjectID:   &projectID,
+    Workflows:   definitions,
+    Activities:  handlers,
+})
+```
+
+See [Embed the engine](/guides/embed-engine) for the full runtime setup.
+
+## Inspect runs
+
+Runs projected for the provisioned project appear in the debugger's
+[Engine runs console](/debugger/engine-runs). Use that page to inspect status, pending
+work, history freshness, and projection repair state.

--- a/docs-site/guides/managing-projects.mdx
+++ b/docs-site/guides/managing-projects.mdx
@@ -103,6 +103,8 @@ curl https://continua.example.com/api/projects \
 ## See also
 
 - [Projects & auth](/concepts/projects-and-auth): the auth model end to end.
+- [Engine project provisioning](/guides/engine-project-provisioning): create a project
+  before starting scoped engine workers.
 - [Auth0 setup](/guides/auth0-setup): operator login.
 - API reference: every project endpoint is listed under
   [API Reference → Endpoints](/api-reference/auth-and-headers).

--- a/docs-site/roadmap.mdx
+++ b/docs-site/roadmap.mdx
@@ -46,9 +46,8 @@ The `continua-engine` worker runtime executes **Go-defined** workflows end-to-en
 Preview caveats:
 
 - **Go-only authoring**: no TypeScript/Python SDK for authoring workflows yet.
-- **No production definition loading**: definitions register through a built-in
-  dark-launch harness against a fixed demo project; there's no multi-tenant
-  register-and-version path yet.
+- **No production definition loading**: definitions register through the Go runtime that
+  starts workers; there's no multi-tenant register-and-version path yet.
 - **Preview-gated REST**: `/v1/engine/*` requires `X-Continua-Engine-Preview` +
   `ENGINE_PUBLIC_API_ENABLED`, and shapes may change before GA.
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -21,7 +21,7 @@ The engine module ships a working durable runtime:
 What is still **preview / not yet there**:
 
 - workflow authoring is Go-only — no TypeScript/Python authoring SDK
-- no production path to register arbitrary user workflow definitions (the dark-launch runtime runs a fixed demo project)
+- no production path to register arbitrary user workflow definitions (the dark-launch CLI still ships a fixed demo registry)
 - the public `/v1/engine/*` REST control plane is gated behind `X-Continua-Engine-Preview` + `ENGINE_PUBLIC_API_ENABLED`
 
 ## Activity Leases
@@ -75,7 +75,7 @@ bin/continua-engine version
 bin/continua-engine migrate up
 bin/continua-engine migrate down 1
 
-# durable runtime (dark-launch demo project)
+# durable runtime (dark-launch demo registry)
 bin/continua-engine serve                                   # run workflow + activity + maintenance + projector workers
 bin/continua-engine start  --instance-key <k> --definition <name> --version <v> --request-key <r> [--input <json>]
 bin/continua-engine signal --instance-key <k> --signal-name <s> [--payload <json>]
@@ -87,6 +87,9 @@ Database config is env-only:
 
 - `ENGINE_DATABASE_URL` overrides `DATABASE_URL`
 - `DATABASE_URL` is the fallback when no engine-specific URL is set
+- `ENGINE_PROJECT_ID` scopes `serve` to an existing platform project; startup fails if
+  that project row is missing. The dark-launch `start` command bootstraps only its local
+  demo project row for CLI demo runs.
 
 ## Schema Overview
 

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -158,11 +158,7 @@ func startCmd() *cobra.Command {
 				defer func() {
 					_ = tx.Rollback(ctx)
 				}()
-				if _, err := tx.Tx().Exec(ctx, `
-					INSERT INTO public.projects (id, name, api_key_hash)
-					VALUES ($1, $2, $3)
-					ON CONFLICT (id) DO NOTHING
-				`, darkLaunchProjectID, "Engine Dark Launch", "engine-dark-launch"); err != nil {
+				if err := ensureDarkLaunchProject(ctx, tx); err != nil {
 					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
 				}
 
@@ -300,6 +296,17 @@ func startCmd() *cobra.Command {
 	cmd.Flags().StringVar(&requestKey, "request-key", "", "Durable request dedupe key")
 	cmd.Flags().StringVar(&input, "input", "", "Optional workflow input as JSON")
 	return cmd
+}
+
+func ensureDarkLaunchProject(ctx context.Context, tx *enginestore.Tx) error {
+	if _, err := tx.Tx().Exec(ctx, `
+		INSERT INTO public.projects (id, name, api_key_hash)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (id) DO NOTHING
+	`, darkLaunchProjectID, "Engine Dark Launch", "engine-dark-launch"); err != nil {
+		return err
+	}
+	return nil
 }
 
 func signalCmd() *cobra.Command {

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -28,9 +28,8 @@ import (
 	"github.com/continua-ai/continua/engine/cmd/continua-engine/internal/darklaunch"
 )
 
-// darkLaunchProjectID aliases the projection writer's single definition of
-// the fixed dark-launch demo project.
-var darkLaunchProjectID = publicprojection.DarkLaunchProjectID
+// darkLaunchProjectID is the fixed demo project used by the dark-launch CLI.
+var darkLaunchProjectID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
 
 type commandExitError struct {
 	code int
@@ -159,6 +158,13 @@ func startCmd() *cobra.Command {
 				defer func() {
 					_ = tx.Rollback(ctx)
 				}()
+				if _, err := tx.Tx().Exec(ctx, `
+					INSERT INTO public.projects (id, name, api_key_hash)
+					VALUES ($1, $2, $3)
+					ON CONFLICT (id) DO NOTHING
+				`, darkLaunchProjectID, "Engine Dark Launch", "engine-dark-launch"); err != nil {
+					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
+				}
 
 				claim, err := tx.ClaimStartRequestDedupe(ctx, enginestore.ClaimStartRequestDedupeParams{
 					ProjectID:    darkLaunchProjectID,
@@ -250,7 +256,7 @@ func startCmd() *cobra.Command {
 				if err != nil {
 					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
 				}
-				if err := publicprojection.NewWriter(tx.Tx()).EnsureDarkLaunchShell(ctx, &instance, &run, definitionName, definitionVersion, inputPayload, startedEvent.ID); err != nil {
+				if err := publicprojection.NewWriter(tx.Tx()).EnsureStartShell(ctx, &instance, &run, definitionName, definitionVersion, inputPayload, startedEvent.ID); err != nil {
 					return writeJSONError(cmd.OutOrStdout(), "internal_error", err.Error())
 				}
 

--- a/engine/cmd/continua-engine/runtime_commands_unit_test.go
+++ b/engine/cmd/continua-engine/runtime_commands_unit_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
 	"testing"
 
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
 	engineworkflow "github.com/continua-ai/continua/engine/internal/workflow"
 	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+
+	"github.com/jackc/pgx/v5"
 )
 
 func TestResolveStartDefinitionVersionOmittedUsesLatestRegisteredVersion(t *testing.T) {
@@ -47,5 +52,58 @@ func TestResolveStartDefinitionVersionExplicitUsesExactMatch(t *testing.T) {
 
 	if _, ok := resolveStartDefinitionVersion(registry, "demo", "v10"); ok {
 		t.Fatalf("resolveStartDefinitionVersion() returned ok=true for unregistered explicit version")
+	}
+}
+
+func TestEnsureDarkLaunchProjectProvisionsProjectInTransaction(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+	if _, err := db.Pool.Exec(ctx, `DELETE FROM public.projects WHERE id = $1`, darkLaunchProjectID); err != nil {
+		t.Fatalf("delete seeded dark-launch project: %v", err)
+	}
+
+	tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := ensureDarkLaunchProject(ctx, tx); err != nil {
+		t.Fatalf("ensureDarkLaunchProject() error = %v", err)
+	}
+	existsBeforeCommit, err := store.PlatformProjectExists(ctx, darkLaunchProjectID)
+	if err != nil {
+		t.Fatalf("PlatformProjectExists() before commit error = %v", err)
+	}
+	if existsBeforeCommit {
+		t.Fatal("project should not be visible outside the transaction before commit")
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	existsAfterCommit, err := store.PlatformProjectExists(ctx, darkLaunchProjectID)
+	if err != nil {
+		t.Fatalf("PlatformProjectExists() after commit error = %v", err)
+	}
+	if !existsAfterCommit {
+		t.Fatal("project should exist after committing dark-launch bootstrap")
+	}
+
+	secondTx, err := store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() second error = %v", err)
+	}
+	defer func() {
+		_ = secondTx.Rollback(ctx)
+	}()
+	if err := ensureDarkLaunchProject(ctx, secondTx); err != nil {
+		t.Fatalf("ensureDarkLaunchProject() second error = %v", err)
+	}
+	if err := secondTx.Commit(ctx); err != nil {
+		t.Fatalf("Commit() second error = %v", err)
 	}
 }

--- a/engine/internal/activity/worker_test.go
+++ b/engine/internal/activity/worker_test.go
@@ -910,6 +910,7 @@ func createRunWithPendingActivityConfig(
 	if cfg.activityType == "" {
 		cfg.activityType = testActivityType
 	}
+	enginetest.EnsurePlatformProject(t, store.Pool(), cfg.projectID)
 
 	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
 		ProjectID:      cfg.projectID,
@@ -939,16 +940,18 @@ func createRunWithPendingActivityConfig(
 	if err != nil {
 		t.Fatalf("MarshalPayload(started) error = %v", err)
 	}
-	if _, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
+	startedHistory, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
 		ProjectID:  cfg.projectID,
 		InstanceID: instance.ID,
 		RunID:      run.ID,
 		SequenceNo: 1,
 		EventType:  enginehistory.EventWorkflowStarted,
 		Payload:    startedPayload,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("AppendHistory(started) error = %v", err)
 	}
+	enginetest.SeedProjectionShell(t, store.Pool(), &instance, &run, "activity-terminate", "v1", nil, startedHistory.ID)
 
 	activityPayload, err := enginehistory.MarshalPayload(enginehistory.ActivityScheduledPayload{
 		ActivityKey:  cfg.activityKey,

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -107,7 +107,7 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	projectIDFilter, err := uuidFromEnv("CONTINUA_ENGINE_TEST_PROJECT_FILTER")
+	projectIDFilter, err := runtimeProjectIDFromEnv()
 	if err != nil {
 		return nil, err
 	}
@@ -135,12 +135,17 @@ func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) 
 	return parsed, nil
 }
 
-func uuidFromEnv(key string) (*uuid.UUID, error) {
-	value := os.Getenv(key)
-	if value == "" {
-		return nil, nil
+func runtimeProjectIDFromEnv() (*uuid.UUID, error) {
+	if value := os.Getenv("ENGINE_PROJECT_ID"); value != "" {
+		return parseUUIDEnv("ENGINE_PROJECT_ID", value)
 	}
+	if value := os.Getenv("CONTINUA_ENGINE_TEST_PROJECT_FILTER"); value != "" {
+		return parseUUIDEnv("CONTINUA_ENGINE_TEST_PROJECT_FILTER", value)
+	}
+	return nil, nil
+}
 
+func parseUUIDEnv(key, value string) (*uuid.UUID, error) {
 	parsed, err := uuid.Parse(value)
 	if err != nil {
 		return nil, errors.New(key + " must be a valid UUID: " + err.Error())

--- a/engine/internal/config/config_project_id_test.go
+++ b/engine/internal/config/config_project_id_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestLoadResolvesEngineProjectIDEnv(t *testing.T) {
+	engineProjectID := uuid.New()
+	legacyProjectID := uuid.New()
+
+	testCases := []struct {
+		name        string
+		engineValue string
+		legacyValue string
+		want        *uuid.UUID
+		wantErr     string
+	}{
+		{
+			name:        "engine project id",
+			engineValue: engineProjectID.String(),
+			want:        &engineProjectID,
+		},
+		{
+			name:        "legacy project filter",
+			legacyValue: legacyProjectID.String(),
+			want:        &legacyProjectID,
+		},
+		{
+			name:        "engine project id wins over legacy",
+			engineValue: engineProjectID.String(),
+			legacyValue: legacyProjectID.String(),
+			want:        &engineProjectID,
+		},
+		{
+			name:        "invalid engine project id",
+			engineValue: "not-a-uuid",
+			wantErr:     "ENGINE_PROJECT_ID",
+		},
+		{
+			name: "unset project id",
+			want: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+			t.Setenv("ENGINE_PROJECT_ID", tc.engineValue)
+			t.Setenv("CONTINUA_ENGINE_TEST_PROJECT_FILTER", tc.legacyValue)
+
+			cfg, err := Load()
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("Load() error = nil, want project id parse error")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("Load() error = %q, want mention %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if tc.want == nil {
+				if cfg.Runtime.ProjectIDFilter != nil {
+					t.Fatalf("ProjectIDFilter = %s, want nil", cfg.Runtime.ProjectIDFilter)
+				}
+				return
+			}
+			if cfg.Runtime.ProjectIDFilter == nil {
+				t.Fatalf("ProjectIDFilter = nil, want %s", *tc.want)
+			}
+			if *cfg.Runtime.ProjectIDFilter != *tc.want {
+				t.Fatalf("ProjectIDFilter = %s, want %s", *cfg.Runtime.ProjectIDFilter, *tc.want)
+			}
+		})
+	}
+}

--- a/engine/internal/projector/projector_test.go
+++ b/engine/internal/projector/projector_test.go
@@ -1378,13 +1378,13 @@ func TestSyncProjectedRunSummary_MissingProjectedTraceFailsForPublicRuns(t *test
 	}
 }
 
-func TestSyncProjectedRunSummary_AllowsDarkLaunchRunsWithoutProjectedTrace(t *testing.T) {
+func TestSyncProjectedRunSummary_FailsForDefaultProjectWithoutProjectedTrace(t *testing.T) {
 	db := enginetest.NewTestDatabase(t)
 	store := enginestore.New(db.Pool)
 	ctx := context.Background()
 
 	_, run := createStartedRun(t, store, workflowTestCase{
-		projectID:         publicprojection.DarkLaunchProjectID,
+		projectID:         enginetest.DefaultPlatformProjectID,
 		instanceKey:       "instance-darklaunch",
 		definitionName:    "darklaunch",
 		definitionVersion: "v1",
@@ -1394,12 +1394,10 @@ func TestSyncProjectedRunSummary_AllowsDarkLaunchRunsWithoutProjectedTrace(t *te
 	if err != nil {
 		t.Fatalf("BeginTx() error = %v", err)
 	}
-	if err := publicprojection.NewWriter(tx.Tx()).SyncRunSummary(ctx, &run); err != nil {
-		_ = tx.Rollback(ctx)
-		t.Fatalf("SyncRunSummary() error = %v", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		t.Fatalf("tx.Commit() error = %v", err)
+	err = publicprojection.NewWriter(tx.Tx()).SyncRunSummary(ctx, &run)
+	_ = tx.Rollback(ctx)
+	if err == nil {
+		t.Fatal("expected SyncRunSummary to fail when projected trace is missing")
 	}
 }
 

--- a/engine/internal/store/platform_projects.go
+++ b/engine/internal/store/platform_projects.go
@@ -1,0 +1,23 @@
+package store
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// PlatformProjectExists reports whether the platform public.projects row exists.
+func (s *Store) PlatformProjectExists(ctx context.Context, projectID uuid.UUID) (bool, error) {
+	var exists bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1
+			FROM public.projects
+			WHERE id = $1
+		)
+	`, projectID).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}

--- a/engine/internal/store/platform_projects_test.go
+++ b/engine/internal/store/platform_projects_test.go
@@ -1,0 +1,41 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+)
+
+func TestPlatformProjectExists(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuid.New()
+	missingProjectID := uuid.New()
+
+	exists, err := ts.store.PlatformProjectExists(ts.ctx, projectID)
+	if err != nil {
+		t.Fatalf("PlatformProjectExists() missing initial error = %v", err)
+	}
+	if exists {
+		t.Fatal("PlatformProjectExists() returned true before project was inserted")
+	}
+
+	enginetest.EnsurePlatformProject(t, ts.db.Pool, projectID)
+
+	exists, err = ts.store.PlatformProjectExists(ts.ctx, projectID)
+	if err != nil {
+		t.Fatalf("PlatformProjectExists() existing error = %v", err)
+	}
+	if !exists {
+		t.Fatal("PlatformProjectExists() returned false for existing project")
+	}
+
+	exists, err = ts.store.PlatformProjectExists(ts.ctx, missingProjectID)
+	if err != nil {
+		t.Fatalf("PlatformProjectExists() missing error = %v", err)
+	}
+	if exists {
+		t.Fatal("PlatformProjectExists() returned true for unrelated missing project")
+	}
+}

--- a/engine/internal/testutil/testdb.go
+++ b/engine/internal/testutil/testdb.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 	"github.com/continua-ai/continua/engine/internal/migrations"
 	"github.com/continua-ai/continua/engine/pkg/projection"
 )
@@ -26,9 +28,8 @@ import (
 // as a built-in function.
 const DefaultTestDatabaseURL = "postgres://continua:continua@localhost:5432/continua_test?sslmode=disable"
 
-// DefaultPlatformProjectID aliases the dark-launch demo project owned by the
-// projection writer, which most engine fixtures seed as their platform project.
-var DefaultPlatformProjectID = projection.DarkLaunchProjectID
+// DefaultPlatformProjectID is the shared platform project most engine fixtures seed.
+var DefaultPlatformProjectID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
 
 // TestDatabase is an isolated Postgres database prepared with both platform and
 // engine migrations.
@@ -149,6 +150,37 @@ func EnsurePlatformProject(t *testing.T, pool *pgxpool.Pool, projectID uuid.UUID
 	}
 }
 
+// SeedProjectionShell creates the platform trace/root-span shell expected by
+// strict projection writes.
+func SeedProjectionShell(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	instance *enginedb.EngineInstance,
+	run *enginedb.EngineRun,
+	definitionName string,
+	definitionVersion string,
+	input json.RawMessage,
+	startedHistoryID int64,
+) {
+	t.Helper()
+
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin seed projection shell tx: %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := projection.NewWriter(tx).EnsureStartShell(ctx, instance, run, definitionName, definitionVersion, input, startedHistoryID); err != nil {
+		t.Fatalf("seed projection shell: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit seed projection shell tx: %v", err)
+	}
+}
+
 func testDatabaseURL() string {
 	if value := os.Getenv("ENGINE_TEST_DATABASE_URL"); value != "" {
 		return value
@@ -189,6 +221,8 @@ func dropDatabase(ctx context.Context, adminPool *pgxpool.Pool, databaseName str
 		FROM pg_stat_activity
 		WHERE datname = $1
 		  AND pid <> pg_backend_pid()
+		  AND usename = current_user
+		  AND backend_type = 'client backend'
 	`, databaseName); err != nil {
 		return fmt.Errorf("terminate active connections: %w", err)
 	}

--- a/engine/internal/workflow/activation.go
+++ b/engine/internal/workflow/activation.go
@@ -200,7 +200,7 @@ func (a *Activator) commitDecision(
 	// checkpoint so projected shells can move into catching_up before the
 	// projector catches up. decisionCancelled remains engine-only per the
 	// operational hardening change.
-	if latestHistoryID != nil && decision.Kind != decisionCancelled {
+	if latestHistoryID != nil && decision.Kind != decisionCancelled && decision.Kind != decisionContinuedAsNew {
 		if err := publicprojection.NewWriter(tx.Tx()).UpdateLatestHistory(ctx, run.ProjectID, run.ID, *latestHistoryID); err != nil {
 			return err
 		}
@@ -325,7 +325,13 @@ func (a *Activator) commitDecision(
 		}
 		return updateRunInstanceStatus(ctx, tx, run.InstanceID, enginedb.EngineInstanceLifecycleStatusCancelled)
 	case decisionContinuedAsNew:
-		return a.commitContinuationDecision(ctx, tx, instance, run, workerClaimedBy, decision)
+		if err := a.commitContinuationDecision(ctx, tx, instance, run, workerClaimedBy, decision); err != nil {
+			return err
+		}
+		if latestHistoryID != nil {
+			return publicprojection.NewWriter(tx.Tx()).UpdateLatestHistory(ctx, run.ProjectID, run.ID, *latestHistoryID)
+		}
+		return nil
 	default:
 		return fmt.Errorf("unsupported activation decision kind %q", decision.Kind)
 	}

--- a/engine/internal/workflow/activation_test.go
+++ b/engine/internal/workflow/activation_test.go
@@ -99,6 +99,7 @@ func TestActivatorFailsRunWhenDefinitionVersionIsMissingWithoutStartedHistory(t 
 	if err != nil {
 		t.Fatalf("CreateRun() error = %v", err)
 	}
+	enginetest.SeedProjectionShell(t, db.Pool, &instance, &run, "demo", "v-missing", nil, 1)
 
 	claimed, err := store.ClaimNextRun(ctx, "worker-a", time.Minute)
 	if err != nil {
@@ -425,11 +426,12 @@ func TestActivatorContinueAsNewCreatesNewRunAndInheritedTraceShell(t *testing.T)
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-continue-as-new",
-		definitionName:    "continue-demo",
-		definitionVersion: "v1",
-		input:             mustJSON(t, map[string]any{"cursor": 1}),
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-continue-as-new",
+		definitionName:      "continue-demo",
+		definitionVersion:   "v1",
+		input:               mustJSON(t, map[string]any{"cursor": 1}),
+		skipProjectionShell: true,
 	}
 	instance, run := createStartedRun(t, store, testCase)
 	startedHistory := mustStartedHistory(t, store, run.ID)
@@ -729,11 +731,12 @@ func TestActivatorContinueAsNewFailsWhenProjectedTraceShellIsMissing(t *testing.
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-continue-missing-shell",
-		definitionName:    "continue-demo",
-		definitionVersion: "v1",
-		input:             mustJSON(t, map[string]any{"cursor": 1}),
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-continue-missing-shell",
+		definitionName:      "continue-demo",
+		definitionVersion:   "v1",
+		input:               mustJSON(t, map[string]any{"cursor": 1}),
+		skipProjectionShell: true,
 	}
 	_, run := createStartedRun(t, store, testCase)
 
@@ -785,11 +788,12 @@ func TestActivatorContinueAsNewPreservesChainAcrossMultipleHops(t *testing.T) {
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-continue-chain",
-		definitionName:    "continue-chain",
-		definitionVersion: "v1",
-		input:             mustJSON(t, map[string]any{"cursor": 1}),
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-continue-chain",
+		definitionName:      "continue-chain",
+		definitionVersion:   "v1",
+		input:               mustJSON(t, map[string]any{"cursor": 1}),
+		skipProjectionShell: true,
 	}
 	instance, run := createStartedRun(t, store, testCase)
 	startedHistory := mustStartedHistory(t, store, run.ID)
@@ -872,11 +876,12 @@ func TestActivatorSchedulesChildWorkflowAndCreatesLineage(t *testing.T) {
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-parent-child",
-		definitionName:    "checkout",
-		definitionVersion: "v1",
-		input:             mustJSON(t, map[string]string{"order_id": "ord-123"}),
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-parent-child",
+		definitionName:      "checkout",
+		definitionVersion:   "v1",
+		input:               mustJSON(t, map[string]string{"order_id": "ord-123"}),
+		skipProjectionShell: true,
 	}
 	instance, run := createStartedRun(t, store, testCase)
 	insertProjectedTraceShell(t, ctx, db.Pool, instance, run, "Checkout Parent Trace", 1)
@@ -1091,11 +1096,12 @@ func TestActivatorChildWorkflowConflictFailsDeterministically(t *testing.T) {
 	}
 
 	instance, run := createStartedRun(t, store, workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-binding-conflict-parent",
-		definitionName:    "checkout-binding-conflict",
-		definitionVersion: "v1",
-		input:             mustJSON(t, map[string]string{"order_id": "ord-conflict"}),
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-binding-conflict-parent",
+		definitionName:      "checkout-binding-conflict",
+		definitionVersion:   "v1",
+		input:               mustJSON(t, map[string]string{"order_id": "ord-conflict"}),
+		skipProjectionShell: true,
 	})
 	insertProjectedTraceShell(t, ctx, db.Pool, instance, run, "Binding Conflict Parent", 1)
 
@@ -1168,11 +1174,12 @@ func TestActivatorChildContinueAsNewBlocksParentUntilTerminalRun(t *testing.T) {
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-child-continue-parent",
-		definitionName:    "checkout-child-continue",
-		definitionVersion: "v1",
-		input:             mustJSON(t, map[string]string{"order_id": "ord-child-continue"}),
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-child-continue-parent",
+		definitionName:      "checkout-child-continue",
+		definitionVersion:   "v1",
+		input:               mustJSON(t, map[string]string{"order_id": "ord-child-continue"}),
+		skipProjectionShell: true,
 	}
 	instance, parentRun := createStartedRun(t, store, testCase)
 	insertProjectedTraceShell(t, ctx, db.Pool, instance, parentRun, "Child Continue Parent", 1)
@@ -1325,11 +1332,12 @@ func TestActivatorChildTerminalOutcomesRecordMatchingParentAndChildHistory(t *te
 
 			parentDefinitionName := "checkout-child-terminal-" + testCase.name
 			instance, parentRun := createStartedRun(t, store, workflowTestCase{
-				projectID:         enginetest.DefaultPlatformProjectID,
-				instanceKey:       "instance-" + testCase.name + "-parent",
-				definitionName:    parentDefinitionName,
-				definitionVersion: "v1",
-				input:             mustJSON(t, map[string]string{"order_id": "ord-" + testCase.name}),
+				projectID:           enginetest.DefaultPlatformProjectID,
+				instanceKey:         "instance-" + testCase.name + "-parent",
+				definitionName:      parentDefinitionName,
+				definitionVersion:   "v1",
+				input:               mustJSON(t, map[string]string{"order_id": "ord-" + testCase.name}),
+				skipProjectionShell: true,
 			})
 			insertProjectedTraceShell(t, ctx, db.Pool, instance, parentRun, "Child Terminal Parent "+testCase.name, 1)
 
@@ -1453,11 +1461,12 @@ func TestActivatorChildContinuationDepthWaitFailureAndLateTerminalGuard(t *testi
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-child-follow-depth",
-		definitionName:    "checkout-child-follow-depth",
-		definitionVersion: "v1",
-		input:             mustJSON(t, map[string]string{"order_id": "ord-follow-depth"}),
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-child-follow-depth",
+		definitionName:      "checkout-child-follow-depth",
+		definitionVersion:   "v1",
+		input:               mustJSON(t, map[string]string{"order_id": "ord-follow-depth"}),
+		skipProjectionShell: true,
 	}
 	instance, parentRun := createStartedRun(t, store, testCase)
 	insertProjectedTraceShell(t, ctx, db.Pool, instance, parentRun, "Child Follow Depth Parent", 1)
@@ -1571,11 +1580,12 @@ func TestActivatorChildTerminalWakeGuardRequiresMatchingWaitIdentity(t *testing.
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-child-wake-guard",
-		definitionName:    "checkout-child-wake-guard",
-		definitionVersion: "v1",
-		input:             mustJSON(t, map[string]string{"order_id": "ord-wake-guard"}),
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-child-wake-guard",
+		definitionName:      "checkout-child-wake-guard",
+		definitionVersion:   "v1",
+		input:               mustJSON(t, map[string]string{"order_id": "ord-wake-guard"}),
+		skipProjectionShell: true,
 	}
 	instance, parentRun := createStartedRun(t, store, testCase)
 	insertProjectedTraceShell(t, ctx, db.Pool, instance, parentRun, "Child Wake Guard Parent", 1)
@@ -1635,11 +1645,12 @@ func TestActivatorCancelledDecisionEnqueuesActiveChildCancelIdempotently(t *test
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-child-cancel-parent",
-		definitionName:    "checkout-child-cancel",
-		definitionVersion: "v1",
-		input:             mustJSON(t, map[string]string{"order_id": "ord-cancel-child"}),
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-child-cancel-parent",
+		definitionName:      "checkout-child-cancel",
+		definitionVersion:   "v1",
+		input:               mustJSON(t, map[string]string{"order_id": "ord-cancel-child"}),
+		skipProjectionShell: true,
 	}
 	instance, parentRun := createStartedRun(t, store, testCase)
 	insertProjectedTraceShell(t, ctx, db.Pool, instance, parentRun, "Child Cancel Parent", 1)
@@ -1957,10 +1968,11 @@ func TestActivatorWaitingDecisionDoesNotMutateProjectedTraceSummary(t *testing.T
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-projected-wait",
-		definitionName:    "projected-wait",
-		definitionVersion: "v1",
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-projected-wait",
+		definitionName:      "projected-wait",
+		definitionVersion:   "v1",
+		skipProjectionShell: true,
 	}
 	instance, run := createStartedRun(t, store, testCase)
 
@@ -2028,10 +2040,11 @@ func TestActivatorFailureMovesProjectedTraceIntoCatchingUpWithoutProjectingTermi
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-projected-failure",
-		definitionName:    "missing-definition",
-		definitionVersion: "v-missing",
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-projected-failure",
+		definitionName:      "missing-definition",
+		definitionVersion:   "v-missing",
+		skipProjectionShell: true,
 	}
 	instance, run := createStartedRun(t, store, testCase)
 
@@ -2113,10 +2126,11 @@ func TestActivatorCancellationTransitionsRunToCancelledWithoutProjectingTerminal
 	ctx := context.Background()
 
 	testCase := workflowTestCase{
-		projectID:         enginetest.DefaultPlatformProjectID,
-		instanceKey:       "instance-cancelled",
-		definitionName:    "cancelled-workflow",
-		definitionVersion: "v1",
+		projectID:           enginetest.DefaultPlatformProjectID,
+		instanceKey:         "instance-cancelled",
+		definitionName:      "cancelled-workflow",
+		definitionVersion:   "v1",
+		skipProjectionShell: true,
 	}
 	instance, run := createStartedRun(t, store, testCase)
 
@@ -2484,11 +2498,12 @@ func TestActivatorLateSignalWakeIsNotStranded(t *testing.T) {
 }
 
 type workflowTestCase struct {
-	projectID         uuid.UUID
-	instanceKey       string
-	definitionName    string
-	definitionVersion string
-	input             json.RawMessage
+	projectID           uuid.UUID
+	instanceKey         string
+	definitionName      string
+	definitionVersion   string
+	input               json.RawMessage
+	skipProjectionShell bool
 }
 
 func createStartedRun(
@@ -2499,6 +2514,7 @@ func createStartedRun(
 	t.Helper()
 
 	ctx := context.Background()
+	enginetest.EnsurePlatformProject(t, store.Pool(), testCase.projectID)
 	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
 		ProjectID:      testCase.projectID,
 		InstanceKey:    testCase.instanceKey,
@@ -2518,12 +2534,15 @@ func createStartedRun(
 		t.Fatalf("CreateRun() error = %v", err)
 	}
 
-	appendHistoryEvent(t, store, testCase.projectID, instance.ID, run.ID, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+	startedHistory := appendHistoryEvent(t, store, testCase.projectID, instance.ID, run.ID, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
 		DefinitionName:    testCase.definitionName,
 		DefinitionVersion: testCase.definitionVersion,
 		InstanceKey:       testCase.instanceKey,
 		Input:             testCase.input,
 	})
+	if !testCase.skipProjectionShell {
+		enginetest.SeedProjectionShell(t, store.Pool(), &instance, &run, testCase.definitionName, testCase.definitionVersion, testCase.input, startedHistory.ID)
+	}
 
 	return instance, run
 }
@@ -2595,23 +2614,25 @@ func appendHistoryEvent(
 	sequenceNo int32,
 	eventType string,
 	payload any,
-) {
+) enginedb.EngineHistory {
 	t.Helper()
 
 	raw, err := enginehistory.MarshalPayload(payload)
 	if err != nil {
 		t.Fatalf("MarshalPayload() error = %v", err)
 	}
-	if _, err := store.AppendHistory(context.Background(), enginedb.AppendHistoryParams{
+	row, err := store.AppendHistory(context.Background(), enginedb.AppendHistoryParams{
 		ProjectID:  projectID,
 		InstanceID: instanceID,
 		RunID:      runID,
 		SequenceNo: sequenceNo,
 		EventType:  eventType,
 		Payload:    raw,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("AppendHistory() error = %v", err)
 	}
+	return row
 }
 
 func mustStartedHistory(t *testing.T, store *enginestore.Store, runID uuid.UUID) enginedb.EngineHistory {

--- a/engine/pkg/projection/writer.go
+++ b/engine/pkg/projection/writer.go
@@ -1,6 +1,6 @@
 // writer.go holds the projection Writer: the single owner of every engine-run
-// write into the platform debugger tables (public.traces, public.spans,
-// public.span_events, and the dark-launch bootstrap row in public.projects).
+// write into the platform debugger tables (public.traces, public.spans, and
+// public.span_events).
 //
 // The Writer sits at the engine→platform seam and has exactly two adapters:
 //
@@ -39,12 +39,6 @@ import (
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 )
-
-// DarkLaunchProjectID is the fixed demo project used by the engine's
-// dark-launch runtime. Projected debugger shells for this project are
-// best-effort: the dark-launch CLI may execute runs whose shells were never
-// created, so guarded writes tolerate missing rows for this project only.
-var DarkLaunchProjectID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
 
 // Sentinel errors surfaced by Writer reads that guard writes.
 var (
@@ -97,12 +91,10 @@ func NewWriter(tx pgx.Tx) *Writer {
 	return &Writer{tx: tx}
 }
 
-// requireProjectedRow is the single statement of the dark-launch tolerance
-// rule: a guarded projection write must match an existing projected row,
-// except for runs in the fixed dark-launch demo project, whose shells are
-// best-effort and may legitimately be absent.
-func requireProjectedRow(tag pgconn.CommandTag, projectID uuid.UUID, missing func() error) error {
-	if tag.RowsAffected() == 0 && projectID != DarkLaunchProjectID {
+// requireProjectedRow ensures a guarded projection write matched an existing
+// projected row.
+func requireProjectedRow(tag pgconn.CommandTag, missing func() error) error {
+	if tag.RowsAffected() == 0 {
 		return missing()
 	}
 	return nil
@@ -176,7 +168,7 @@ func (w *Writer) UpdateLatestHistory(
 	if err != nil {
 		return err
 	}
-	return requireProjectedRow(commandTag, projectID, func() error {
+	return requireProjectedRow(commandTag, func() error {
 		return fmt.Errorf("projected trace not found for run %s", runID)
 	})
 }
@@ -222,7 +214,7 @@ func (w *Writer) WriteTerminalSummary(
 	if err != nil {
 		return err
 	}
-	if err := requireProjectedRow(commandTag, projectID, func() error {
+	if err := requireProjectedRow(commandTag, func() error {
 		return fmt.Errorf("projected trace not found for run %s", runID)
 	}); err != nil {
 		return err
@@ -251,7 +243,7 @@ func (w *Writer) WriteTerminalSummary(
 	if err != nil {
 		return err
 	}
-	return requireProjectedRow(commandTag, projectID, func() error {
+	return requireProjectedRow(commandTag, func() error {
 		return fmt.Errorf("projected root span not found for run %s", runID)
 	})
 }
@@ -289,7 +281,7 @@ func (w *Writer) SyncRunSummary(ctx context.Context, run *enginedb.EngineRun) er
 	if err != nil {
 		return err
 	}
-	return requireProjectedRow(commandTag, run.ProjectID, func() error {
+	return requireProjectedRow(commandTag, func() error {
 		return fmt.Errorf("projected trace not found for run %s", run.ID)
 	})
 }
@@ -329,7 +321,7 @@ func (w *Writer) WriteTerminalProjection(
 	if err != nil {
 		return err
 	}
-	if err := requireProjectedRow(commandTag, ref.ProjectID, func() error {
+	if err := requireProjectedRow(commandTag, func() error {
 		return fmt.Errorf("projected trace not found for run %s", ref.RunID)
 	}); err != nil {
 		return err
@@ -400,7 +392,7 @@ func (w *Writer) upsertTerminalRootSpan(
 	if err != nil {
 		return err
 	}
-	return requireProjectedRow(commandTag, ref.ProjectID, func() error {
+	return requireProjectedRow(commandTag, func() error {
 		return fmt.Errorf("projected trace not found for run %s", ref.RunID)
 	})
 }

--- a/engine/pkg/projection/writer_shell.go
+++ b/engine/pkg/projection/writer_shell.go
@@ -1,6 +1,6 @@
 // writer_shell.go holds the Writer methods that create projected trace shells:
 // the initial trace+root-span pair for new runs, continuations, and child
-// workflows, plus the dark-launch CLI bootstrap shell.
+// workflows, plus start-path shells.
 package projection
 
 import (
@@ -204,10 +204,9 @@ func (w *Writer) CreateTraceShell(
 	return nil
 }
 
-// EnsureDarkLaunchShell bootstraps the fixed dark-launch demo project and a
-// projected shell for a CLI-started run. Dark-launch shells are best-effort;
-// see requireProjectedRow for the matching tolerance rule on later writes.
-func (w *Writer) EnsureDarkLaunchShell(
+// EnsureStartShell creates the projected shell for a started run. Start paths
+// create shells transactionally; the platform project row must already exist.
+func (w *Writer) EnsureStartShell(
 	ctx context.Context,
 	instance *enginedb.EngineInstance,
 	run *enginedb.EngineRun,
@@ -221,13 +220,6 @@ func (w *Writer) EnsureDarkLaunchShell(
 	}
 
 	now := time.Now()
-	if _, err := w.tx.Exec(ctx, `
-		INSERT INTO public.projects (id, name, api_key_hash)
-		VALUES ($1, $2, $3)
-		ON CONFLICT (id) DO NOTHING
-	`, DarkLaunchProjectID, "Engine Dark Launch", "engine-dark-launch"); err != nil {
-		return err
-	}
 
 	traceID := TraceExternalID(run.ID)
 	traceUUID := uuid.New()
@@ -280,7 +272,7 @@ func (w *Writer) EnsureDarkLaunchShell(
 		    $12,
 		    $6::timestamptz
 		)
-	`, traceUUID, DarkLaunchProjectID, traceID, definitionName, cloneRaw(input), now, run.ID, instance.InstanceKey, definitionName, definitionVersion, run.ID, startedHistoryID); err != nil {
+	`, traceUUID, run.ProjectID, traceID, definitionName, cloneRaw(input), now, run.ID, instance.InstanceKey, definitionName, definitionVersion, run.ID, startedHistoryID); err != nil {
 		return err
 	}
 
@@ -298,7 +290,7 @@ func (w *Writer) EnsureDarkLaunchShell(
 		    depth
 		)
 		VALUES ($1, $2, $3, $4, 'chain', 'running', 'default', $5::timestamptz, $6::jsonb, 0)
-	`, DarkLaunchProjectID, traceUUID, RootSpanExternalID(run.ID), definitionName, now, cloneRaw(input))
+	`, run.ProjectID, traceUUID, RootSpanExternalID(run.ID), definitionName, now, cloneRaw(input))
 	return spanErr
 }
 

--- a/engine/pkg/projection/writer_shell.go
+++ b/engine/pkg/projection/writer_shell.go
@@ -206,6 +206,8 @@ func (w *Writer) CreateTraceShell(
 
 // EnsureStartShell creates the projected shell for a started run. Start paths
 // create shells transactionally; the platform project row must already exist.
+// It is only valid for root-level run starts: it writes a NULL parent run and
+// root_run_id = run.ID. Child and continuation runs must use CreateTraceShell.
 func (w *Writer) EnsureStartShell(
 	ctx context.Context,
 	instance *enginedb.EngineInstance,

--- a/engine/pkg/projection/writer_strict_test.go
+++ b/engine/pkg/projection/writer_strict_test.go
@@ -1,0 +1,175 @@
+package projection_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	"github.com/continua-ai/continua/engine/pkg/projection"
+)
+
+func TestGuardedWriteFailsWithoutShellForFormerSentinelProject(t *testing.T) {
+	ctx := context.Background()
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	enginetest.EnsurePlatformProject(t, db.Pool, projectID)
+
+	store := enginestore.New(db.Pool)
+	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "former-sentinel-no-shell",
+		DefinitionName: "strict.no-shell",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+
+	tx, err := db.Pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	err = projection.NewWriter(tx).SyncRunSummary(ctx, &run)
+	if err == nil {
+		t.Fatal("SyncRunSummary() error = nil, want missing trace shell error")
+	}
+}
+
+func TestEnsureStartShellWritesShellUnderRunProject(t *testing.T) {
+	ctx := context.Background()
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.New()
+	if _, err := db.Pool.Exec(ctx, `DELETE FROM public.projects`); err != nil {
+		t.Fatalf("delete seeded projects: %v", err)
+	}
+	if _, err := db.Pool.Exec(ctx, `
+		INSERT INTO public.projects (id, name, api_key_hash)
+		VALUES ($1, $2, $3)
+	`, projectID, "Real Engine Project", "real-engine-project-key"); err != nil {
+		t.Fatalf("insert real project: %v", err)
+	}
+
+	store := enginestore.New(db.Pool)
+	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "real-project-instance",
+		DefinitionName: "strict.start",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	input := []byte(`{"name":"Ada"}`)
+	startedPayload, err := enginehistory.MarshalPayload(enginehistory.WorkflowStartedPayload{
+		DefinitionName:    "strict.start",
+		DefinitionVersion: "v1",
+		InstanceKey:       "real-project-instance",
+		Input:             input,
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(workflow started) error = %v", err)
+	}
+	startedEvent, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 1,
+		EventType:  enginehistory.EventWorkflowStarted,
+		Payload:    startedPayload,
+	})
+	if err != nil {
+		t.Fatalf("AppendHistory(workflow started) error = %v", err)
+	}
+
+	tx, err := db.Pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+	if err := projection.NewWriter(tx).EnsureStartShell(ctx, &instance, &run, "strict.start", "v1", input, startedEvent.ID); err != nil {
+		t.Fatalf("EnsureStartShell() error = %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	var traceCount int
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM public.traces
+		WHERE project_id = $1
+		  AND engine_run_id = $2
+		  AND trace_id = $3
+	`, projectID, run.ID, "engine:"+run.ID.String()).Scan(&traceCount); err != nil {
+		t.Fatalf("query projected trace: %v", err)
+	}
+	if traceCount != 1 {
+		t.Fatalf("projected trace count = %d, want 1", traceCount)
+	}
+
+	var rootSpanCount int
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM public.spans AS s
+		JOIN public.traces AS t ON t.id = s.trace_id
+		WHERE s.project_id = $1
+		  AND t.engine_run_id = $2
+		  AND s.span_id = $3
+	`, projectID, run.ID, "engine:root:"+run.ID.String()).Scan(&rootSpanCount); err != nil {
+		t.Fatalf("query projected root span: %v", err)
+	}
+	if rootSpanCount != 1 {
+		t.Fatalf("projected root span count = %d, want 1", rootSpanCount)
+	}
+
+	var projectCount int
+	if err := db.Pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.projects`).Scan(&projectCount); err != nil {
+		t.Fatalf("query project count: %v", err)
+	}
+	if projectCount != 1 {
+		t.Fatalf("project count = %d, want only the real project", projectCount)
+	}
+
+	var sentinelCount int
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM public.projects
+		WHERE id = '00000000-0000-0000-0000-000000000001'
+	`).Scan(&sentinelCount); err != nil {
+		t.Fatalf("query sentinel project count: %v", err)
+	}
+	if sentinelCount != 0 {
+		t.Fatalf("sentinel project count = %d, want 0", sentinelCount)
+	}
+}

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -97,6 +97,9 @@ func (r *Runtime) Run(ctx context.Context) error {
 		return err
 	}
 	store := enginestore.New(pool)
+	defer func() {
+		store.Close()
+	}()
 	if r.options.ProjectID != nil {
 		exists, err := store.PlatformProjectExists(ctx, *r.options.ProjectID)
 		if err != nil {
@@ -107,7 +110,6 @@ func (r *Runtime) Run(ctx context.Context) error {
 		}
 		store = store.WithProjectFilter(*r.options.ProjectID)
 	}
-	defer store.Close()
 
 	if err := catalog.PublishStoreDefinitions(ctx, store, r.definitions.List()); err != nil {
 		return err

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -97,6 +98,13 @@ func (r *Runtime) Run(ctx context.Context) error {
 	}
 	store := enginestore.New(pool)
 	if r.options.ProjectID != nil {
+		exists, err := store.PlatformProjectExists(ctx, *r.options.ProjectID)
+		if err != nil {
+			return fmt.Errorf("runtime: validate project %s: %w", r.options.ProjectID.String(), err)
+		}
+		if !exists {
+			return fmt.Errorf("runtime: project %s not found; create the project in the platform and set ENGINE_PROJECT_ID before starting the engine runtime", r.options.ProjectID.String())
+		}
 		store = store.WithProjectFilter(*r.options.ProjectID)
 	}
 	defer store.Close()

--- a/engine/pkg/runtime/runtime_project_validation_test.go
+++ b/engine/pkg/runtime/runtime_project_validation_test.go
@@ -1,0 +1,57 @@
+package runtime_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestRuntimeRunFailsWhenProjectMissing(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	missingProjectID := uuid.New()
+
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL: db.DatabaseURL,
+		Workflows: []workflow.Definition{
+			{
+				Name:    "missingproject.noop",
+				Version: "v1",
+				Run: func(ctx workflow.Context) error {
+					return ctx.SetResult(map[string]bool{"ok": true})
+				},
+			},
+		},
+		ProjectID:            &missingProjectID,
+		WorkflowPollInterval: 25 * time.Millisecond,
+		ActivityPollInterval: 25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("runtime.New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	started := time.Now()
+	err = rt.Run(ctx)
+	if err == nil {
+		t.Fatal("Runtime.Run() error = nil, want missing project error")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Runtime.Run() error = %v, want missing project error before context deadline", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("Runtime.Run() returned after context expired in %s with err=%v", time.Since(started), err)
+	}
+	if !strings.Contains(err.Error(), missingProjectID.String()) {
+		t.Fatalf("Runtime.Run() error = %q, want missing project id %s", err.Error(), missingProjectID)
+	}
+}

--- a/internal/api/engine_provisioning_e2e_test.go
+++ b/internal/api/engine_provisioning_e2e_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+)
+
+func TestEngineServeUnderProvisionedProjectE2E(t *testing.T) {
+	missingProjectID := uuid.New()
+	missingProjectServe := startExternalEngineServeProcessWithEnv(
+		t,
+		missingProjectID,
+		"ENGINE_PROJECT_ID="+missingProjectID.String(),
+		"CONTINUA_ENGINE_TEST_PROJECT_FILTER=",
+	)
+
+	select {
+	case err := <-missingProjectServe.done:
+		if err == nil {
+			t.Fatal("engine serve exited successfully for missing project, want non-nil error")
+		}
+		output := missingProjectServe.stdout.String() + missingProjectServe.stderr.String()
+		if !strings.Contains(output, missingProjectID.String()) {
+			t.Fatalf("engine serve output = %q, want missing project id %s", output, missingProjectID)
+		}
+	case <-time.After(60 * time.Second):
+		missingProjectServe.stop(t)
+		t.Fatalf("engine serve did not fail within 60s for missing project %s", missingProjectID)
+	}
+
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	apiKey := "engine-provisioned-" + uuid.NewString()
+	_, err := platformStore.Pool().Exec(ctx, `
+		UPDATE public.projects
+		SET api_key_hash = $2
+		WHERE id = $1
+	`, projectID, hashTestAPIKey(apiKey))
+	require.NoError(t, err)
+	require.NoError(t, publishEngineDefinition(ctx, engineQueries, "darklaunch.demo"))
+
+	engineServe := startExternalEngineServeProcessWithEnv(
+		t,
+		projectID,
+		"ENGINE_PROJECT_ID="+projectID.String(),
+		"CONTINUA_ENGINE_TEST_PROJECT_FILTER=",
+		"ENGINE_ACTIVITY_POLL_INTERVAL=50ms",
+		"ENGINE_MAINTENANCE_POLL_INTERVAL=50ms",
+	)
+	defer engineServe.stop(t)
+
+	router := newAuthenticatedRouter(t, server, platformStore)
+	start := startEngineRunThroughRouter(t, router, apiKey, EngineStartRunRequest{
+		DefinitionName:    "darklaunch.demo",
+		DefinitionVersion: "v1",
+		InstanceKey:       "provisioned-e2e-instance",
+		RequestKey:        "provisioned-e2e-request",
+		Input: map[string]any{
+			"name":     "Provisioned",
+			"timer_at": "1970-01-01T00:00:00Z",
+		},
+		Trace: &EngineStartTrace{
+			Name: ptrString("Provisioned Demo"),
+		},
+	})
+
+	require.Equal(t, http.StatusOK, invokeSignalEngineRun(t, server, projectID, start.RunId, EngineSignalRunRequest{
+		SignalName: "approval",
+		Payload:    map[string]any{"approval": "yes"},
+	}).Code)
+
+	completed := waitForEngineRun(t, server, projectID, start.RunId, func(run EngineRunResponse) bool {
+		return run.Status == EngineRunStatusCOMPLETED
+	})
+	require.Equal(t, EngineRunStatusCOMPLETED, completed.Status)
+
+	resultRec := invokeGetEngineRunResult(t, server, projectID, start.RunId)
+	require.Equal(t, http.StatusOK, resultRec.Code)
+	result := decodeJSONBody[EngineRunResultResponse](t, resultRec)
+	require.Equal(t, EngineRunStatusCOMPLETED, result.Status)
+	require.NotNil(t, result.Result)
+
+	traceListRec := invokeListTraces(t, server, projectID, ListTracesParams{})
+	require.Equal(t, http.StatusOK, traceListRec.Code)
+	traceList := decodeJSONBody[TraceList](t, traceListRec)
+	var found bool
+	for _, trace := range traceList.Traces {
+		if trace.Engine == nil || trace.Engine.RunId != start.RunId {
+			continue
+		}
+		found = true
+		require.Equal(t, "darklaunch.demo", trace.Engine.DefinitionName)
+		break
+	}
+	if !found {
+		t.Fatalf("GET /api/traces did not include engine run linkage for run %s: %+v", start.RunId, traceList.Traces)
+	}
+
+	var sentinelCount int
+	err = platformStore.Pool().QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM public.projects
+		WHERE id = '00000000-0000-0000-0000-000000000001'
+	`).Scan(&sentinelCount)
+	require.NoError(t, err)
+	require.Equal(t, 0, sentinelCount)
+
+	_, err = engineQueries.GetRunByProjectAndID(ctx, enginedb.GetRunByProjectAndIDParams{
+		ProjectID: projectID,
+		ID:        start.RunId,
+	})
+	require.NoError(t, err)
+}
+
+func startEngineRunThroughRouter(t *testing.T, router http.Handler, apiKey string, reqBody EngineStartRunRequest) EngineStartRunResponse {
+	t.Helper()
+
+	body, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/runs", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set(enginePreviewHeader, "1")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	return decodeJSONBody[EngineStartRunResponse](t, rec)
+}
+
+func ptrString(value string) *string {
+	return &value
+}


### PR DESCRIPTION
## What / why

The engine previously supported only one real project: the hardcoded `DarkLaunchProjectID` sentinel (`00000000-0000-0000-0000-000000000001`), with projection tolerances special-cased on that magic UUID and no provisioning path for a user project. This PR lets a self-hosted operator create a platform project, point the engine runtime at it, and see runs in the debugger — no sentinel, no special cases. Dark-launch remains a plain demo consumer.

## Changes

- **Startup validation**: new `Store.PlatformProjectExists` (raw SQL against `public.projects`, matching the projection writer's platform-table pattern); `runtime.Run` now fails fast when `Options.ProjectID` points at a project that does not exist, with the project id and provisioning hint in the error.
- **Operator-facing env**: `ENGINE_PROJECT_ID` now resolves the runtime project filter (legacy `CONTINUA_ENGINE_TEST_PROJECT_FILTER` kept as a fallback; the new var wins when both are set).
- **Sentinel retired**: `projection.DarkLaunchProjectID` is deleted. `requireProjectedRow` no longer exempts any project — zero rows affected on a guarded projection write is always an error. `EnsureDarkLaunchShell` is renamed to `EnsureStartShell`: it writes the trace/root-span shell under `run.ProjectID` and no longer bootstraps a `public.projects` row.
- **Dark-launch CLI**: owns its demo project id locally and bootstraps the demo project row inside the `start` transaction before creating the shell.
- **Continue-as-new ordering**: the guarded `UpdateLatestHistory` for `decisionContinuedAsNew` now runs after `commitContinuationDecision`, so a missing shell surfaces as the typed `store.ErrInvariant` (per #159) instead of a generic projection error; final transactional state is unchanged.
- **Test fixtures**: new `testutil.SeedProjectionShell` helper; engine fixtures that relied on the old tolerance now seed real shells. The old tolerance test is inverted to assert strict behavior. Test-DB teardown now only terminates same-user client backends (works under non-superuser roles).
- **Docs**: new provisioning guide (`docs-site/guides/engine-project-provisioning.mdx`: create project → API key → `ENGINE_PROJECT_ID`/`ENGINE_DATABASE_URL` → runs in the debugger), plus a sweep of stale sentinel claims in `embed-engine`, `engine-foundation`, `engine-runs`, `managing-projects`, the roadmap, and `engine/README.md`.

## Test evidence

Acceptance tests were written first (committed red in `23b78bf`) and the implementation was built against them:

- `TestRuntimeRunFailsWhenProjectMissing` — runtime fails fast with the project id in the error.
- `TestGuardedWriteFailsWithoutShellForFormerSentinelProject` — the former sentinel gets no tolerance.
- `TestEnsureStartShellWritesShellUnderRunProject` — shells land under the run's real project; no sentinel bootstrap.
- `TestLoadResolvesEngineProjectIDEnv` — env precedence, fallback, and validation.
- `TestEngineServeUnderProvisionedProjectE2E` — serve fails fast for an unprovisioned project, then a provisioned project runs end-to-end via `POST /v1/engine/runs` and appears in the traces console reads, with zero sentinel rows.

Verified: `cd engine && go test ./...` and `go test ./internal/api/...` green on a fresh database; `make generate` leaves the tree clean.

Closes #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for provisioning platform projects before running scoped engine workflows.
  * Documented project configuration using `ENGINE_PROJECT_ID` and `ENGINE_DATABASE_URL`.
  * Added navigation to the new project provisioning guide.
  * Engine startup now verifies that the configured project exists and reports a clear error if it does not.

* **Bug Fixes**
  * Improved workflow projection handling to use the configured project and enforce missing projection errors.
  * Clarified dark-launch behavior and runtime setup across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->