### PR TITLE
test(engine): E2E — Go engine driving a Python ActivityWorker over REST

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,7 +109,7 @@ jobs:
           ./bin/continua-engine serve > engine.log 2>&1 &
           echo $! > engine.pid
           for i in {1..30}; do
-            if psql "${DATABASE_URL}" -Atc "SELECT 1 FROM engine.definition_catalog WHERE definition_name = 'darklaunch.remote-demo' AND definition_version = 'v1' AND enabled = true LIMIT 1;" | grep -q 1; then
+            if psql "${DATABASE_URL}" -Atc "SELECT 1 FROM engine.definition_catalog WHERE definition_name = 'darklaunch.remote-demo' AND definition_version = 'v1' LIMIT 1;" | grep -q 1; then
               echo "Engine is ready"
               break
             fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,14 +50,45 @@ jobs:
       - name: Build server
         run: go build -o bin/continua ./cmd/continua
 
+      - name: Build engine CLI
+        run: cd engine && go build -o ../bin/continua-engine ./cmd/continua-engine
+
       - name: Run migrations
         run: ./bin/continua migrate up
         env:
           DATABASE_URL: postgres://continua:continua@localhost:5432/continua?sslmode=disable
 
+      - name: Run engine migrations
+        run: ./bin/continua-engine migrate up
+        env:
+          DATABASE_URL: postgres://continua:continua@localhost:5432/continua?sslmode=disable
+
+      - name: Seed worker E2E API key
+        run: |
+          API_KEY="continua-worker-e2e-ci"
+          API_KEY_HASH="$(printf '%s' "${API_KEY}" | shasum -a 256 | awk '{print $1}')"
+          psql "${DATABASE_URL}" \
+            -v ON_ERROR_STOP=1 \
+            -v demo_project_id="11111111-1111-4111-8111-111111111111" \
+            -v demo_project_name="Worker E2E Project" \
+            -v demo_api_key_hash="${API_KEY_HASH}" <<'SQL'
+          DELETE FROM projects
+          WHERE id = :'demo_project_id'::uuid;
+
+          INSERT INTO projects (id, name, api_key_hash)
+          VALUES (
+            :'demo_project_id'::uuid,
+            :'demo_project_name',
+            :'demo_api_key_hash'
+          );
+          SQL
+          echo "CONTINUA_WORKER_E2E_API_KEY=${API_KEY}" >> "${GITHUB_ENV}"
+        env:
+          DATABASE_URL: postgres://continua:continua@localhost:5432/continua?sslmode=disable
+
       - name: Start server
         run: |
-          ./bin/continua serve &
+          ./bin/continua serve > server.log 2>&1 &
           echo $! > server.pid
           # Wait for server to be ready
           for i in {1..30}; do
@@ -70,7 +101,23 @@ jobs:
           done
         env:
           DATABASE_URL: postgres://continua:continua@localhost:5432/continua?sslmode=disable
+          ENGINE_PUBLIC_API_ENABLED: "true"
           PORT: 8081
+
+      - name: Start engine
+        run: |
+          ./bin/continua-engine serve > engine.log 2>&1 &
+          echo $! > engine.pid
+          for i in {1..30}; do
+            if psql "${DATABASE_URL}" -Atc "SELECT 1 FROM engine.definition_catalog WHERE definition_name = 'darklaunch.remote-demo' AND definition_version = 'v1' AND enabled = true LIMIT 1;" | grep -q 1; then
+              echo "Engine is ready"
+              break
+            fi
+            echo "Waiting for engine... ($i/30)"
+            sleep 1
+          done
+        env:
+          DATABASE_URL: postgres://continua:continua@localhost:5432/continua?sslmode=disable
 
       - name: Install Python SDK dependencies
         run: |
@@ -84,15 +131,32 @@ jobs:
         env:
           CONTINUA_API_URL: http://localhost:8081
 
+      - name: Run Python worker E2E
+        run: |
+          cd sdks/python
+          uv run pytest tests/test_worker_e2e_integration.py -v
+        env:
+          CONTINUA_ENDPOINT: http://localhost:8081
+          CONTINUA_API_KEY: ${{ env.CONTINUA_WORKER_E2E_API_KEY }}
+
       - name: Stop server
         if: always()
         run: |
           if [ -f server.pid ]; then
             kill $(cat server.pid) || true
           fi
+          if [ -f engine.pid ]; then
+            kill $(cat engine.pid) || true
+          fi
 
       - name: Collect server logs
         if: failure()
         run: |
-          echo "=== Server logs would be collected here ==="
-          # In a real setup, you'd redirect server output to a file and cat it here
+          if [ -f server.log ]; then
+            echo "=== Server logs ==="
+            cat server.log
+          fi
+          if [ -f engine.log ]; then
+            echo "=== Engine logs ==="
+            cat engine.log
+          fi

--- a/engine/cmd/continua-engine/internal/darklaunch/activities.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/activities.go
@@ -8,7 +8,10 @@ import (
 	"github.com/continua-ai/continua/engine/internal/activity"
 )
 
-const DemoActivityType = "darklaunch.compose-greeting"
+const (
+	DemoActivityType   = "darklaunch.compose-greeting"
+	RemoteActivityType = "darklaunch.remote-compose-greeting"
+)
 
 type ActivityInput struct {
 	Name string `json:"name"`

--- a/engine/cmd/continua-engine/internal/darklaunch/workflow.go
+++ b/engine/cmd/continua-engine/internal/darklaunch/workflow.go
@@ -20,6 +20,8 @@ const (
 	RetryHandledDefinitionVersion    = "v1"
 	InvalidRetryDefinitionName       = "darklaunch.invalid-retry-policy"
 	InvalidRetryDefinitionVersion    = "v1"
+	RemoteDemoDefinitionName         = "darklaunch.remote-demo"
+	RemoteDemoDefinitionVersion      = "v1"
 	SleepDemoDefinitionName          = "darklaunch.sleep-demo"
 	SleepDemoDefinitionVersion       = "v1"
 	VersionDemoDefinitionName        = "darklaunch.version-demo"
@@ -82,6 +84,11 @@ func Definitions() []workflow.Definition {
 			Run:     runInvalidRetryWorkflow,
 		},
 		{
+			Name:    RemoteDemoDefinitionName,
+			Version: RemoteDemoDefinitionVersion,
+			Run:     runRemoteDemoWorkflow,
+		},
+		{
 			Name:    SleepDemoDefinitionName,
 			Version: SleepDemoDefinitionVersion,
 			Run:     runSleepDemoWorkflow,
@@ -123,6 +130,37 @@ func runInvalidRetryWorkflow(ctx workflow.Context) error {
 		&output,
 		workflow.ActivityOptions{RetryPolicy: &workflow.RetryPolicy{MaxAttempts: 0}},
 	)
+}
+
+func runRemoteDemoWorkflow(ctx workflow.Context) error {
+	var input WorkflowInput
+	if err := ctx.Input(&input); err != nil {
+		return err
+	}
+	if input.Name == "" {
+		input.Name = "world"
+	}
+
+	var output ActivityOutput
+	if err := ctx.ActivityWithOptions(
+		"remote-greeting",
+		RemoteActivityType,
+		ActivityInput{Name: input.Name},
+		&output,
+		workflow.ActivityOptions{
+			ExecutionTarget: workflow.ActivityExecutionTargetRemote,
+			RetryPolicy: &workflow.RetryPolicy{
+				MaxAttempts:       3,
+				InitialBackoff:    500 * time.Millisecond,
+				MaxBackoff:        500 * time.Millisecond,
+				BackoffMultiplier: 1,
+			},
+		},
+	); err != nil {
+		return err
+	}
+
+	return ctx.SetResult(output)
 }
 
 func runSleepDemoWorkflow(ctx workflow.Context) error {

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -78,6 +78,15 @@ uv run mypy src/
 uv build
 ```
 
+### Engine worker E2E test
+
+`tests/test_worker_e2e_integration.py` exercises a live Python `ActivityWorker`
+against the Go engine remote activity REST endpoints. Run it with
+`CONTINUA_ENDPOINT` and `CONTINUA_API_KEY` pointing at a local platform server
+started with `ENGINE_PUBLIC_API_ENABLED=true`. The same database must also have
+`continua-engine migrate up` applied and `continua-engine serve` running, with a
+project/API key seeded using the SHA-256 hash scheme in `scripts/seed-demo.sh`.
+
 ## Publishing
 
 The Python package is published from this directory:

--- a/sdks/python/tests/test_worker_e2e_integration.py
+++ b/sdks/python/tests/test_worker_e2e_integration.py
@@ -1,0 +1,279 @@
+"""Live end-to-end tests for Go engine workflows calling Python remote activities.
+
+Local runbook:
+- Start Postgres and set DATABASE_URL for the target database.
+- Run `continua serve` with ENGINE_PUBLIC_API_ENABLED=true.
+- Run `continua-engine migrate up` and `continua-engine serve` against the same DATABASE_URL.
+- Seed a project API key using the same scheme as `scripts/seed-demo.sh`.
+- Set CONTINUA_ENDPOINT and CONTINUA_API_KEY for that server and project.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import httpx
+import pytest
+
+from continua import (
+    ActivityWorker,
+    EngineControlClient,
+    EngineRunNotFoundError,
+    NonRetryableError,
+    ValidationError,
+)
+from continua.types import EngineRunResponse, EngineRunStatus, EngineStartRunResponse
+
+CONTINUA_ENDPOINT = os.environ.get("CONTINUA_ENDPOINT", "http://localhost:8081")
+CONTINUA_API_KEY = os.environ.get("CONTINUA_API_KEY", "test-api-key-12345")
+REMOTE_DEMO_DEFINITION_NAME = "darklaunch.remote-demo"
+REMOTE_DEMO_DEFINITION_VERSION = "v1"
+REMOTE_ACTIVITY_TYPE = "darklaunch.remote-compose-greeting"
+
+
+def server_available() -> bool:
+    try:
+        response = httpx.get(f"{CONTINUA_ENDPOINT}/api/health", timeout=2.0)
+        return response.status_code == 200
+    except httpx.RequestError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not server_available(),
+    reason=f"Continua server not available at {CONTINUA_ENDPOINT}",
+)
+
+
+def _client() -> EngineControlClient:
+    return EngineControlClient(
+        api_key=CONTINUA_API_KEY,
+        endpoint=CONTINUA_ENDPOINT,
+        timeout=10.0,
+    )
+
+
+def _start_remote_run(
+    client: EngineControlClient,
+    *,
+    input: dict[str, object],
+) -> EngineStartRunResponse:
+    try:
+        return client.start(
+            {
+                "definition_name": REMOTE_DEMO_DEFINITION_NAME,
+                "definition_version": REMOTE_DEMO_DEFINITION_VERSION,
+                "instance_key": f"py-worker-e2e-{uuid.uuid4()}",
+                "request_key": f"py-worker-e2e-req-{uuid.uuid4()}",
+                "input": input,
+            }
+        )
+    except (EngineRunNotFoundError, ValidationError) as exc:
+        pytest.fail(
+            "darklaunch.remote-demo/v1 is not published; a current continua-engine serve "
+            f"must be running with that definition registered: {exc}"
+        )
+
+
+@contextmanager
+def running_worker(
+    handler: Callable[[dict[str, Any]], dict[str, Any]],
+    *,
+    worker_id: str | None = None,
+    lease_duration: str = "10s",
+    heartbeat_interval: float | None = None,
+    poll_interval: float = 0.2,
+) -> Iterator[ActivityWorker]:
+    worker = ActivityWorker(
+        api_key=CONTINUA_API_KEY,
+        endpoint=CONTINUA_ENDPOINT,
+        worker_id=worker_id,
+        lease_duration=lease_duration,
+        heartbeat_interval=heartbeat_interval,
+        poll_interval=poll_interval,
+    )
+    worker.register(REMOTE_ACTIVITY_TYPE, handler)
+    stop = threading.Event()
+
+    def poll_loop() -> None:
+        while not stop.is_set():
+            worker.poll_once()
+            time.sleep(poll_interval)
+
+    thread = threading.Thread(target=poll_loop, name=f"{worker.worker_id}-poll", daemon=True)
+    thread.start()
+    try:
+        yield worker
+    finally:
+        stop.set()
+        thread.join(timeout=2.0)
+        worker.wait_for_idle(timeout=worker.shutdown_timeout)
+        worker.close()
+
+
+def _terminate_if_needed(client: EngineControlClient, run_id: object | None) -> None:
+    if run_id is None:
+        return
+    try:
+        run = client.get_run(run_id)
+    except Exception:
+        return
+    if run.status not in _TERMINAL_STATUSES:
+        client.terminate(run_id)
+
+
+_TERMINAL_STATUSES = {
+    EngineRunStatus.COMPLETED,
+    EngineRunStatus.FAILED,
+    EngineRunStatus.CANCELLED,
+    EngineRunStatus.TERMINATED,
+    EngineRunStatus.CONTINUED_AS_NEW,
+}
+
+
+def test_remote_activity_happy_path_completes_workflow() -> None:
+    nonce = uuid.uuid4().hex
+    seen_inputs: list[dict[str, Any]] = []
+    seen_lock = threading.Lock()
+    client = _client()
+    run_id = None
+
+    def handler(inp: dict[str, Any]) -> dict[str, str]:
+        with seen_lock:
+            seen_inputs.append(dict(inp))
+        return {"greeting": f"hello, {inp['name']}"}
+
+    try:
+        started = _start_remote_run(client, input={"name": nonce})
+        run_id = started.run_id
+        with running_worker(handler):
+            terminal = client.wait_for_terminal(run_id, timeout=60.0, poll_interval=0.2)
+
+        assert terminal.status == EngineRunStatus.COMPLETED
+        result = client.get_result(run_id)
+        assert result.status == EngineRunStatus.COMPLETED
+        assert result.result == {"greeting": f"hello, {nonce}"}
+        assert {"name": nonce} in seen_inputs
+    finally:
+        _terminate_if_needed(client, run_id)
+        client.close()
+
+
+def test_remote_activity_retryable_failure_then_success() -> None:
+    nonce = uuid.uuid4().hex
+    invocation_counts: dict[str, int] = {}
+    counts_lock = threading.Lock()
+    client = _client()
+    run_id = None
+
+    def handler(inp: dict[str, Any]) -> dict[str, str]:
+        name = str(inp["name"])
+        with counts_lock:
+            invocation_counts[name] = invocation_counts.get(name, 0) + 1
+            count = invocation_counts[name]
+        if name == nonce and count == 1:
+            raise RuntimeError("transient boom")
+        return {"greeting": f"retry:{inp['name']}"}
+
+    try:
+        started = _start_remote_run(client, input={"name": nonce})
+        run_id = started.run_id
+        with running_worker(handler):
+            terminal = client.wait_for_terminal(run_id, timeout=60.0, poll_interval=0.2)
+
+        assert terminal.status == EngineRunStatus.COMPLETED
+        result = client.get_result(run_id)
+        assert result.status == EngineRunStatus.COMPLETED
+        assert result.result == {"greeting": f"retry:{nonce}"}
+        assert invocation_counts.get(nonce, 0) >= 2
+    finally:
+        _terminate_if_needed(client, run_id)
+        client.close()
+
+
+def test_remote_activity_lease_loss_second_worker_completes() -> None:
+    nonce = uuid.uuid4().hex
+    worker_a_claimed = threading.Event()
+    release_worker_a = threading.Event()
+    client = _client()
+    run_id = None
+
+    def worker_a_handler(inp: dict[str, Any]) -> dict[str, str]:
+        if inp["name"] == nonce:
+            worker_a_claimed.set()
+            release_worker_a.wait(timeout=120.0)
+        return {"greeting": f"a:{inp['name']}"}
+
+    def worker_b_handler(inp: dict[str, Any]) -> dict[str, str]:
+        return {"greeting": f"b:{inp['name']}"}
+
+    try:
+        started = _start_remote_run(client, input={"name": nonce})
+        run_id = started.run_id
+        with running_worker(
+            worker_a_handler,
+            worker_id=f"py-worker-e2e-a-{nonce}",
+            lease_duration="10s",
+            heartbeat_interval=3600.0,
+        ):
+            assert worker_a_claimed.wait(timeout=30.0), "worker A did not claim the activity"
+            with running_worker(
+                worker_b_handler,
+                worker_id=f"py-worker-e2e-b-{nonce}",
+            ):
+                terminal = client.wait_for_terminal(run_id, timeout=90.0, poll_interval=0.2)
+
+            assert terminal.status == EngineRunStatus.COMPLETED
+            result = client.get_result(run_id)
+            assert result.status == EngineRunStatus.COMPLETED
+            assert result.result == {"greeting": f"b:{nonce}"}
+
+            release_worker_a.set()
+
+        result_after_late_completion = client.get_result(run_id)
+        assert result_after_late_completion.status == EngineRunStatus.COMPLETED
+        assert result_after_late_completion.result == {"greeting": f"b:{nonce}"}
+    finally:
+        release_worker_a.set()
+        _terminate_if_needed(client, run_id)
+        client.close()
+
+
+def test_remote_activity_non_retryable_failure_fails_workflow() -> None:
+    nonce = uuid.uuid4().hex
+    invocation_counts: dict[str, int] = {}
+    counts_lock = threading.Lock()
+    client = _client()
+    run_id = None
+
+    def handler(inp: dict[str, Any]) -> dict[str, str]:
+        name = str(inp["name"])
+        with counts_lock:
+            invocation_counts[name] = invocation_counts.get(name, 0) + 1
+        raise NonRetryableError("permanent boom")
+
+    try:
+        started = _start_remote_run(client, input={"name": nonce})
+        run_id = started.run_id
+        with running_worker(handler):
+            terminal: EngineRunResponse = client.wait_for_terminal(
+                run_id,
+                timeout=60.0,
+                poll_interval=0.2,
+            )
+
+        assert terminal.status == EngineRunStatus.FAILED
+        result = client.get_result(run_id)
+        assert result.status == EngineRunStatus.FAILED
+        assert result.failure is not None
+        assert "permanent boom" in result.failure.error_message
+        assert invocation_counts.get(nonce, 0) == 1
+    finally:
+        _terminate_if_needed(client, run_id)
+        client.close()


### PR DESCRIPTION
## What / why

The Python `ActivityWorker` was verified only against mocks; nothing proved a real Python worker can drive a Go workflow's remote activities end-to-end through `POST /v1/engine/activities/claim | {id}/heartbeat | complete | fail`. Since "Go workflows + Python activities" is the confirmed authoring vision, this was the single most important missing test in the repo. This PR adds that E2E integration suite, the darklaunch workflow it exercises, and CI wiring.

Closes #165

## What's in here

**Acceptance tests** (`sdks/python/tests/test_worker_e2e_integration.py`, written first and committed red):
- `test_remote_activity_happy_path_completes_workflow` — worker claims, completes; run result is exactly the worker's output; the claim payload carried the workflow's activity input.
- `test_remote_activity_retryable_failure_then_success` — handler raises a retryable error once; the engine re-dispatches per the retry policy and the run completes on a later attempt (≥2 invocations asserted).
- `test_remote_activity_lease_loss_second_worker_completes` — worker A claims with a 10s lease and never heartbeats; the lease expires, worker B claims and completes; A's late completion is rejected and the result stays B's.
- `test_remote_activity_non_retryable_failure_fails_workflow` — `NonRetryableError` short-circuits retries (exactly 1 invocation); the run reaches FAILED and `GET /v1/engine/runs/{id}/result` exposes the worker-supplied `failure.error_message`.

The suite follows the existing env-gated convention (`skipif` when no server is reachable). A reachable server *without* `darklaunch.remote-demo/v1` published is a hard failure, not a skip, so a misprovisioned CI stack can't fake green.

**Implementation:**
- `engine/cmd/continua-engine/internal/darklaunch`: new `darklaunch.remote-demo/v1` definition scheduling one `execution_target='remote'` activity (`darklaunch.remote-compose-greeting`, retry policy: 3 attempts, 500ms flat backoff) and echoing the activity output as the run result. No Go handler is registered for the remote type — remote tasks are only executed by external REST workers.
- `.github/workflows/e2e.yml`: the existing e2e job now also builds `continua-engine`, runs engine migrations, seeds a project API key (same SHA-256 scheme as `scripts/seed-demo.sh`), starts the platform server with `ENGINE_PUBLIC_API_ENABLED=true`, starts `continua-engine serve` with a catalog-based readiness probe, runs the new pytest suite, and collects server/engine logs on failure.
- `sdks/python/README.md`: short local runbook for the suite (full runbook is in the test module docstring).

No contract, migration, or generated-code changes (`make generate` verified as a no-op).

## Verification

- Red-verified before implementation: all 4 tests failed against a locally provisioned stack with the definition-not-published cause.
- Green after implementation: the suite passed twice consecutively against a local stack (Postgres + `continua serve` with `ENGINE_PUBLIC_API_ENABLED=true` + `continua-engine serve`), covering the ~10s lease-expiry path both times.
- `cd engine && go build ./... && go test ./cmd/continua-engine/... ./internal/...` green; `go vet` and `gofmt -l` clean; `uv run pytest tests/test_worker.py` (worker unit tests) green; ruff clean on the new test file.
- Tests and implementation were authored by independent sessions; the committed test file is byte-identical between the red and green states (tamper-checked).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for workflows that execute activities through remote workers.
  * Added retry handling and worker failover for remote activities.
  * Added failure handling for non-retryable remote activity errors.

* **Tests**
  * Added end-to-end coverage for successful execution, retries, worker lease recovery, and failure scenarios.
  * Enhanced automated testing to start and validate both server and engine services.

* **Documentation**
  * Added Python SDK instructions for running remote activity worker integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->