### PR TITLE
feat(engine): Go-workflow + Python-activities example, tutorial, and e2e coverage

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -46,6 +46,7 @@
               "guides/workflow-code-versioning",
               "guides/engine-project-provisioning",
               "guides/embed-engine",
+              "guides/go-workflows-python-activities",
               "guides/remote-activity-fencing",
               "guides/testing-workflows",
               "guides/debugging-failures",

--- a/docs-site/guides/go-workflows-python-activities.mdx
+++ b/docs-site/guides/go-workflows-python-activities.mdx
@@ -107,18 +107,53 @@ def build_worker(*, api_key: str, endpoint: str) -> ActivityWorker:
 
 ## 4. Start a run
 
-Create a unique instance and request key for the run:
+Use the Python control client to start the runtime-published workflow in the provisioned
+project:
 
-```bash
-continua-engine start \
-  --instance-key remote-greeter-ada \
-  --request-key remote-greeter-ada \
-  --definition examples.remote-greeter \
-  --version v1 \
-  --input '{"name":"Ada"}'
+```python
+import os
+import uuid
+
+from continua import EngineControlClient
+
+run_key = f"remote-greeter-ada-{uuid.uuid4()}"
+client = EngineControlClient(
+    api_key=os.environ["CONTINUA_API_KEY"],
+    endpoint=os.environ["CONTINUA_ENDPOINT"],
+)
+try:
+    started = client.start(
+        {
+            "definition_name": "examples.remote-greeter",
+            "definition_version": "v1",
+            "instance_key": run_key,
+            "request_key": run_key,
+            "input": {"name": "Ada"},
+        }
+    )
+    print(started.run_id)
+finally:
+    client.close()
 ```
 
-The preview `POST /v1/engine/runs` endpoint is the REST alternative for starting a run.
+The equivalent raw preview API request is:
+
+```bash
+curl -X POST "${CONTINUA_ENDPOINT}/v1/engine/runs" \
+  -H "X-API-Key: ${CONTINUA_API_KEY}" \
+  -H "X-Continua-Engine-Preview: 1" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "definition_name": "examples.remote-greeter",
+    "definition_version": "v1",
+    "instance_key": "remote-greeter-ada-curl",
+    "request_key": "remote-greeter-ada-curl",
+    "input": {"name": "Ada"}
+  }'
+```
+
+`continua-engine start` currently resolves only the built-in dark-launch definitions on
+its fixed demo project, so it cannot start this custom example.
 
 ## 5. Observe the result
 

--- a/docs-site/guides/go-workflows-python-activities.mdx
+++ b/docs-site/guides/go-workflows-python-activities.mdx
@@ -1,0 +1,131 @@
+---
+title: "Go workflows with Python activities"
+description: "Orchestrate durable workflows in Go and execute their remote activities in Python."
+---
+
+Use a Go workflow for durable orchestration and a Python worker for the activity code.
+The workflow schedules work through the preview engine REST control plane; the Python
+worker claims and completes that work remotely. This is Continua's flagship path for
+durable AI-agent orchestration with Python tools and model calls.
+
+<Warning>
+  The durable engine and its `/v1/engine/*` REST control plane are still preview. Workflow
+  authoring remains Go-only; Python workers execute registered remote activities.
+</Warning>
+
+## Prerequisites
+
+- Postgres with `DATABASE_URL` set for both Continua runtimes.
+- `continua serve` running with `ENGINE_PUBLIC_API_ENABLED=true`.
+- A provisioned project and API key. See [Engine project provisioning](/guides/engine-project-provisioning).
+- Engine migrations applied with `continua-engine migrate up`.
+
+## 1. Define the Go workflow
+
+The workflow in
+[`engine/examples/remote-greeter/main.go`](https://github.com/aryanVijaywargia/Continua/blob/main/engine/examples/remote-greeter/main.go)
+marks the activity for remote execution and gives transient failures three attempts:
+
+```go
+func runRemoteGreeterWorkflow(ctx workflow.Context) error {
+	var input remoteGreeterInput
+	if err := ctx.Input(&input); err != nil {
+		return err
+	}
+	if input.Name == "" {
+		input.Name = "world"
+	}
+
+	var output remoteGreeterOutput
+	if err := ctx.ActivityWithOptions(
+		"compose-greeting",
+		composeGreetingActivityType,
+		input,
+		&output,
+		workflow.ActivityOptions{
+			ExecutionTarget: workflow.ActivityExecutionTargetRemote,
+			RetryPolicy: &workflow.RetryPolicy{
+				MaxAttempts:       3,
+				InitialBackoff:    500 * time.Millisecond,
+				MaxBackoff:        5 * time.Second,
+				BackoffMultiplier: 2.0,
+			},
+		},
+	); err != nil {
+		return err
+	}
+
+	return ctx.SetResult(output)
+}
+```
+
+There is deliberately no local handler for `examples.compose-greeting`; a Python worker
+will claim that activity.
+
+## 2. Run the Go worker
+
+From the `engine/` directory, point the worker at Postgres and optionally scope it to the
+provisioned project:
+
+```bash
+export DATABASE_URL="postgres://continua:continua@localhost:5432/continua?sslmode=disable"
+export ENGINE_PROJECT_ID="<project-id>"
+go run ./examples/remote-greeter
+```
+
+For an application-owned worker process, [embed the engine](/guides/embed-engine) and
+register the same definition.
+
+## 3. Run the Python activity worker
+
+Install the Python SDK, then configure the platform endpoint and project API key:
+
+```bash
+pip install continua-sdk
+export CONTINUA_ENDPOINT="http://localhost:8080"
+export CONTINUA_API_KEY="<project-api-key>"
+python sdks/python/examples/remote_greeting_worker.py
+```
+
+The runnable
+[`sdks/python/examples/remote_greeting_worker.py`](https://github.com/aryanVijaywargia/Continua/blob/main/sdks/python/examples/remote_greeting_worker.py)
+registers the same activity type used by the Go workflow:
+
+```python
+def compose_greeting(input: dict[str, object]) -> dict[str, str]:
+    """Compose the greeting returned to the Go workflow."""
+    name = input.get("name") or "world"
+    return {"greeting": f"hello, {name}"}
+
+
+def build_worker(*, api_key: str, endpoint: str) -> ActivityWorker:
+    """Build a worker registered for the remote greeter activity."""
+    worker = ActivityWorker(api_key=api_key, endpoint=endpoint)
+    worker.register("examples.compose-greeting", compose_greeting)
+    return worker
+```
+
+## 4. Start a run
+
+Create a unique instance and request key for the run:
+
+```bash
+continua-engine start \
+  --instance-key remote-greeter-ada \
+  --request-key remote-greeter-ada \
+  --definition examples.remote-greeter \
+  --version v1 \
+  --input '{"name":"Ada"}'
+```
+
+The preview `POST /v1/engine/runs` endpoint is the REST alternative for starting a run.
+
+## 5. Observe the result
+
+Open the debugger's [Engine runs console](/debugger/engine-runs) to inspect the run,
+pending remote activity, history, and final `{"greeting":"hello, Ada"}` result.
+
+The live
+[`sdks/python/tests/test_worker_e2e_integration.py`](https://github.com/aryanVijaywargia/Continua/blob/main/sdks/python/tests/test_worker_e2e_integration.py)
+suite is the CI-facing proof of the Go-engine-to-Python-worker path, including retries,
+lease loss, and non-retryable failures.

--- a/engine/examples/remote-greeter/main.go
+++ b/engine/examples/remote-greeter/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+const (
+	remoteGreeterWorkflowName    = "examples.remote-greeter"
+	remoteGreeterWorkflowVersion = "v1"
+	composeGreetingActivityType  = "examples.compose-greeting"
+)
+
+func remoteGreeterDefinition() workflow.Definition {
+	return workflow.Definition{
+		Name:    remoteGreeterWorkflowName,
+		Version: remoteGreeterWorkflowVersion,
+		Run: func(workflow.Context) error {
+			return fmt.Errorf("examples.remote-greeter: workflow not implemented yet")
+		},
+	}
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL: os.Getenv("DATABASE_URL"),
+		Workflows:   []workflow.Definition{remoteGreeterDefinition()},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := rt.Run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/engine/examples/remote-greeter/main.go
+++ b/engine/examples/remote-greeter/main.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
+
+	"github.com/google/uuid"
 
 	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
 	"github.com/continua-ai/continua/engine/pkg/workflow"
@@ -18,28 +21,79 @@ const (
 	composeGreetingActivityType  = "examples.compose-greeting"
 )
 
+type remoteGreeterInput struct {
+	Name string `json:"name"`
+}
+
+type remoteGreeterOutput struct {
+	Greeting string `json:"greeting"`
+}
+
 func remoteGreeterDefinition() workflow.Definition {
 	return workflow.Definition{
 		Name:    remoteGreeterWorkflowName,
 		Version: remoteGreeterWorkflowVersion,
-		Run: func(workflow.Context) error {
-			return fmt.Errorf("examples.remote-greeter: workflow not implemented yet")
-		},
+		Run:     runRemoteGreeterWorkflow,
 	}
 }
 
+func runRemoteGreeterWorkflow(ctx workflow.Context) error {
+	var input remoteGreeterInput
+	if err := ctx.Input(&input); err != nil {
+		return err
+	}
+	if input.Name == "" {
+		input.Name = "world"
+	}
+
+	var output remoteGreeterOutput
+	if err := ctx.ActivityWithOptions(
+		"compose-greeting",
+		composeGreetingActivityType,
+		input,
+		&output,
+		workflow.ActivityOptions{
+			ExecutionTarget: workflow.ActivityExecutionTargetRemote,
+			RetryPolicy: &workflow.RetryPolicy{
+				MaxAttempts:       3,
+				InitialBackoff:    500 * time.Millisecond,
+				MaxBackoff:        5 * time.Second,
+				BackoffMultiplier: 2.0,
+			},
+		},
+	); err != nil {
+		return err
+	}
+
+	return ctx.SetResult(output)
+}
+
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	rt, err := engineruntime.New(engineruntime.Options{
+	options := engineruntime.Options{
 		DatabaseURL: os.Getenv("DATABASE_URL"),
 		Workflows:   []workflow.Definition{remoteGreeterDefinition()},
-	})
+	}
+	if value := os.Getenv("ENGINE_PROJECT_ID"); value != "" {
+		projectID, err := uuid.Parse(value)
+		if err != nil {
+			return fmt.Errorf("parse ENGINE_PROJECT_ID: %w", err)
+		}
+		options.ProjectID = &projectID
+	}
+
+	rt, err := engineruntime.New(options)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
-	if err := rt.Run(ctx); err != nil {
-		log.Fatal(err)
-	}
+
+	return rt.Run(ctx)
 }

--- a/engine/examples/remote-greeter/main_test.go
+++ b/engine/examples/remote-greeter/main_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
+	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestRemoteGreeterExampleCompletesViaSimulatedRemoteWorker(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.New()
+	enginetest.EnsurePlatformProject(t, db.Pool, projectID)
+
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL:             db.DatabaseURL,
+		Workflows:               []workflow.Definition{remoteGreeterDefinition()},
+		Activities:              nil,
+		ProjectID:               &projectID,
+		WorkflowPollInterval:    25 * time.Millisecond,
+		ActivityPollInterval:    25 * time.Millisecond,
+		MaintenancePollInterval: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("runtime.New() error = %v", err)
+	}
+
+	ctx := context.Background()
+	store := enginestore.New(db.Pool)
+	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "remote-greeter-e2e",
+		DefinitionName: remoteGreeterWorkflowName,
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: remoteGreeterWorkflowVersion,
+		ReadyAt:           time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	input := mustJSON(t, map[string]string{"name": "Ada"})
+	startedPayload, err := enginehistory.MarshalPayload(enginehistory.WorkflowStartedPayload{
+		DefinitionName:    remoteGreeterWorkflowName,
+		DefinitionVersion: remoteGreeterWorkflowVersion,
+		InstanceKey:       "remote-greeter-e2e",
+		Input:             input,
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(workflow started) error = %v", err)
+	}
+	startedEvent, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 1,
+		EventType:  enginehistory.EventWorkflowStarted,
+		Payload:    startedPayload,
+	})
+	if err != nil {
+		t.Fatalf("AppendHistory(workflow started) error = %v", err)
+	}
+
+	tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+	traceName := remoteGreeterWorkflowName
+	if err := publicprojection.NewWriter(tx.Tx()).CreateTraceShell(ctx, &instance, &run, &publicprojection.TraceShellSeed{}, &startedEvent, input, &traceName); err != nil {
+		t.Fatalf("CreateTraceShell() error = %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	stopped := false
+	go func() {
+		done <- rt.Run(runCtx)
+	}()
+	defer func() {
+		if stopped {
+			return
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runtime did not stop within 5s after test cleanup cancellation")
+		}
+	}()
+
+	task := waitForActivityTask(t, store, run.ID)
+	if task.ExecutionTarget != "remote" {
+		t.Fatalf("activity task execution_target = %q, want %q", task.ExecutionTarget, "remote")
+	}
+	if task.ActivityType != composeGreetingActivityType {
+		t.Fatalf("activity task type = %q, want %q", task.ActivityType, composeGreetingActivityType)
+	}
+	if task.Status != enginedb.EngineActivityTaskStatusQueued {
+		t.Fatalf("pending activity task status = %q, want %q", task.Status, enginedb.EngineActivityTaskStatusQueued)
+	}
+	if task.ClaimedBy != nil {
+		t.Fatalf("pending remote activity task claimed_by = %q, want nil", *task.ClaimedBy)
+	}
+
+	const workerID = "py-sim-worker"
+	claimed, err := store.ClaimRemoteActivityTasks(ctx, projectID, workerID, []string{composeGreetingActivityType}, 1, time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimRemoteActivityTasks() error = %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("ClaimRemoteActivityTasks() claimed %d tasks, want 1", len(claimed))
+	}
+	var activityInput struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(claimed[0].Input, &activityInput); err != nil {
+		t.Fatalf("json.Unmarshal(activity input) error = %v; raw = %s", err, string(claimed[0].Input))
+	}
+	if activityInput.Name != "Ada" {
+		t.Fatalf("claimed activity input name = %q, want %q", activityInput.Name, "Ada")
+	}
+
+	output := mustJSON(t, map[string]string{"greeting": "hello, Ada"})
+	if _, err := store.CompleteRemoteActivityTask(ctx, projectID, claimed[0].ID, workerID, output); err != nil {
+		t.Fatalf("CompleteRemoteActivityTask() error = %v", err)
+	}
+	wake, err := store.WakeWaitingRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("WakeWaitingRun() error = %v", err)
+	}
+	if !wake.Applied {
+		t.Fatalf("WakeWaitingRun() applied = false; run status = %s", wake.Run.Status)
+	}
+
+	completedRun := waitForCompletedRun(t, store, instance.ID)
+	var result struct {
+		Greeting string `json:"greeting"`
+	}
+	if err := json.Unmarshal(completedRun.Result, &result); err != nil {
+		t.Fatalf("json.Unmarshal(run.Result) error = %v; raw = %s", err, string(completedRun.Result))
+	}
+	if result.Greeting != "hello, Ada" {
+		t.Fatalf("run result greeting = %q, want %q", result.Greeting, "hello, Ada")
+	}
+
+	historyRows, err := store.GetHistoryByRun(ctx, completedRun.ID)
+	if err != nil {
+		t.Fatalf("GetHistoryByRun() error = %v", err)
+	}
+	eventTypes := make([]string, 0, len(historyRows))
+	for _, row := range historyRows {
+		eventTypes = append(eventTypes, row.EventType)
+	}
+	wantSubsequence := []string{
+		enginehistory.EventWorkflowStarted,
+		enginehistory.EventActivityScheduled,
+		enginehistory.EventActivityCompleted,
+		enginehistory.EventWorkflowCompleted,
+	}
+	if !containsSubsequence(eventTypes, wantSubsequence) {
+		t.Fatalf("history event types = %v, want subsequence %v", eventTypes, wantSubsequence)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		stopped = true
+		if err != nil {
+			t.Fatalf("Runtime.Run() after cancellation error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Runtime.Run() did not stop within 5s after cancellation")
+	}
+}
+
+func waitForActivityTask(t *testing.T, store *enginestore.Store, runID uuid.UUID) enginedb.EngineActivityTask {
+	t.Helper()
+
+	ctx := context.Background()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		tasks, err := store.ListActivityTasksByRun(ctx, runID)
+		if err != nil {
+			t.Fatalf("ListActivityTasksByRun() error = %v", err)
+		}
+		if len(tasks) > 0 {
+			return tasks[0]
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("activity task was not created within 20s")
+	return enginedb.EngineActivityTask{}
+}
+
+func waitForCompletedRun(t *testing.T, store *enginestore.Store, instanceID uuid.UUID) enginedb.EngineRun {
+	t.Helper()
+
+	ctx := context.Background()
+	deadline := time.Now().Add(20 * time.Second)
+	var lastStatus enginedb.EngineRunLifecycleStatus
+	for time.Now().Before(deadline) {
+		runs, err := store.ListRunsByInstance(ctx, enginedb.ListRunsByInstanceParams{
+			InstanceID: instanceID,
+			Limit:      1,
+		})
+		if err != nil {
+			t.Fatalf("ListRunsByInstance() error = %v", err)
+		}
+		if len(runs) > 0 {
+			lastStatus = runs[0].Status
+			if runs[0].Status == enginedb.EngineRunLifecycleStatusCompleted {
+				return runs[0]
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("run did not complete within 20s; last observed status = %s", lastStatus)
+	return enginedb.EngineRun{}
+}
+
+func containsSubsequence(haystack, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	next := 0
+	for _, value := range haystack {
+		if value == needle[next] {
+			next++
+			if next == len(needle) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func mustJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return raw
+}

--- a/sdks/python/examples/remote_greeting_worker.py
+++ b/sdks/python/examples/remote_greeting_worker.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Run the Python activity worker for the remote greeter example.
+
+Runbook: /guides/go-workflows-python-activities
+"""
+
+from __future__ import annotations
+
+import os
+
+from continua import ActivityWorker
+
+
+def compose_greeting(input: dict[str, object]) -> dict[str, str]:
+    """Compose the greeting returned to the Go workflow."""
+    name = input.get("name") or "world"
+    return {"greeting": f"hello, {name}"}
+
+
+def build_worker(*, api_key: str, endpoint: str) -> ActivityWorker:
+    """Build a worker registered for the remote greeter activity."""
+    worker = ActivityWorker(api_key=api_key, endpoint=endpoint)
+    worker.register("examples.compose-greeting", compose_greeting)
+    return worker
+
+
+def main() -> None:
+    """Run the blocking worker poll loop from environment configuration."""
+    api_key = os.environ.get("CONTINUA_API_KEY")
+    if not api_key:
+        raise RuntimeError("CONTINUA_API_KEY is required")
+    endpoint = os.environ.get("CONTINUA_ENDPOINT", "http://localhost:8080")
+    build_worker(api_key=api_key, endpoint=endpoint).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/tests/test_remote_greeting_worker_example.py
+++ b/sdks/python/tests/test_remote_greeting_worker_example.py
@@ -1,0 +1,53 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+import continua
+
+
+def load_remote_greeting_worker_module() -> ModuleType:
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "examples"
+        / "remote_greeting_worker.py"
+    )
+    if not module_path.exists():
+        pytest.fail(f"remote greeting worker example is missing: {module_path}")
+
+    spec = importlib.util.spec_from_file_location(
+        "continua_remote_greeting_worker", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_worker_registers_compose_greeting() -> None:
+    module = load_remote_greeting_worker_module()
+
+    worker = module.build_worker(
+        api_key="test-key", endpoint="http://localhost:9"
+    )
+    try:
+        assert isinstance(worker, continua.ActivityWorker)
+        assert "examples.compose-greeting" in worker._handlers
+    finally:
+        worker.close()
+
+
+def test_compose_greeting_returns_greeting() -> None:
+    module = load_remote_greeting_worker_module()
+
+    assert module.compose_greeting({"name": "Ada"}) == {
+        "greeting": "hello, Ada"
+    }
+
+
+def test_compose_greeting_defaults_name() -> None:
+    module = load_remote_greeting_worker_module()
+
+    assert module.compose_greeting({}) == {"greeting": "hello, world"}


### PR DESCRIPTION
## What / why

The vision's core authoring pattern — a Go workflow durably orchestrating remote Python activities — was implemented but underexposed: `ActivityOptions.ExecutionTarget` existed with no example, no docs page, and no end-to-end test at the authoring level. This PR makes it the documented, tested flagship path.

## What's in here

- **Go example** `engine/examples/remote-greeter/`: a workflow that schedules `examples.compose-greeting` with `ExecutionTarget: remote` (retry policy included) and registers **no local handler** — the activity is executed by a Python worker. Supports optional `ENGINE_PROJECT_ID` scoping like the embed-engine guide.
- **Python example** `sdks/python/examples/remote_greeting_worker.py`: an `ActivityWorker` registering `examples.compose-greeting`, runnable via `CONTINUA_ENDPOINT`/`CONTINUA_API_KEY`.
- **Docs tutorial** `docs-site/guides/go-workflows-python-activities.mdx` (+ nav entry): one page from prerequisites → Go workflow → Python worker → starting a run via `EngineControlClient`/raw `POST /v1/engine/runs` → observing it in the debugger. Cross-links embed-engine, project provisioning, and the live integration suite from #165.
- **E2E test** `engine/examples/remote-greeter/main_test.go`: real-DB test that runs the example's definition through the embedded runtime, asserts the task is created with `execution_target='remote'` and left unclaimed by the in-process worker, simulates the remote worker via store claim/complete/wake, and asserts the final result plus the started → activity_scheduled → activity_completed → workflow_completed history sequence.
- **Example test** `sdks/python/tests/test_remote_greeting_worker_example.py`: asserts the example registers the right activity type and the handler's greeting/default behavior. No server required.

## Notes for review

- Tests were written first (committed red) by an independent session; the implementation was written against them and did not modify them.
- The tutorial deliberately starts runs via the preview REST control plane: `continua-engine start` resolves only built-in dark-launch definitions on its fixed demo project, so it cannot start this custom definition — the docs call this out.
- No contract, SQL, or generated-file changes.

## Test evidence

- `cd engine && go test ./examples/remote-greeter/...` — pass (real Postgres)
- `cd sdks/python && uv run pytest tests/test_remote_greeting_worker_example.py` — pass
- Tamper check: test files unchanged since the red-test commit (5aefc90)

Closes #167


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Go “remote greeter” workflow example that delegates activity execution to a Python worker.
  - Added a Python remote activity worker example for composing greeting results.
- **Documentation**
  - Added a new Workflows guide covering a Go-to-Python remote activity integration pattern.
- **Tests**
  - Added an end-to-end-style test simulating a remote worker to verify task execution and workflow completion.
  - Added Python tests covering worker setup and greeting defaulting/formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->