### PR TITLE
feat(engine): definition catalog as registry truth — liveness + version metadata

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -463,6 +463,21 @@ type EngineControlResponse struct {
 	WakeApplied bool               `json:"wake_applied"`
 }
 
+// EngineDefinition defines model for EngineDefinition.
+type EngineDefinition struct {
+	DefinitionName     string    `json:"definition_name"`
+	DefinitionVersion  string    `json:"definition_version"`
+	Enabled            bool      `json:"enabled"`
+	Live               bool      `json:"live"`
+	PublishedAt        time.Time `json:"published_at"`
+	RuntimePublishedAt time.Time `json:"runtime_published_at"`
+}
+
+// EngineDefinitionListResponse defines model for EngineDefinitionListResponse.
+type EngineDefinitionListResponse struct {
+	Definitions []EngineDefinition `json:"definitions"`
+}
+
 // EngineFailureSummary defines model for EngineFailureSummary.
 type EngineFailureSummary struct {
 	// ErrorCode Stable reserved value: `definition_version_mismatch`. Clients may
@@ -1782,6 +1797,9 @@ type ServerInterface interface {
 	// Renew a remote activity task lease
 	// (POST /v1/engine/activities/{id}/heartbeat)
 	HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params HeartbeatRemoteActivityTaskParams)
+	// List registered engine workflow definitions
+	// (GET /v1/engine/definitions)
+	ListEngineDefinitions(w http.ResponseWriter, r *http.Request)
 	// Get an engine instance and current run
 	// (GET /v1/engine/instances/{instance_key})
 	GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string)
@@ -1941,6 +1959,12 @@ func (_ Unimplemented) FailRemoteActivityTask(w http.ResponseWriter, r *http.Req
 // Renew a remote activity task lease
 // (POST /v1/engine/activities/{id}/heartbeat)
 func (_ Unimplemented) HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params HeartbeatRemoteActivityTaskParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List registered engine workflow definitions
+// (GET /v1/engine/definitions)
+func (_ Unimplemented) ListEngineDefinitions(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -3045,6 +3069,28 @@ func (siw *ServerInterfaceWrapper) HeartbeatRemoteActivityTask(w http.ResponseWr
 	handler.ServeHTTP(w, r)
 }
 
+// ListEngineDefinitions operation middleware
+func (siw *ServerInterfaceWrapper) ListEngineDefinitions(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, Auth0BearerScopes, []string{})
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListEngineDefinitions(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetEngineInstance operation middleware
 func (siw *ServerInterfaceWrapper) GetEngineInstance(w http.ResponseWriter, r *http.Request) {
 
@@ -4011,6 +4057,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/engine/activities/{id}/heartbeat", wrapper.HeartbeatRemoteActivityTask)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/engine/definitions", wrapper.ListEngineDefinitions)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/instances/{instance_key}", wrapper.GetEngineInstance)

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -47,6 +47,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/engine/definitions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List registered engine workflow definitions */
+        get: operations["listEngineDefinitions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/engine/runs": {
         parameters: {
             query?: never;
@@ -928,6 +945,19 @@ export interface components {
             instance_key: string;
             trace_id: string;
         };
+        EngineDefinition: {
+            definition_name: string;
+            definition_version: string;
+            enabled: boolean;
+            live: boolean;
+            /** Format: date-time */
+            runtime_published_at: string;
+            /** Format: date-time */
+            published_at: string;
+        };
+        EngineDefinitionListResponse: {
+            definitions: components["schemas"]["EngineDefinition"][];
+        };
         EngineInstanceResponse: {
             /** Format: uuid */
             instance_id: string;
@@ -1583,6 +1613,44 @@ export interface operations {
                 };
             };
             /** @description Batch not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listEngineDefinitions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Engine definition catalog */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EngineDefinitionListResponse"];
+                };
+            };
+            /** @description Unauthorized - missing or invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Engine API disabled */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -112,6 +112,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /v1/engine/definitions:
+    get:
+      operationId: listEngineDefinitions
+      summary: List registered engine workflow definitions
+      tags:
+        - Engine
+      responses:
+        '200':
+          description: Engine definition catalog
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineDefinitionListResponse'
+        '401':
+          description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Engine API disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /v1/engine/runs:
     post:
       operationId: startEngineRun
@@ -2331,6 +2356,39 @@ components:
           type: string
         trace_id:
           type: string
+    EngineDefinition:
+      type: object
+      required:
+        - definition_name
+        - definition_version
+        - enabled
+        - live
+        - runtime_published_at
+        - published_at
+      properties:
+        definition_name:
+          type: string
+        definition_version:
+          type: string
+        enabled:
+          type: boolean
+        live:
+          type: boolean
+        runtime_published_at:
+          type: string
+          format: date-time
+        published_at:
+          type: string
+          format: date-time
+    EngineDefinitionListResponse:
+      type: object
+      required:
+        - definitions
+      properties:
+        definitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineDefinition'
     EngineInstanceResponse:
       type: object
       required:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -118,6 +118,31 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /v1/engine/definitions:
+    get:
+      operationId: listEngineDefinitions
+      summary: List registered engine workflow definitions
+      tags: [Engine]
+      responses:
+        '200':
+          description: Engine definition catalog
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineDefinitionListResponse'
+        '401':
+          description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Engine API disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /v1/engine/runs:
     post:
       operationId: startEngineRun
@@ -2248,6 +2273,34 @@ components:
           type: string
         trace_id:
           type: string
+
+    EngineDefinition:
+      type: object
+      required: [definition_name, definition_version, enabled, live, runtime_published_at, published_at]
+      properties:
+        definition_name:
+          type: string
+        definition_version:
+          type: string
+        enabled:
+          type: boolean
+        live:
+          type: boolean
+        runtime_published_at:
+          type: string
+          format: date-time
+        published_at:
+          type: string
+          format: date-time
+
+    EngineDefinitionListResponse:
+      type: object
+      required: [definitions]
+      properties:
+        definitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineDefinition'
 
     EngineInstanceResponse:
       type: object

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -112,6 +112,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /v1/engine/definitions:
+    get:
+      operationId: listEngineDefinitions
+      summary: List registered engine workflow definitions
+      tags:
+        - Engine
+      responses:
+        '200':
+          description: Engine definition catalog
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngineDefinitionListResponse'
+        '401':
+          description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Engine API disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /v1/engine/runs:
     post:
       operationId: startEngineRun
@@ -2331,6 +2356,39 @@ components:
           type: string
         trace_id:
           type: string
+    EngineDefinition:
+      type: object
+      required:
+        - definition_name
+        - definition_version
+        - enabled
+        - live
+        - runtime_published_at
+        - published_at
+      properties:
+        definition_name:
+          type: string
+        definition_version:
+          type: string
+        enabled:
+          type: boolean
+        live:
+          type: boolean
+        runtime_published_at:
+          type: string
+          format: date-time
+        published_at:
+          type: string
+          format: date-time
+    EngineDefinitionListResponse:
+      type: object
+      required:
+        - definitions
+      properties:
+        definitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineDefinition'
     EngineInstanceResponse:
       type: object
       required:

--- a/engine/db/gen/go/definition_catalog.sql.go
+++ b/engine/db/gen/go/definition_catalog.sql.go
@@ -7,6 +7,7 @@ package engine
 
 import (
 	"context"
+	"time"
 )
 
 const deleteDefinitionCatalogEntry = `-- name: DeleteDefinitionCatalogEntry :execrows
@@ -85,6 +86,50 @@ func (q *Queries) ListDefinitionCatalog(ctx context.Context) ([]EngineDefinition
 		return nil, err
 	}
 	return items, nil
+}
+
+const setDefinitionCatalogEnabled = `-- name: SetDefinitionCatalogEnabled :execrows
+UPDATE engine.definition_catalog
+SET enabled = $3,
+    updated_at = NOW()
+WHERE definition_name = $1
+  AND definition_version = $2
+`
+
+type SetDefinitionCatalogEnabledParams struct {
+	DefinitionName    string `json:"definition_name"`
+	DefinitionVersion string `json:"definition_version"`
+	Enabled           bool   `json:"enabled"`
+}
+
+func (q *Queries) SetDefinitionCatalogEnabled(ctx context.Context, arg SetDefinitionCatalogEnabledParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setDefinitionCatalogEnabled, arg.DefinitionName, arg.DefinitionVersion, arg.Enabled)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const setDefinitionCatalogRuntimePublishedAt = `-- name: SetDefinitionCatalogRuntimePublishedAt :one
+UPDATE engine.definition_catalog
+SET runtime_published_at = $3,
+    updated_at = NOW()
+WHERE definition_name = $1
+  AND definition_version = $2
+RETURNING runtime_published_at
+`
+
+type SetDefinitionCatalogRuntimePublishedAtParams struct {
+	DefinitionName     string    `json:"definition_name"`
+	DefinitionVersion  string    `json:"definition_version"`
+	RuntimePublishedAt time.Time `json:"runtime_published_at"`
+}
+
+func (q *Queries) SetDefinitionCatalogRuntimePublishedAt(ctx context.Context, arg SetDefinitionCatalogRuntimePublishedAtParams) (time.Time, error) {
+	row := q.db.QueryRow(ctx, setDefinitionCatalogRuntimePublishedAt, arg.DefinitionName, arg.DefinitionVersion, arg.RuntimePublishedAt)
+	var runtime_published_at time.Time
+	err := row.Scan(&runtime_published_at)
+	return runtime_published_at, err
 }
 
 const touchDefinitionCatalogEntry = `-- name: TouchDefinitionCatalogEntry :execrows

--- a/engine/db/gen/go/definition_catalog.sql.go
+++ b/engine/db/gen/go/definition_catalog.sql.go
@@ -29,7 +29,7 @@ func (q *Queries) DeleteDefinitionCatalogEntry(ctx context.Context, arg DeleteDe
 }
 
 const getDefinitionCatalogEntry = `-- name: GetDefinitionCatalogEntry :one
-SELECT definition_name, definition_version, published_at, updated_at
+SELECT definition_name, definition_version, published_at, updated_at, runtime_published_at, enabled
 FROM engine.definition_catalog
 WHERE definition_name = $1
   AND definition_version = $2
@@ -48,12 +48,14 @@ func (q *Queries) GetDefinitionCatalogEntry(ctx context.Context, arg GetDefiniti
 		&i.DefinitionVersion,
 		&i.PublishedAt,
 		&i.UpdatedAt,
+		&i.RuntimePublishedAt,
+		&i.Enabled,
 	)
 	return i, err
 }
 
 const listDefinitionCatalog = `-- name: ListDefinitionCatalog :many
-SELECT definition_name, definition_version, published_at, updated_at
+SELECT definition_name, definition_version, published_at, updated_at, runtime_published_at, enabled
 FROM engine.definition_catalog
 ORDER BY definition_name ASC, definition_version ASC
 `
@@ -72,6 +74,8 @@ func (q *Queries) ListDefinitionCatalog(ctx context.Context) ([]EngineDefinition
 			&i.DefinitionVersion,
 			&i.PublishedAt,
 			&i.UpdatedAt,
+			&i.RuntimePublishedAt,
+			&i.Enabled,
 		); err != nil {
 			return nil, err
 		}
@@ -91,7 +95,7 @@ INSERT INTO engine.definition_catalog (
 VALUES ($1, $2)
 ON CONFLICT (definition_name, definition_version) DO UPDATE SET
     updated_at = NOW()
-RETURNING definition_name, definition_version, published_at, updated_at
+RETURNING definition_name, definition_version, published_at, updated_at, runtime_published_at, enabled
 `
 
 type UpsertDefinitionCatalogEntryParams struct {
@@ -107,6 +111,8 @@ func (q *Queries) UpsertDefinitionCatalogEntry(ctx context.Context, arg UpsertDe
 		&i.DefinitionVersion,
 		&i.PublishedAt,
 		&i.UpdatedAt,
+		&i.RuntimePublishedAt,
+		&i.Enabled,
 	)
 	return i, err
 }

--- a/engine/db/gen/go/definition_catalog.sql.go
+++ b/engine/db/gen/go/definition_catalog.sql.go
@@ -87,6 +87,27 @@ func (q *Queries) ListDefinitionCatalog(ctx context.Context) ([]EngineDefinition
 	return items, nil
 }
 
+const touchDefinitionCatalogEntry = `-- name: TouchDefinitionCatalogEntry :execrows
+UPDATE engine.definition_catalog
+SET runtime_published_at = NOW(),
+    updated_at = NOW()
+WHERE definition_name = $1
+  AND definition_version = $2
+`
+
+type TouchDefinitionCatalogEntryParams struct {
+	DefinitionName    string `json:"definition_name"`
+	DefinitionVersion string `json:"definition_version"`
+}
+
+func (q *Queries) TouchDefinitionCatalogEntry(ctx context.Context, arg TouchDefinitionCatalogEntryParams) (int64, error) {
+	result, err := q.db.Exec(ctx, touchDefinitionCatalogEntry, arg.DefinitionName, arg.DefinitionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const upsertDefinitionCatalogEntry = `-- name: UpsertDefinitionCatalogEntry :one
 INSERT INTO engine.definition_catalog (
     definition_name,
@@ -94,6 +115,7 @@ INSERT INTO engine.definition_catalog (
 )
 VALUES ($1, $2)
 ON CONFLICT (definition_name, definition_version) DO UPDATE SET
+    runtime_published_at = NOW(),
     updated_at = NOW()
 RETURNING definition_name, definition_version, published_at, updated_at, runtime_published_at, enabled
 `

--- a/engine/db/gen/go/models.go
+++ b/engine/db/gen/go/models.go
@@ -339,10 +339,12 @@ type EngineChildWorkflow struct {
 }
 
 type EngineDefinitionCatalog struct {
-	DefinitionName    string    `json:"definition_name"`
-	DefinitionVersion string    `json:"definition_version"`
-	PublishedAt       time.Time `json:"published_at"`
-	UpdatedAt         time.Time `json:"updated_at"`
+	DefinitionName     string    `json:"definition_name"`
+	DefinitionVersion  string    `json:"definition_version"`
+	PublishedAt        time.Time `json:"published_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	RuntimePublishedAt time.Time `json:"runtime_published_at"`
+	Enabled            bool      `json:"enabled"`
 }
 
 type EngineHistory struct {

--- a/engine/db/migrations/postgres/000014_definition_catalog_liveness.down.sql
+++ b/engine/db/migrations/postgres/000014_definition_catalog_liveness.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE engine.definition_catalog
+    DROP COLUMN enabled,
+    DROP COLUMN runtime_published_at;

--- a/engine/db/migrations/postgres/000014_definition_catalog_liveness.up.sql
+++ b/engine/db/migrations/postgres/000014_definition_catalog_liveness.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE engine.definition_catalog
+    ADD COLUMN runtime_published_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/engine/db/queries/definition_catalog.sql
+++ b/engine/db/queries/definition_catalog.sql
@@ -5,6 +5,7 @@ INSERT INTO engine.definition_catalog (
 )
 VALUES ($1, $2)
 ON CONFLICT (definition_name, definition_version) DO UPDATE SET
+    runtime_published_at = NOW(),
     updated_at = NOW()
 RETURNING *;
 
@@ -18,6 +19,13 @@ WHERE definition_name = $1
 SELECT *
 FROM engine.definition_catalog
 ORDER BY definition_name ASC, definition_version ASC;
+
+-- name: TouchDefinitionCatalogEntry :execrows
+UPDATE engine.definition_catalog
+SET runtime_published_at = NOW(),
+    updated_at = NOW()
+WHERE definition_name = $1
+  AND definition_version = $2;
 
 -- name: DeleteDefinitionCatalogEntry :execrows
 DELETE FROM engine.definition_catalog

--- a/engine/db/queries/definition_catalog.sql
+++ b/engine/db/queries/definition_catalog.sql
@@ -27,6 +27,21 @@ SET runtime_published_at = NOW(),
 WHERE definition_name = $1
   AND definition_version = $2;
 
+-- name: SetDefinitionCatalogRuntimePublishedAt :one
+UPDATE engine.definition_catalog
+SET runtime_published_at = $3,
+    updated_at = NOW()
+WHERE definition_name = $1
+  AND definition_version = $2
+RETURNING runtime_published_at;
+
+-- name: SetDefinitionCatalogEnabled :execrows
+UPDATE engine.definition_catalog
+SET enabled = $3,
+    updated_at = NOW()
+WHERE definition_name = $1
+  AND definition_version = $2;
+
 -- name: DeleteDefinitionCatalogEntry :execrows
 DELETE FROM engine.definition_catalog
 WHERE definition_name = $1

--- a/engine/internal/catalog/publisher.go
+++ b/engine/internal/catalog/publisher.go
@@ -12,6 +12,7 @@ import (
 
 type definitionCatalogWriter interface {
 	UpsertDefinitionCatalogEntry(context.Context, enginedb.UpsertDefinitionCatalogEntryParams) (enginedb.EngineDefinitionCatalog, error)
+	TouchDefinitionCatalogEntry(context.Context, enginedb.TouchDefinitionCatalogEntryParams) (int64, error)
 	ListDefinitionCatalog(context.Context) ([]enginedb.EngineDefinitionCatalog, error)
 	DeleteDefinitionCatalogEntry(context.Context, enginedb.DeleteDefinitionCatalogEntryParams) (int64, error)
 }
@@ -62,6 +63,50 @@ func PublishStoreDefinitions(ctx context.Context, engineStore *store.Store, defi
 	}()
 
 	if err := PublishDefinitions(ctx, tx, definitions); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+func HeartbeatDefinitions(
+	ctx context.Context,
+	writer definitionCatalogWriter,
+	definitions []publicworkflow.Definition,
+) error {
+	for _, definition := range definitions {
+		params := enginedb.TouchDefinitionCatalogEntryParams{
+			DefinitionName:    definition.Name,
+			DefinitionVersion: definition.Version,
+		}
+		affected, err := writer.TouchDefinitionCatalogEntry(ctx, params)
+		if err != nil {
+			return err
+		}
+		if affected > 0 {
+			continue
+		}
+		if _, err := writer.UpsertDefinitionCatalogEntry(ctx, enginedb.UpsertDefinitionCatalogEntryParams{
+			DefinitionName:    definition.Name,
+			DefinitionVersion: definition.Version,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func HeartbeatStoreDefinitions(ctx context.Context, engineStore *store.Store, definitions []publicworkflow.Definition) error {
+	tx, err := engineStore.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := HeartbeatDefinitions(ctx, tx, definitions); err != nil {
 		return err
 	}
 

--- a/engine/internal/catalog/publisher_heartbeat_test.go
+++ b/engine/internal/catalog/publisher_heartbeat_test.go
@@ -23,15 +23,15 @@ func TestHeartbeatStoreDefinitions_RefreshesAllRegisteredDefinitions(t *testing.
 	if err := PublishDefinitions(ctx, store, definitions); err != nil {
 		t.Fatalf("PublishDefinitions() error = %v", err)
 	}
-	checkoutBackdated := backdatePublishedRuntime(t, db, ctx, "checkout", "v1")
-	shippingBackdated := backdatePublishedRuntime(t, db, ctx, "shipping", "v2")
-	setPublishedDefinitionEnabled(t, db, ctx, "shipping", "v2", false)
+	checkoutBackdated := backdatePublishedRuntime(ctx, t, db, "checkout", "v1")
+	shippingBackdated := backdatePublishedRuntime(ctx, t, db, "shipping", "v2")
+	setPublishedDefinitionEnabled(ctx, t, db, "shipping", "v2", false)
 
 	if err := HeartbeatStoreDefinitions(ctx, store, definitions); err != nil {
 		t.Fatalf("HeartbeatStoreDefinitions() error = %v", err)
 	}
 
-	checkout := getPublishedDefinition(t, db, ctx, "checkout", "v1")
+	checkout := getPublishedDefinition(ctx, t, db, "checkout", "v1")
 	if !checkout.RuntimePublishedAt.After(checkoutBackdated) {
 		t.Fatalf("expected checkout runtime_published_at to refresh after %s, got %s",
 			checkoutBackdated, checkout.RuntimePublishedAt)
@@ -40,7 +40,7 @@ func TestHeartbeatStoreDefinitions_RefreshesAllRegisteredDefinitions(t *testing.
 		t.Fatalf("expected checkout to remain enabled, got %+v", checkout)
 	}
 
-	shipping := getPublishedDefinition(t, db, ctx, "shipping", "v2")
+	shipping := getPublishedDefinition(ctx, t, db, "shipping", "v2")
 	if !shipping.RuntimePublishedAt.After(shippingBackdated) {
 		t.Fatalf("expected shipping runtime_published_at to refresh after %s, got %s",
 			shippingBackdated, shipping.RuntimePublishedAt)
@@ -109,9 +109,9 @@ func heartbeatTestDefinitions(t *testing.T) []publicworkflow.Definition {
 }
 
 func backdatePublishedRuntime(
+	ctx context.Context,
 	t *testing.T,
 	db *enginetest.TestDatabase,
-	ctx context.Context,
 	definitionName string,
 	definitionVersion string,
 ) time.Time {
@@ -132,9 +132,9 @@ func backdatePublishedRuntime(
 }
 
 func setPublishedDefinitionEnabled(
+	ctx context.Context,
 	t *testing.T,
 	db *enginetest.TestDatabase,
-	ctx context.Context,
 	definitionName string,
 	definitionVersion string,
 	enabled bool,
@@ -156,9 +156,9 @@ func setPublishedDefinitionEnabled(
 }
 
 func getPublishedDefinition(
+	ctx context.Context,
 	t *testing.T,
 	db *enginetest.TestDatabase,
-	ctx context.Context,
 	definitionName string,
 	definitionVersion string,
 ) enginedb.EngineDefinitionCatalog {

--- a/engine/internal/catalog/publisher_heartbeat_test.go
+++ b/engine/internal/catalog/publisher_heartbeat_test.go
@@ -1,0 +1,178 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	engineworkflow "github.com/continua-ai/continua/engine/internal/workflow"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestHeartbeatStoreDefinitions_RefreshesAllRegisteredDefinitions(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+	definitions := heartbeatTestDefinitions(t)
+
+	if err := PublishDefinitions(ctx, store, definitions); err != nil {
+		t.Fatalf("PublishDefinitions() error = %v", err)
+	}
+	checkoutBackdated := backdatePublishedRuntime(t, db, ctx, "checkout", "v1")
+	shippingBackdated := backdatePublishedRuntime(t, db, ctx, "shipping", "v2")
+	setPublishedDefinitionEnabled(t, db, ctx, "shipping", "v2", false)
+
+	if err := HeartbeatStoreDefinitions(ctx, store, definitions); err != nil {
+		t.Fatalf("HeartbeatStoreDefinitions() error = %v", err)
+	}
+
+	checkout := getPublishedDefinition(t, db, ctx, "checkout", "v1")
+	if !checkout.RuntimePublishedAt.After(checkoutBackdated) {
+		t.Fatalf("expected checkout runtime_published_at to refresh after %s, got %s",
+			checkoutBackdated, checkout.RuntimePublishedAt)
+	}
+	if !checkout.Enabled {
+		t.Fatalf("expected checkout to remain enabled, got %+v", checkout)
+	}
+
+	shipping := getPublishedDefinition(t, db, ctx, "shipping", "v2")
+	if !shipping.RuntimePublishedAt.After(shippingBackdated) {
+		t.Fatalf("expected shipping runtime_published_at to refresh after %s, got %s",
+			shippingBackdated, shipping.RuntimePublishedAt)
+	}
+	if shipping.Enabled {
+		t.Fatalf("expected heartbeat to preserve shipping enabled=false, got %+v", shipping)
+	}
+}
+
+func TestHeartbeatStoreDefinitions_ReinsertsMissingRow(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	store := enginestore.New(db.Pool)
+	ctx := context.Background()
+	definitions := heartbeatTestDefinitions(t)
+
+	if err := PublishDefinitions(ctx, store, definitions); err != nil {
+		t.Fatalf("PublishDefinitions() error = %v", err)
+	}
+	deleted, err := store.DeleteDefinitionCatalogEntry(ctx, enginedb.DeleteDefinitionCatalogEntryParams{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("DeleteDefinitionCatalogEntry() error = %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected to delete 1 checkout definition, deleted %d", deleted)
+	}
+
+	if err := HeartbeatStoreDefinitions(ctx, store, definitions); err != nil {
+		t.Fatalf("HeartbeatStoreDefinitions() error = %v", err)
+	}
+
+	_, err = store.GetDefinitionCatalogEntry(ctx, enginedb.GetDefinitionCatalogEntryParams{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("expected heartbeat to reinsert checkout@v1, got error %v", err)
+	}
+}
+
+func heartbeatTestDefinitions(t *testing.T) []publicworkflow.Definition {
+	t.Helper()
+
+	registry, err := engineworkflow.NewRegistry(
+		publicworkflow.Definition{
+			Name:    "checkout",
+			Version: "v1",
+			Run: func(publicworkflow.Context) error {
+				return nil
+			},
+		},
+		publicworkflow.Definition{
+			Name:    "shipping",
+			Version: "v2",
+			Run: func(publicworkflow.Context) error {
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	return registry.List()
+}
+
+func backdatePublishedRuntime(
+	t *testing.T,
+	db *enginetest.TestDatabase,
+	ctx context.Context,
+	definitionName string,
+	definitionVersion string,
+) time.Time {
+	t.Helper()
+
+	var backdated time.Time
+	err := db.Pool.QueryRow(ctx, `
+		UPDATE engine.definition_catalog
+		SET runtime_published_at = NOW() - INTERVAL '10 minutes'
+		WHERE definition_name = $1
+		  AND definition_version = $2
+		RETURNING runtime_published_at
+	`, definitionName, definitionVersion).Scan(&backdated)
+	if err != nil {
+		t.Fatalf("backdate definition catalog runtime: %v", err)
+	}
+	return backdated
+}
+
+func setPublishedDefinitionEnabled(
+	t *testing.T,
+	db *enginetest.TestDatabase,
+	ctx context.Context,
+	definitionName string,
+	definitionVersion string,
+	enabled bool,
+) {
+	t.Helper()
+
+	tag, err := db.Pool.Exec(ctx, `
+		UPDATE engine.definition_catalog
+		SET enabled = $3
+		WHERE definition_name = $1
+		  AND definition_version = $2
+	`, definitionName, definitionVersion, enabled)
+	if err != nil {
+		t.Fatalf("set definition catalog enabled: %v", err)
+	}
+	if tag.RowsAffected() != 1 {
+		t.Fatalf("expected to update 1 definition catalog row, updated %d", tag.RowsAffected())
+	}
+}
+
+func getPublishedDefinition(
+	t *testing.T,
+	db *enginetest.TestDatabase,
+	ctx context.Context,
+	definitionName string,
+	definitionVersion string,
+) enginedb.EngineDefinitionCatalog {
+	t.Helper()
+
+	row, err := enginedb.New(db.Pool).GetDefinitionCatalogEntry(ctx, enginedb.GetDefinitionCatalogEntryParams{
+		DefinitionName:    definitionName,
+		DefinitionVersion: definitionVersion,
+	})
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			t.Fatalf("expected definition %s@%s to exist", definitionName, definitionVersion)
+		}
+		t.Fatalf("GetDefinitionCatalogEntry() error = %v", err)
+	}
+	return row
+}

--- a/engine/internal/catalog/publisher_heartbeat_test.go
+++ b/engine/internal/catalog/publisher_heartbeat_test.go
@@ -117,14 +117,11 @@ func backdatePublishedRuntime(
 ) time.Time {
 	t.Helper()
 
-	var backdated time.Time
-	err := db.Pool.QueryRow(ctx, `
-		UPDATE engine.definition_catalog
-		SET runtime_published_at = NOW() - INTERVAL '10 minutes'
-		WHERE definition_name = $1
-		  AND definition_version = $2
-		RETURNING runtime_published_at
-	`, definitionName, definitionVersion).Scan(&backdated)
+	backdated, err := enginedb.New(db.Pool).SetDefinitionCatalogRuntimePublishedAt(ctx, enginedb.SetDefinitionCatalogRuntimePublishedAtParams{
+		DefinitionName:     definitionName,
+		DefinitionVersion:  definitionVersion,
+		RuntimePublishedAt: time.Now().Add(-10 * time.Minute),
+	})
 	if err != nil {
 		t.Fatalf("backdate definition catalog runtime: %v", err)
 	}
@@ -141,17 +138,16 @@ func setPublishedDefinitionEnabled(
 ) {
 	t.Helper()
 
-	tag, err := db.Pool.Exec(ctx, `
-		UPDATE engine.definition_catalog
-		SET enabled = $3
-		WHERE definition_name = $1
-		  AND definition_version = $2
-	`, definitionName, definitionVersion, enabled)
+	affected, err := enginedb.New(db.Pool).SetDefinitionCatalogEnabled(ctx, enginedb.SetDefinitionCatalogEnabledParams{
+		DefinitionName:    definitionName,
+		DefinitionVersion: definitionVersion,
+		Enabled:           enabled,
+	})
 	if err != nil {
 		t.Fatalf("set definition catalog enabled: %v", err)
 	}
-	if tag.RowsAffected() != 1 {
-		t.Fatalf("expected to update 1 definition catalog row, updated %d", tag.RowsAffected())
+	if affected != 1 {
+		t.Fatalf("expected to update 1 definition catalog row, updated %d", affected)
 	}
 }
 

--- a/engine/internal/store/definition_catalog.go
+++ b/engine/internal/store/definition_catalog.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"time"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 )
@@ -29,6 +30,20 @@ func (o *storeOps) TouchDefinitionCatalogEntry(
 	arg enginedb.TouchDefinitionCatalogEntryParams,
 ) (int64, error) {
 	return o.q.TouchDefinitionCatalogEntry(ctx, arg)
+}
+
+func (o *storeOps) SetDefinitionCatalogRuntimePublishedAt(
+	ctx context.Context,
+	arg enginedb.SetDefinitionCatalogRuntimePublishedAtParams,
+) (time.Time, error) {
+	return mapResult(o.q.SetDefinitionCatalogRuntimePublishedAt(ctx, arg))
+}
+
+func (o *storeOps) SetDefinitionCatalogEnabled(
+	ctx context.Context,
+	arg enginedb.SetDefinitionCatalogEnabledParams,
+) (int64, error) {
+	return o.q.SetDefinitionCatalogEnabled(ctx, arg)
 }
 
 func (o *storeOps) DeleteDefinitionCatalogEntry(

--- a/engine/internal/store/definition_catalog.go
+++ b/engine/internal/store/definition_catalog.go
@@ -24,6 +24,13 @@ func (o *storeOps) ListDefinitionCatalog(ctx context.Context) ([]enginedb.Engine
 	return o.q.ListDefinitionCatalog(ctx)
 }
 
+func (o *storeOps) TouchDefinitionCatalogEntry(
+	ctx context.Context,
+	arg enginedb.TouchDefinitionCatalogEntryParams,
+) (int64, error) {
+	return o.q.TouchDefinitionCatalogEntry(ctx, arg)
+}
+
 func (o *storeOps) DeleteDefinitionCatalogEntry(
 	ctx context.Context,
 	arg enginedb.DeleteDefinitionCatalogEntryParams,

--- a/engine/internal/store/definition_catalog_test.go
+++ b/engine/internal/store/definition_catalog_test.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+)
+
+func TestUpsertDefinitionCatalogEntry_RefreshesHeartbeatPreservesEnabled(t *testing.T) {
+	ts := newTestStore(t)
+
+	if _, err := ts.store.UpsertDefinitionCatalogEntry(ts.ctx, enginedb.UpsertDefinitionCatalogEntryParams{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+	}); err != nil {
+		t.Fatalf("UpsertDefinitionCatalogEntry(initial) error = %v", err)
+	}
+	backdated := backdateDefinitionCatalogRuntime(t, ts, "checkout", "v1")
+	setDefinitionCatalogEnabled(t, ts, "checkout", "v1", false)
+
+	row, err := ts.store.UpsertDefinitionCatalogEntry(ts.ctx, enginedb.UpsertDefinitionCatalogEntryParams{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("UpsertDefinitionCatalogEntry(refresh) error = %v", err)
+	}
+
+	if !row.RuntimePublishedAt.After(backdated) {
+		t.Fatalf("expected runtime_published_at to refresh after %s, got %s", backdated, row.RuntimePublishedAt)
+	}
+	if row.Enabled {
+		t.Fatalf("expected upsert to preserve enabled=false, got %+v", row)
+	}
+}
+
+func TestTouchDefinitionCatalogEntry_UpdatesHeartbeat(t *testing.T) {
+	ts := newTestStore(t)
+
+	if _, err := ts.store.UpsertDefinitionCatalogEntry(ts.ctx, enginedb.UpsertDefinitionCatalogEntryParams{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+	}); err != nil {
+		t.Fatalf("UpsertDefinitionCatalogEntry(initial) error = %v", err)
+	}
+	backdated := backdateDefinitionCatalogRuntime(t, ts, "checkout", "v1")
+
+	affected, err := ts.store.TouchDefinitionCatalogEntry(ts.ctx, enginedb.TouchDefinitionCatalogEntryParams{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("TouchDefinitionCatalogEntry(existing) error = %v", err)
+	}
+	if affected != 1 {
+		t.Fatalf("expected TouchDefinitionCatalogEntry to affect 1 row, got %d", affected)
+	}
+
+	row, err := ts.store.GetDefinitionCatalogEntry(ts.ctx, enginedb.GetDefinitionCatalogEntryParams{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("GetDefinitionCatalogEntry() error = %v", err)
+	}
+	if !row.RuntimePublishedAt.After(backdated) {
+		t.Fatalf("expected runtime_published_at to refresh after %s, got %s", backdated, row.RuntimePublishedAt)
+	}
+
+	affected, err = ts.store.TouchDefinitionCatalogEntry(ts.ctx, enginedb.TouchDefinitionCatalogEntryParams{
+		DefinitionName:    "missing",
+		DefinitionVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("TouchDefinitionCatalogEntry(missing) error = %v", err)
+	}
+	if affected != 0 {
+		t.Fatalf("expected TouchDefinitionCatalogEntry to affect 0 rows for a missing definition, got %d", affected)
+	}
+}
+
+func backdateDefinitionCatalogRuntime(
+	t *testing.T,
+	ts *testStore,
+	definitionName string,
+	definitionVersion string,
+) time.Time {
+	t.Helper()
+
+	var backdated time.Time
+	err := ts.db.Pool.QueryRow(ts.ctx, `
+		UPDATE engine.definition_catalog
+		SET runtime_published_at = NOW() - INTERVAL '10 minutes'
+		WHERE definition_name = $1
+		  AND definition_version = $2
+		RETURNING runtime_published_at
+	`, definitionName, definitionVersion).Scan(&backdated)
+	if err != nil {
+		t.Fatalf("backdate definition catalog runtime: %v", err)
+	}
+	return backdated
+}
+
+func setDefinitionCatalogEnabled(
+	t *testing.T,
+	ts *testStore,
+	definitionName string,
+	definitionVersion string,
+	enabled bool,
+) {
+	t.Helper()
+
+	tag, err := ts.db.Pool.Exec(ts.ctx, `
+		UPDATE engine.definition_catalog
+		SET enabled = $3
+		WHERE definition_name = $1
+		  AND definition_version = $2
+	`, definitionName, definitionVersion, enabled)
+	if err != nil {
+		t.Fatalf("set definition catalog enabled: %v", err)
+	}
+	if tag.RowsAffected() != 1 {
+		t.Fatalf("expected to update 1 definition catalog row, updated %d", tag.RowsAffected())
+	}
+}

--- a/engine/internal/store/definition_catalog_test.go
+++ b/engine/internal/store/definition_catalog_test.go
@@ -88,14 +88,11 @@ func backdateDefinitionCatalogRuntime(
 ) time.Time {
 	t.Helper()
 
-	var backdated time.Time
-	err := ts.db.Pool.QueryRow(ts.ctx, `
-		UPDATE engine.definition_catalog
-		SET runtime_published_at = NOW() - INTERVAL '10 minutes'
-		WHERE definition_name = $1
-		  AND definition_version = $2
-		RETURNING runtime_published_at
-	`, definitionName, definitionVersion).Scan(&backdated)
+	backdated, err := ts.store.SetDefinitionCatalogRuntimePublishedAt(ts.ctx, enginedb.SetDefinitionCatalogRuntimePublishedAtParams{
+		DefinitionName:     definitionName,
+		DefinitionVersion:  definitionVersion,
+		RuntimePublishedAt: time.Now().Add(-10 * time.Minute),
+	})
 	if err != nil {
 		t.Fatalf("backdate definition catalog runtime: %v", err)
 	}
@@ -111,16 +108,15 @@ func setDefinitionCatalogEnabled(
 ) {
 	t.Helper()
 
-	tag, err := ts.db.Pool.Exec(ts.ctx, `
-		UPDATE engine.definition_catalog
-		SET enabled = $3
-		WHERE definition_name = $1
-		  AND definition_version = $2
-	`, definitionName, definitionVersion, enabled)
+	affected, err := ts.store.SetDefinitionCatalogEnabled(ts.ctx, enginedb.SetDefinitionCatalogEnabledParams{
+		DefinitionName:    definitionName,
+		DefinitionVersion: definitionVersion,
+		Enabled:           enabled,
+	})
 	if err != nil {
 		t.Fatalf("set definition catalog enabled: %v", err)
 	}
-	if tag.RowsAffected() != 1 {
-		t.Fatalf("expected to update 1 definition catalog row, updated %d", tag.RowsAffected())
+	if affected != 1 {
+		t.Fatalf("expected to update 1 definition catalog row, updated %d", affected)
 	}
 }

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -131,6 +131,11 @@ func (r *Runtime) Run(ctx context.Context) error {
 		return engineworker.RunLoop(groupCtx, cfg.Runtime.MaintenancePollInterval, "maintenance", maintenanceWorker.PollOnce)
 	})
 	group.Go(func() error {
+		return engineworker.RunLoop(groupCtx, cfg.Runtime.MaintenancePollInterval, "catalog-heartbeat", func(ctx context.Context, _ string) error {
+			return catalog.HeartbeatStoreDefinitions(ctx, store, r.definitions.List())
+		})
+	})
+	group.Go(func() error {
 		return engineworker.RunLoop(groupCtx, cfg.Runtime.WorkflowPollInterval, "projector", projectorWorker.PollOnce)
 	})
 

--- a/internal/api/engine_control.go
+++ b/internal/api/engine_control.go
@@ -25,6 +25,8 @@ const (
 	engineCancelDedupeKey   = "cancel:"
 	engineTerminateCode     = "terminated"
 	engineTerminateMessage  = "run terminated by operator"
+
+	engineDefinitionLivenessWindow = 60 * time.Second
 )
 
 type engineControlService struct {
@@ -146,6 +148,11 @@ type enginePendingSignalItem struct {
 	AvailableAt time.Time
 }
 
+type engineDefinitionCatalogResult struct {
+	Entry enginedb.EngineDefinitionCatalog
+	Live  bool
+}
+
 type engineAPIError struct {
 	Code       string
 	Message    string
@@ -173,6 +180,13 @@ func engineNotFoundError(message string) *engineAPIError {
 		Message:    message,
 		HTTPStatus: 404,
 	}
+}
+
+func definitionCatalogEntryLive(entry *enginedb.EngineDefinitionCatalog, now time.Time) bool {
+	if entry == nil || !entry.Enabled {
+		return false
+	}
+	return !entry.RuntimePublishedAt.Before(now.Add(-engineDefinitionLivenessWindow))
 }
 
 func (s *engineControlService) getRunForScope(
@@ -283,10 +297,12 @@ func (s *engineControlService) StartRun(
 		}
 	}
 
-	if _, err := engineTx.GetDefinitionCatalogEntry(ctx, enginedb.GetDefinitionCatalogEntryParams{
+	now := time.Now().UTC()
+	entry, err := engineTx.GetDefinitionCatalogEntry(ctx, enginedb.GetDefinitionCatalogEntryParams{
 		DefinitionName:    req.DefinitionName,
 		DefinitionVersion: req.DefinitionVersion,
-	}); err != nil {
+	})
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return engineStartRunResult{}, finalizeStartFailure(ctx, engineTx, tx.Tx(), claim.Row.ID, &engineAPIError{
 				Code:       "definition_not_registered",
@@ -296,8 +312,20 @@ func (s *engineControlService) StartRun(
 		}
 		return engineStartRunResult{}, err
 	}
-
-	now := time.Now().UTC()
+	if !entry.Enabled {
+		return engineStartRunResult{}, finalizeStartFailure(ctx, engineTx, tx.Tx(), claim.Row.ID, &engineAPIError{
+			Code:       "definition_not_registered",
+			Message:    fmt.Sprintf("definition %s@%s is disabled", req.DefinitionName, req.DefinitionVersion),
+			HTTPStatus: 400,
+		})
+	}
+	if entry.RuntimePublishedAt.Before(now.Add(-engineDefinitionLivenessWindow)) {
+		return engineStartRunResult{}, finalizeStartFailure(ctx, engineTx, tx.Tx(), claim.Row.ID, &engineAPIError{
+			Code:       "definition_not_registered",
+			Message:    fmt.Sprintf("definition %s@%s has no live runtime", req.DefinitionName, req.DefinitionVersion),
+			HTTPStatus: 400,
+		})
+	}
 
 	if _, err := tx.Tx().Exec(ctx, "SAVEPOINT start_create_instance"); err != nil {
 		return engineStartRunResult{}, err
@@ -505,6 +533,35 @@ func (s *engineControlService) GetRun(
 	}
 
 	return s.buildRunSummary(ctx, &instance, &run)
+}
+
+func (s *engineControlService) ListDefinitions(ctx context.Context) ([]engineDefinitionCatalogResult, error) {
+	tx, err := s.platform.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	rows, err := enginedb.New(tx.Tx()).ListDefinitionCatalog(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	definitions := make([]engineDefinitionCatalogResult, len(rows))
+	for i := range rows {
+		definitions[i] = engineDefinitionCatalogResult{
+			Entry: rows[i],
+			Live:  definitionCatalogEntryLive(&rows[i], now),
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return definitions, nil
 }
 
 func (s *engineControlService) GetRunResult(

--- a/internal/api/engine_definitions_test.go
+++ b/internal/api/engine_definitions_test.go
@@ -1,0 +1,244 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	platformdb "github.com/continua-ai/continua/db/gen/go/platform"
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestStartEngineRun_RejectsDisabledDefinition(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	deleteDefinitionCatalogEntry(t, ctx, engineQueries, "checkout", "v1")
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+	disableDefinitionCatalogEntry(t, ctx, platformStore, "checkout", "v1")
+	instanceKey := "disabled-definition-" + uuid.NewString()
+
+	rec := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       instanceKey,
+		RequestKey:        "req-" + instanceKey,
+	})
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "definition_not_registered", decodeJSONBody[Error](t, rec).Code)
+	requireNoEngineInstance(t, ctx, engineQueries, projectID, instanceKey)
+}
+
+func TestStartEngineRun_RejectsStaleDefinition(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	deleteDefinitionCatalogEntry(t, ctx, engineQueries, "checkout", "v1")
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+	backdateDefinitionCatalogEntry(t, ctx, platformStore, "checkout", "v1")
+	instanceKey := "stale-definition-" + uuid.NewString()
+
+	rec := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       instanceKey,
+		RequestKey:        "req-" + instanceKey,
+	})
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "definition_not_registered", decodeJSONBody[Error](t, rec).Code)
+	requireNoEngineInstance(t, ctx, engineQueries, projectID, instanceKey)
+}
+
+func TestStartEngineRun_AcceptsFreshEnabledDefinition(t *testing.T) {
+	ctx, _, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	deleteDefinitionCatalogEntry(t, ctx, engineQueries, "checkout", "v1")
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+	instanceKey := "fresh-definition-" + uuid.NewString()
+
+	rec := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       instanceKey,
+		RequestKey:        "req-" + instanceKey,
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestListEngineDefinitions_ReportsLiveness(t *testing.T) {
+	ctx := context.Background()
+	platformStore := store.New(testutil.TestDB(t))
+	engineQueries := enginedb.New(platformStore.Pool())
+	server := NewServer(platformStore, nil)
+	server.engineControl = newEngineControlService(platformStore)
+	server.enginePublicAPIEnabled = true
+
+	apiKey := "engine-definitions-" + uuid.NewString()
+	_, err := platformStore.Queries().CreateProject(ctx, platformdb.CreateProjectParams{
+		Name:       "engine-definitions-" + uuid.NewString()[:8],
+		ApiKeyHash: hashTestAPIKey(apiKey),
+	})
+	require.NoError(t, err)
+
+	suffix := uuid.NewString()[:8]
+	freshName := "fresh-" + suffix
+	staleName := "stale-" + suffix
+	disabledName := "disabled-" + suffix
+	for _, definition := range []struct {
+		name    string
+		version string
+	}{
+		{name: freshName, version: "v1"},
+		{name: staleName, version: "v1"},
+		{name: disabledName, version: "v2"},
+	} {
+		_, err := engineQueries.UpsertDefinitionCatalogEntry(ctx, enginedb.UpsertDefinitionCatalogEntryParams{
+			DefinitionName:    definition.name,
+			DefinitionVersion: definition.version,
+		})
+		require.NoError(t, err)
+	}
+	backdateDefinitionCatalogEntry(t, ctx, platformStore, staleName, "v1")
+	disableDefinitionCatalogEntry(t, ctx, platformStore, disabledName, "v2")
+
+	handler := newAuthenticatedRouter(t, server, platformStore)
+	req := httptest.NewRequest(http.MethodGet, "/v1/engine/definitions", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeJSONBody[engineDefinitionListResponse](t, rec)
+	byKey := make(map[string]engineDefinitionListEntry, len(resp.Definitions))
+	for _, definition := range resp.Definitions {
+		byKey[definition.DefinitionName+"@"+definition.DefinitionVersion] = definition
+	}
+
+	fresh := requireEngineDefinitionEntry(t, byKey, freshName+"@v1")
+	assert.True(t, fresh.Enabled)
+	assert.True(t, fresh.Live)
+	require.False(t, fresh.RuntimePublishedAt.IsZero())
+	require.False(t, fresh.PublishedAt.IsZero())
+
+	stale := requireEngineDefinitionEntry(t, byKey, staleName+"@v1")
+	assert.True(t, stale.Enabled)
+	assert.False(t, stale.Live)
+
+	disabled := requireEngineDefinitionEntry(t, byKey, disabledName+"@v2")
+	assert.False(t, disabled.Enabled)
+	assert.False(t, disabled.Live)
+
+	disabledServer := NewServer(platformStore, nil)
+	disabledHandler := newAuthenticatedRouter(t, disabledServer, platformStore)
+	disabledReq := httptest.NewRequest(http.MethodGet, "/v1/engine/definitions", nil)
+	disabledReq.Header.Set("X-API-Key", apiKey)
+	disabledRec := httptest.NewRecorder()
+
+	disabledHandler.ServeHTTP(disabledRec, disabledReq)
+
+	require.Equal(t, http.StatusNotFound, disabledRec.Code)
+}
+
+func deleteDefinitionCatalogEntry(
+	t *testing.T,
+	ctx context.Context,
+	engineQueries *enginedb.Queries,
+	definitionName string,
+	definitionVersion string,
+) {
+	t.Helper()
+
+	_, err := engineQueries.DeleteDefinitionCatalogEntry(ctx, enginedb.DeleteDefinitionCatalogEntryParams{
+		DefinitionName:    definitionName,
+		DefinitionVersion: definitionVersion,
+	})
+	require.NoError(t, err)
+}
+
+type engineDefinitionListResponse struct {
+	Definitions []engineDefinitionListEntry `json:"definitions"`
+}
+
+type engineDefinitionListEntry struct {
+	DefinitionName     string    `json:"definition_name"`
+	DefinitionVersion  string    `json:"definition_version"`
+	Enabled            bool      `json:"enabled"`
+	Live               bool      `json:"live"`
+	RuntimePublishedAt time.Time `json:"runtime_published_at"`
+	PublishedAt        time.Time `json:"published_at"`
+}
+
+func requireEngineDefinitionEntry(
+	t *testing.T,
+	entries map[string]engineDefinitionListEntry,
+	key string,
+) engineDefinitionListEntry {
+	t.Helper()
+
+	entry, ok := entries[key]
+	require.Truef(t, ok, "expected definition %s in response, got %+v", key, entries)
+	return entry
+}
+
+func disableDefinitionCatalogEntry(
+	t *testing.T,
+	ctx context.Context,
+	platformStore *store.Store,
+	definitionName string,
+	definitionVersion string,
+) {
+	t.Helper()
+
+	tag, err := platformStore.Pool().Exec(ctx, `
+		UPDATE engine.definition_catalog
+		SET enabled = false
+		WHERE definition_name = $1
+		  AND definition_version = $2
+	`, definitionName, definitionVersion)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+}
+
+func backdateDefinitionCatalogEntry(
+	t *testing.T,
+	ctx context.Context,
+	platformStore *store.Store,
+	definitionName string,
+	definitionVersion string,
+) {
+	t.Helper()
+
+	tag, err := platformStore.Pool().Exec(ctx, `
+		UPDATE engine.definition_catalog
+		SET runtime_published_at = NOW() - INTERVAL '10 minutes'
+		WHERE definition_name = $1
+		  AND definition_version = $2
+	`, definitionName, definitionVersion)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+}
+
+func requireNoEngineInstance(
+	t *testing.T,
+	ctx context.Context,
+	engineQueries *enginedb.Queries,
+	projectID uuid.UUID,
+	instanceKey string,
+) {
+	t.Helper()
+
+	_, err := engineQueries.GetInstanceByProjectAndKey(ctx, enginedb.GetInstanceByProjectAndKeyParams{
+		ProjectID:   projectID,
+		InstanceKey: instanceKey,
+	})
+	require.True(t, errors.Is(err, pgx.ErrNoRows))
+}

--- a/internal/api/engine_definitions_test.go
+++ b/internal/api/engine_definitions_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestStartEngineRun_RejectsDisabledDefinition(t *testing.T) {
-	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	ctx, _, engineQueries, server, projectID := setupEngineHandlerTest(t)
 	deleteDefinitionCatalogEntry(ctx, t, engineQueries, "checkout", "v1")
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
-	disableDefinitionCatalogEntry(ctx, t, platformStore, "checkout", "v1")
+	disableDefinitionCatalogEntry(ctx, t, engineQueries, "checkout", "v1")
 	instanceKey := "disabled-definition-" + uuid.NewString()
 
 	rec := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
@@ -39,10 +39,10 @@ func TestStartEngineRun_RejectsDisabledDefinition(t *testing.T) {
 }
 
 func TestStartEngineRun_RejectsStaleDefinition(t *testing.T) {
-	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+	ctx, _, engineQueries, server, projectID := setupEngineHandlerTest(t)
 	deleteDefinitionCatalogEntry(ctx, t, engineQueries, "checkout", "v1")
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
-	backdateDefinitionCatalogEntry(ctx, t, platformStore, "checkout", "v1")
+	backdateDefinitionCatalogEntry(ctx, t, engineQueries, "checkout", "v1")
 	instanceKey := "stale-definition-" + uuid.NewString()
 
 	rec := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
@@ -106,8 +106,8 @@ func TestListEngineDefinitions_ReportsLiveness(t *testing.T) {
 		})
 		require.NoError(t, err)
 	}
-	backdateDefinitionCatalogEntry(ctx, t, platformStore, staleName, "v1")
-	disableDefinitionCatalogEntry(ctx, t, platformStore, disabledName, "v2")
+	backdateDefinitionCatalogEntry(ctx, t, engineQueries, staleName, "v1")
+	disableDefinitionCatalogEntry(ctx, t, engineQueries, disabledName, "v2")
 
 	handler := newAuthenticatedRouter(t, server, platformStore)
 	req := httptest.NewRequest(http.MethodGet, "/v1/engine/definitions", nil)
@@ -192,39 +192,36 @@ func requireEngineDefinitionEntry(
 func disableDefinitionCatalogEntry(
 	ctx context.Context,
 	t *testing.T,
-	platformStore *store.Store,
+	engineQueries *enginedb.Queries,
 	definitionName string,
 	definitionVersion string,
 ) {
 	t.Helper()
 
-	tag, err := platformStore.Pool().Exec(ctx, `
-		UPDATE engine.definition_catalog
-		SET enabled = false
-		WHERE definition_name = $1
-		  AND definition_version = $2
-	`, definitionName, definitionVersion)
+	affected, err := engineQueries.SetDefinitionCatalogEnabled(ctx, enginedb.SetDefinitionCatalogEnabledParams{
+		DefinitionName:    definitionName,
+		DefinitionVersion: definitionVersion,
+		Enabled:           false,
+	})
 	require.NoError(t, err)
-	require.EqualValues(t, 1, tag.RowsAffected())
+	require.EqualValues(t, 1, affected)
 }
 
 func backdateDefinitionCatalogEntry(
 	ctx context.Context,
 	t *testing.T,
-	platformStore *store.Store,
+	engineQueries *enginedb.Queries,
 	definitionName string,
 	definitionVersion string,
 ) {
 	t.Helper()
 
-	tag, err := platformStore.Pool().Exec(ctx, `
-		UPDATE engine.definition_catalog
-		SET runtime_published_at = NOW() - INTERVAL '10 minutes'
-		WHERE definition_name = $1
-		  AND definition_version = $2
-	`, definitionName, definitionVersion)
+	_, err := engineQueries.SetDefinitionCatalogRuntimePublishedAt(ctx, enginedb.SetDefinitionCatalogRuntimePublishedAtParams{
+		DefinitionName:     definitionName,
+		DefinitionVersion:  definitionVersion,
+		RuntimePublishedAt: time.Now().Add(-10 * time.Minute),
+	})
 	require.NoError(t, err)
-	require.EqualValues(t, 1, tag.RowsAffected())
 }
 
 func requireNoEngineInstance(

--- a/internal/api/engine_definitions_test.go
+++ b/internal/api/engine_definitions_test.go
@@ -21,9 +21,9 @@ import (
 
 func TestStartEngineRun_RejectsDisabledDefinition(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
-	deleteDefinitionCatalogEntry(t, ctx, engineQueries, "checkout", "v1")
+	deleteDefinitionCatalogEntry(ctx, t, engineQueries, "checkout", "v1")
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
-	disableDefinitionCatalogEntry(t, ctx, platformStore, "checkout", "v1")
+	disableDefinitionCatalogEntry(ctx, t, platformStore, "checkout", "v1")
 	instanceKey := "disabled-definition-" + uuid.NewString()
 
 	rec := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
@@ -35,14 +35,14 @@ func TestStartEngineRun_RejectsDisabledDefinition(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Equal(t, "definition_not_registered", decodeJSONBody[Error](t, rec).Code)
-	requireNoEngineInstance(t, ctx, engineQueries, projectID, instanceKey)
+	requireNoEngineInstance(ctx, t, engineQueries, projectID, instanceKey)
 }
 
 func TestStartEngineRun_RejectsStaleDefinition(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
-	deleteDefinitionCatalogEntry(t, ctx, engineQueries, "checkout", "v1")
+	deleteDefinitionCatalogEntry(ctx, t, engineQueries, "checkout", "v1")
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
-	backdateDefinitionCatalogEntry(t, ctx, platformStore, "checkout", "v1")
+	backdateDefinitionCatalogEntry(ctx, t, platformStore, "checkout", "v1")
 	instanceKey := "stale-definition-" + uuid.NewString()
 
 	rec := invokeStartEngineRun(t, server, projectID, EngineStartRunRequest{
@@ -54,12 +54,12 @@ func TestStartEngineRun_RejectsStaleDefinition(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Equal(t, "definition_not_registered", decodeJSONBody[Error](t, rec).Code)
-	requireNoEngineInstance(t, ctx, engineQueries, projectID, instanceKey)
+	requireNoEngineInstance(ctx, t, engineQueries, projectID, instanceKey)
 }
 
 func TestStartEngineRun_AcceptsFreshEnabledDefinition(t *testing.T) {
 	ctx, _, engineQueries, server, projectID := setupEngineHandlerTest(t)
-	deleteDefinitionCatalogEntry(t, ctx, engineQueries, "checkout", "v1")
+	deleteDefinitionCatalogEntry(ctx, t, engineQueries, "checkout", "v1")
 	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
 	instanceKey := "fresh-definition-" + uuid.NewString()
 
@@ -106,8 +106,8 @@ func TestListEngineDefinitions_ReportsLiveness(t *testing.T) {
 		})
 		require.NoError(t, err)
 	}
-	backdateDefinitionCatalogEntry(t, ctx, platformStore, staleName, "v1")
-	disableDefinitionCatalogEntry(t, ctx, platformStore, disabledName, "v2")
+	backdateDefinitionCatalogEntry(ctx, t, platformStore, staleName, "v1")
+	disableDefinitionCatalogEntry(ctx, t, platformStore, disabledName, "v2")
 
 	handler := newAuthenticatedRouter(t, server, platformStore)
 	req := httptest.NewRequest(http.MethodGet, "/v1/engine/definitions", nil)
@@ -149,8 +149,8 @@ func TestListEngineDefinitions_ReportsLiveness(t *testing.T) {
 }
 
 func deleteDefinitionCatalogEntry(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	engineQueries *enginedb.Queries,
 	definitionName string,
 	definitionVersion string,
@@ -190,8 +190,8 @@ func requireEngineDefinitionEntry(
 }
 
 func disableDefinitionCatalogEntry(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	platformStore *store.Store,
 	definitionName string,
 	definitionVersion string,
@@ -209,8 +209,8 @@ func disableDefinitionCatalogEntry(
 }
 
 func backdateDefinitionCatalogEntry(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	platformStore *store.Store,
 	definitionName string,
 	definitionVersion string,
@@ -228,8 +228,8 @@ func backdateDefinitionCatalogEntry(
 }
 
 func requireNoEngineInstance(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	engineQueries *enginedb.Queries,
 	projectID uuid.UUID,
 	instanceKey string,

--- a/internal/api/engine_handlers.go
+++ b/internal/api/engine_handlers.go
@@ -59,6 +59,24 @@ func (s *Server) GetEngineInstance(w http.ResponseWriter, r *http.Request, insta
 	writeJSON(w, http.StatusOK, engineInstanceResponseToAPI(&result))
 }
 
+func (s *Server) ListEngineDefinitions(w http.ResponseWriter, r *http.Request) {
+	if _, ok := scopeFromRequest(w, r, scopePolicyAllowUnbounded); !ok {
+		return
+	}
+	if s.engineControl == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	result, err := s.engineControl.ListDefinitions(r.Context())
+	if err != nil {
+		writeEngineError(w, err, "Failed to list engine definitions")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, engineDefinitionListResponseToAPI(result))
+}
+
 func (s *Server) StartEngineRun(w http.ResponseWriter, r *http.Request, _ StartEngineRunParams) {
 	projectID, ok := projectIDOrUnauthorized(w, r)
 	if !ok {

--- a/internal/api/engine_mapper.go
+++ b/internal/api/engine_mapper.go
@@ -127,6 +127,27 @@ func engineHistoryEventToAPI(event *enginedb.EngineHistory) EngineHistoryEvent {
 	}
 }
 
+func engineDefinitionListResponseToAPI(definitions []engineDefinitionCatalogResult) EngineDefinitionListResponse {
+	response := EngineDefinitionListResponse{
+		Definitions: make([]EngineDefinition, 0, len(definitions)),
+	}
+	for i := range definitions {
+		response.Definitions = append(response.Definitions, engineDefinitionToAPI(&definitions[i]))
+	}
+	return response
+}
+
+func engineDefinitionToAPI(definition *engineDefinitionCatalogResult) EngineDefinition {
+	return EngineDefinition{
+		DefinitionName:     definition.Entry.DefinitionName,
+		DefinitionVersion:  definition.Entry.DefinitionVersion,
+		Enabled:            definition.Entry.Enabled,
+		Live:               definition.Live,
+		PublishedAt:        definition.Entry.PublishedAt,
+		RuntimePublishedAt: definition.Entry.RuntimePublishedAt,
+	}
+}
+
 func engineControlResponseToAPI(result *engineControlResult) EngineControlResponse {
 	return EngineControlResponse{
 		Accepted:    result.Accepted,

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -463,6 +463,21 @@ type EngineControlResponse struct {
 	WakeApplied bool               `json:"wake_applied"`
 }
 
+// EngineDefinition defines model for EngineDefinition.
+type EngineDefinition struct {
+	DefinitionName     string    `json:"definition_name"`
+	DefinitionVersion  string    `json:"definition_version"`
+	Enabled            bool      `json:"enabled"`
+	Live               bool      `json:"live"`
+	PublishedAt        time.Time `json:"published_at"`
+	RuntimePublishedAt time.Time `json:"runtime_published_at"`
+}
+
+// EngineDefinitionListResponse defines model for EngineDefinitionListResponse.
+type EngineDefinitionListResponse struct {
+	Definitions []EngineDefinition `json:"definitions"`
+}
+
 // EngineFailureSummary defines model for EngineFailureSummary.
 type EngineFailureSummary struct {
 	// ErrorCode Stable reserved value: `definition_version_mismatch`. Clients may
@@ -1782,6 +1797,9 @@ type ServerInterface interface {
 	// Renew a remote activity task lease
 	// (POST /v1/engine/activities/{id}/heartbeat)
 	HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params HeartbeatRemoteActivityTaskParams)
+	// List registered engine workflow definitions
+	// (GET /v1/engine/definitions)
+	ListEngineDefinitions(w http.ResponseWriter, r *http.Request)
 	// Get an engine instance and current run
 	// (GET /v1/engine/instances/{instance_key})
 	GetEngineInstance(w http.ResponseWriter, r *http.Request, instanceKey string)
@@ -1941,6 +1959,12 @@ func (_ Unimplemented) FailRemoteActivityTask(w http.ResponseWriter, r *http.Req
 // Renew a remote activity task lease
 // (POST /v1/engine/activities/{id}/heartbeat)
 func (_ Unimplemented) HeartbeatRemoteActivityTask(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params HeartbeatRemoteActivityTaskParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List registered engine workflow definitions
+// (GET /v1/engine/definitions)
+func (_ Unimplemented) ListEngineDefinitions(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -3045,6 +3069,28 @@ func (siw *ServerInterfaceWrapper) HeartbeatRemoteActivityTask(w http.ResponseWr
 	handler.ServeHTTP(w, r)
 }
 
+// ListEngineDefinitions operation middleware
+func (siw *ServerInterfaceWrapper) ListEngineDefinitions(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, Auth0BearerScopes, []string{})
+
+	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListEngineDefinitions(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetEngineInstance operation middleware
 func (siw *ServerInterfaceWrapper) GetEngineInstance(w http.ResponseWriter, r *http.Request) {
 
@@ -4011,6 +4057,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/engine/activities/{id}/heartbeat", wrapper.HeartbeatRemoteActivityTask)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/engine/definitions", wrapper.ListEngineDefinitions)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/engine/instances/{instance_key}", wrapper.GetEngineInstance)

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -302,6 +302,19 @@ class EngineStartRunResponse(BaseModel):
     trace_id: str
 
 
+class EngineDefinition(BaseModel):
+    definition_name: str
+    definition_version: str
+    enabled: bool
+    live: bool
+    runtime_published_at: AwareDatetime
+    published_at: AwareDatetime
+
+
+class EngineDefinitionListResponse(BaseModel):
+    definitions: list[EngineDefinition]
+
+
 class EngineRunResultResponse(BaseModel):
     run_id: UUID
     continued_from_run_id: UUID | None = None


### PR DESCRIPTION
## What / why

Closes #163.

`engine.definition_catalog` was half-dead scaffolding: published once at runtime start and consumed only by StartRun's existence check, with no liveness signal and no version metadata. This PR makes the catalog the trustworthy registration surface — it reflects what live runtimes can actually execute and backs both StartRun validation and a console-facing definitions listing.

## What changed

**Schema & queries** (engine migration `000014_definition_catalog_liveness`)
- `engine.definition_catalog` gains `runtime_published_at TIMESTAMPTZ NOT NULL DEFAULT NOW()` (runtime heartbeat) and `enabled BOOLEAN NOT NULL DEFAULT TRUE`.
- `UpsertDefinitionCatalogEntry` now refreshes `runtime_published_at` on conflict while **preserving** `enabled` — an operator's disable survives a runtime republish.
- New `TouchDefinitionCatalogEntry` heartbeat query + thin engine-store wrapper.

**Publisher heartbeat** (`engine/internal/catalog`, `engine/pkg/runtime`)
- New `HeartbeatDefinitions`/`HeartbeatStoreDefinitions`: refreshes the heartbeat for every registered definition, re-upserting rows deleted out-of-band, never flipping `enabled`.
- `runtime.Run` gains a `catalog-heartbeat` loop on the maintenance poll interval (default 10s); `continua-engine serve` inherits it since it delegates to the library runtime.

**StartRun validation** (`internal/api/engine_control.go`)
- After the existence check, StartRun now rejects with `definition_not_registered` (HTTP 400, dedupe-finalized like the existing rejection) when the entry is disabled or its heartbeat is older than the 60s liveness window.

**Console listing** (`contracts/openapi/openapi.yaml`, `internal/api`)
- New `GET /v1/engine/definitions` (read route — no preview header; 404 when the engine API is disabled) returning each catalog entry with `enabled`, computed `live`, `runtime_published_at`, and `published_at`. This backs the upcoming console Start Run definition picker (#189).

## Test evidence

Acceptance tests were written first (TDD, independent author/implementer sessions) and committed red, then the implementation turned them green:
- `internal/api`: disabled and stale definitions rejected at start with no rows created; fresh definitions start; `GET /v1/engine/definitions` reports enabled/live per entry and 404s when the engine API is disabled.
- `engine/internal/store`: upsert refreshes the heartbeat and preserves `enabled=false`; touch updates the heartbeat and reports 0 rows for missing definitions.
- `engine/internal/catalog`: heartbeat refreshes all registered definitions, preserves disabled rows, and re-inserts deleted rows.
- `engine/pkg/runtime` e2e suite and both module builds verified green with the heartbeat loop wired in.

`make generate` is clean (sqlc + OpenAPI outputs regenerated, none hand-edited).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /v1/engine/definitions` to list registered engine workflow definitions (name/version, enabled/live status, and publication timestamps).
  * Engine catalog now maintains runtime “live” data via periodic heartbeats, including reinserting missing catalog entries.
* **Behavior Changes**
  * Starting an engine run now requires the requested definition to be enabled and live (recently published within the liveness window).
* **Documentation**
  * Updated OpenAPI specs and API reference with the new endpoint and schemas.
* **SDK Updates**
  * Added matching Python SDK response models for engine definition listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->