### PR TITLE
feat(engine): in-memory workflow unit-test kit (pkg/workflowtest) + testing docs

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -45,6 +45,7 @@
               "guides/workflow-code-versioning",
               "guides/engine-project-provisioning",
               "guides/embed-engine",
+              "guides/testing-workflows",
               "guides/debugging-failures",
               "guides/comparing-sessions"
             ]

--- a/docs-site/guides/testing-workflows.mdx
+++ b/docs-site/guides/testing-workflows.mdx
@@ -1,0 +1,119 @@
+---
+title: "Testing workflows"
+description: "Unit test Go workflow definitions in memory with scripted activities, signals, timers, and child workflows."
+---
+
+`github.com/continua-ai/continua/engine/pkg/workflowtest` runs a `workflow.Definition`
+through the same replay runner used by the durable engine, but without Postgres or
+workers. Use it for fast unit tests around workflow logic, deterministic replay, and
+activity or signal handling.
+
+<Warning>
+  The kit is for the preview Go workflow SDK. It does not simulate every production
+  worker behavior: activity retries are not replayed, activities run once, and workflow
+  authoring is Go-only.
+</Warning>
+
+## Example
+
+```go
+package workflows_test
+
+import (
+    "encoding/json"
+    "testing"
+
+    "github.com/continua-ai/continua/engine/pkg/workflow"
+    "github.com/continua-ai/continua/engine/pkg/workflowtest"
+)
+
+func TestGreetingWorkflow(t *testing.T) {
+    def := workflow.Definition{
+        Name:    "examples.greeter",
+        Version: "v1",
+        Run: func(ctx workflow.Context) error {
+            var greeting struct {
+                Message string `json:"message"`
+            }
+            if err := ctx.Activity("greet", "examples.greet", map[string]string{"name": "Ada"}, &greeting); err != nil {
+                return err
+            }
+
+            var approval struct {
+                Value string `json:"value"`
+            }
+            if err := ctx.ReceiveSignal("approval", &approval); err != nil {
+                return err
+            }
+
+            return ctx.SetResult(map[string]string{
+                "message":  greeting.Message,
+                "approval": approval.Value,
+            })
+        },
+    }
+
+    env := workflowtest.NewEnvironment()
+    env.RegisterActivity("examples.greet", func(input json.RawMessage) (any, error) {
+        var decoded map[string]string
+        if err := json.Unmarshal(input, &decoded); err != nil {
+            return nil, err
+        }
+        return map[string]string{"message": "hello, " + decoded["name"]}, nil
+    })
+    if err := env.QueueSignal("approval", map[string]string{"value": "granted"}); err != nil {
+        t.Fatal(err)
+    }
+
+    result, err := env.Execute(def, nil)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if result.Status != workflowtest.StatusCompleted {
+        t.Fatalf("status = %q", result.Status)
+    }
+
+    var out map[string]string
+    if err := result.DecodeResult(&out); err != nil {
+        t.Fatal(err)
+    }
+    if out["approval"] != "granted" {
+        t.Fatalf("approval = %q", out["approval"])
+    }
+}
+```
+
+## Timers
+
+Timers auto-fire. `ctx.Sleep` and `ctx.SleepUntil` schedule a timer, the test kit adds
+the matching timer inbox item, and the next activation observes the fired timer without
+waiting for wall-clock time.
+
+## Cancellation
+
+Call `env.RequestCancellation()` before `Execute` to enqueue a cancellation request
+after any queued signals. A workflow that returns `workflow.ErrCancelled` finishes with
+`workflowtest.StatusCancelled`; a workflow that observes cancellation and returns nil
+or sets a result can still complete.
+
+## Child workflows
+
+Register child definitions with `env.RegisterDefinition`. Children share the same
+activity handlers and child definition registry, but they do not inherit the parent's
+queued signals or cancellation request. If a child definition is not registered, the
+parent result is `workflowtest.StatusBlocked` with a child-workflow wait key.
+
+## Determinism
+
+The kit records side effects, time reads, scheduled activities, timers, signals, and
+child workflows in history, then replays through the real runner on later activations.
+`ctx.SideEffect` functions run once, and `ctx.Now()` returns the recorded time across
+activations. If workflow code diverges from recorded history, the result is
+`workflowtest.StatusQuarantined` with error code `replay_mismatch`.
+
+## Activity failures
+
+Activity handlers return `(any, error)`. A plain error records an activity failure with
+code `activity_failed`. Use `workflowtest.NewActivityError(code, message)` when a test
+needs a specific activity failure code. The kit records one attempt only; retry policy
+timing and repeated worker attempts are outside the in-memory simulation.

--- a/engine/cmd/continua-engine/internal/darklaunch/workflow_kit_test.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/workflow_kit_test.go
@@ -1,0 +1,153 @@
+package darklaunch_test
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/continua-ai/continua/engine/cmd/continua-engine/internal/darklaunch"
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+	"github.com/continua-ai/continua/engine/pkg/workflowtest"
+)
+
+func TestSleepDemoWorkflowKit(t *testing.T) {
+	env := workflowtest.NewEnvironment()
+	if err := env.QueueSignal("approval", darklaunch.SignalPayload{Approval: "granted"}); err != nil {
+		t.Fatalf("QueueSignal returned error: %v", err)
+	}
+	def := lookupDefinition(t, darklaunch.SleepDemoDefinitionName, darklaunch.SleepDemoDefinitionVersion)
+
+	start := time.Now()
+	result, err := env.Execute(def, darklaunch.SleepDemoInput{Name: "Ada", SleepMS: 60000})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusCompleted {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+	}
+	if elapsed >= 10*time.Second {
+		t.Fatalf("Execute elapsed = %s, want less than 10s", elapsed)
+	}
+	var decoded darklaunch.WorkflowResult
+	if err := result.DecodeResult(&decoded); err != nil {
+		t.Fatalf("DecodeResult returned error: %v", err)
+	}
+	want := darklaunch.WorkflowResult{Greeting: "hello, Ada", Approval: "granted"}
+	if decoded != want {
+		t.Fatalf("result = %#v, want %#v", decoded, want)
+	}
+}
+
+func TestDemoWorkflowKit(t *testing.T) {
+	env := workflowtest.NewEnvironment()
+	env.RegisterActivity(darklaunch.DemoActivityType, func(input json.RawMessage) (any, error) {
+		var decoded darklaunch.ActivityInput
+		if err := json.Unmarshal(input, &decoded); err != nil {
+			return nil, err
+		}
+		return darklaunch.ActivityOutput{Greeting: "hello, " + decoded.Name}, nil
+	})
+	if err := env.QueueSignal("approval", darklaunch.SignalPayload{Approval: "granted"}); err != nil {
+		t.Fatalf("QueueSignal returned error: %v", err)
+	}
+
+	result, err := env.Execute(
+		lookupDefinition(t, darklaunch.DemoDefinitionName, darklaunch.DemoDefinitionVersion),
+		darklaunch.WorkflowInput{Name: "Ada"},
+	)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusCompleted {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+	}
+	var decoded darklaunch.WorkflowResult
+	if err := result.DecodeResult(&decoded); err != nil {
+		t.Fatalf("DecodeResult returned error: %v", err)
+	}
+	want := darklaunch.WorkflowResult{Greeting: "hello, Ada", Approval: "granted"}
+	if decoded != want {
+		t.Fatalf("result = %#v, want %#v", decoded, want)
+	}
+	var status map[string]string
+	if err := json.Unmarshal(result.CustomStatus, &status); err != nil {
+		t.Fatalf("CustomStatus unmarshal returned error: %v", err)
+	}
+	if status["phase"] != "completed" {
+		t.Fatalf("custom status phase = %q, want %q", status["phase"], "completed")
+	}
+	if status["approval"] != "granted" {
+		t.Fatalf("custom status approval = %q, want %q", status["approval"], "granted")
+	}
+}
+
+func TestDemoWorkflowCancellationKit(t *testing.T) {
+	t.Run("demo cancels", func(t *testing.T) {
+		env := workflowtest.NewEnvironment()
+		env.RequestCancellation()
+		result, err := env.Execute(
+			lookupDefinition(t, darklaunch.DemoDefinitionName, darklaunch.DemoDefinitionVersion),
+			darklaunch.WorkflowInput{Name: "Ada"},
+		)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if result.Status != workflowtest.StatusCancelled {
+			t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCancelled)
+		}
+	})
+
+	t.Run("cancel-completes completes", func(t *testing.T) {
+		env := workflowtest.NewEnvironment()
+		env.RequestCancellation()
+		result, err := env.Execute(
+			lookupDefinition(t, darklaunch.CancelCompletesDefinitionName, darklaunch.CancelCompletesDefinitionVersion),
+			darklaunch.WorkflowInput{Name: "Ada"},
+		)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if result.Status != workflowtest.StatusCompleted {
+			t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+		}
+	})
+}
+
+func TestRetryHandledDemoKit(t *testing.T) {
+	env := workflowtest.NewEnvironment()
+	env.RegisterActivity(darklaunch.DemoActivityType, func(input json.RawMessage) (any, error) {
+		return nil, errors.New("boom")
+	})
+
+	result, err := env.Execute(
+		lookupDefinition(t, darklaunch.RetryHandledDefinitionName, darklaunch.RetryHandledDefinitionVersion),
+		darklaunch.WorkflowInput{Name: "Ada"},
+	)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusCompleted {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+	}
+	var decoded map[string]any
+	if err := result.DecodeResult(&decoded); err != nil {
+		t.Fatalf("DecodeResult returned error: %v", err)
+	}
+	if got, want := decoded["handled"], true; !reflect.DeepEqual(got, want) {
+		t.Fatalf("handled = %#v, want %#v", got, want)
+	}
+}
+
+func lookupDefinition(t *testing.T, name, version string) workflow.Definition {
+	t.Helper()
+	for _, def := range darklaunch.Definitions() {
+		if def.Name == name && def.Version == version {
+			return def
+		}
+	}
+	t.Fatalf("definition %s@%s not found", name, version)
+	return workflow.Definition{}
+}

--- a/engine/cmd/continua-engine/internal/darklaunch/workflow_kit_test.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/workflow_kit_test.go
@@ -141,7 +141,7 @@ func TestRetryHandledDemoKit(t *testing.T) {
 	}
 }
 
-func lookupDefinition(t *testing.T, name, version string) workflow.Definition {
+func lookupDefinition(t *testing.T, name, version string) workflow.Definition { //nolint:unparam // all dark-launch demo definitions are v1 today
 	t.Helper()
 	for _, def := range darklaunch.Definitions() {
 		if def.Name == name && def.Version == version {

--- a/engine/internal/workflow/replay_test.go
+++ b/engine/internal/workflow/replay_test.go
@@ -70,6 +70,68 @@ func TestReplayDefinitionHappyPath(t *testing.T) {
 	}
 }
 
+func TestReplayDefinitionNilActivityInputRoundTrip(t *testing.T) {
+	historyRows := make([]enginedb.EngineHistory, 0, 2)
+	historyRows = append(historyRows,
+		historyRow(t, 1, enginehistory.EventWorkflowStarted, enginehistory.WorkflowStartedPayload{
+			DefinitionName:    "nil-input",
+			DefinitionVersion: "v1",
+			InstanceKey:       "instance-1",
+		}),
+	)
+	definition := publicworkflow.Definition{
+		Name:    "nil-input",
+		Version: "v1",
+		Run: func(ctx publicworkflow.Context) error {
+			var out string
+			if err := ctx.Activity("nil-activity", "demo.nil", nil, &out); err != nil {
+				return err
+			}
+			return ctx.SetResult(out)
+		},
+	}
+
+	firstDecision, err := replayDefinition(definition, historyRows, nil, nil)
+	if err != nil {
+		t.Fatalf("first replayDefinition() error = %v", err)
+	}
+	if firstDecision.Kind != decisionWaiting {
+		t.Fatalf("expected waiting decision, got %+v", firstDecision)
+	}
+	if len(firstDecision.Events) != 1 || firstDecision.Events[0].EventType != enginehistory.EventActivityScheduled {
+		t.Fatalf("expected activity scheduled event, got %+v", firstDecision.Events)
+	}
+
+	historyRows = append(historyRows, enginedb.EngineHistory{
+		SequenceNo: 2,
+		EventType:  firstDecision.Events[0].EventType,
+		Payload:    firstDecision.Events[0].Payload,
+	})
+	output := mustRawJSON(t, "done")
+	activityTasks := []enginedb.EngineActivityTask{{
+		ActivityKey:  "nil-activity",
+		ActivityType: "demo.nil",
+		Output:       output,
+		Status:       enginedb.EngineActivityTaskStatusCompleted,
+	}}
+	secondDecision, err := replayDefinition(definition, historyRows, activityTasks, nil)
+	if err != nil {
+		t.Fatalf("second replayDefinition() error = %v", err)
+	}
+	if secondDecision.Kind != decisionCompleted {
+		t.Fatalf("expected completed decision, got %+v", secondDecision)
+	}
+	if len(secondDecision.Events) != 2 {
+		t.Fatalf("expected activity completed + workflow completed events, got %+v", secondDecision.Events)
+	}
+	if secondDecision.Events[0].EventType != enginehistory.EventActivityCompleted {
+		t.Fatalf("expected activity completed event, got %+v", secondDecision.Events)
+	}
+	if secondDecision.Events[1].EventType != enginehistory.EventWorkflowCompleted {
+		t.Fatalf("expected workflow completed event, got %+v", secondDecision.Events)
+	}
+}
+
 func TestReplayDefinitionChildWorkflowRoundTrip(t *testing.T) {
 	projectID := uuid.New()
 	runID := uuid.New()

--- a/engine/internal/workflow/sim.go
+++ b/engine/internal/workflow/sim.go
@@ -1,0 +1,105 @@
+package workflow
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	publicworkflow "github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+type SimEvent struct {
+	EventType string
+	Payload   json.RawMessage
+}
+
+type SimActivity struct {
+	Key   string
+	Type  string
+	Input json.RawMessage
+}
+
+type SimTimer struct {
+	TimerKey string
+	DueAt    time.Time
+	Payload  json.RawMessage
+}
+
+type SimChild struct {
+	ChildKey          string
+	DefinitionName    string
+	DefinitionVersion string
+	ChildInstanceKey  string
+	Input             json.RawMessage
+}
+
+type SimDecision struct {
+	Kind              string
+	Events            []SimEvent
+	NextSequence      int32
+	WaitingFor        json.RawMessage
+	CustomStatus      json.RawMessage
+	Result            json.RawMessage
+	ContinuationInput json.RawMessage
+	NewActivity       *SimActivity
+	NewTimer          *SimTimer
+	NewChildWorkflow  *SimChild
+	ConsumedInboxIDs  []uuid.UUID
+	FailureCode       string
+	FailureMessage    string
+}
+
+func SimulateActivation(
+	def publicworkflow.Definition,
+	run *enginedb.EngineRun,
+	history []enginedb.EngineHistory,
+	tasks []enginedb.EngineActivityTask,
+	children []enginedb.ListChildWorkflowOutcomesByParentRunRow,
+	inbox []enginedb.EngineInbox,
+) (SimDecision, error) {
+	decision, err := replayDefinitionForRun(def, run, history, tasks, children, inbox)
+	if err != nil {
+		return SimDecision{}, err
+	}
+
+	out := SimDecision{
+		Kind:              string(decision.Kind),
+		NextSequence:      decision.NextSequence,
+		WaitingFor:        cloneRaw(decision.WaitingFor),
+		CustomStatus:      cloneRaw(decision.CustomStatus),
+		Result:            cloneRaw(decision.Result),
+		ContinuationInput: cloneRaw(decision.ContinuationInput),
+		ConsumedInboxIDs:  append([]uuid.UUID(nil), decision.ConsumedInboxIDs...),
+		FailureCode:       decision.FailureCode,
+		FailureMessage:    decision.FailureMessage,
+	}
+	for _, event := range decision.Events {
+		out.Events = append(out.Events, SimEvent{EventType: event.EventType, Payload: cloneRaw(event.Payload)})
+	}
+	if decision.NewActivity != nil {
+		out.NewActivity = &SimActivity{
+			Key:   decision.NewActivity.Scheduled.ActivityKey,
+			Type:  decision.NewActivity.Scheduled.ActivityType,
+			Input: cloneRaw(decision.NewActivity.Scheduled.Input),
+		}
+	}
+	if decision.NewTimer != nil {
+		out.NewTimer = &SimTimer{
+			TimerKey: decision.NewTimer.TimerKey,
+			DueAt:    decision.NewTimer.DueAt,
+			Payload:  mustMarshalPayload(*decision.NewTimer),
+		}
+	}
+	if decision.NewChildWorkflow != nil {
+		out.NewChildWorkflow = &SimChild{
+			ChildKey:          decision.NewChildWorkflow.Scheduled.ChildKey,
+			DefinitionName:    decision.NewChildWorkflow.Scheduled.DefinitionName,
+			DefinitionVersion: decision.NewChildWorkflow.Scheduled.DefinitionVersion,
+			ChildInstanceKey:  decision.NewChildWorkflow.Scheduled.ChildInstanceKey,
+			Input:             cloneRaw(decision.NewChildWorkflow.Scheduled.Input),
+		}
+	}
+	return out, nil
+}

--- a/engine/pkg/history/history.go
+++ b/engine/pkg/history/history.go
@@ -116,7 +116,7 @@ type WorkflowVersionMarkerPayload struct {
 type ActivityScheduledPayload struct {
 	ActivityKey  string          `json:"activity_key"`
 	ActivityType string          `json:"activity_type"`
-	Input        json.RawMessage `json:"input"`
+	Input        json.RawMessage `json:"input,omitempty"`
 }
 
 type ActivityCompletedPayload struct {
@@ -145,7 +145,7 @@ type ChildWorkflowScheduledPayload struct {
 	ChildKey          string          `json:"child_key"`
 	DefinitionName    string          `json:"definition_name"`
 	DefinitionVersion string          `json:"definition_version"`
-	Input             json.RawMessage `json:"input"`
+	Input             json.RawMessage `json:"input,omitempty"`
 	ChildInstanceKey  string          `json:"child_instance_key"`
 }
 

--- a/engine/pkg/workflowtest/workflowtest.go
+++ b/engine/pkg/workflowtest/workflowtest.go
@@ -213,7 +213,10 @@ func (s *simulation) run(remaining int) (*Result, error) {
 				continue
 			}
 			if decision.NewChildWorkflow != nil {
-				if handled, err := s.resolveChild(decision.NewChildWorkflow, remaining); err != nil || !handled {
+				if handled, blocked, err := s.resolveChild(decision.NewChildWorkflow, remaining); err != nil || !handled || blocked != nil {
+					if blocked != nil {
+						return blocked, nil
+					}
 					return result, err
 				}
 				continue
@@ -297,10 +300,10 @@ func (s *simulation) resolveActivity(activity *internalworkflow.SimActivity) (bo
 	return true, nil
 }
 
-func (s *simulation) resolveChild(child *internalworkflow.SimChild, remaining int) (bool, error) {
+func (s *simulation) resolveChild(child *internalworkflow.SimChild, remaining int) (handled bool, blocked *Result, err error) {
 	def, ok := s.env.definitions[definitionKey(child.DefinitionName, child.DefinitionVersion)]
 	if !ok {
-		return false, nil
+		return false, nil, nil
 	}
 	childRunID := uuid.New()
 	childInstanceID := uuid.New()
@@ -313,7 +316,7 @@ func (s *simulation) resolveChild(child *internalworkflow.SimChild, remaining in
 		ChildDepth:       s.engineRun.ChildDepth + 1,
 	})
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 	s.history = append(s.history, s.historyRow(nextSequence(s.history), history.EventChildWorkflowStarted, startedPayload))
 
@@ -329,8 +332,46 @@ func (s *simulation) resolveChild(child *internalworkflow.SimChild, remaining in
 
 	childResult, err := childSim.run(remaining)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
+	for childResult.Status == StatusContinuedAsNew {
+		if remaining <= 0 {
+			return false, nil, fmt.Errorf("workflowtest: activation cap %d exceeded", activationCap)
+		}
+		remaining--
+		childSim = newSimulation(s.env, def, cloneRaw(childResult.ContinuationInput))
+		childSim.engineRun.ProjectID = s.engineRun.ProjectID
+		childSim.engineRun.RootRunID = s.engineRun.RootRunID
+		childSim.engineRun.ChildDepth = s.engineRun.ChildDepth + 1
+		childSim.engineRun.ID = uuid.New()
+		childSim.engineRun.InstanceID = childInstanceID
+		childSim.history[0].ProjectID = s.engineRun.ProjectID
+		childSim.history[0].InstanceID = childInstanceID
+		childSim.history[0].RunID = childSim.engineRun.ID
+		childResult, err = childSim.run(remaining)
+		if err != nil {
+			return false, nil, err
+		}
+	}
+	if childResult.Status == StatusBlocked {
+		blocked := &Result{
+			Status:   StatusBlocked,
+			WaitKind: history.WaitKindChildWorkflow,
+			WaitKey:  child.ChildKey,
+			history:  append([]enginedb.EngineHistory(nil), s.history...),
+		}
+		return true, blocked, nil
+	}
+	if childResult.Status == StatusQuarantined {
+		return false, nil, fmt.Errorf(
+			"workflowtest: child definition %s@%s quarantined: %s %s",
+			child.DefinitionName,
+			child.DefinitionVersion,
+			childResult.ErrorCode,
+			childResult.ErrorMessage,
+		)
+	}
+	terminalChildRunID := childSim.engineRun.ID
 	status, runStatus := childStatuses(childResult.Status)
 	code := childResult.ErrorCode
 	message := childResult.ErrorMessage
@@ -348,7 +389,7 @@ func (s *simulation) resolveChild(child *internalworkflow.SimChild, remaining in
 		ChildInstanceID:            childInstanceID,
 		ChildInstanceKey:           child.ChildInstanceKey,
 		CurrentChildRunID:          childRunID,
-		TerminalChildRunID:         pgtype.UUID{Bytes: childRunID, Valid: true},
+		TerminalChildRunID:         pgtype.UUID{Bytes: terminalChildRunID, Valid: true},
 		RootRunID:                  s.engineRun.RootRunID,
 		ChildDepth:                 s.engineRun.ChildDepth + 1,
 		Status:                     status,
@@ -357,13 +398,13 @@ func (s *simulation) resolveChild(child *internalworkflow.SimChild, remaining in
 		TerminalLastErrorMessage:   stringPtr(message),
 		TerminalRunStatus:          enginedb.NullEngineRunLifecycleStatus{EngineRunLifecycleStatus: runStatus, Valid: true},
 	})
-	return true, nil
+	return true, nil, nil
 }
 
 func (s *simulation) appendEvents(nextSequence int32, events []internalworkflow.SimEvent) {
 	seq := nextSequence
 	for _, event := range events {
-		s.history = append(s.history, s.historyRow(seq, event.EventType, normalizeEventPayload(event.EventType, event.Payload)))
+		s.history = append(s.history, s.historyRow(seq, event.EventType, event.Payload))
 		seq++
 	}
 }
@@ -485,25 +526,6 @@ func cloneRaw(raw json.RawMessage) json.RawMessage {
 		return nil
 	}
 	return append(json.RawMessage(nil), raw...)
-}
-
-func normalizeEventPayload(eventType string, payload json.RawMessage) json.RawMessage {
-	if eventType != history.EventActivityScheduled && eventType != history.EventChildWorkflowScheduled {
-		return payload
-	}
-	var value map[string]json.RawMessage
-	if err := json.Unmarshal(payload, &value); err != nil {
-		return payload
-	}
-	if string(value["input"]) != "null" {
-		return payload
-	}
-	delete(value, "input")
-	normalized, err := json.Marshal(value)
-	if err != nil {
-		return payload
-	}
-	return normalized
 }
 
 func stringPtr(value string) *string {

--- a/engine/pkg/workflowtest/workflowtest.go
+++ b/engine/pkg/workflowtest/workflowtest.go
@@ -1,0 +1,88 @@
+// Package workflowtest provides an in-memory workflow unit-test kit.
+package workflowtest
+
+import (
+	"encoding/json"
+
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+// ActivityHandler is a scripted activity implementation, keyed by activity type.
+type ActivityHandler func(input json.RawMessage) (any, error)
+
+// NewActivityError returns an error that fails the activity with a specific code.
+// A plain (non-ActivityError) handler error fails with code "activity_failed"
+// (same as the real activity worker).
+func NewActivityError(code, message string) error {
+	panic("workflowtest: not implemented")
+}
+
+type Status string
+
+const (
+	StatusCompleted      Status = "completed"
+	StatusFailed         Status = "failed"
+	StatusCancelled      Status = "cancelled"
+	StatusContinuedAsNew Status = "continued_as_new"
+	StatusQuarantined    Status = "quarantined"
+	StatusBlocked        Status = "blocked"
+)
+
+type Environment struct{}
+
+func NewEnvironment() *Environment {
+	return &Environment{}
+}
+
+// RegisterActivity scripts the outcome of every activity of the given type. One
+// attempt per activity key; retry policies are not simulated.
+func (e *Environment) RegisterActivity(activityType string, handler ActivityHandler) {
+	panic("workflowtest: not implemented")
+}
+
+// RegisterDefinition makes a definition available for ChildWorkflow calls,
+// looked up by (Name, Version). Children share the environment's activity
+// handlers and child registry but not its signal queue or cancellation.
+func (e *Environment) RegisterDefinition(def workflow.Definition) {
+	panic("workflowtest: not implemented")
+}
+
+// QueueSignal enqueues a signal delivered to the workflow inbox in call order
+// (before Execute). Payload is JSON-marshaled.
+func (e *Environment) QueueSignal(name string, payload any) error {
+	panic("workflowtest: not implemented")
+}
+
+// RequestCancellation enqueues a cancellation request in the inbox after any
+// already-queued signals (real inbox arrival-order semantics).
+func (e *Environment) RequestCancellation() {
+	panic("workflowtest: not implemented")
+}
+
+// Execute runs def from input to a terminal state, auto-firing timers and
+// resolving scripted activities/children between activations. Returns an error
+// only for kit-level problems (marshal failure, activation loop cap exceeded).
+func (e *Environment) Execute(def workflow.Definition, input any) (*Result, error) {
+	panic("workflowtest: not implemented")
+}
+
+type Result struct {
+	Status            Status
+	ErrorCode         string
+	ErrorMessage      string
+	CustomStatus      json.RawMessage
+	ContinuationInput json.RawMessage
+	WaitKind          string
+	WaitKey           string
+}
+
+// DecodeResult unmarshals the workflow result (SetResult value) into out.
+func (r *Result) DecodeResult(out any) error {
+	panic("workflowtest: not implemented")
+}
+
+// HistoryEventTypes returns the full recorded history event types in order,
+// starting with history.EventWorkflowStarted.
+func (r *Result) HistoryEventTypes() []string {
+	panic("workflowtest: not implemented")
+}

--- a/engine/pkg/workflowtest/workflowtest.go
+++ b/engine/pkg/workflowtest/workflowtest.go
@@ -3,18 +3,38 @@ package workflowtest
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	internalworkflow "github.com/continua-ai/continua/engine/internal/workflow"
+	"github.com/continua-ai/continua/engine/pkg/history"
 	"github.com/continua-ai/continua/engine/pkg/workflow"
 )
 
+const activationCap = 1024
+
 // ActivityHandler is a scripted activity implementation, keyed by activity type.
 type ActivityHandler func(input json.RawMessage) (any, error)
+
+type activityError struct {
+	code    string
+	message string
+}
+
+func (e *activityError) Error() string {
+	return e.message
+}
 
 // NewActivityError returns an error that fails the activity with a specific code.
 // A plain (non-ActivityError) handler error fails with code "activity_failed"
 // (same as the real activity worker).
 func NewActivityError(code, message string) error {
-	panic("workflowtest: not implemented")
+	return &activityError{code: code, message: message}
 }
 
 type Status string
@@ -28,42 +48,66 @@ const (
 	StatusBlocked        Status = "blocked"
 )
 
-type Environment struct{}
+type queuedSignal struct {
+	name    string
+	payload json.RawMessage
+}
+
+type Environment struct {
+	activities  map[string]ActivityHandler
+	definitions map[string]workflow.Definition
+	signals     []queuedSignal
+	cancel      bool
+}
 
 func NewEnvironment() *Environment {
-	return &Environment{}
+	return &Environment{
+		activities:  make(map[string]ActivityHandler),
+		definitions: make(map[string]workflow.Definition),
+	}
 }
 
 // RegisterActivity scripts the outcome of every activity of the given type. One
 // attempt per activity key; retry policies are not simulated.
 func (e *Environment) RegisterActivity(activityType string, handler ActivityHandler) {
-	panic("workflowtest: not implemented")
+	e.activities[activityType] = handler
 }
 
 // RegisterDefinition makes a definition available for ChildWorkflow calls,
 // looked up by (Name, Version). Children share the environment's activity
 // handlers and child registry but not its signal queue or cancellation.
 func (e *Environment) RegisterDefinition(def workflow.Definition) {
-	panic("workflowtest: not implemented")
+	e.definitions[definitionKey(def.Name, def.Version)] = def
 }
 
 // QueueSignal enqueues a signal delivered to the workflow inbox in call order
 // (before Execute). Payload is JSON-marshaled.
 func (e *Environment) QueueSignal(name string, payload any) error {
-	panic("workflowtest: not implemented")
+	raw, err := history.MarshalPayload(payload)
+	if err != nil {
+		return err
+	}
+	e.signals = append(e.signals, queuedSignal{name: name, payload: raw})
+	return nil
 }
 
 // RequestCancellation enqueues a cancellation request in the inbox after any
 // already-queued signals (real inbox arrival-order semantics).
 func (e *Environment) RequestCancellation() {
-	panic("workflowtest: not implemented")
+	e.cancel = true
 }
 
 // Execute runs def from input to a terminal state, auto-firing timers and
 // resolving scripted activities/children between activations. Returns an error
 // only for kit-level problems (marshal failure, activation loop cap exceeded).
 func (e *Environment) Execute(def workflow.Definition, input any) (*Result, error) {
-	panic("workflowtest: not implemented")
+	inputRaw, err := history.MarshalPayload(input)
+	if err != nil {
+		return nil, err
+	}
+	sim := newSimulation(e, def, inputRaw)
+	sim.inbox = e.materializeInbox(sim)
+	return sim.run(activationCap)
 }
 
 type Result struct {
@@ -74,15 +118,397 @@ type Result struct {
 	ContinuationInput json.RawMessage
 	WaitKind          string
 	WaitKey           string
+
+	result  json.RawMessage
+	history []enginedb.EngineHistory
 }
 
 // DecodeResult unmarshals the workflow result (SetResult value) into out.
 func (r *Result) DecodeResult(out any) error {
-	panic("workflowtest: not implemented")
+	return history.UnmarshalPayload(r.result, out)
 }
 
 // HistoryEventTypes returns the full recorded history event types in order,
 // starting with history.EventWorkflowStarted.
 func (r *Result) HistoryEventTypes() []string {
-	panic("workflowtest: not implemented")
+	events := make([]string, 0, len(r.history))
+	for i := range r.history {
+		events = append(events, r.history[i].EventType)
+	}
+	return events
+}
+
+type simulation struct {
+	env       *Environment
+	def       workflow.Definition
+	engineRun enginedb.EngineRun
+	history   []enginedb.EngineHistory
+	tasks     []enginedb.EngineActivityTask
+	children  []enginedb.ListChildWorkflowOutcomesByParentRunRow
+	inbox     []enginedb.EngineInbox
+}
+
+func newSimulation(env *Environment, def workflow.Definition, input json.RawMessage) *simulation {
+	now := time.Now().UTC()
+	projectID := uuid.New()
+	instanceID := uuid.New()
+	runID := uuid.New()
+	engineRun := enginedb.EngineRun{
+		ID:                runID,
+		ProjectID:         projectID,
+		InstanceID:        instanceID,
+		DefinitionVersion: def.Version,
+		Status:            enginedb.EngineRunLifecycleStatusRunning,
+		ReadyAt:           now,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		RootRunID:         runID,
+	}
+	started, _ := history.MarshalPayload(history.WorkflowStartedPayload{
+		DefinitionName:    def.Name,
+		DefinitionVersion: def.Version,
+		InstanceKey:       uuid.NewString(),
+		Input:             cloneRaw(input),
+	})
+	return &simulation{
+		env:       env,
+		def:       def,
+		engineRun: engineRun,
+		history: []enginedb.EngineHistory{{
+			ID:         1,
+			ProjectID:  projectID,
+			InstanceID: instanceID,
+			RunID:      runID,
+			SequenceNo: 1,
+			EventType:  history.EventWorkflowStarted,
+			Payload:    started,
+			CreatedAt:  now,
+		}},
+	}
+}
+
+func (s *simulation) run(remaining int) (*Result, error) {
+	for remaining > 0 {
+		remaining--
+		decision, err := internalworkflow.SimulateActivation(s.def, &s.engineRun, s.history, s.tasks, s.children, s.inbox)
+		if err != nil {
+			return nil, err
+		}
+		s.appendEvents(decision.NextSequence, decision.Events)
+		s.removeInbox(decision.ConsumedInboxIDs)
+		result := s.resultFromDecision(&decision)
+
+		switch decision.Kind {
+		case "completed", "failed", "cancelled", "continued_as_new", "quarantined":
+			return result, nil
+		case "waiting":
+			if decision.NewActivity != nil {
+				if handled, err := s.resolveActivity(decision.NewActivity); err != nil || !handled {
+					return result, err
+				}
+				continue
+			}
+			if decision.NewTimer != nil {
+				s.inbox = append(s.inbox, s.inboxRow("timer", decision.NewTimer.Payload))
+				continue
+			}
+			if decision.NewChildWorkflow != nil {
+				if handled, err := s.resolveChild(decision.NewChildWorkflow, remaining); err != nil || !handled {
+					return result, err
+				}
+				continue
+			}
+			return result, nil
+		default:
+			return nil, fmt.Errorf("workflowtest: unsupported decision kind %q", decision.Kind)
+		}
+	}
+	return nil, fmt.Errorf("workflowtest: activation cap %d exceeded", activationCap)
+}
+
+func (s *simulation) resultFromDecision(decision *internalworkflow.SimDecision) *Result {
+	r := &Result{
+		CustomStatus:      cloneRaw(decision.CustomStatus),
+		ContinuationInput: cloneRaw(decision.ContinuationInput),
+		ErrorCode:         decision.FailureCode,
+		ErrorMessage:      decision.FailureMessage,
+		result:            cloneRaw(decision.Result),
+		history:           append([]enginedb.EngineHistory(nil), s.history...),
+	}
+	switch decision.Kind {
+	case "completed":
+		r.Status = StatusCompleted
+	case "failed":
+		r.Status = StatusFailed
+	case "cancelled":
+		r.Status = StatusCancelled
+		if r.ErrorCode == "" {
+			r.ErrorCode = "cancelled"
+		}
+	case "continued_as_new":
+		r.Status = StatusContinuedAsNew
+	case "quarantined":
+		r.Status = StatusQuarantined
+	case "waiting":
+		r.Status = StatusBlocked
+		r.WaitKind, r.WaitKey = decodeWait(decision.WaitingFor)
+	}
+	return r
+}
+
+func (s *simulation) resolveActivity(activity *internalworkflow.SimActivity) (bool, error) {
+	handler := s.env.activities[activity.Type]
+	if handler == nil {
+		return false, nil
+	}
+	output, err := handler(cloneRaw(activity.Input))
+	now := time.Now().UTC()
+	task := enginedb.EngineActivityTask{
+		ID:           uuid.New(),
+		ProjectID:    s.engineRun.ProjectID,
+		InstanceID:   s.engineRun.InstanceID,
+		RunID:        s.engineRun.ID,
+		ActivityKey:  activity.Key,
+		ActivityType: activity.Type,
+		Input:        cloneRaw(activity.Input),
+		AttemptCount: 1,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err != nil {
+		code := "activity_failed"
+		var coded *activityError
+		if errors.As(err, &coded) {
+			code = coded.code
+		}
+		msg := err.Error()
+		task.Status = enginedb.EngineActivityTaskStatusFailed
+		task.LastErrorCode = &code
+		task.LastErrorMessage = &msg
+	} else {
+		raw, marshalErr := history.MarshalPayload(output)
+		if marshalErr != nil {
+			return false, marshalErr
+		}
+		task.Status = enginedb.EngineActivityTaskStatusCompleted
+		task.Output = raw
+	}
+	s.tasks = append(s.tasks, task)
+	return true, nil
+}
+
+func (s *simulation) resolveChild(child *internalworkflow.SimChild, remaining int) (bool, error) {
+	def, ok := s.env.definitions[definitionKey(child.DefinitionName, child.DefinitionVersion)]
+	if !ok {
+		return false, nil
+	}
+	childRunID := uuid.New()
+	childInstanceID := uuid.New()
+	startedPayload, err := history.MarshalPayload(history.ChildWorkflowStartedPayload{
+		ChildKey:         child.ChildKey,
+		ChildInstanceID:  childInstanceID.String(),
+		ChildInstanceKey: child.ChildInstanceKey,
+		ChildRunID:       childRunID.String(),
+		RootRunID:        s.engineRun.RootRunID.String(),
+		ChildDepth:       s.engineRun.ChildDepth + 1,
+	})
+	if err != nil {
+		return false, err
+	}
+	s.history = append(s.history, s.historyRow(nextSequence(s.history), history.EventChildWorkflowStarted, startedPayload))
+
+	childSim := newSimulation(s.env, def, cloneRaw(child.Input))
+	childSim.engineRun.ProjectID = s.engineRun.ProjectID
+	childSim.engineRun.RootRunID = s.engineRun.RootRunID
+	childSim.engineRun.ChildDepth = s.engineRun.ChildDepth + 1
+	childSim.engineRun.ID = childRunID
+	childSim.engineRun.InstanceID = childInstanceID
+	childSim.history[0].ProjectID = s.engineRun.ProjectID
+	childSim.history[0].InstanceID = childInstanceID
+	childSim.history[0].RunID = childRunID
+
+	childResult, err := childSim.run(remaining)
+	if err != nil {
+		return false, err
+	}
+	status, runStatus := childStatuses(childResult.Status)
+	code := childResult.ErrorCode
+	message := childResult.ErrorMessage
+	if childResult.Status == StatusFailed && code == "" {
+		code = "workflow_failed"
+	}
+	s.children = append(s.children, enginedb.ListChildWorkflowOutcomesByParentRunRow{
+		ID:                         uuid.New(),
+		ProjectID:                  s.engineRun.ProjectID,
+		ParentInstanceID:           s.engineRun.InstanceID,
+		ParentRunID:                s.engineRun.ID,
+		ChildKey:                   child.ChildKey,
+		RequestedDefinitionName:    child.DefinitionName,
+		RequestedDefinitionVersion: child.DefinitionVersion,
+		ChildInstanceID:            childInstanceID,
+		ChildInstanceKey:           child.ChildInstanceKey,
+		CurrentChildRunID:          childRunID,
+		TerminalChildRunID:         pgtype.UUID{Bytes: childRunID, Valid: true},
+		RootRunID:                  s.engineRun.RootRunID,
+		ChildDepth:                 s.engineRun.ChildDepth + 1,
+		Status:                     status,
+		TerminalResult:             cloneRaw(childResult.result),
+		TerminalLastErrorCode:      stringPtr(code),
+		TerminalLastErrorMessage:   stringPtr(message),
+		TerminalRunStatus:          enginedb.NullEngineRunLifecycleStatus{EngineRunLifecycleStatus: runStatus, Valid: true},
+	})
+	return true, nil
+}
+
+func (s *simulation) appendEvents(nextSequence int32, events []internalworkflow.SimEvent) {
+	seq := nextSequence
+	for _, event := range events {
+		s.history = append(s.history, s.historyRow(seq, event.EventType, normalizeEventPayload(event.EventType, event.Payload)))
+		seq++
+	}
+}
+
+func (s *simulation) historyRow(sequence int32, eventType string, payload json.RawMessage) enginedb.EngineHistory {
+	return enginedb.EngineHistory{
+		ID:         int64(len(s.history) + 1),
+		ProjectID:  s.engineRun.ProjectID,
+		InstanceID: s.engineRun.InstanceID,
+		RunID:      s.engineRun.ID,
+		SequenceNo: sequence,
+		EventType:  eventType,
+		Payload:    cloneRaw(payload),
+		CreatedAt:  time.Now().UTC(),
+	}
+}
+
+func (s *simulation) inboxRow(kind string, payload json.RawMessage) enginedb.EngineInbox {
+	return enginedb.EngineInbox{
+		ID:          uuid.New(),
+		ProjectID:   s.engineRun.ProjectID,
+		InstanceID:  s.engineRun.InstanceID,
+		RunID:       pgtype.UUID{Bytes: s.engineRun.ID, Valid: true},
+		Kind:        kind,
+		Payload:     cloneRaw(payload),
+		Status:      enginedb.EngineInboxStatusPending,
+		AvailableAt: time.Now().UTC(),
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+}
+
+func (e *Environment) materializeInbox(sim *simulation) []enginedb.EngineInbox {
+	rows := make([]enginedb.EngineInbox, 0, len(e.signals)+1)
+	for _, signal := range e.signals {
+		payload, _ := history.MarshalPayload(history.SignalReceivedPayload{
+			SignalName: signal.name,
+			Payload:    cloneRaw(signal.payload),
+		})
+		rows = append(rows, sim.inboxRow("signal", payload))
+	}
+	if e.cancel {
+		payload, _ := history.MarshalPayload(history.CancelRequestedPayload{})
+		rows = append(rows, sim.inboxRow("cancel", payload))
+	}
+	return rows
+}
+
+func (s *simulation) removeInbox(ids []uuid.UUID) {
+	if len(ids) == 0 {
+		return
+	}
+	consumed := make(map[uuid.UUID]struct{}, len(ids))
+	for _, id := range ids {
+		consumed[id] = struct{}{}
+	}
+	filtered := s.inbox[:0]
+	for i := range s.inbox {
+		if _, ok := consumed[s.inbox[i].ID]; !ok {
+			filtered = append(filtered, s.inbox[i])
+		}
+	}
+	s.inbox = filtered
+}
+
+func decodeWait(raw json.RawMessage) (kind, key string) {
+	var probe struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return "", ""
+	}
+	switch probe.Kind {
+	case history.WaitKindActivity:
+		var wait history.ActivityWait
+		_ = json.Unmarshal(raw, &wait)
+		return wait.Kind, wait.ActivityKey
+	case history.WaitKindTimer:
+		var wait history.TimerWait
+		_ = json.Unmarshal(raw, &wait)
+		return wait.Kind, wait.TimerKey
+	case history.WaitKindSignal:
+		var wait history.SignalWait
+		_ = json.Unmarshal(raw, &wait)
+		return wait.Kind, wait.SignalName
+	case history.WaitKindChildWorkflow:
+		var wait history.ChildWorkflowWait
+		_ = json.Unmarshal(raw, &wait)
+		return wait.Kind, wait.ChildKey
+	default:
+		return probe.Kind, ""
+	}
+}
+
+func childStatuses(status Status) (enginedb.EngineChildWorkflowStatus, enginedb.EngineRunLifecycleStatus) {
+	switch status {
+	case StatusCompleted:
+		return enginedb.EngineChildWorkflowStatusCompleted, enginedb.EngineRunLifecycleStatusCompleted
+	case StatusCancelled:
+		return enginedb.EngineChildWorkflowStatusCancelled, enginedb.EngineRunLifecycleStatusCancelled
+	default:
+		return enginedb.EngineChildWorkflowStatusFailed, enginedb.EngineRunLifecycleStatusFailed
+	}
+}
+
+func definitionKey(name, version string) string {
+	return name + "\x00" + version
+}
+
+func nextSequence(rows []enginedb.EngineHistory) int32 {
+	if len(rows) == 0 {
+		return 1
+	}
+	return rows[len(rows)-1].SequenceNo + 1
+}
+
+func cloneRaw(raw json.RawMessage) json.RawMessage {
+	if raw == nil {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}
+
+func normalizeEventPayload(eventType string, payload json.RawMessage) json.RawMessage {
+	if eventType != history.EventActivityScheduled && eventType != history.EventChildWorkflowScheduled {
+		return payload
+	}
+	var value map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return payload
+	}
+	if string(value["input"]) != "null" {
+		return payload
+	}
+	delete(value, "input")
+	normalized, err := json.Marshal(value)
+	if err != nil {
+		return payload
+	}
+	return normalized
+}
+
+func stringPtr(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
 }

--- a/engine/pkg/workflowtest/workflowtest_test.go
+++ b/engine/pkg/workflowtest/workflowtest_test.go
@@ -1,0 +1,608 @@
+package workflowtest_test
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/continua-ai/continua/engine/pkg/history"
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+	"github.com/continua-ai/continua/engine/pkg/workflowtest"
+)
+
+func TestExecuteCompletesSimpleWorkflow(t *testing.T) {
+	def := workflow.Definition{
+		Name:    "simple",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			var input map[string]string
+			if err := ctx.Input(&input); err != nil {
+				return err
+			}
+			if input["name"] != "Ada" {
+				return errors.New("unexpected workflow input")
+			}
+			return ctx.SetResult(map[string]string{"greeting": "hello, Ada"})
+		},
+	}
+
+	result, err := workflowtest.NewEnvironment().Execute(def, map[string]string{"name": "Ada"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusCompleted {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+	}
+	var decoded map[string]string
+	if err := result.DecodeResult(&decoded); err != nil {
+		t.Fatalf("DecodeResult returned error: %v", err)
+	}
+	if want := map[string]string{"greeting": "hello, Ada"}; !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("result = %#v, want %#v", decoded, want)
+	}
+	events := result.HistoryEventTypes()
+	if len(events) == 0 {
+		t.Fatal("HistoryEventTypes returned no events")
+	}
+	if events[0] != history.EventWorkflowStarted {
+		t.Fatalf("first event = %q, want %q", events[0], history.EventWorkflowStarted)
+	}
+	if got, want := events[len(events)-1], history.EventWorkflowCompleted; got != want {
+		t.Fatalf("last event = %q, want %q", got, want)
+	}
+}
+
+func TestExecuteRunsScriptedActivity(t *testing.T) {
+	env := workflowtest.NewEnvironment()
+	env.RegisterActivity("demo.greet", func(input json.RawMessage) (any, error) {
+		var decoded map[string]string
+		if err := json.Unmarshal(input, &decoded); err != nil {
+			return nil, err
+		}
+		if want := map[string]string{"name": "Ada"}; !reflect.DeepEqual(decoded, want) {
+			return nil, errors.New("unexpected activity input")
+		}
+		return map[string]string{"greeting": "hello, Ada"}, nil
+	})
+	def := workflow.Definition{
+		Name:    "activity",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			var out map[string]string
+			if err := ctx.Activity("greet", "demo.greet", map[string]string{"name": "Ada"}, &out); err != nil {
+				return err
+			}
+			return ctx.SetResult(out)
+		},
+	}
+
+	result, err := env.Execute(def, nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusCompleted {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+	}
+	var decoded map[string]string
+	if err := result.DecodeResult(&decoded); err != nil {
+		t.Fatalf("DecodeResult returned error: %v", err)
+	}
+	if want := map[string]string{"greeting": "hello, Ada"}; !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("result = %#v, want %#v", decoded, want)
+	}
+	assertEventOrder(t, result.HistoryEventTypes(), history.EventActivityScheduled, history.EventActivityCompleted, history.EventWorkflowCompleted)
+}
+
+func TestExecuteActivityFailureCodes(t *testing.T) {
+	tests := []struct {
+		name      string
+		handler   workflowtest.ActivityHandler
+		errorCode string
+		message   string
+	}{
+		{
+			name: "coded error",
+			handler: func(input json.RawMessage) (any, error) {
+				return nil, workflowtest.NewActivityError("quota_exceeded", "boom")
+			},
+			errorCode: "quota_exceeded",
+			message:   "boom",
+		},
+		{
+			name: "plain error",
+			handler: func(input json.RawMessage) (any, error) {
+				return nil, errors.New("boom")
+			},
+			errorCode: "activity_failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := workflowtest.NewEnvironment()
+			env.RegisterActivity("demo.fail", tt.handler)
+			def := workflow.Definition{
+				Name:    "activity-fails",
+				Version: "v1",
+				Run: func(ctx workflow.Context) error {
+					return ctx.Activity("fail", "demo.fail", nil, nil)
+				},
+			}
+
+			result, err := env.Execute(def, nil)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if result.Status != workflowtest.StatusFailed {
+				t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusFailed)
+			}
+			if result.ErrorCode != tt.errorCode {
+				t.Fatalf("ErrorCode = %q, want %q", result.ErrorCode, tt.errorCode)
+			}
+			if tt.message != "" && result.ErrorMessage != tt.message {
+				t.Fatalf("ErrorMessage = %q, want %q", result.ErrorMessage, tt.message)
+			}
+			events := result.HistoryEventTypes()
+			assertContainsEvent(t, events, history.EventActivityFailed)
+			if got, want := events[len(events)-1], history.EventWorkflowFailed; got != want {
+				t.Fatalf("last event = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestExecuteBlocksOnUnregisteredActivity(t *testing.T) {
+	def := workflow.Definition{
+		Name:    "missing-activity",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			return ctx.Activity("greet", "demo.greet", nil, nil)
+		},
+	}
+
+	result, err := workflowtest.NewEnvironment().Execute(def, nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusBlocked {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusBlocked)
+	}
+	if result.WaitKind != history.WaitKindActivity {
+		t.Fatalf("WaitKind = %q, want %q", result.WaitKind, history.WaitKindActivity)
+	}
+	if result.WaitKey != "greet" {
+		t.Fatalf("WaitKey = %q, want %q", result.WaitKey, "greet")
+	}
+	assertContainsEvent(t, result.HistoryEventTypes(), history.EventActivityScheduled)
+}
+
+func TestExecuteAutoFiresTimers(t *testing.T) {
+	def := workflow.Definition{
+		Name:    "timer",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			if err := ctx.Sleep("wait", time.Hour); err != nil {
+				return err
+			}
+			return ctx.SetResult("done")
+		},
+	}
+
+	start := time.Now()
+	result, err := workflowtest.NewEnvironment().Execute(def, nil)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusCompleted {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+	}
+	if elapsed >= 10*time.Second {
+		t.Fatalf("Execute elapsed = %s, want less than 10s", elapsed)
+	}
+	assertEventOrder(t, result.HistoryEventTypes(), history.EventTimerScheduled, history.EventTimerFired)
+}
+
+func TestExecuteDeliversQueuedSignals(t *testing.T) {
+	def := workflow.Definition{
+		Name:    "signal",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			var sig map[string]string
+			if err := ctx.ReceiveSignal("approval", &sig); err != nil {
+				return err
+			}
+			return ctx.SetResult(sig)
+		},
+	}
+
+	t.Run("queued signal delivered", func(t *testing.T) {
+		env := workflowtest.NewEnvironment()
+		if err := env.QueueSignal("approval", map[string]string{"approval": "granted"}); err != nil {
+			t.Fatalf("QueueSignal returned error: %v", err)
+		}
+		result, err := env.Execute(def, nil)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if result.Status != workflowtest.StatusCompleted {
+			t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+		}
+		var decoded map[string]string
+		if err := result.DecodeResult(&decoded); err != nil {
+			t.Fatalf("DecodeResult returned error: %v", err)
+		}
+		if want := map[string]string{"approval": "granted"}; !reflect.DeepEqual(decoded, want) {
+			t.Fatalf("result = %#v, want %#v", decoded, want)
+		}
+		assertContainsEvent(t, result.HistoryEventTypes(), history.EventSignalReceived)
+	})
+
+	t.Run("missing signal blocks", func(t *testing.T) {
+		result, err := workflowtest.NewEnvironment().Execute(def, nil)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if result.Status != workflowtest.StatusBlocked {
+			t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusBlocked)
+		}
+		if result.WaitKind != history.WaitKindSignal {
+			t.Fatalf("WaitKind = %q, want %q", result.WaitKind, history.WaitKindSignal)
+		}
+		if result.WaitKey != "approval" {
+			t.Fatalf("WaitKey = %q, want %q", result.WaitKey, "approval")
+		}
+	})
+}
+
+func TestExecuteCancellation(t *testing.T) {
+	t.Run("cancel produces cancelled", func(t *testing.T) {
+		env := workflowtest.NewEnvironment()
+		env.RequestCancellation()
+		def := workflow.Definition{
+			Name:    "cancel",
+			Version: "v1",
+			Run: func(ctx workflow.Context) error {
+				if ctx.CancellationRequested() {
+					return workflow.ErrCancelled
+				}
+				return errors.New("expected cancel")
+			},
+		}
+
+		result, err := env.Execute(def, nil)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if result.Status != workflowtest.StatusCancelled {
+			t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCancelled)
+		}
+		if result.ErrorCode != "cancelled" {
+			t.Fatalf("ErrorCode = %q, want %q", result.ErrorCode, "cancelled")
+		}
+		events := result.HistoryEventTypes()
+		assertContainsEvent(t, events, history.EventCancelRequested)
+		if got, want := events[len(events)-1], history.EventWorkflowCancelled; got != want {
+			t.Fatalf("last event = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("observed cancel with nil return completes", func(t *testing.T) {
+		env := workflowtest.NewEnvironment()
+		env.RequestCancellation()
+		def := workflow.Definition{
+			Name:    "graceful-cancel",
+			Version: "v1",
+			Run: func(ctx workflow.Context) error {
+				if ctx.CancellationRequested() {
+					return ctx.SetResult("graceful")
+				}
+				return errors.New("expected cancel")
+			},
+		}
+
+		result, err := env.Execute(def, nil)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if result.Status != workflowtest.StatusCompleted {
+			t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+		}
+	})
+}
+
+func TestExecuteChildWorkflowOutcomes(t *testing.T) {
+	t.Run("child result flows to parent", func(t *testing.T) {
+		env := workflowtest.NewEnvironment()
+		env.RegisterDefinition(workflow.Definition{
+			Name:    "child",
+			Version: "v1",
+			Run: func(ctx workflow.Context) error {
+				var input int
+				if err := ctx.Input(&input); err != nil {
+					return err
+				}
+				return ctx.SetResult(input * 2)
+			},
+		})
+		parent := workflow.Definition{
+			Name:    "parent",
+			Version: "v1",
+			Run: func(ctx workflow.Context) error {
+				var out int
+				if err := ctx.ChildWorkflow("c1", "child", "v1", 21, &out); err != nil {
+					return err
+				}
+				return ctx.SetResult(out)
+			},
+		}
+
+		result, err := env.Execute(parent, nil)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if result.Status != workflowtest.StatusCompleted {
+			t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+		}
+		var decoded int
+		if err := result.DecodeResult(&decoded); err != nil {
+			t.Fatalf("DecodeResult returned error: %v", err)
+		}
+		if decoded != 42 {
+			t.Fatalf("result = %d, want 42", decoded)
+		}
+		assertEventOrder(t, result.HistoryEventTypes(), history.EventChildWorkflowScheduled, history.EventChildWorkflowStarted, history.EventChildWorkflowCompleted)
+	})
+
+	t.Run("child failure surfaces as ChildWorkflowError", func(t *testing.T) {
+		env := workflowtest.NewEnvironment()
+		env.RegisterDefinition(workflow.Definition{
+			Name:    "child",
+			Version: "v1",
+			Run: func(ctx workflow.Context) error {
+				return errors.New("child boom")
+			},
+		})
+		parent := workflow.Definition{
+			Name:    "parent",
+			Version: "v1",
+			Run: func(ctx workflow.Context) error {
+				err := ctx.ChildWorkflow("c1", "child", "v1", nil, nil)
+				if err == nil {
+					return errors.New("expected child workflow error")
+				}
+				var cwe *workflow.ChildWorkflowError
+				if !errors.As(err, &cwe) {
+					return err
+				}
+				return ctx.SetResult(map[string]string{"code": cwe.Code(), "state": cwe.TerminalState()})
+			},
+		}
+
+		result, err := env.Execute(parent, nil)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if result.Status != workflowtest.StatusCompleted {
+			t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+		}
+		var decoded map[string]string
+		if err := result.DecodeResult(&decoded); err != nil {
+			t.Fatalf("DecodeResult returned error: %v", err)
+		}
+		if decoded["code"] != "workflow_failed" {
+			t.Fatalf("child error code = %q, want %q", decoded["code"], "workflow_failed")
+		}
+		if decoded["state"] != "failed" {
+			t.Fatalf("child terminal state = %q, want %q", decoded["state"], "failed")
+		}
+	})
+
+	t.Run("unregistered child blocks", func(t *testing.T) {
+		parent := workflow.Definition{
+			Name:    "parent",
+			Version: "v1",
+			Run: func(ctx workflow.Context) error {
+				return ctx.ChildWorkflow("c1", "nope", "v1", nil, nil)
+			},
+		}
+
+		result, err := workflowtest.NewEnvironment().Execute(parent, nil)
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+		if result.Status != workflowtest.StatusBlocked {
+			t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusBlocked)
+		}
+		if result.WaitKind != history.WaitKindChildWorkflow {
+			t.Fatalf("WaitKind = %q, want %q", result.WaitKind, history.WaitKindChildWorkflow)
+		}
+		if result.WaitKey != "c1" {
+			t.Fatalf("WaitKey = %q, want %q", result.WaitKey, "c1")
+		}
+	})
+}
+
+func TestExecuteContinueAsNew(t *testing.T) {
+	def := workflow.Definition{
+		Name:    "continue",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			return workflow.ContinueAsNew(map[string]int{"round": 2})
+		},
+	}
+
+	result, err := workflowtest.NewEnvironment().Execute(def, nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusContinuedAsNew {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusContinuedAsNew)
+	}
+	var decoded map[string]int
+	if err := json.Unmarshal(result.ContinuationInput, &decoded); err != nil {
+		t.Fatalf("ContinuationInput unmarshal returned error: %v", err)
+	}
+	if want := map[string]int{"round": 2}; !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("ContinuationInput = %#v, want %#v", decoded, want)
+	}
+}
+
+func TestExecuteSideEffectRunsOnce(t *testing.T) {
+	var calls int
+	def := workflow.Definition{
+		Name:    "side-effect",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			var out string
+			if err := ctx.SideEffect("gen", func() (any, error) {
+				calls++
+				return "value-1", nil
+			}, &out); err != nil {
+				return err
+			}
+			if err := ctx.Sleep("wait", time.Minute); err != nil {
+				return err
+			}
+			return ctx.SetResult(out)
+		},
+	}
+
+	result, err := workflowtest.NewEnvironment().Execute(def, nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusCompleted {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+	}
+	var decoded string
+	if err := result.DecodeResult(&decoded); err != nil {
+		t.Fatalf("DecodeResult returned error: %v", err)
+	}
+	if decoded != "value-1" {
+		t.Fatalf("result = %q, want %q", decoded, "value-1")
+	}
+	if calls != 1 {
+		t.Fatalf("side effect calls = %d, want 1", calls)
+	}
+}
+
+func TestExecuteNowStableAcrossActivations(t *testing.T) {
+	var seen []time.Time
+	def := workflow.Definition{
+		Name:    "now",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			t := ctx.Now()
+			seen = append(seen, t)
+			if err := ctx.Sleep("wait", time.Minute); err != nil {
+				return err
+			}
+			return ctx.SetResult(t)
+		},
+	}
+
+	result, err := workflowtest.NewEnvironment().Execute(def, nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusCompleted {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+	}
+	if len(seen) < 2 {
+		t.Fatalf("Now observed %d activation(s), want at least 2", len(seen))
+	}
+	for i, got := range seen {
+		if !got.Equal(seen[0]) {
+			t.Fatalf("seen[%d] = %s, want %s", i, got, seen[0])
+		}
+	}
+}
+
+func TestExecuteDetectsNonDeterminism(t *testing.T) {
+	var attempts int
+	env := workflowtest.NewEnvironment()
+	env.RegisterActivity("type.a", func(input json.RawMessage) (any, error) { return nil, nil })
+	env.RegisterActivity("type.b", func(input json.RawMessage) (any, error) { return nil, nil })
+	def := workflow.Definition{
+		Name:    "nondeterministic",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			attempts++
+			if attempts == 1 {
+				if err := ctx.Activity("a", "type.a", nil, nil); err != nil {
+					return err
+				}
+				return ctx.SetResult("a")
+			}
+			if err := ctx.Activity("b", "type.b", nil, nil); err != nil {
+				return err
+			}
+			return ctx.SetResult("b")
+		},
+	}
+
+	result, err := env.Execute(def, nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusQuarantined {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusQuarantined)
+	}
+	if result.ErrorCode != "replay_mismatch" {
+		t.Fatalf("ErrorCode = %q, want %q", result.ErrorCode, "replay_mismatch")
+	}
+}
+
+func TestExecuteCustomStatus(t *testing.T) {
+	def := workflow.Definition{
+		Name:    "custom-status",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			if err := ctx.SetCustomStatus(map[string]string{"phase": "done"}); err != nil {
+				return err
+			}
+			return ctx.SetResult(nil)
+		},
+	}
+
+	result, err := workflowtest.NewEnvironment().Execute(def, nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Status != workflowtest.StatusCompleted {
+		t.Fatalf("status = %q, want %q", result.Status, workflowtest.StatusCompleted)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(result.CustomStatus, &decoded); err != nil {
+		t.Fatalf("CustomStatus unmarshal returned error: %v", err)
+	}
+	if want := map[string]string{"phase": "done"}; !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("CustomStatus = %#v, want %#v", decoded, want)
+	}
+}
+
+func assertContainsEvent(t *testing.T, events []string, want string) {
+	t.Helper()
+	for _, eventType := range events {
+		if eventType == want {
+			return
+		}
+	}
+	t.Fatalf("events %v do not contain %q", events, want)
+}
+
+func assertEventOrder(t *testing.T, events []string, ordered ...string) {
+	t.Helper()
+	next := 0
+	for _, eventType := range events {
+		if next < len(ordered) && eventType == ordered[next] {
+			next++
+		}
+	}
+	if next != len(ordered) {
+		t.Fatalf("events %v do not contain relative order %v", events, ordered)
+	}
+}

--- a/engine/pkg/workflowtest/workflowtest_test.go
+++ b/engine/pkg/workflowtest/workflowtest_test.go
@@ -451,7 +451,7 @@ func TestExecuteContinueAsNew(t *testing.T) {
 }
 
 func TestExecuteSideEffectRunsOnce(t *testing.T) {
-	var calls int
+	calls := 0
 	def := workflow.Definition{
 		Name:    "side-effect",
 		Version: "v1",
@@ -490,7 +490,7 @@ func TestExecuteSideEffectRunsOnce(t *testing.T) {
 }
 
 func TestExecuteNowStableAcrossActivations(t *testing.T) {
-	var seen []time.Time
+	seen := make([]time.Time, 0)
 	def := workflow.Definition{
 		Name:    "now",
 		Version: "v1",
@@ -522,7 +522,7 @@ func TestExecuteNowStableAcrossActivations(t *testing.T) {
 }
 
 func TestExecuteDetectsNonDeterminism(t *testing.T) {
-	var attempts int
+	attempts := 0
 	env := workflowtest.NewEnvironment()
 	env.RegisterActivity("type.a", func(input json.RawMessage) (any, error) { return nil, nil })
 	env.RegisterActivity("type.b", func(input json.RawMessage) (any, error) { return nil, nil })


### PR DESCRIPTION
## What / why

`workflow.Context` had exactly one implementation — the internal replay runner — so workflow authors could not unit-test definitions without a real Postgres. This PR adds **`engine/pkg/workflowtest`**, an in-memory unit-test kit that runs a `workflow.Definition` through the *same* internal replay runner used in production (no parallel `Context` implementation), plus a docs-site authoring guide. Required for `pkg/workflow` to be a real public SDK surface.

## Design

- **Simulation seam** (`engine/internal/workflow/sim.go`): a thin exported wrapper (`SimulateActivation` + `SimDecision`) around the unexported replay runner. Pure type conversion — no behavior changes to replay or activation.
- **Kit loop** (`engine/pkg/workflowtest`): `Environment.Execute` replays the definition activation-by-activation entirely in memory, mirroring `Activator.commitDecision` — appending queued history events, resolving scripted activities (keyed by activity type, coded failures via `NewActivityError`), auto-firing timers, delivering queued signals/cancellation as inbox rows in arrival order, and executing registered child definitions recursively (continue-as-new followed; blocked children surface as blocked; a quarantined child is a loud kit error).
- **Result surface**: terminal status (completed / failed / cancelled / continued-as-new / quarantined / blocked), decoded result, error code/message, custom status, wait kind+key, and full history event-type sequence for assertions.
- Because every block re-replays from recorded history through the real runner, **non-deterministic workflow code surfaces as `StatusQuarantined` with `replay_mismatch`** — the kit doubles as a determinism test.

## Engine fix surfaced by the kit

The kit's byte-faithful replay exposed a real asymmetry: `MarshalPayload(nil)` returns `nil`, but `ActivityScheduledPayload.Input` / `ChildWorkflowScheduledPayload.Input` lacked `omitempty` (unlike the other history payloads), so a **nil activity/child input round-trips as `"input":null` and fails `equalJSON` on the next activation — quarantining the run in the real engine**. Fixed by adding `omitempty` to those two fields (new events store absent input for nil), with a replay regression test (`TestReplayDefinitionNilActivityInputRoundTrip`).

## Tests (written first, committed red, implementation by a separate session)

- `engine/pkg/workflowtest/workflowtest_test.go` — 13 acceptance tests: simple completion, scripted activities (input assertion + result flow), coded/plain activity failure codes, blocked-on-unregistered-activity, auto-fired timers (1h sleep completes in ms), queued/missing signals, cancellation (both `ErrCancelled` and graceful-completion semantics), child workflow success/failure/unregistered, continue-as-new, side-effect runs-once, `Now()` stability across activations, non-determinism quarantine, custom status.
- `engine/cmd/continua-engine/internal/darklaunch/workflow_kit_test.go` — the dark-launch demo workflows unit-tested with the kit as the reference example (sleep-demo, demo incl. custom status, cancellation pair, retry-handled).
- All of the above run with **no database** (`cd engine && go test ./pkg/workflowtest/... ./cmd/continua-engine/internal/darklaunch/...`) — acceptance criterion of #164.
- Full engine suite green on a real Postgres (14 packages), `go vet ./...` clean, `golangci-lint run ./...` 0 issues.

## Docs

- New guide: `docs-site/guides/testing-workflows.mdx` (kit usage, timers, cancellation, child workflows, determinism, activity failures, scope caveats), registered in the docs nav after the embed-engine guide.

Closes #164


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-memory Go workflow testing kit for running workflow definitions without Postgres or workers.
  * Supports scripted activities, signals, timers, cancellation, child workflows, retries, continuation, custom status, and result validation.
  * Added a new “testing workflows” documentation guide (with examples and current limitations).
* **Bug Fixes**
  * Empty activity and child-workflow inputs are no longer serialized into history payloads.
* **Tests**
  * Expanded coverage for workflow replay edge cases, determinism/quarantine, and multiple workflow kit scenarios (sleep, demo, cancellation, retry-handled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->