### PR TITLE
[engine] Structured slog logging across engine workers (#169)

### DIFF
--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -117,10 +117,12 @@ func serveCmd() *cobra.Command {
 
 			logger.Info("starting continua-engine serve", "event", "serve_start")
 			err = rt.Run(ctx)
-			if err == nil {
-				logger.Info("continua-engine serve stopped", "event", "serve_stop")
+			if err != nil {
+				logger.Error("continua-engine serve failed", "event", "serve_failed", "err", err)
+				return err
 			}
-			return err
+			logger.Info("continua-engine serve stopped", "event", "serve_stop")
+			return nil
 		},
 	}
 }

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os/signal"
 	"syscall"
 	"time"
@@ -96,10 +95,12 @@ func serveCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			logger := config.NewLogger(cfg.Logging, cmd.ErrOrStderr())
 			rt, err := engineruntime.New(engineruntime.Options{
 				DatabaseURL:             cfg.Database.URL,
 				Workflows:               darklaunch.Definitions(),
 				Activities:              runtimeHandlers(darklaunch.Handlers()),
+				Logger:                  logger,
 				ProjectID:               cfg.Runtime.ProjectIDFilter,
 				WorkflowPollInterval:    cfg.Runtime.WorkflowPollInterval,
 				ActivityPollInterval:    cfg.Runtime.ActivityPollInterval,
@@ -114,10 +115,10 @@ func serveCmd() *cobra.Command {
 				return err
 			}
 
-			log.Printf("starting continua-engine serve")
+			logger.Info("starting continua-engine serve", "event", "serve_start")
 			err = rt.Run(ctx)
 			if err == nil {
-				log.Printf("continua-engine serve stopped")
+				logger.Info("continua-engine serve stopped", "event", "serve_stop")
 			}
 			return err
 		},

--- a/engine/internal/activity/worker.go
+++ b/engine/internal/activity/worker.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,13 +22,18 @@ type Worker struct {
 	store            *store.Store
 	registry         *Registry
 	activityLeaseTTL time.Duration
+	logger           *slog.Logger
 }
 
-func NewWorker(engineStore *store.Store, registry *Registry, activityLeaseTTL time.Duration) *Worker {
+func NewWorker(engineStore *store.Store, registry *Registry, activityLeaseTTL time.Duration, logger *slog.Logger) *Worker {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Worker{
 		store:            engineStore,
 		registry:         registry,
 		activityLeaseTTL: activityLeaseTTL,
+		logger:           logger,
 	}
 }
 
@@ -70,7 +75,14 @@ func (w *Worker) PollOnce(ctx context.Context, workerID string) error {
 	if err != nil {
 		if errors.Is(err, store.ErrStaleClaim) {
 			w.store.Metrics().IncClaim("activity_task", "stale")
-			log.Printf("activity worker stale completion for task %s", task.ID)
+			w.logger.Warn("activity worker stale completion",
+				"worker", "activity",
+				"worker_id", workerID,
+				"project_id", task.ProjectID,
+				"run_id", task.RunID,
+				"task_id", task.ID,
+				"event", "stale_completion",
+			)
 			return nil
 		}
 		return err
@@ -140,13 +152,28 @@ func (w *Worker) runHandlerWithHeartbeat(
 			heartbeatCancel()
 			if err != nil {
 				if errors.Is(err, store.ErrStaleClaim) || errors.Is(err, store.ErrNotFound) {
-					log.Printf("activity worker lost lease for task %s", task.ID)
+					w.logger.Warn("activity worker lost lease",
+						"worker", "activity",
+						"worker_id", workerID,
+						"project_id", task.ProjectID,
+						"run_id", task.RunID,
+						"task_id", task.ID,
+						"event", "lease_lost",
+					)
 					cancel()
 					ticker.Stop()
 					heartbeatC = nil
 					continue
 				}
-				log.Printf("activity worker heartbeat failed for task %s: %v", task.ID, err)
+				w.logger.Warn("activity worker heartbeat failed",
+					"worker", "activity",
+					"worker_id", workerID,
+					"project_id", task.ProjectID,
+					"run_id", task.RunID,
+					"task_id", task.ID,
+					"event", "heartbeat_failed",
+					"err", err,
+				)
 			}
 		}
 	}
@@ -182,7 +209,14 @@ func (w *Worker) retryTask(
 	if err != nil {
 		if errors.Is(err, store.ErrStaleClaim) {
 			w.store.Metrics().IncClaim("activity_task", "stale")
-			log.Printf("activity worker stale retry for task %s", task.ID)
+			w.logger.Warn("activity worker stale retry",
+				"worker", "activity",
+				"worker_id", workerID,
+				"project_id", task.ProjectID,
+				"run_id", task.RunID,
+				"task_id", task.ID,
+				"event", "stale_retry",
+			)
 			return nil
 		}
 		return err
@@ -286,7 +320,13 @@ func (w *Worker) failTask(
 	if err != nil {
 		if errors.Is(err, store.ErrStaleClaim) {
 			w.store.Metrics().IncClaim("activity_task", "stale")
-			log.Printf("activity worker stale failure for task %s", taskID)
+			w.logger.Warn("activity worker stale failure",
+				"worker", "activity",
+				"worker_id", workerID,
+				"run_id", runID,
+				"task_id", taskID,
+				"event", "stale_failure",
+			)
 			return nil
 		}
 		return err

--- a/engine/internal/activity/worker_metrics_test.go
+++ b/engine/internal/activity/worker_metrics_test.go
@@ -46,7 +46,7 @@ func TestWorkerRecordsRetryAndFailureAttempts(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	worker := NewWorker(store, activityRegistry, time.Minute)
+	worker := NewWorker(store, activityRegistry, time.Minute, nil)
 	if err := worker.PollOnce(ctx, "activity-worker"); err != nil {
 		t.Fatalf("PollOnce() first attempt error = %v", err)
 	}

--- a/engine/internal/activity/worker_test.go
+++ b/engine/internal/activity/worker_test.go
@@ -41,7 +41,7 @@ func TestWorkerLateCompletionAfterTerminateReturnsNoOp(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	worker := NewWorker(store, registry, time.Minute)
+	worker := NewWorker(store, registry, time.Minute, nil)
 	workerDone := make(chan error, 1)
 	go func() {
 		workerDone <- worker.PollOnce(ctx, "activity-worker")
@@ -163,7 +163,7 @@ func TestWorkerLongRunningLocalActivityHeartbeatsLease(t *testing.T) {
 	}
 
 	leaseTTL := 300 * time.Millisecond
-	worker := NewWorker(store, registry, leaseTTL)
+	worker := NewWorker(store, registry, leaseTTL, nil)
 	workerDone := make(chan error, 1)
 	go func() {
 		workerDone <- worker.PollOnce(ctx, "activity-worker")
@@ -267,7 +267,7 @@ func TestWorkerLocalActivityLeaseLossCancelsHandlerContext(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	worker := NewWorker(store, registry, 200*time.Millisecond)
+	worker := NewWorker(store, registry, 200*time.Millisecond, nil)
 	workerDone := make(chan error, 1)
 	go func() {
 		workerDone <- worker.PollOnce(ctx, "activity-worker")
@@ -408,7 +408,7 @@ func TestWorkerRetryableFailureSchedulesRetryWithoutWakingRun(t *testing.T) {
 	}
 
 	before := time.Now()
-	worker := NewWorker(store, registry, time.Minute)
+	worker := NewWorker(store, registry, time.Minute, nil)
 	if err := worker.PollOnce(ctx, "activity-worker"); err != nil {
 		t.Fatalf("PollOnce() error = %v", err)
 	}
@@ -509,7 +509,7 @@ func TestWorkerRetryScheduledSequenceContinuesFromMaxHistory(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	worker := NewWorker(store, registry, time.Minute)
+	worker := NewWorker(store, registry, time.Minute, nil)
 	if err := worker.PollOnce(ctx, "activity-worker"); err != nil {
 		t.Fatalf("PollOnce() error = %v", err)
 	}
@@ -560,7 +560,7 @@ func TestWorkerSingleAttemptFailureWakesWaitingRun(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	worker := NewWorker(store, registry, time.Minute)
+	worker := NewWorker(store, registry, time.Minute, nil)
 	if err := worker.PollOnce(ctx, "activity-worker"); err != nil {
 		t.Fatalf("PollOnce() error = %v", err)
 	}
@@ -611,7 +611,7 @@ func TestWorkerNonRetryableFailureBypassesRetry(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	worker := NewWorker(store, registry, time.Minute)
+	worker := NewWorker(store, registry, time.Minute, nil)
 	if err := worker.PollOnce(ctx, "activity-worker"); err != nil {
 		t.Fatalf("PollOnce() error = %v", err)
 	}
@@ -668,7 +668,7 @@ func TestWorkerExhaustedRetriesWakesWaitingRun(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	worker := NewWorker(store, registry, time.Minute)
+	worker := NewWorker(store, registry, time.Minute, nil)
 	if err := worker.PollOnce(ctx, "activity-worker"); err != nil {
 		t.Fatalf("PollOnce() first attempt error = %v", err)
 	}
@@ -740,7 +740,7 @@ func TestWorkerMissingHandlerFailsImmediatelyWithoutRetry(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	worker := NewWorker(store, registry, time.Minute)
+	worker := NewWorker(store, registry, time.Minute, nil)
 	if err := worker.PollOnce(ctx, "activity-worker"); err != nil {
 		t.Fatalf("PollOnce() error = %v", err)
 	}
@@ -808,7 +808,7 @@ func TestWorkerStaleRetryClaimReturnsNil(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 
-	worker := NewWorker(store, registry, time.Minute)
+	worker := NewWorker(store, registry, time.Minute, nil)
 	workerDone := make(chan error, 1)
 	go func() {
 		workerDone <- worker.PollOnce(ctx, "activity-worker")

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"errors"
+	"io"
+	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,12 +24,21 @@ const (
 	defaultRunLeaseTTL     = 30 * time.Second
 	defaultActivityLease   = 5 * time.Minute
 	defaultRequestDedupe   = time.Hour
+	defaultLogLevel        = slog.LevelInfo
+	defaultLogFormat       = "json"
 )
 
 // Config holds engine runtime configuration.
 type Config struct {
 	Database DatabaseConfig
 	Runtime  RuntimeConfig
+	Logging  LoggingConfig
+}
+
+// LoggingConfig holds the engine structured logging settings.
+type LoggingConfig struct {
+	Level  slog.Level
+	Format string
 }
 
 // DatabaseConfig holds the engine database settings.
@@ -72,6 +84,10 @@ func Defaults(databaseURL string) *Config {
 			RunLeaseTTL:             defaultRunLeaseTTL,
 			ActivityLeaseTTL:        defaultActivityLease,
 			RequestDedupeTTL:        defaultRequestDedupe,
+		},
+		Logging: LoggingConfig{
+			Level:  defaultLogLevel,
+			Format: defaultLogFormat,
 		},
 	}
 }
@@ -127,6 +143,14 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	logLevel, err := logLevelFromEnv("ENGINE_LOG_LEVEL", cfg.Logging.Level)
+	if err != nil {
+		return nil, err
+	}
+	logFormat, err := logFormatFromEnv("ENGINE_LOG_FORMAT", cfg.Logging.Format)
+	if err != nil {
+		return nil, err
+	}
 
 	cfg.Runtime.WorkflowPollInterval = workflowPollInterval
 	cfg.Runtime.ActivityPollInterval = activityPollInterval
@@ -138,7 +162,22 @@ func Load() (*Config, error) {
 	cfg.Runtime.RequestDedupeTTL = requestDedupeTTL
 	cfg.Runtime.ProjectIDFilter = projectIDFilter
 	cfg.Runtime.MetricsAddr = os.Getenv("ENGINE_METRICS_ADDR")
+	cfg.Logging.Level = logLevel
+	cfg.Logging.Format = logFormat
 	return cfg, nil
+}
+
+// NewLogger constructs an engine structured logger.
+func NewLogger(cfg LoggingConfig, w io.Writer) *slog.Logger {
+	if w == nil {
+		w = os.Stderr
+	}
+
+	options := &slog.HandlerOptions{Level: cfg.Level}
+	if cfg.Format == "text" {
+		return slog.New(slog.NewTextHandler(w, options))
+	}
+	return slog.New(slog.NewJSONHandler(w, options))
 }
 
 func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) {
@@ -152,6 +191,40 @@ func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) 
 		return 0, errors.New(key + " must be a valid duration: " + err.Error())
 	}
 	return parsed, nil
+}
+
+func logLevelFromEnv(key string, fallback slog.Level) (slog.Level, error) {
+	value := strings.ToLower(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+
+	switch value {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return 0, errors.New(key + " must be one of debug, info, warn, error")
+	}
+}
+
+func logFormatFromEnv(key, fallback string) (string, error) {
+	value := strings.ToLower(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+
+	switch value {
+	case "json", "text":
+		return value, nil
+	default:
+		return "", errors.New(key + " must be one of json, text")
+	}
 }
 
 func runtimeProjectIDFromEnv() (*uuid.UUID, error) {

--- a/engine/internal/config/config_test.go
+++ b/engine/internal/config/config_test.go
@@ -1,6 +1,11 @@
 package config
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 )
@@ -134,4 +139,162 @@ func TestLoadLeaseCompletionGrace(t *testing.T) {
 			t.Fatal("Load() error = nil, want invalid completion grace error")
 		}
 	})
+}
+
+func TestLoadLoggingDefaults(t *testing.T) {
+	t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_LOG_LEVEL", "")
+	t.Setenv("ENGINE_LOG_FORMAT", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.Logging.Level != slog.LevelInfo {
+		t.Errorf("Logging.Level = %v, want %v", cfg.Logging.Level, slog.LevelInfo)
+	}
+	if cfg.Logging.Format != "json" {
+		t.Errorf("Logging.Format = %q, want %q", cfg.Logging.Format, "json")
+	}
+}
+
+func TestLoadLogLevelOverrides(t *testing.T) {
+	tests := []struct {
+		input string
+		want  slog.Level
+	}{
+		{input: "debug", want: slog.LevelDebug},
+		{input: "DEBUG", want: slog.LevelDebug},
+		{input: "info", want: slog.LevelInfo},
+		{input: "Warn", want: slog.LevelWarn},
+		{input: "error", want: slog.LevelError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+			t.Setenv("ENGINE_LOG_LEVEL", tt.input)
+			t.Setenv("ENGINE_LOG_FORMAT", "")
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Logging.Level != tt.want {
+				t.Fatalf("Logging.Level = %v, want %v", cfg.Logging.Level, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsInvalidLogLevel(t *testing.T) {
+	t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_LOG_LEVEL", "verbose")
+	t.Setenv("ENGINE_LOG_FORMAT", "")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want invalid log level error")
+	}
+}
+
+func TestLoadLogFormatOverrides(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "json", want: "json"},
+		{input: "text", want: "text"},
+		{input: "TEXT", want: "text"},
+		{input: "JSON", want: "json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+			t.Setenv("ENGINE_LOG_LEVEL", "")
+			t.Setenv("ENGINE_LOG_FORMAT", tt.input)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Logging.Format != tt.want {
+				t.Fatalf("Logging.Format = %q, want %q", cfg.Logging.Format, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsInvalidLogFormat(t *testing.T) {
+	t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_LOG_LEVEL", "")
+	t.Setenv("ENGINE_LOG_FORMAT", "xml")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want invalid log format error")
+	}
+}
+
+func TestNewLoggerJSONFormat(t *testing.T) {
+	var buffer bytes.Buffer
+	var output io.Writer = &buffer
+	logger := NewLogger(LoggingConfig{Level: slog.LevelInfo, Format: "json"}, output)
+
+	logger.Info("hello", "k", "v")
+
+	if !json.Valid(buffer.Bytes()) {
+		t.Fatalf("logger output is not valid JSON: %q", buffer.String())
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(buffer.Bytes(), &entry); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if entry["msg"] != "hello" {
+		t.Errorf("msg = %v, want %q", entry["msg"], "hello")
+	}
+	if entry["level"] != "INFO" {
+		t.Errorf("level = %v, want %q", entry["level"], "INFO")
+	}
+	if entry["k"] != "v" {
+		t.Errorf("k = %v, want %q", entry["k"], "v")
+	}
+}
+
+func TestNewLoggerTextFormat(t *testing.T) {
+	var buffer bytes.Buffer
+	var output io.Writer = &buffer
+	logger := NewLogger(LoggingConfig{Level: slog.LevelInfo, Format: "text"}, output)
+
+	logger.Info("hello")
+
+	got := buffer.String()
+	if !strings.Contains(got, "level=INFO") {
+		t.Errorf("logger output %q does not contain %q", got, "level=INFO")
+	}
+	if !strings.Contains(got, "msg=hello") {
+		t.Errorf("logger output %q does not contain %q", got, "msg=hello")
+	}
+	if json.Valid(buffer.Bytes()) {
+		t.Errorf("text logger output is valid JSON: %q", got)
+	}
+}
+
+func TestNewLoggerRespectsLevelFilter(t *testing.T) {
+	var buffer bytes.Buffer
+	var output io.Writer = &buffer
+	logger := NewLogger(LoggingConfig{Level: slog.LevelWarn, Format: "json"}, output)
+
+	logger.Info("skip")
+	if buffer.Len() != 0 {
+		t.Fatalf("Info output at warn level = %q, want empty", buffer.String())
+	}
+
+	logger.Warn("kept")
+	if buffer.Len() == 0 {
+		t.Fatal("Warn output at warn level is empty")
+	}
+	if !strings.Contains(buffer.String(), "kept") {
+		t.Errorf("Warn output %q does not contain %q", buffer.String(), "kept")
+	}
 }

--- a/engine/internal/worker/logging_policy_test.go
+++ b/engine/internal/worker/logging_policy_test.go
@@ -1,0 +1,51 @@
+package worker
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestNoBareLogPrintfUnderEngineInternalAndPkg(t *testing.T) {
+	engineRoot := filepath.Join("..", "..")
+	bareLogCall := regexp.MustCompile(`(^|[^\w.])log\.(Printf|Print|Println)`)
+
+	for _, directory := range []string{"internal", "pkg"} {
+		root := filepath.Join(engineRoot, directory)
+		if _, err := os.Stat(root); os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			t.Logf("skipping %s: %v", root, err)
+			continue
+		}
+
+		_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				t.Logf("skipping %s: %v", path, walkErr)
+				return nil
+			}
+			if entry.IsDir() || filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+
+			contents, err := os.ReadFile(path)
+			if err != nil {
+				t.Logf("skipping %s: %v", path, err)
+				return nil
+			}
+
+			scanner := bufio.NewScanner(bytes.NewReader(contents))
+			for lineNumber := 1; scanner.Scan(); lineNumber++ {
+				line := scanner.Text()
+				if bareLogCall.MatchString(line) {
+					t.Errorf("%s:%d: %s", path, lineNumber, strings.TrimSpace(line))
+				}
+			}
+			return nil
+		})
+	}
+}

--- a/engine/internal/worker/logging_policy_test.go
+++ b/engine/internal/worker/logging_policy_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -16,17 +17,14 @@ func TestNoBareLogPrintfUnderEngineInternalAndPkg(t *testing.T) {
 
 	for _, directory := range []string{"internal", "pkg"} {
 		root := filepath.Join(engineRoot, directory)
-		if _, err := os.Stat(root); os.IsNotExist(err) {
-			continue
-		} else if err != nil {
-			t.Logf("skipping %s: %v", root, err)
+		if _, err := os.Stat(root); err != nil {
+			t.Errorf("stat %s: %v", root, err)
 			continue
 		}
 
-		_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
 			if walkErr != nil {
-				t.Logf("skipping %s: %v", path, walkErr)
-				return nil
+				return walkErr
 			}
 			if entry.IsDir() || filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
 				return nil
@@ -34,8 +32,7 @@ func TestNoBareLogPrintfUnderEngineInternalAndPkg(t *testing.T) {
 
 			contents, err := os.ReadFile(path)
 			if err != nil {
-				t.Logf("skipping %s: %v", path, err)
-				return nil
+				return fmt.Errorf("read %s: %w", path, err)
 			}
 
 			scanner := bufio.NewScanner(bytes.NewReader(contents))
@@ -45,7 +42,13 @@ func TestNoBareLogPrintfUnderEngineInternalAndPkg(t *testing.T) {
 					t.Errorf("%s:%d: %s", path, lineNumber, strings.TrimSpace(line))
 				}
 			}
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("scan %s: %w", path, err)
+			}
 			return nil
 		})
+		if err != nil {
+			t.Errorf("scan %s: %v", root, err)
+		}
 	}
 }

--- a/engine/internal/workflow/worker.go
+++ b/engine/internal/workflow/worker.go
@@ -3,7 +3,7 @@ package workflow
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/continua-ai/continua/engine/internal/store"
@@ -13,13 +13,18 @@ type Worker struct {
 	store       *store.Store
 	activator   *Activator
 	runLeaseTTL time.Duration
+	logger      *slog.Logger
 }
 
-func NewWorker(engineStore *store.Store, definitions *Registry, runLeaseTTL time.Duration) *Worker {
+func NewWorker(engineStore *store.Store, definitions *Registry, runLeaseTTL time.Duration, logger *slog.Logger) *Worker {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Worker{
 		store:       engineStore,
 		activator:   NewActivator(engineStore, definitions),
 		runLeaseTTL: runLeaseTTL,
+		logger:      logger,
 	}
 }
 
@@ -41,7 +46,12 @@ func (w *Worker) PollOnce(ctx context.Context, workerID string) error {
 	if err := w.activator.Activate(ctx, &run); err != nil {
 		if errors.Is(err, store.ErrStaleClaim) {
 			metrics.IncClaim("run", "stale")
-			log.Printf("workflow worker stale claim for run %s", run.ID)
+			w.logger.Warn("workflow worker stale claim",
+				"worker", "workflow",
+				"worker_id", workerID,
+				"run_id", run.ID,
+				"event", "stale_claim",
+			)
 			return nil
 		}
 		return err

--- a/engine/internal/workflow/worker.go
+++ b/engine/internal/workflow/worker.go
@@ -49,6 +49,7 @@ func (w *Worker) PollOnce(ctx context.Context, workerID string) error {
 			w.logger.Warn("workflow worker stale claim",
 				"worker", "workflow",
 				"worker_id", workerID,
+				"project_id", run.ProjectID,
 				"run_id", run.ID,
 				"event", "stale_claim",
 			)

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"sync"
@@ -41,6 +42,8 @@ type Options struct {
 	Workflows []workflow.Definition
 	// Activities maps activity type to handler.
 	Activities map[string]ActivityHandler
+	// Logger receives structured workflow and activity worker events.
+	Logger *slog.Logger
 	// ProjectID optionally scopes all polling to a single project.
 	ProjectID *uuid.UUID
 	// Poll intervals and lease TTLs; zero values use the engine defaults.
@@ -144,8 +147,8 @@ func (r *Runtime) Run(ctx context.Context) error {
 		return err
 	}
 
-	workflowWorker := engineworkflow.NewWorker(store, r.definitions, cfg.Runtime.RunLeaseTTL)
-	activityWorker := activity.NewWorker(store, r.activities, cfg.Runtime.ActivityLeaseTTL)
+	workflowWorker := engineworkflow.NewWorker(store, r.definitions, cfg.Runtime.RunLeaseTTL, r.options.Logger)
+	activityWorker := activity.NewWorker(store, r.activities, cfg.Runtime.ActivityLeaseTTL, r.options.Logger)
 	maintenanceWorker := engineworker.NewMaintenanceWorker(store)
 	projectorWorker := engineprojector.New(store)
 	metricsListener := r.options.MetricsListener


### PR DESCRIPTION
## What & why

Engine logging was ad-hoc stdlib `log.Printf` — no levels, no structured fields, no run/task correlation. Debugging a production incident meant grepping unstructured text with no guaranteed project/run/task identifiers. This replaces it with `log/slog` structured, leveled logging across the engine workers, configurable via env.

Closes #169

## Plan outline

1. Add a validated logging config to `engine/internal/config`: `ENGINE_LOG_LEVEL` (default `info`, one of debug/info/warn/error) and `ENGINE_LOG_FORMAT` (default `json`, json|text), both case-insensitive; invalid values are a load error. Add a `NewLogger(LoggingConfig, io.Writer)` constructor (JSON/Text handler honoring the level filter).
2. Thread a nil-safe `*slog.Logger` into the activity and workflow workers and replace every bare `log.Printf` under `engine/internal/` with structured, leveled slog events carrying consistent fields: `worker`, `worker_id`, `project_id` (where in scope), `run_id`, `task_id`, `event`.
3. Inject the logger through `runtime.Options` (the runtime owns worker construction) and build it from `cfg.Logging` in `continua-engine serve`; move the two serve-lifecycle logs to slog on stderr. CLI command JSON output stays on stdout unchanged.

## What was implemented

- `engine/internal/config/config.go`: `LoggingConfig{Level, Format}` on `Config`, env parsing with validation + defaults, and `NewLogger`.
- `engine/internal/activity/worker.go` and `engine/internal/workflow/worker.go`: logger field + constructor param (nil → `slog.Default()`); all 6 internal `log.Printf` sites (stale completion/retry/failure, lost lease, heartbeat failed, stale claim) converted to `slog.Warn` with correlation fields. Existing `Metrics()` calls left intact.
- `engine/pkg/runtime/runtime.go`: `Logger *slog.Logger` on `Options`, threaded into both workers.
- `engine/cmd/continua-engine/runtime_commands.go`: build the logger from `cfg.Logging` on `cmd.ErrOrStderr()`, inject via `Options.Logger`, and log serve start/stop through it. Stdout JSON output untouched.

## Review + test evidence

- **Acceptance tests** (committed red first, in a separate authoring session): `engine/internal/config/config_test.go` covers logging defaults, case-insensitive level/format parsing, invalid-value rejection, JSON vs text output, and warn-level filtering; `engine/internal/worker/logging_policy_test.go` is a filesystem guard asserting no bare `log.Printf`/`Print`/`Println` remains under `engine/internal/` or `engine/pkg/`.
- Both were verified failing red before implementation, then green after.
- Independently verified: `go build ./...` clean at repo root; `go vet ./engine/... ./scripts/...` clean; `go test ./engine/internal/config/... ./engine/internal/worker/... ./engine/internal/activity/... ./engine/internal/workflow/...` all pass. No generated files or migrations touched.

## Acceptance criteria

- ✅ No bare `log.Printf` remains under `engine/internal/` and `engine/pkg/` (grep-verifiable via the guard test); CLI user-facing output unchanged.
- ✅ `go test ./engine/internal/config/...` covers the new `ENGINE_LOG_LEVEL` / `ENGINE_LOG_FORMAT` env vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable structured logging with selectable text or JSON output.
  - Added environment-based controls for log level and format.
  - Improved runtime, workflow, and activity logs with consistent event details and context.

- **Bug Fixes**
  - Improved visibility into stale tasks, lease losses, heartbeat failures, and retry issues.

- **Tests**
  - Added coverage for logging configuration, formatting, filtering, and prevention of unstructured logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->