### PR TITLE
feat(engine): clock-skew completion grace and documented fencing for remote lease operations

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -45,6 +45,7 @@
               "guides/workflow-code-versioning",
               "guides/engine-project-provisioning",
               "guides/embed-engine",
+              "guides/remote-activity-fencing",
               "guides/testing-workflows",
               "guides/debugging-failures",
               "guides/comparing-sessions"

--- a/docs-site/guides/installation.mdx
+++ b/docs-site/guides/installation.mdx
@@ -144,6 +144,7 @@ Engine surface (preview: see [Roadmap](/roadmap) for status):
 | --- | --- | --- |
 | `ENGINE_PUBLIC_API_ENABLED` | `false` | Expose `/v1/engine/*` endpoints. Requires `X-Continua-Engine-Preview` on requests |
 | `ENGINE_DATABASE_URL` | falls back to `DATABASE_URL` | Optional separate Postgres for the engine schema |
+| `ENGINE_LEASE_COMPLETION_GRACE` | `0` | Optional clock-skew grace for remote activity complete, fail, and retry fences only |
 | `ENGINE_PROJECTION_RETENTION_AFTER` | unset | How long to retain projection state after a run reaches terminal state |
 | `ENGINE_HISTORY_RETENTION_AFTER` | unset | Retention window for run history. Must be greater than `ENGINE_PROJECTION_RETENTION_AFTER` |
 

--- a/docs-site/guides/remote-activity-fencing.mdx
+++ b/docs-site/guides/remote-activity-fencing.mdx
@@ -1,0 +1,45 @@
+---
+title: "Remote activity fencing"
+description: "Implement remote activity workers safely with lease fencing and at-least-once execution."
+---
+
+Remote activities use leases to coordinate work across SDK workers. Their execution is
+**at least once**: a task can run again after its lease expires, including when the first
+worker is still running or its completion response is delayed.
+
+## Lease fences
+
+Each remote operation is fenced independently:
+
+| Operation | Required fence |
+| --- | --- |
+| Claim | The task is queued, or its existing lease has strictly expired. A claim records the worker as the owner and starts a new lease. |
+| Heartbeat | The task is still claimed by that worker and its lease has not expired. Completion grace never applies. |
+| Complete, fail, or retry | The task is still claimed by that worker and its lease is valid, optionally including the configured completion-grace window. |
+
+If a completion-side request loses its fence, the API returns
+`409 activity_task_conflict`. Continua discards the submitted result. The worker must
+assume the task has been or can be claimed again, so the activity may re-run.
+
+## Completion grace
+
+`ENGINE_LEASE_COMPLETION_GRACE` is an optional Go duration such as `5s`. Its default is
+`0`, which preserves strict lease-expiry behavior.
+
+Grace applies only to remote activity complete, fail, and retry fences. It does not
+extend claims or heartbeats. Only the original owner can use the grace window while the
+task remains in `claimed` status. If another worker re-claims the expired task first,
+the new `claimed_by` value wins and the stale owner's result is rejected.
+
+Use a small grace window only to tolerate expected clock skew or completion-request
+latency. It does not change the at-least-once execution model.
+
+## SDK worker guidance
+
+- Heartbeat more frequently than one third of the lease duration.
+- Treat `409 activity_task_conflict` from heartbeat, complete, or fail as a lost lease;
+  stop work when possible and discard the result locally.
+- Make activities idempotent. Use a stable activity or business-operation identifier
+  when calling external systems so a re-run does not duplicate side effects.
+- Do not rely on completion grace to keep a lease alive. Only successful heartbeats
+  extend the active lease.

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -106,6 +106,7 @@ func serveCmd() *cobra.Command {
 				MaintenancePollInterval: cfg.Runtime.MaintenancePollInterval,
 				RunLeaseTTL:             cfg.Runtime.RunLeaseTTL,
 				ActivityLeaseTTL:        cfg.Runtime.ActivityLeaseTTL,
+				LeaseCompletionGrace:    cfg.Runtime.LeaseCompletionGrace,
 			})
 			if err != nil {
 				return err
@@ -564,7 +565,7 @@ func withRuntime(
 	if err != nil {
 		return err
 	}
-	store := enginestore.New(pool)
+	store := enginestore.New(pool).WithLeaseCompletionGrace(cfg.Runtime.LeaseCompletionGrace)
 	if cfg.Runtime.ProjectIDFilter != nil {
 		store = store.WithProjectFilter(*cfg.Runtime.ProjectIDFilter)
 	}

--- a/engine/db/gen/go/activity_tasks.sql.go
+++ b/engine/db/gen/go/activity_tasks.sql.go
@@ -370,23 +370,26 @@ WHERE id = $2
   AND status = 'claimed'
   AND claimed_by = $4
   AND lease_expires_at IS NOT NULL
-  AND lease_expires_at > NOW()
+  AND lease_expires_at > NOW() - ($5::bigint * INTERVAL '1 millisecond')
 RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 type CompleteRemoteActivityTaskParams struct {
-	Output    []byte    `json:"output"`
-	ID        uuid.UUID `json:"id"`
-	ProjectID uuid.UUID `json:"project_id"`
-	ClaimedBy *string   `json:"claimed_by"`
+	Output            []byte    `json:"output"`
+	ID                uuid.UUID `json:"id"`
+	ProjectID         uuid.UUID `json:"project_id"`
+	ClaimedBy         *string   `json:"claimed_by"`
+	CompletionGraceMs int64     `json:"completion_grace_ms"`
 }
 
+// Completion-side fence only; grace never applies to claims; claimed_by + status = 'claimed' still guard re-claims.
 func (q *Queries) CompleteRemoteActivityTask(ctx context.Context, arg CompleteRemoteActivityTaskParams) (EngineActivityTask, error) {
 	row := q.db.QueryRow(ctx, completeRemoteActivityTask,
 		arg.Output,
 		arg.ID,
 		arg.ProjectID,
 		arg.ClaimedBy,
+		arg.CompletionGraceMs,
 	)
 	var i EngineActivityTask
 	err := row.Scan(
@@ -596,18 +599,20 @@ WHERE id = $3
   AND status = 'claimed'
   AND claimed_by = $5
   AND lease_expires_at IS NOT NULL
-  AND lease_expires_at > NOW()
+  AND lease_expires_at > NOW() - ($6::bigint * INTERVAL '1 millisecond')
 RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 type FailRemoteActivityTaskParams struct {
-	LastErrorCode    *string   `json:"last_error_code"`
-	LastErrorMessage *string   `json:"last_error_message"`
-	ID               uuid.UUID `json:"id"`
-	ProjectID        uuid.UUID `json:"project_id"`
-	ClaimedBy        *string   `json:"claimed_by"`
+	LastErrorCode     *string   `json:"last_error_code"`
+	LastErrorMessage  *string   `json:"last_error_message"`
+	ID                uuid.UUID `json:"id"`
+	ProjectID         uuid.UUID `json:"project_id"`
+	ClaimedBy         *string   `json:"claimed_by"`
+	CompletionGraceMs int64     `json:"completion_grace_ms"`
 }
 
+// Completion-side fence only; grace never applies to claims; claimed_by + status = 'claimed' still guard re-claims.
 func (q *Queries) FailRemoteActivityTask(ctx context.Context, arg FailRemoteActivityTaskParams) (EngineActivityTask, error) {
 	row := q.db.QueryRow(ctx, failRemoteActivityTask,
 		arg.LastErrorCode,
@@ -615,6 +620,7 @@ func (q *Queries) FailRemoteActivityTask(ctx context.Context, arg FailRemoteActi
 		arg.ID,
 		arg.ProjectID,
 		arg.ClaimedBy,
+		arg.CompletionGraceMs,
 	)
 	var i EngineActivityTask
 	err := row.Scan(
@@ -1162,19 +1168,21 @@ WHERE id = $4
   AND status = 'claimed'
   AND claimed_by = $6
   AND lease_expires_at IS NOT NULL
-  AND lease_expires_at > NOW()
+  AND lease_expires_at > NOW() - ($7::bigint * INTERVAL '1 millisecond')
 RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
 `
 
 type RetryRemoteActivityTaskParams struct {
-	RetryDelayMs     int64     `json:"retry_delay_ms"`
-	LastErrorCode    *string   `json:"last_error_code"`
-	LastErrorMessage *string   `json:"last_error_message"`
-	ID               uuid.UUID `json:"id"`
-	ProjectID        uuid.UUID `json:"project_id"`
-	ClaimedBy        *string   `json:"claimed_by"`
+	RetryDelayMs      int64     `json:"retry_delay_ms"`
+	LastErrorCode     *string   `json:"last_error_code"`
+	LastErrorMessage  *string   `json:"last_error_message"`
+	ID                uuid.UUID `json:"id"`
+	ProjectID         uuid.UUID `json:"project_id"`
+	ClaimedBy         *string   `json:"claimed_by"`
+	CompletionGraceMs int64     `json:"completion_grace_ms"`
 }
 
+// Completion-side fence only; grace never applies to claims; claimed_by + status = 'claimed' still guard re-claims.
 func (q *Queries) RetryRemoteActivityTask(ctx context.Context, arg RetryRemoteActivityTaskParams) (EngineActivityTask, error) {
 	row := q.db.QueryRow(ctx, retryRemoteActivityTask,
 		arg.RetryDelayMs,
@@ -1183,6 +1191,7 @@ func (q *Queries) RetryRemoteActivityTask(ctx context.Context, arg RetryRemoteAc
 		arg.ID,
 		arg.ProjectID,
 		arg.ClaimedBy,
+		arg.CompletionGraceMs,
 	)
 	var i EngineActivityTask
 	err := row.Scan(

--- a/engine/db/queries/activity_tasks.sql
+++ b/engine/db/queries/activity_tasks.sql
@@ -165,6 +165,7 @@ WHERE id = sqlc.arg(id)
 RETURNING *;
 
 -- name: CompleteRemoteActivityTask :one
+-- Completion-side fence only; grace never applies to claims; claimed_by + status = 'claimed' still guard re-claims.
 UPDATE engine.activity_tasks
 SET status = 'completed',
     output = sqlc.arg(output),
@@ -179,10 +180,11 @@ WHERE id = sqlc.arg(id)
   AND status = 'claimed'
   AND claimed_by = sqlc.arg(claimed_by)
   AND lease_expires_at IS NOT NULL
-  AND lease_expires_at > NOW()
+  AND lease_expires_at > NOW() - (sqlc.arg(completion_grace_ms)::bigint * INTERVAL '1 millisecond')
 RETURNING *;
 
 -- name: RetryRemoteActivityTask :one
+-- Completion-side fence only; grace never applies to claims; claimed_by + status = 'claimed' still guard re-claims.
 UPDATE engine.activity_tasks
 SET status = 'queued',
     available_at = NOW() + (sqlc.arg(retry_delay_ms)::bigint * INTERVAL '1 millisecond'),
@@ -198,10 +200,11 @@ WHERE id = sqlc.arg(id)
   AND status = 'claimed'
   AND claimed_by = sqlc.arg(claimed_by)
   AND lease_expires_at IS NOT NULL
-  AND lease_expires_at > NOW()
+  AND lease_expires_at > NOW() - (sqlc.arg(completion_grace_ms)::bigint * INTERVAL '1 millisecond')
 RETURNING *;
 
 -- name: FailRemoteActivityTask :one
+-- Completion-side fence only; grace never applies to claims; claimed_by + status = 'claimed' still guard re-claims.
 UPDATE engine.activity_tasks
 SET status = 'failed',
     last_error_code = sqlc.arg(last_error_code),
@@ -217,7 +220,7 @@ WHERE id = sqlc.arg(id)
   AND status = 'claimed'
   AND claimed_by = sqlc.arg(claimed_by)
   AND lease_expires_at IS NOT NULL
-  AND lease_expires_at > NOW()
+  AND lease_expires_at > NOW() - (sqlc.arg(completion_grace_ms)::bigint * INTERVAL '1 millisecond')
 RETURNING *;
 
 -- name: CompleteActivityTask :one

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -104,6 +104,13 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	leaseCompletionGrace, err := durationFromEnv("ENGINE_LEASE_COMPLETION_GRACE", cfg.Runtime.LeaseCompletionGrace)
+	if err != nil {
+		return nil, err
+	}
+	if leaseCompletionGrace < 0 {
+		return nil, errors.New("ENGINE_LEASE_COMPLETION_GRACE must be non-negative")
+	}
 	requestDedupeTTL, err := durationFromEnv("ENGINE_REQUEST_DEDUPE_TTL", cfg.Runtime.RequestDedupeTTL)
 	if err != nil {
 		return nil, err
@@ -118,6 +125,7 @@ func Load() (*Config, error) {
 	cfg.Runtime.MaintenancePollInterval = maintenancePollInterval
 	cfg.Runtime.RunLeaseTTL = runLeaseTTL
 	cfg.Runtime.ActivityLeaseTTL = activityLeaseTTL
+	cfg.Runtime.LeaseCompletionGrace = leaseCompletionGrace
 	cfg.Runtime.RequestDedupeTTL = requestDedupeTTL
 	cfg.Runtime.ProjectIDFilter = projectIDFilter
 	return cfg, nil

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -45,6 +45,7 @@ type RuntimeConfig struct {
 	MaintenancePollInterval time.Duration
 	RunLeaseTTL             time.Duration
 	ActivityLeaseTTL        time.Duration
+	LeaseCompletionGrace    time.Duration
 	RequestDedupeTTL        time.Duration
 	ProjectIDFilter         *uuid.UUID
 }

--- a/engine/internal/config/config_test.go
+++ b/engine/internal/config/config_test.go
@@ -85,3 +85,53 @@ func TestLoadRejectsInvalidDuration(t *testing.T) {
 		t.Fatal("expected invalid duration error")
 	}
 }
+
+func TestLoadLeaseCompletionGrace(t *testing.T) {
+	t.Run("configured duration", func(t *testing.T) {
+		t.Setenv("ENGINE_DATABASE_URL", "")
+		t.Setenv("DATABASE_URL", "postgres://placeholder")
+		t.Setenv("ENGINE_LEASE_COMPLETION_GRACE", "15s")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if cfg.Runtime.LeaseCompletionGrace != 15*time.Second {
+			t.Fatalf("LeaseCompletionGrace = %s, want 15s", cfg.Runtime.LeaseCompletionGrace)
+		}
+	})
+
+	t.Run("default is zero", func(t *testing.T) {
+		t.Setenv("ENGINE_DATABASE_URL", "")
+		t.Setenv("DATABASE_URL", "postgres://placeholder")
+		t.Setenv("ENGINE_LEASE_COMPLETION_GRACE", "")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if cfg.Runtime.LeaseCompletionGrace != 0 {
+			t.Fatalf("LeaseCompletionGrace = %s, want 0", cfg.Runtime.LeaseCompletionGrace)
+		}
+	})
+
+	t.Run("negative duration rejected", func(t *testing.T) {
+		t.Setenv("ENGINE_DATABASE_URL", "")
+		t.Setenv("DATABASE_URL", "postgres://placeholder")
+		t.Setenv("ENGINE_LEASE_COMPLETION_GRACE", "-5s")
+
+		if _, err := Load(); err == nil {
+			t.Fatal("Load() error = nil, want negative completion grace error")
+		}
+	})
+
+	t.Run("invalid duration rejected", func(t *testing.T) {
+		t.Setenv("ENGINE_DATABASE_URL", "")
+		t.Setenv("DATABASE_URL", "postgres://placeholder")
+		t.Setenv("ENGINE_LEASE_COMPLETION_GRACE", "bogus")
+
+		if _, err := Load(); err == nil {
+			t.Fatal("Load() error = nil, want invalid completion grace error")
+		}
+	})
+}

--- a/engine/internal/store/activity_tasks.go
+++ b/engine/internal/store/activity_tasks.go
@@ -144,10 +144,11 @@ func (o *storeOps) CompleteRemoteActivityTask(
 	output []byte,
 ) (enginedb.EngineActivityTask, error) {
 	task, err := o.q.CompleteRemoteActivityTask(ctx, enginedb.CompleteRemoteActivityTaskParams{
-		ID:        id,
-		ProjectID: projectID,
-		ClaimedBy: nullableWorkerID(claimedBy),
-		Output:    output,
+		ID:                id,
+		ProjectID:         projectID,
+		ClaimedBy:         nullableWorkerID(claimedBy),
+		Output:            output,
+		CompletionGraceMs: o.completionGrace.Milliseconds(),
 	})
 	if err == nil {
 		return task, nil
@@ -184,12 +185,13 @@ func (o *storeOps) RetryRemoteActivityTask(
 	errorMessage *string,
 ) (enginedb.EngineActivityTask, error) {
 	task, err := o.q.RetryRemoteActivityTask(ctx, enginedb.RetryRemoteActivityTaskParams{
-		ID:               id,
-		ProjectID:        projectID,
-		ClaimedBy:        nullableWorkerID(claimedBy),
-		RetryDelayMs:     retryDelayMS,
-		LastErrorCode:    errorCode,
-		LastErrorMessage: errorMessage,
+		ID:                id,
+		ProjectID:         projectID,
+		ClaimedBy:         nullableWorkerID(claimedBy),
+		RetryDelayMs:      retryDelayMS,
+		LastErrorCode:     errorCode,
+		LastErrorMessage:  errorMessage,
+		CompletionGraceMs: o.completionGrace.Milliseconds(),
 	})
 	if err == nil {
 		return task, nil
@@ -206,11 +208,12 @@ func (o *storeOps) FailRemoteActivityTask(
 	errorMessage *string,
 ) (enginedb.EngineActivityTask, error) {
 	task, err := o.q.FailRemoteActivityTask(ctx, enginedb.FailRemoteActivityTaskParams{
-		ID:               id,
-		ProjectID:        projectID,
-		ClaimedBy:        nullableWorkerID(claimedBy),
-		LastErrorCode:    errorCode,
-		LastErrorMessage: errorMessage,
+		ID:                id,
+		ProjectID:         projectID,
+		ClaimedBy:         nullableWorkerID(claimedBy),
+		LastErrorCode:     errorCode,
+		LastErrorMessage:  errorMessage,
+		CompletionGraceMs: o.completionGrace.Milliseconds(),
 	})
 	if err == nil {
 		return task, nil

--- a/engine/internal/store/leases_test.go
+++ b/engine/internal/store/leases_test.go
@@ -1,9 +1,12 @@
 package store
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
 	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
@@ -175,6 +178,240 @@ func TestLocalAndRemoteActivityTaskClaimIsolation(t *testing.T) {
 	}
 	if len(empty) != 0 {
 		t.Fatalf("expected unmatched remote type claim to return no tasks, got %+v", empty)
+	}
+}
+
+func TestCompleteRemoteActivityTaskWithinGraceAccepted(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	task := ts.createRemoteLeaseTestTask(t, projectID, "complete-within-grace", "email.send", 1)
+	claimed := ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType, 1)
+	ts.expireRemoteLeaseTestTask(t, task.ID)
+
+	output := []byte(`{}`)
+	completed, err := ts.store.WithLeaseCompletionGrace(30*time.Second).CompleteRemoteActivityTask(
+		ts.ctx, projectID, claimed[0].ID, "worker-a", output,
+	)
+	if err != nil {
+		t.Fatalf("CompleteRemoteActivityTask() error = %v", err)
+	}
+	if completed.Status != enginedb.EngineActivityTaskStatusCompleted {
+		t.Fatalf("completed task status = %s, want completed", completed.Status)
+	}
+	if !bytes.Equal(completed.Output, output) {
+		t.Fatalf("completed task output = %q, want %q", completed.Output, output)
+	}
+
+	persisted, err := ts.store.GetActivityTask(ts.ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask() error = %v", err)
+	}
+	if persisted.Status != enginedb.EngineActivityTaskStatusCompleted ||
+		persisted.ClaimedBy != nil || persisted.LeaseExpiresAt.Valid {
+		t.Fatalf("persisted completed task has stale lease state: %+v", persisted)
+	}
+	if !bytes.Equal(persisted.Output, output) {
+		t.Fatalf("persisted output = %q, want %q", persisted.Output, output)
+	}
+}
+
+func TestCompleteRemoteActivityTaskBeyondGraceRejected(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	task := ts.createRemoteLeaseTestTask(t, projectID, "complete-beyond-grace", "email.send", 1)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType, 1)
+	ts.expireRemoteLeaseTestTask(t, task.ID)
+
+	_, err := ts.store.WithLeaseCompletionGrace(5*time.Second).CompleteRemoteActivityTask(
+		ts.ctx, projectID, task.ID, "worker-a", []byte(`{"late":true}`),
+	)
+	if !errors.Is(err, ErrStaleClaim) {
+		t.Fatalf("grace completion error = %v, want ErrStaleClaim", err)
+	}
+	_, err = ts.store.CompleteRemoteActivityTask(
+		ts.ctx, projectID, task.ID, "worker-a", []byte(`{"late":true}`),
+	)
+	if !errors.Is(err, ErrStaleClaim) {
+		t.Fatalf("zero-grace completion error = %v, want ErrStaleClaim", err)
+	}
+
+	persisted, err := ts.store.GetActivityTask(ts.ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask() error = %v", err)
+	}
+	if persisted.Status != enginedb.EngineActivityTaskStatusClaimed ||
+		persisted.ClaimedBy == nil || *persisted.ClaimedBy != "worker-a" || !persisted.LeaseExpiresAt.Valid {
+		t.Fatalf("rejected completion changed task row: %+v", persisted)
+	}
+}
+
+func TestRemoteActivityTaskReclaimRejectsStaleOwnerDespiteGrace(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	task := ts.createRemoteLeaseTestTask(t, projectID, "reclaimed-task", "email.send", 2)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType, 1)
+	ts.expireRemoteLeaseTestTask(t, task.ID)
+
+	reclaimed := ts.claimRemoteLeaseTestTasks(t, projectID, "worker-b", task.ActivityType, 1)
+	if reclaimed[0].ID != task.ID || reclaimed[0].AttemptCount != 2 ||
+		reclaimed[0].ClaimedBy == nil || *reclaimed[0].ClaimedBy != "worker-b" {
+		t.Fatalf("worker-b reclaim = %+v, want task %s at attempt 2", reclaimed[0], task.ID)
+	}
+
+	_, err := ts.store.WithLeaseCompletionGrace(30*time.Second).CompleteRemoteActivityTask(
+		ts.ctx, projectID, task.ID, "worker-a", []byte(`{"owner":"worker-a"}`),
+	)
+	if !errors.Is(err, ErrStaleClaim) {
+		t.Fatalf("stale owner completion error = %v, want ErrStaleClaim", err)
+	}
+	persisted, err := ts.store.GetActivityTask(ts.ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask() error = %v", err)
+	}
+	if persisted.Status != enginedb.EngineActivityTaskStatusClaimed ||
+		persisted.ClaimedBy == nil || *persisted.ClaimedBy != "worker-b" {
+		t.Fatalf("stale owner changed reclaimed task: %+v", persisted)
+	}
+
+	completed, err := ts.store.CompleteRemoteActivityTask(
+		ts.ctx, projectID, task.ID, "worker-b", []byte(`{"owner":"worker-b"}`),
+	)
+	if err != nil {
+		t.Fatalf("current owner CompleteRemoteActivityTask() error = %v", err)
+	}
+	if completed.Status != enginedb.EngineActivityTaskStatusCompleted {
+		t.Fatalf("current owner completion status = %s, want completed", completed.Status)
+	}
+}
+
+func TestRetryAndFailRemoteActivityTaskWithinGraceAccepted(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	failTask := ts.createRemoteLeaseTestTask(t, projectID, "fail-within-grace", "email.fail", 1)
+	retryTask := ts.createRemoteLeaseTestTask(t, projectID, "retry-within-grace", "email.retry", 2)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", failTask.ActivityType, 1)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", retryTask.ActivityType, 1)
+	ts.expireRemoteLeaseTestTask(t, failTask.ID)
+	ts.expireRemoteLeaseTestTask(t, retryTask.ID)
+
+	code := "remote_error"
+	message := "remote activity failed"
+	graceStore := ts.store.WithLeaseCompletionGrace(30 * time.Second)
+	failed, err := graceStore.FailRemoteActivityTask(
+		ts.ctx, projectID, failTask.ID, "worker-a", &code, &message,
+	)
+	if err != nil {
+		t.Fatalf("FailRemoteActivityTask() error = %v", err)
+	}
+	if failed.Status != enginedb.EngineActivityTaskStatusFailed || failed.LastErrorCode == nil ||
+		*failed.LastErrorCode != code || failed.LastErrorMessage == nil || *failed.LastErrorMessage != message {
+		t.Fatalf("failed task = %+v, want failed status and persisted error", failed)
+	}
+
+	retryStartedAt := time.Now()
+	retried, err := graceStore.RetryRemoteActivityTask(
+		ts.ctx, projectID, retryTask.ID, "worker-a", 1000, &code, &message,
+	)
+	if err != nil {
+		t.Fatalf("RetryRemoteActivityTask() error = %v", err)
+	}
+	if retried.Status != enginedb.EngineActivityTaskStatusQueued || retried.ClaimedBy != nil ||
+		!retried.AvailableAt.After(retryStartedAt) {
+		t.Fatalf("retried task = %+v, want unclaimed queued task available in future", retried)
+	}
+
+	persistedFailed, err := ts.store.GetActivityTask(ts.ctx, failTask.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask(failed) error = %v", err)
+	}
+	if persistedFailed.Status != enginedb.EngineActivityTaskStatusFailed ||
+		persistedFailed.LastErrorCode == nil || *persistedFailed.LastErrorCode != code ||
+		persistedFailed.LastErrorMessage == nil || *persistedFailed.LastErrorMessage != message {
+		t.Fatalf("persisted failed task = %+v", persistedFailed)
+	}
+	persistedRetried, err := ts.store.GetActivityTask(ts.ctx, retryTask.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask(retried) error = %v", err)
+	}
+	if persistedRetried.Status != enginedb.EngineActivityTaskStatusQueued ||
+		persistedRetried.ClaimedBy != nil || persistedRetried.LeaseExpiresAt.Valid ||
+		!persistedRetried.AvailableAt.After(retryStartedAt) {
+		t.Fatalf("persisted retried task = %+v", persistedRetried)
+	}
+}
+
+func TestHeartbeatRemoteActivityTaskIgnoresCompletionGrace(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	task := ts.createRemoteLeaseTestTask(t, projectID, "heartbeat-strict", "email.send", 1)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType, 1)
+	ts.expireRemoteLeaseTestTask(t, task.ID)
+
+	_, err := ts.store.WithLeaseCompletionGrace(30*time.Second).HeartbeatRemoteActivityTask(
+		ts.ctx, projectID, task.ID, "worker-a",
+	)
+	if !errors.Is(err, ErrStaleClaim) {
+		t.Fatalf("HeartbeatRemoteActivityTask() error = %v, want ErrStaleClaim", err)
+	}
+}
+
+func (ts *testStore) createRemoteLeaseTestTask(
+	t *testing.T,
+	projectID uuid.UUID,
+	activityKey string,
+	activityType string,
+	maxAttempts int32,
+) enginedb.EngineActivityTask {
+	t.Helper()
+	instance := ts.createInstance(t, projectID, "instance-"+activityKey)
+	run := ts.createRun(t, instance, 1)
+	history := ts.createHistory(t, projectID, instance.ID, run.ID, 1, "activity.scheduled")
+	task, err := ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &history.ID,
+		ActivityKey:     activityKey,
+		ActivityType:    activityType,
+		Input:           []byte(`{"source":"lease-test"}`),
+		AvailableAt:     time.Now().Add(-time.Minute),
+		ExecutionTarget: "remote",
+		MaxAttempts:     maxAttempts,
+	})
+	if err != nil {
+		t.Fatalf("CreateActivityTask() error = %v", err)
+	}
+	return task
+}
+
+func (ts *testStore) claimRemoteLeaseTestTasks(
+	t *testing.T,
+	projectID uuid.UUID,
+	workerID string,
+	activityType string,
+	maxTasks int32,
+) []enginedb.EngineActivityTask {
+	t.Helper()
+	tasks, err := ts.store.ClaimRemoteActivityTasks(
+		ts.ctx, projectID, workerID, []string{activityType}, maxTasks, time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("ClaimRemoteActivityTasks() error = %v", err)
+	}
+	if len(tasks) != int(maxTasks) {
+		t.Fatalf("ClaimRemoteActivityTasks() returned %d tasks, want %d", len(tasks), maxTasks)
+	}
+	return tasks
+}
+
+func (ts *testStore) expireRemoteLeaseTestTask(t *testing.T, taskID uuid.UUID) {
+	t.Helper()
+	if _, err := ts.db.Pool.Exec(ts.ctx, `
+		UPDATE engine.activity_tasks
+		SET lease_expires_at = NOW() - INTERVAL '10 seconds'
+		WHERE id = $1
+	`, taskID); err != nil {
+		t.Fatalf("expire remote activity lease: %v", err)
 	}
 }
 

--- a/engine/internal/store/leases_test.go
+++ b/engine/internal/store/leases_test.go
@@ -185,7 +185,7 @@ func TestCompleteRemoteActivityTaskWithinGraceAccepted(t *testing.T) {
 	ts := newTestStore(t)
 	projectID := uuidOrFatal(t)
 	task := ts.createRemoteLeaseTestTask(t, projectID, "complete-within-grace", "email.send", 1)
-	claimed := ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType, 1)
+	claimed := ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType)
 	ts.expireRemoteLeaseTestTask(t, task.ID)
 
 	output := []byte(`{}`)
@@ -219,7 +219,7 @@ func TestCompleteRemoteActivityTaskBeyondGraceRejected(t *testing.T) {
 	ts := newTestStore(t)
 	projectID := uuidOrFatal(t)
 	task := ts.createRemoteLeaseTestTask(t, projectID, "complete-beyond-grace", "email.send", 1)
-	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType, 1)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType)
 	ts.expireRemoteLeaseTestTask(t, task.ID)
 
 	_, err := ts.store.WithLeaseCompletionGrace(5*time.Second).CompleteRemoteActivityTask(
@@ -249,10 +249,10 @@ func TestRemoteActivityTaskReclaimRejectsStaleOwnerDespiteGrace(t *testing.T) {
 	ts := newTestStore(t)
 	projectID := uuidOrFatal(t)
 	task := ts.createRemoteLeaseTestTask(t, projectID, "reclaimed-task", "email.send", 2)
-	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType, 1)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType)
 	ts.expireRemoteLeaseTestTask(t, task.ID)
 
-	reclaimed := ts.claimRemoteLeaseTestTasks(t, projectID, "worker-b", task.ActivityType, 1)
+	reclaimed := ts.claimRemoteLeaseTestTasks(t, projectID, "worker-b", task.ActivityType)
 	if reclaimed[0].ID != task.ID || reclaimed[0].AttemptCount != 2 ||
 		reclaimed[0].ClaimedBy == nil || *reclaimed[0].ClaimedBy != "worker-b" {
 		t.Fatalf("worker-b reclaim = %+v, want task %s at attempt 2", reclaimed[0], task.ID)
@@ -289,8 +289,8 @@ func TestRetryAndFailRemoteActivityTaskWithinGraceAccepted(t *testing.T) {
 	projectID := uuidOrFatal(t)
 	failTask := ts.createRemoteLeaseTestTask(t, projectID, "fail-within-grace", "email.fail", 1)
 	retryTask := ts.createRemoteLeaseTestTask(t, projectID, "retry-within-grace", "email.retry", 2)
-	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", failTask.ActivityType, 1)
-	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", retryTask.ActivityType, 1)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", failTask.ActivityType)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", retryTask.ActivityType)
 	ts.expireRemoteLeaseTestTask(t, failTask.ID)
 	ts.expireRemoteLeaseTestTask(t, retryTask.ID)
 
@@ -344,7 +344,7 @@ func TestHeartbeatRemoteActivityTaskIgnoresCompletionGrace(t *testing.T) {
 	ts := newTestStore(t)
 	projectID := uuidOrFatal(t)
 	task := ts.createRemoteLeaseTestTask(t, projectID, "heartbeat-strict", "email.send", 1)
-	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType, 1)
+	ts.claimRemoteLeaseTestTasks(t, projectID, "worker-a", task.ActivityType)
 	ts.expireRemoteLeaseTestTask(t, task.ID)
 
 	_, err := ts.store.WithLeaseCompletionGrace(30*time.Second).HeartbeatRemoteActivityTask(
@@ -389,9 +389,9 @@ func (ts *testStore) claimRemoteLeaseTestTasks(
 	projectID uuid.UUID,
 	workerID string,
 	activityType string,
-	maxTasks int32,
 ) []enginedb.EngineActivityTask {
 	t.Helper()
+	const maxTasks int32 = 1
 	tasks, err := ts.store.ClaimRemoteActivityTasks(
 		ts.ctx, projectID, workerID, []string{activityType}, maxTasks, time.Minute,
 	)

--- a/engine/internal/store/store.go
+++ b/engine/internal/store/store.go
@@ -26,8 +26,9 @@ var (
 )
 
 type storeOps struct {
-	q             *enginedb.Queries
-	projectFilter *uuid.UUID
+	q               *enginedb.Queries
+	projectFilter   *uuid.UUID
+	completionGrace time.Duration
 }
 
 // Store provides engine database access backed by a dedicated pgx pool.
@@ -59,8 +60,23 @@ func (s *Store) WithProjectFilter(projectID uuid.UUID) *Store {
 	return &Store{
 		pool: s.pool,
 		storeOps: &storeOps{
-			q:             s.q,
-			projectFilter: &filter,
+			q:               s.q,
+			projectFilter:   &filter,
+			completionGrace: s.completionGrace,
+		},
+	}
+}
+
+func (s *Store) WithLeaseCompletionGrace(d time.Duration) *Store {
+	if s == nil {
+		return nil
+	}
+	return &Store{
+		pool: s.pool,
+		storeOps: &storeOps{
+			q:               s.q,
+			projectFilter:   s.projectFilter,
+			completionGrace: d,
 		},
 	}
 }
@@ -129,8 +145,9 @@ func (s *Store) BeginTx(ctx context.Context, opts pgx.TxOptions) (*Tx, error) {
 	return &Tx{
 		tx: tx,
 		storeOps: &storeOps{
-			q:             s.q.WithTx(tx),
-			projectFilter: s.projectFilter,
+			q:               s.q.WithTx(tx),
+			projectFilter:   s.projectFilter,
+			completionGrace: s.completionGrace,
 		},
 	}, nil
 }

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -43,6 +43,9 @@ type Options struct {
 	MaintenancePollInterval time.Duration
 	RunLeaseTTL             time.Duration
 	ActivityLeaseTTL        time.Duration
+	// LeaseCompletionGrace allows the current remote activity owner to complete,
+	// fail, or retry briefly after lease expiry. It does not extend claims or heartbeats.
+	LeaseCompletionGrace time.Duration
 }
 
 // Runtime is an embedded engine instance built from Options.
@@ -96,7 +99,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	store := enginestore.New(pool)
+	store := enginestore.New(pool).WithLeaseCompletionGrace(cfg.Runtime.LeaseCompletionGrace)
 	defer func() {
 		store.Close()
 	}()
@@ -157,6 +160,9 @@ func applyRuntimeOverrides(cfg *config.Config, opts *Options) {
 	}
 	if opts.ActivityLeaseTTL != 0 {
 		cfg.Runtime.ActivityLeaseTTL = opts.ActivityLeaseTTL
+	}
+	if opts.LeaseCompletionGrace != 0 {
+		cfg.Runtime.LeaseCompletionGrace = opts.LeaseCompletionGrace
 	}
 	cfg.Runtime.ProjectIDFilter = opts.ProjectID
 }

--- a/internal/api/engine_activities.go
+++ b/internal/api/engine_activities.go
@@ -251,10 +251,11 @@ func (s *engineControlService) CompleteRemoteActivityTask(
 
 	engineTx := enginedb.New(tx.Tx())
 	task, err := engineTx.CompleteRemoteActivityTask(ctx, enginedb.CompleteRemoteActivityTaskParams{
-		ID:        taskID,
-		ProjectID: projectID,
-		ClaimedBy: &workerID,
-		Output:    output,
+		ID:                taskID,
+		ProjectID:         projectID,
+		ClaimedBy:         &workerID,
+		Output:            output,
+		CompletionGraceMs: s.completionGrace.Milliseconds(),
 	})
 	if err != nil {
 		return classifyRemoteActivityOwnershipMiss(ctx, engineTx, projectID, taskID, err)
@@ -286,12 +287,12 @@ func (s *engineControlService) FailRemoteActivityTask(
 	if err != nil {
 		return classifyRemoteActivityOwnershipMiss(ctx, engineTx, projectID, taskID, err)
 	}
-	if !remoteActivityTaskOwnedByWorker(&task, req.WorkerID, time.Now()) {
+	if !remoteActivityTaskOwnedByWorker(&task, req.WorkerID, time.Now(), s.completionGrace) {
 		return remoteActivityOwnershipConflict()
 	}
 
 	if !req.NonRetryable && task.AttemptCount < task.MaxAttempts {
-		retried, retryErr := retryRemoteActivityTask(ctx, engineTx, projectID, &task, req)
+		retried, retryErr := retryRemoteActivityTask(ctx, engineTx, projectID, &task, req, s.completionGrace)
 		if retryErr != nil {
 			return retryErr
 		}
@@ -321,11 +322,12 @@ func (s *engineControlService) FailRemoteActivityTask(
 	}
 
 	failed, err := engineTx.FailRemoteActivityTask(ctx, enginedb.FailRemoteActivityTaskParams{
-		ID:               task.ID,
-		ProjectID:        projectID,
-		ClaimedBy:        &req.WorkerID,
-		LastErrorCode:    &req.ErrorCode,
-		LastErrorMessage: &req.ErrorMessage,
+		ID:                task.ID,
+		ProjectID:         projectID,
+		ClaimedBy:         &req.WorkerID,
+		LastErrorCode:     &req.ErrorCode,
+		LastErrorMessage:  &req.ErrorMessage,
+		CompletionGraceMs: s.completionGrace.Milliseconds(),
 	})
 	if err != nil {
 		return classifyRemoteActivityOwnershipMiss(ctx, engineTx, projectID, taskID, err)
@@ -507,7 +509,12 @@ func truncateRunes(value string, maxLength int) string {
 	return string(runes[:maxLength])
 }
 
-func remoteActivityTaskOwnedByWorker(task *enginedb.EngineActivityTask, workerID string, now time.Time) bool {
+func remoteActivityTaskOwnedByWorker(
+	task *enginedb.EngineActivityTask,
+	workerID string,
+	now time.Time,
+	completionGrace time.Duration,
+) bool {
 	if task == nil || task.ExecutionTarget != publicworkflow.ActivityExecutionTargetRemote {
 		return false
 	}
@@ -517,7 +524,7 @@ func remoteActivityTaskOwnedByWorker(task *enginedb.EngineActivityTask, workerID
 	if task.ClaimedBy == nil || *task.ClaimedBy != workerID {
 		return false
 	}
-	return task.LeaseExpiresAt.Valid && task.LeaseExpiresAt.Time.After(now)
+	return task.LeaseExpiresAt.Valid && task.LeaseExpiresAt.Time.Add(completionGrace).After(now)
 }
 
 func retryRemoteActivityTask(
@@ -526,6 +533,7 @@ func retryRemoteActivityTask(
 	projectID uuid.UUID,
 	task *enginedb.EngineActivityTask,
 	req remoteActivityFailRequest,
+	completionGrace time.Duration,
 ) (enginedb.EngineActivityTask, error) {
 	if task == nil {
 		return enginedb.EngineActivityTask{}, errors.New("remote activity task is required")
@@ -541,12 +549,13 @@ func retryRemoteActivityTask(
 	}
 
 	retried, err := engineTx.RetryRemoteActivityTask(ctx, enginedb.RetryRemoteActivityTaskParams{
-		ID:               task.ID,
-		ProjectID:        projectID,
-		ClaimedBy:        &req.WorkerID,
-		RetryDelayMs:     retryDelayMS,
-		LastErrorCode:    &req.ErrorCode,
-		LastErrorMessage: &req.ErrorMessage,
+		ID:                task.ID,
+		ProjectID:         projectID,
+		ClaimedBy:         &req.WorkerID,
+		RetryDelayMs:      retryDelayMS,
+		LastErrorCode:     &req.ErrorCode,
+		LastErrorMessage:  &req.ErrorMessage,
+		CompletionGraceMs: completionGrace.Milliseconds(),
 	})
 	if err != nil {
 		return enginedb.EngineActivityTask{}, classifyRemoteActivityOwnershipMiss(ctx, engineTx, projectID, task.ID, err)

--- a/internal/api/engine_activities_test.go
+++ b/internal/api/engine_activities_test.go
@@ -328,6 +328,55 @@ func TestRemoteActivityCompleteAndDuplicateConflict(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, missingCompleteRec.Code)
 }
 
+func TestCompleteRemoteActivityTaskHonorsCompletionGrace(t *testing.T) {
+	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
+
+	createExpiredClaim := func(activityKey string) remoteActivityTestTask {
+		t.Helper()
+		fixture := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{
+			ProjectID:       projectID,
+			ActivityKey:     activityKey,
+			ActivityType:    "email." + activityKey,
+			ExecutionTarget: "remote",
+			AvailableAt:     time.Now().Add(-time.Minute),
+			MaxAttempts:     1,
+			Waiting:         true,
+		})
+		claimRemoteActivityForTest(t, server, projectID, "worker-a", fixture.Task.ActivityType)
+		_, err := platformStore.Pool().Exec(ctx, `
+			UPDATE engine.activity_tasks
+			SET lease_expires_at = NOW() - INTERVAL '10 seconds'
+			WHERE id = $1
+		`, fixture.Task.ID)
+		require.NoError(t, err)
+		return fixture
+	}
+
+	withinGrace := createExpiredClaim("complete-with-grace")
+	server.engineControl.completionGrace = 30 * time.Second
+	graceRec := invokeCompleteRemoteActivityTask(t, server, projectID, withinGrace.Task.ID, EngineRemoteActivityCompleteRequest{
+		WorkerId: "worker-a",
+		Output:   map[string]any{"grace": true},
+	})
+	require.Equal(t, http.StatusNoContent, graceRec.Code)
+	completed, err := engineQueries.GetActivityTask(ctx, withinGrace.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineActivityTaskStatusCompleted, completed.Status)
+
+	zeroGrace := createExpiredClaim("complete-without-grace")
+	server.engineControl.completionGrace = 0
+	zeroGraceRec := invokeCompleteRemoteActivityTask(t, server, projectID, zeroGrace.Task.ID, EngineRemoteActivityCompleteRequest{
+		WorkerId: "worker-a",
+		Output:   map[string]any{"grace": false},
+	})
+	require.Equal(t, http.StatusConflict, zeroGraceRec.Code)
+	unchanged, err := engineQueries.GetActivityTask(ctx, zeroGrace.Task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, enginedb.EngineActivityTaskStatusClaimed, unchanged.Status)
+	require.NotNil(t, unchanged.ClaimedBy)
+	assert.Equal(t, "worker-a", *unchanged.ClaimedBy)
+}
+
 func TestRemoteActivityFailRetryAndNonRetryable(t *testing.T) {
 	ctx, platformStore, engineQueries, server, projectID := setupEngineHandlerTest(t)
 	retryFixture := createRemoteActivityTestTask(t, ctx, platformStore, engineQueries, createRemoteActivityTestTaskParams{

--- a/internal/api/engine_control.go
+++ b/internal/api/engine_control.go
@@ -30,8 +30,9 @@ const (
 )
 
 type engineControlService struct {
-	platform *store.Store
-	engine   *enginedb.Queries
+	platform        *store.Store
+	engine          *enginedb.Queries
+	completionGrace time.Duration
 }
 
 type engineStartRunRequest struct {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -45,6 +45,7 @@ func newConfiguredServer(
 	server.engineSharedControl = shared
 	if cfg != nil {
 		server.enginePublicAPIEnabled = cfg.Engine.PublicAPIEnabled
+		server.engineControl.completionGrace = cfg.Engine.LeaseCompletionGrace
 		server.auth0Config = cfg.Auth0
 		server.publicDemoConfig = cfg.PublicDemo
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type EngineConfig struct {
 	PublicAPIEnabled         bool
 	ProjectionRetentionAfter time.Duration
 	HistoryRetentionAfter    time.Duration
+	LeaseCompletionGrace     time.Duration
 }
 
 // Auth0Config holds hosted operator authentication settings.
@@ -110,6 +111,10 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 	engineHistoryRetentionAfter, err := loadOptionalDuration("ENGINE_HISTORY_RETENTION_AFTER")
+	if err != nil {
+		return nil, err
+	}
+	engineLeaseCompletionGrace, err := loadDuration("ENGINE_LEASE_COMPLETION_GRACE", 0)
 	if err != nil {
 		return nil, err
 	}
@@ -173,6 +178,7 @@ func Load() (*Config, error) {
 			PublicAPIEnabled:         enginePublicAPIEnabled,
 			ProjectionRetentionAfter: engineProjectionRetentionAfter,
 			HistoryRetentionAfter:    engineHistoryRetentionAfter,
+			LeaseCompletionGrace:     engineLeaseCompletionGrace,
 		},
 		Jobs: JobsConfig{
 			IngestWorkers:      ingestWorkers,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,38 @@ func TestLoad_RejectsUnparseableRetentionDuration(t *testing.T) {
 	assert.Contains(t, err.Error(), "ENGINE_PROJECTION_RETENTION_AFTER")
 }
 
+func TestLoad_LeaseCompletionGrace(t *testing.T) {
+	t.Run("configured duration", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://example")
+		t.Setenv("ENGINE_LEASE_COMPLETION_GRACE", "15s")
+
+		cfg, err := config.Load()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, 15*time.Second, cfg.Engine.LeaseCompletionGrace)
+	})
+
+	t.Run("default is zero", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://example")
+		t.Setenv("ENGINE_LEASE_COMPLETION_GRACE", "")
+
+		cfg, err := config.Load()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Zero(t, cfg.Engine.LeaseCompletionGrace)
+	})
+
+	t.Run("negative duration rejected", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://example")
+		t.Setenv("ENGINE_LEASE_COMPLETION_GRACE", "-5s")
+
+		cfg, err := config.Load()
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "ENGINE_LEASE_COMPLETION_GRACE")
+	})
+}
+
 func TestLoad_RejectsPartialAuth0Configuration(t *testing.T) {
 	t.Setenv("DATABASE_URL", "postgres://example")
 	t.Setenv("AUTH0_DOMAIN", "continua.us.auth0.com")


### PR DESCRIPTION
Closes #166

## What / why

All remote-activity fencing queries (complete / fail / retry) required
`lease_expires_at > NOW()` with zero tolerance, so a worker finishing exactly at the
lease boundary — or with modest client/DB clock skew — got a stale-claim rejection: the
completed result was discarded and the task re-executed. The at-least-once semantics were
also undocumented for SDK implementers.

This PR adds an optional, configurable completion grace window and documents the
worker-protocol fencing semantics:

- `ENGINE_LEASE_COMPLETION_GRACE` (Go duration, default `0` = exact current behavior),
  validated non-negative, parsed by both the engine runtime config and the platform
  server config.
- The grace applies **only** to the completion-side fences of
  `CompleteRemoteActivityTask`, `RetryRemoteActivityTask`, and `FailRemoteActivityTask`
  (`lease_expires_at > NOW() - grace`). Claim queries and heartbeats keep strict
  fencing.
- Safety is unchanged: `claimed_by` + `status = 'claimed'` still guard every fence, and a
  re-claim by another worker overwrites `claimed_by` — so a late completion can only land
  if nobody re-claimed the task. A stale owner is rejected even inside the grace window.
- The Go-side ownership check in the REST fail/retry path
  (`remoteActivityTaskOwnedByWorker`) honors the same grace.
- New docs page `docs-site/guides/remote-activity-fencing.mdx` describes the
  at-least-once model, the per-operation fence table, 409 conflict semantics, the grace
  window, and SDK-implementer guidance; `installation.mdx` gains the env var row.

## Implementation outline

1. `engine/db/queries/activity_tasks.sql`: grace arg on the three completion-side
   fences only, with comments stating the invariant; `make generate` (sqlc) regenerated
   `engine/db/gen/go`.
2. `engine/internal/config`: `Runtime.LeaseCompletionGrace` from
   `ENGINE_LEASE_COMPLETION_GRACE`, negative values rejected.
3. `engine/internal/store`: `WithLeaseCompletionGrace` store option; the three remote
   wrappers pass the grace; propagated through `WithProjectFilter`/`BeginTx`.
4. Engine wiring: `engine/pkg/runtime` (new `Options.LeaseCompletionGrace`) and
   `continua-engine` CLI both apply the configured grace to the store.
5. Platform wiring: `internal/config` `EngineConfig.LeaseCompletionGrace` ->
   `newConfiguredServer` -> `engineControlService`; REST complete/fail/retry paths pass
   the grace into the fenced queries and the ownership check.

## Tests (written first, committed red, then implemented green)

- `engine/internal/store/leases_test.go`: boundary completion accepted within grace;
  rejected beyond grace and at zero grace; **rejected when re-claimed by another worker
  despite grace** (and the new owner can still complete); fail/retry accepted within
  grace with persisted state assertions; heartbeat stays strict under grace.
- `engine/internal/config/config_test.go` and `internal/config/config_test.go`: env
  parsing, zero default, negative and malformed values rejected.
- `internal/api/engine_activities_test.go`: REST complete returns 204 within grace and
  409 at zero grace on an expired lease.

Verification: `go test ./engine/internal/store/... ./engine/internal/config/...
./internal/api/...` green on real Postgres; `make generate` produces no further diff;
acceptance tests unchanged since their red commit (531efbd).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable completion grace for remote activity leases.
  * Workers may complete, fail, or retry shortly after lease expiry when grace is enabled.
  * Claims and heartbeats continue to enforce strict lease expiration.
  * Added documentation covering lease fencing, conflicts, and at-least-once execution.

* **Documentation**
  * Added the remote activity fencing guide to the Guides navigation.
  * Documented the optional `ENGINE_LEASE_COMPLETION_GRACE` setting, which defaults to `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->