### PR TITLE
feat(engine): automated retention/GC for engine tables (history, inbox, tasks, dedupe)

### DIFF
--- a/docs-site/debugger/engine-runs.mdx
+++ b/docs-site/debugger/engine-runs.mdx
@@ -50,6 +50,10 @@ panels enabled:
 The span waterfall on the underlying trace shows the workflow's emitted spans, so engine
 runs benefit from the same failure-first navigation as any other trace.
 
+Run-history availability is bounded by `ENGINE_RETENTION_TERMINAL_RUNS`. Once retention
+deletes a terminal run's journal, the projected trace and root span remain and the
+debugger renders the run's expired-history state.
+
 ## Projection repair
 
 The Projection repair page at `/tools/engine-projections` is an operator tool for

--- a/docs-site/guides/embed-engine.mdx
+++ b/docs-site/guides/embed-engine.mdx
@@ -54,6 +54,21 @@ start. Create the project first and set `ENGINE_PROJECT_ID`; see
 
 See `engine/examples/greeter` for a minimal compilable program with signal handling.
 
+## Retention
+
+The runtime periodically bounds finalized engine journals and request-dedupe rows. The
+`ENGINE_RETENTION_TERMINAL_RUNS` / `runtime.Options.RetentionTerminalRuns` window
+defaults to `168h`, `ENGINE_RETENTION_DEDUPE_GRACE` /
+`runtime.Options.RetentionDedupeGrace` defaults to `24h`, and
+`ENGINE_RETENTION_BATCH_SIZE` / `runtime.Options.RetentionBatchSize` defaults to `500`.
+For environment configuration, a retention window of `0` disables that class. In Go
+options, leave a window at `0` to inherit its default or use a negative duration to
+disable it.
+
+After terminal-run retention, the projected trace and its root span remain available in
+the debugger, but the engine history journal, inbox rows, and activity tasks for the run
+are deleted.
+
 ## Start runs
 
 The embedded process executes runs for definitions it registered. Creating those runs is

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -108,6 +108,9 @@ func serveCmd() *cobra.Command {
 				MetricsSampleInterval:   cfg.Runtime.MetricsSampleInterval,
 				RunLeaseTTL:             cfg.Runtime.RunLeaseTTL,
 				ActivityLeaseTTL:        cfg.Runtime.ActivityLeaseTTL,
+				RetentionTerminalRuns:   retentionWindowOption(cfg.Runtime.RetentionTerminalRuns),
+				RetentionDedupeGrace:    retentionWindowOption(cfg.Runtime.RetentionDedupeGrace),
+				RetentionBatchSize:      cfg.Runtime.RetentionBatchSize,
 				MetricsAddr:             cfg.Runtime.MetricsAddr,
 				LeaseCompletionGrace:    cfg.Runtime.LeaseCompletionGrace,
 			})
@@ -125,6 +128,13 @@ func serveCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func retentionWindowOption(configured time.Duration) time.Duration {
+	if configured == 0 {
+		return -1
+	}
+	return configured
 }
 
 func startCmd() *cobra.Command {

--- a/engine/db/gen/go/activity_tasks.sql.go
+++ b/engine/db/gen/go/activity_tasks.sql.go
@@ -521,6 +521,19 @@ func (q *Queries) CreateActivityTask(ctx context.Context, arg CreateActivityTask
 	return i, err
 }
 
+const deleteActivityTasksByRun = `-- name: DeleteActivityTasksByRun :execrows
+DELETE FROM engine.activity_tasks
+WHERE run_id = $1
+`
+
+func (q *Queries) DeleteActivityTasksByRun(ctx context.Context, runID uuid.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteActivityTasksByRun, runID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const failActivityTask = `-- name: FailActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'failed',

--- a/engine/db/gen/go/history.sql.go
+++ b/engine/db/gen/go/history.sql.go
@@ -66,6 +66,19 @@ func (q *Queries) DeleteHistoryByRun(ctx context.Context, runID uuid.UUID) error
 	return err
 }
 
+const deleteHistoryByRunCounted = `-- name: DeleteHistoryByRunCounted :execrows
+DELETE FROM engine.history
+WHERE run_id = $1
+`
+
+func (q *Queries) DeleteHistoryByRunCounted(ctx context.Context, runID uuid.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteHistoryByRunCounted, runID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getHistoryByInstance = `-- name: GetHistoryByInstance :many
 SELECT id, project_id, instance_id, run_id, sequence_no, event_type, payload, created_at
 FROM engine.history

--- a/engine/db/gen/go/inbox.sql.go
+++ b/engine/db/gen/go/inbox.sql.go
@@ -153,6 +153,19 @@ func (q *Queries) CreateInboxItem(ctx context.Context, arg CreateInboxItemParams
 	return i, err
 }
 
+const deleteInboxByRun = `-- name: DeleteInboxByRun :execrows
+DELETE FROM engine.inbox
+WHERE run_id = $1
+`
+
+func (q *Queries) DeleteInboxByRun(ctx context.Context, runID pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteInboxByRun, runID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const discardOpenInboxItemsByRun = `-- name: DiscardOpenInboxItemsByRun :many
 UPDATE engine.inbox
 SET status = 'discarded',

--- a/engine/db/gen/go/request_dedupe.sql.go
+++ b/engine/db/gen/go/request_dedupe.sql.go
@@ -278,6 +278,32 @@ func (q *Queries) GetRequestDedupeByScopeAndKeyForUpdate(ctx context.Context, ar
 	return i, err
 }
 
+const reapRequestDedupe = `-- name: ReapRequestDedupe :execrows
+DELETE FROM engine.request_dedupe AS target
+WHERE target.id IN (
+    SELECT candidate.id
+    FROM engine.request_dedupe AS candidate
+    WHERE ($1::uuid IS NULL OR candidate.project_id = $1::uuid)
+      AND candidate.status IN ('completed', 'failed', 'expired')
+      AND candidate.expires_at < $2
+    LIMIT $3
+)
+`
+
+type ReapRequestDedupeParams struct {
+	ProjectFilter pgtype.UUID `json:"project_filter"`
+	Cutoff        time.Time   `json:"cutoff"`
+	BatchSize     int32       `json:"batch_size"`
+}
+
+func (q *Queries) ReapRequestDedupe(ctx context.Context, arg ReapRequestDedupeParams) (int64, error) {
+	result, err := q.db.Exec(ctx, reapRequestDedupe, arg.ProjectFilter, arg.Cutoff, arg.BatchSize)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const renewRequestDedupeClaim = `-- name: RenewRequestDedupeClaim :one
 UPDATE engine.request_dedupe
 SET status = 'in_progress',

--- a/engine/db/gen/go/runs.sql.go
+++ b/engine/db/gen/go/runs.sql.go
@@ -317,6 +317,32 @@ func (q *Queries) GetLatestRunByInstance(ctx context.Context, instanceID uuid.UU
 	return i, err
 }
 
+const getRetainableTerminalRunForUpdate = `-- name: GetRetainableTerminalRunForUpdate :one
+SELECT r.id
+FROM engine.runs AS r
+JOIN public.traces AS t ON t.engine_run_id = r.id
+WHERE r.id = $1
+  AND ($2::uuid IS NULL OR r.project_id = $2::uuid)
+  AND r.status IN ('completed', 'failed', 'cancelled', 'terminated')
+  AND t.engine_latest_history_id IS NOT NULL
+  AND t.engine_last_projected_history_id IS NOT NULL
+  AND t.engine_last_projected_history_id >= t.engine_latest_history_id
+  AND COALESCE(t.engine_projection_state, '') <> 'journal_expired'
+FOR UPDATE OF r, t
+`
+
+type GetRetainableTerminalRunForUpdateParams struct {
+	RunID         uuid.UUID   `json:"run_id"`
+	ProjectFilter pgtype.UUID `json:"project_filter"`
+}
+
+func (q *Queries) GetRetainableTerminalRunForUpdate(ctx context.Context, arg GetRetainableTerminalRunForUpdateParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, getRetainableTerminalRunForUpdate, arg.RunID, arg.ProjectFilter)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getRun = `-- name: GetRun :one
 SELECT id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id, parent_run_id, root_run_id, child_key, child_depth
 FROM engine.runs
@@ -485,6 +511,48 @@ func (q *Queries) GetRunForUpdate(ctx context.Context, id uuid.UUID) (EngineRun,
 		&i.ChildDepth,
 	)
 	return i, err
+}
+
+const listRetainableTerminalRunIDs = `-- name: ListRetainableTerminalRunIDs :many
+SELECT r.id
+FROM engine.runs AS r
+JOIN public.traces AS t ON t.engine_run_id = r.id
+WHERE ($1::uuid IS NULL OR r.project_id = $1::uuid)
+  AND r.status IN ('completed', 'failed', 'cancelled', 'terminated')
+  AND r.completed_at IS NOT NULL
+  AND r.completed_at < $2::timestamptz
+  AND t.engine_latest_history_id IS NOT NULL
+  AND t.engine_last_projected_history_id IS NOT NULL
+  AND t.engine_last_projected_history_id >= t.engine_latest_history_id
+  AND COALESCE(t.engine_projection_state, '') <> 'journal_expired'
+ORDER BY r.completed_at ASC
+LIMIT $3
+`
+
+type ListRetainableTerminalRunIDsParams struct {
+	ProjectFilter pgtype.UUID `json:"project_filter"`
+	Cutoff        time.Time   `json:"cutoff"`
+	BatchSize     int32       `json:"batch_size"`
+}
+
+func (q *Queries) ListRetainableTerminalRunIDs(ctx context.Context, arg ListRetainableTerminalRunIDsParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, listRetainableTerminalRunIDs, arg.ProjectFilter, arg.Cutoff, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []uuid.UUID{}
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listRunsByInstance = `-- name: ListRunsByInstance :many

--- a/engine/db/migrations/postgres/000015_engine_retention_gc_indexes.down.sql
+++ b/engine/db/migrations/postgres/000015_engine_retention_gc_indexes.down.sql
@@ -1,2 +1,0 @@
-DROP INDEX IF EXISTS engine.idx_engine_request_dedupe_reap;
-DROP INDEX IF EXISTS engine.idx_engine_inbox_run_id;

--- a/engine/db/migrations/postgres/000015_engine_retention_gc_indexes.down.sql
+++ b/engine/db/migrations/postgres/000015_engine_retention_gc_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS engine.idx_engine_request_dedupe_reap;
+DROP INDEX IF EXISTS engine.idx_engine_inbox_run_id;

--- a/engine/db/migrations/postgres/000015_engine_retention_gc_indexes.up.sql
+++ b/engine/db/migrations/postgres/000015_engine_retention_gc_indexes.up.sql
@@ -1,0 +1,7 @@
+CREATE INDEX idx_engine_inbox_run_id
+    ON engine.inbox (run_id)
+    WHERE run_id IS NOT NULL;
+
+CREATE INDEX idx_engine_request_dedupe_reap
+    ON engine.request_dedupe (expires_at)
+    WHERE status IN ('completed', 'failed', 'expired');

--- a/engine/db/migrations/postgres/000015_engine_retention_gc_indexes.up.sql
+++ b/engine/db/migrations/postgres/000015_engine_retention_gc_indexes.up.sql
@@ -1,7 +1,0 @@
-CREATE INDEX idx_engine_inbox_run_id
-    ON engine.inbox (run_id)
-    WHERE run_id IS NOT NULL;
-
-CREATE INDEX idx_engine_request_dedupe_reap
-    ON engine.request_dedupe (expires_at)
-    WHERE status IN ('completed', 'failed', 'expired');

--- a/engine/db/migrations/postgres/000015_engine_retention_inbox_index.down.sql
+++ b/engine/db/migrations/postgres/000015_engine_retention_inbox_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS engine.idx_engine_inbox_run_id;

--- a/engine/db/migrations/postgres/000015_engine_retention_inbox_index.up.sql
+++ b/engine/db/migrations/postgres/000015_engine_retention_inbox_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_engine_inbox_run_id
+    ON engine.inbox (run_id)
+    WHERE run_id IS NOT NULL;

--- a/engine/db/migrations/postgres/000016_engine_retention_dedupe_index.down.sql
+++ b/engine/db/migrations/postgres/000016_engine_retention_dedupe_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS engine.idx_engine_request_dedupe_reap;

--- a/engine/db/migrations/postgres/000016_engine_retention_dedupe_index.up.sql
+++ b/engine/db/migrations/postgres/000016_engine_retention_dedupe_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_engine_request_dedupe_reap
+    ON engine.request_dedupe (expires_at)
+    WHERE status IN ('completed', 'failed', 'expired');

--- a/engine/db/queries/activity_tasks.sql
+++ b/engine/db/queries/activity_tasks.sql
@@ -283,3 +283,7 @@ SET history_id = NULL,
     updated_at = NOW()
 WHERE run_id = $1
   AND history_id IS NOT NULL;
+
+-- name: DeleteActivityTasksByRun :execrows
+DELETE FROM engine.activity_tasks
+WHERE run_id = $1;

--- a/engine/db/queries/history.sql
+++ b/engine/db/queries/history.sql
@@ -51,3 +51,7 @@ ORDER BY id ASC;
 -- name: DeleteHistoryByRun :exec
 DELETE FROM engine.history
 WHERE run_id = $1;
+
+-- name: DeleteHistoryByRunCounted :execrows
+DELETE FROM engine.history
+WHERE run_id = $1;

--- a/engine/db/queries/inbox.sql
+++ b/engine/db/queries/inbox.sql
@@ -121,3 +121,7 @@ SET history_id = NULL,
     updated_at = NOW()
 WHERE run_id = $1
   AND history_id IS NOT NULL;
+
+-- name: DeleteInboxByRun :execrows
+DELETE FROM engine.inbox
+WHERE run_id = $1;

--- a/engine/db/queries/request_dedupe.sql
+++ b/engine/db/queries/request_dedupe.sql
@@ -78,3 +78,14 @@ SET status = 'expired',
     updated_at = NOW()
 WHERE status = 'in_progress'
   AND expires_at < NOW();
+
+-- name: ReapRequestDedupe :execrows
+DELETE FROM engine.request_dedupe AS target
+WHERE target.id IN (
+    SELECT candidate.id
+    FROM engine.request_dedupe AS candidate
+    WHERE (sqlc.narg(project_filter)::uuid IS NULL OR candidate.project_id = sqlc.narg(project_filter)::uuid)
+      AND candidate.status IN ('completed', 'failed', 'expired')
+      AND candidate.expires_at < sqlc.arg(cutoff)
+    LIMIT sqlc.arg(batch_size)
+);

--- a/engine/db/queries/runs.sql
+++ b/engine/db/queries/runs.sql
@@ -59,6 +59,34 @@ WHERE project_id = $1
   AND id = $2
 FOR UPDATE;
 
+-- name: ListRetainableTerminalRunIDs :many
+SELECT r.id
+FROM engine.runs AS r
+JOIN public.traces AS t ON t.engine_run_id = r.id
+WHERE (sqlc.narg(project_filter)::uuid IS NULL OR r.project_id = sqlc.narg(project_filter)::uuid)
+  AND r.status IN ('completed', 'failed', 'cancelled', 'terminated')
+  AND r.completed_at IS NOT NULL
+  AND r.completed_at < sqlc.arg(cutoff)::timestamptz
+  AND t.engine_latest_history_id IS NOT NULL
+  AND t.engine_last_projected_history_id IS NOT NULL
+  AND t.engine_last_projected_history_id >= t.engine_latest_history_id
+  AND COALESCE(t.engine_projection_state, '') <> 'journal_expired'
+ORDER BY r.completed_at ASC
+LIMIT sqlc.arg(batch_size);
+
+-- name: GetRetainableTerminalRunForUpdate :one
+SELECT r.id
+FROM engine.runs AS r
+JOIN public.traces AS t ON t.engine_run_id = r.id
+WHERE r.id = sqlc.arg(run_id)
+  AND (sqlc.narg(project_filter)::uuid IS NULL OR r.project_id = sqlc.narg(project_filter)::uuid)
+  AND r.status IN ('completed', 'failed', 'cancelled', 'terminated')
+  AND t.engine_latest_history_id IS NOT NULL
+  AND t.engine_last_projected_history_id IS NOT NULL
+  AND t.engine_last_projected_history_id >= t.engine_latest_history_id
+  AND COALESCE(t.engine_projection_state, '') <> 'journal_expired'
+FOR UPDATE OF r, t;
+
 -- name: ListRunsByInstance :many
 SELECT *
 FROM engine.runs

--- a/engine/db/sqlc.yaml
+++ b/engine/db/sqlc.yaml
@@ -2,7 +2,10 @@ version: "2"
 sql:
   - engine: "postgresql"
     queries: "queries/"
-    schema: "migrations/postgres/"
+    schema:
+      - "../../db/platform/migrations/postgres/000001_initial_schema.up.sql"
+      - "../../db/platform/migrations/postgres/000013_engine_trace_linkage.up.sql"
+      - "migrations/postgres/"
     gen:
       go:
         package: "engine"
@@ -11,6 +14,7 @@ sql:
         emit_json_tags: true
         emit_empty_slices: true
         emit_pointers_for_null_types: true
+        omit_unused_structs: true
         overrides:
           - db_type: "uuid"
             go_type: "github.com/google/uuid.UUID"

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -148,6 +149,27 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	retentionTerminalRuns, err := durationFromEnv("ENGINE_RETENTION_TERMINAL_RUNS", cfg.Runtime.RetentionTerminalRuns)
+	if err != nil {
+		return nil, err
+	}
+	if retentionTerminalRuns < 0 {
+		return nil, errors.New("ENGINE_RETENTION_TERMINAL_RUNS must be non-negative")
+	}
+	retentionDedupeGrace, err := durationFromEnv("ENGINE_RETENTION_DEDUPE_GRACE", cfg.Runtime.RetentionDedupeGrace)
+	if err != nil {
+		return nil, err
+	}
+	if retentionDedupeGrace < 0 {
+		return nil, errors.New("ENGINE_RETENTION_DEDUPE_GRACE must be non-negative")
+	}
+	retentionBatchSize, err := int32FromEnv("ENGINE_RETENTION_BATCH_SIZE", cfg.Runtime.RetentionBatchSize)
+	if err != nil {
+		return nil, err
+	}
+	if retentionBatchSize < 1 {
+		return nil, errors.New("ENGINE_RETENTION_BATCH_SIZE must be at least 1")
+	}
 	projectIDFilter, err := runtimeProjectIDFromEnv()
 	if err != nil {
 		return nil, err
@@ -169,6 +191,9 @@ func Load() (*Config, error) {
 	cfg.Runtime.ActivityLeaseTTL = activityLeaseTTL
 	cfg.Runtime.LeaseCompletionGrace = leaseCompletionGrace
 	cfg.Runtime.RequestDedupeTTL = requestDedupeTTL
+	cfg.Runtime.RetentionTerminalRuns = retentionTerminalRuns
+	cfg.Runtime.RetentionDedupeGrace = retentionDedupeGrace
+	cfg.Runtime.RetentionBatchSize = retentionBatchSize
 	cfg.Runtime.ProjectIDFilter = projectIDFilter
 	cfg.Runtime.MetricsAddr = os.Getenv("ENGINE_METRICS_ADDR")
 	cfg.Logging.Level = logLevel
@@ -200,6 +225,19 @@ func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) 
 		return 0, errors.New(key + " must be a valid duration: " + err.Error())
 	}
 	return parsed, nil
+}
+
+func int32FromEnv(key string, fallback int32) (int32, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback, nil
+	}
+
+	parsed, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return 0, errors.New(key + " must be a valid integer: " + err.Error())
+	}
+	return int32(parsed), nil
 }
 
 func logLevelFromEnv(key string, fallback slog.Level) (slog.Level, error) {

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -24,6 +24,9 @@ const (
 	defaultRunLeaseTTL     = 30 * time.Second
 	defaultActivityLease   = 5 * time.Minute
 	defaultRequestDedupe   = time.Hour
+	defaultRetentionRuns   = 168 * time.Hour
+	defaultRetentionDedupe = 24 * time.Hour
+	defaultRetentionBatch  = int32(500)
 	defaultLogLevel        = slog.LevelInfo
 	defaultLogFormat       = "json"
 )
@@ -61,6 +64,9 @@ type RuntimeConfig struct {
 	ActivityLeaseTTL        time.Duration
 	LeaseCompletionGrace    time.Duration
 	RequestDedupeTTL        time.Duration
+	RetentionTerminalRuns   time.Duration
+	RetentionDedupeGrace    time.Duration
+	RetentionBatchSize      int32
 	ProjectIDFilter         *uuid.UUID
 	MetricsAddr             string
 }
@@ -84,6 +90,9 @@ func Defaults(databaseURL string) *Config {
 			RunLeaseTTL:             defaultRunLeaseTTL,
 			ActivityLeaseTTL:        defaultActivityLease,
 			RequestDedupeTTL:        defaultRequestDedupe,
+			RetentionTerminalRuns:   defaultRetentionRuns,
+			RetentionDedupeGrace:    defaultRetentionDedupe,
+			RetentionBatchSize:      defaultRetentionBatch,
 		},
 		Logging: LoggingConfig{
 			Level:  defaultLogLevel,

--- a/engine/internal/config/config_retention_test.go
+++ b/engine/internal/config/config_retention_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadRetentionDefaults(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_DATABASE_URL", "")
+	t.Setenv("ENGINE_RETENTION_TERMINAL_RUNS", "")
+	t.Setenv("ENGINE_RETENTION_DEDUPE_GRACE", "")
+	t.Setenv("ENGINE_RETENTION_BATCH_SIZE", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Runtime.RetentionTerminalRuns != 168*time.Hour {
+		t.Errorf("RetentionTerminalRuns = %s, want %s", cfg.Runtime.RetentionTerminalRuns, 168*time.Hour)
+	}
+	if cfg.Runtime.RetentionDedupeGrace != 24*time.Hour {
+		t.Errorf("RetentionDedupeGrace = %s, want %s", cfg.Runtime.RetentionDedupeGrace, 24*time.Hour)
+	}
+	if cfg.Runtime.RetentionBatchSize != 500 {
+		t.Errorf("RetentionBatchSize = %d, want 500", cfg.Runtime.RetentionBatchSize)
+	}
+}
+
+func TestLoadRetentionFromEnv(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_DATABASE_URL", "")
+	t.Setenv("ENGINE_RETENTION_TERMINAL_RUNS", "36h")
+	t.Setenv("ENGINE_RETENTION_DEDUPE_GRACE", "1h")
+	t.Setenv("ENGINE_RETENTION_BATCH_SIZE", "50")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Runtime.RetentionTerminalRuns != 36*time.Hour {
+		t.Errorf("RetentionTerminalRuns = %s, want %s", cfg.Runtime.RetentionTerminalRuns, 36*time.Hour)
+	}
+	if cfg.Runtime.RetentionDedupeGrace != time.Hour {
+		t.Errorf("RetentionDedupeGrace = %s, want %s", cfg.Runtime.RetentionDedupeGrace, time.Hour)
+	}
+	if cfg.Runtime.RetentionBatchSize != 50 {
+		t.Errorf("RetentionBatchSize = %d, want 50", cfg.Runtime.RetentionBatchSize)
+	}
+}
+
+func TestLoadRetentionZeroDisables(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_DATABASE_URL", "")
+	t.Setenv("ENGINE_RETENTION_TERMINAL_RUNS", "0")
+	t.Setenv("ENGINE_RETENTION_DEDUPE_GRACE", "0")
+	t.Setenv("ENGINE_RETENTION_BATCH_SIZE", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Runtime.RetentionTerminalRuns != 0 {
+		t.Errorf("RetentionTerminalRuns = %s, want disabled (0)", cfg.Runtime.RetentionTerminalRuns)
+	}
+	if cfg.Runtime.RetentionDedupeGrace != 0 {
+		t.Errorf("RetentionDedupeGrace = %s, want disabled (0)", cfg.Runtime.RetentionDedupeGrace)
+	}
+}
+
+func TestLoadRetentionInvalid(t *testing.T) {
+	testCases := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "terminal runs malformed", key: "ENGINE_RETENTION_TERMINAL_RUNS", value: "bogus"},
+		{name: "dedupe grace negative", key: "ENGINE_RETENTION_DEDUPE_GRACE", value: "-1h"},
+		{name: "terminal runs negative", key: "ENGINE_RETENTION_TERMINAL_RUNS", value: "-1h"},
+		{name: "batch size malformed", key: "ENGINE_RETENTION_BATCH_SIZE", value: "abc"},
+		{name: "batch size zero", key: "ENGINE_RETENTION_BATCH_SIZE", value: "0"},
+		{name: "batch size negative", key: "ENGINE_RETENTION_BATCH_SIZE", value: "-5"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DATABASE_URL", "postgres://engine")
+			t.Setenv("ENGINE_DATABASE_URL", "")
+			t.Setenv("ENGINE_RETENTION_TERMINAL_RUNS", "")
+			t.Setenv("ENGINE_RETENTION_DEDUPE_GRACE", "")
+			t.Setenv("ENGINE_RETENTION_BATCH_SIZE", "")
+			t.Setenv(tc.key, tc.value)
+
+			if _, err := Load(); err == nil {
+				t.Fatalf("Load() with %s=%q error = nil, want validation error", tc.key, tc.value)
+			}
+		})
+	}
+}

--- a/engine/internal/metrics/metrics.go
+++ b/engine/internal/metrics/metrics.go
@@ -19,6 +19,7 @@ type Metrics struct {
 	projectorLagRows        prometheus.Gauge
 	queueDepth              *prometheus.GaugeVec
 	dedupeClaims            *prometheus.CounterVec
+	retentionReapedRows     *prometheus.CounterVec
 }
 
 // New registers and returns the engine metrics recorder.
@@ -81,6 +82,12 @@ func New(registerer prometheus.Registerer) *Metrics {
 			Name:      "dedupe_claims_total",
 			Help:      "Total start-request deduplication claim outcomes.",
 		}, []string{"outcome"}),
+		retentionReapedRows: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "continua",
+			Subsystem: "engine",
+			Name:      "retention_reaped_rows_total",
+			Help:      "Total engine rows deleted by retention.",
+		}, []string{"table"}),
 	}
 	registerer.MustRegister(
 		metrics.workerIterationDuration,
@@ -91,6 +98,7 @@ func New(registerer prometheus.Registerer) *Metrics {
 		metrics.projectorLagRows,
 		metrics.queueDepth,
 		metrics.dedupeClaims,
+		metrics.retentionReapedRows,
 	)
 	return metrics
 }
@@ -159,8 +167,13 @@ func (m *Metrics) IncDedupeClaim(outcome string) {
 	m.dedupeClaims.WithLabelValues(outcome).Inc()
 }
 
-// AddRetentionReaped is the retention metrics API scaffold.
-func (m *Metrics) AddRetentionReaped(string, float64) {}
+// AddRetentionReaped records rows deleted by engine retention.
+func (m *Metrics) AddRetentionReaped(table string, rows float64) {
+	if m == nil || m.retentionReapedRows == nil {
+		return
+	}
+	m.retentionReapedRows.WithLabelValues(table).Add(rows)
+}
 
 // Handler exposes metrics from gatherer using the Prometheus text format.
 func Handler(gatherer prometheus.Gatherer) http.Handler {

--- a/engine/internal/metrics/metrics.go
+++ b/engine/internal/metrics/metrics.go
@@ -159,6 +159,9 @@ func (m *Metrics) IncDedupeClaim(outcome string) {
 	m.dedupeClaims.WithLabelValues(outcome).Inc()
 }
 
+// AddRetentionReaped is the retention metrics API scaffold.
+func (m *Metrics) AddRetentionReaped(string, float64) {}
+
 // Handler exposes metrics from gatherer using the Prometheus text format.
 func Handler(gatherer prometheus.Gatherer) http.Handler {
 	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})

--- a/engine/internal/store/retention.go
+++ b/engine/internal/store/retention.go
@@ -5,6 +5,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
 )
 
 // RetentionReapCounts reports journal rows deleted for a terminal run.
@@ -14,17 +19,104 @@ type RetentionReapCounts struct {
 	ActivityTasks int64
 }
 
-// ReapRequestDedupe is the retention store API scaffold.
-func (s *Store) ReapRequestDedupe(context.Context, time.Time, int32) (int64, error) {
-	return 0, nil
+// ReapRequestDedupe deletes one batch of finalized dedupe rows older than cutoff.
+func (o *storeOps) ReapRequestDedupe(ctx context.Context, cutoff time.Time, limit int32) (int64, error) {
+	projectFilter := pgtype.UUID{}
+	if o.projectFilter != nil {
+		projectFilter = pgtype.UUID{Bytes: *o.projectFilter, Valid: true}
+	}
+	return o.q.ReapRequestDedupe(ctx, enginedb.ReapRequestDedupeParams{
+		ProjectFilter: projectFilter,
+		Cutoff:        cutoff,
+		BatchSize:     limit,
+	})
 }
 
-// ListRetainableTerminalRunIDs is the retention store API scaffold.
-func (s *Store) ListRetainableTerminalRunIDs(context.Context, time.Time, int32) ([]uuid.UUID, error) {
-	return nil, nil
+// ListRetainableTerminalRunIDs returns oldest-first terminal runs whose
+// projected trace has consumed the complete history journal.
+func (s *Store) ListRetainableTerminalRunIDs(
+	ctx context.Context,
+	cutoff time.Time,
+	limit int32,
+) ([]uuid.UUID, error) {
+	projectFilter := pgtype.UUID{}
+	if s.projectFilter != nil {
+		projectFilter = pgtype.UUID{Bytes: *s.projectFilter, Valid: true}
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT r.id
+		FROM engine.runs AS r
+		JOIN public.traces AS t ON t.engine_run_id = r.id
+		WHERE ($1::uuid IS NULL OR r.project_id = $1)
+		  AND r.status IN ('completed', 'failed', 'cancelled', 'terminated')
+		  AND r.completed_at IS NOT NULL
+		  AND r.completed_at < $2
+		  AND t.engine_latest_history_id IS NOT NULL
+		  AND t.engine_last_projected_history_id IS NOT NULL
+		  AND t.engine_last_projected_history_id >= t.engine_latest_history_id
+		  AND COALESCE(t.engine_projection_state, '') <> 'journal_expired'
+		ORDER BY r.completed_at ASC
+		LIMIT $3
+	`, projectFilter, cutoff, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	runIDs := make([]uuid.UUID, 0, limit)
+	for rows.Next() {
+		var runID uuid.UUID
+		if err := rows.Scan(&runID); err != nil {
+			return nil, err
+		}
+		runIDs = append(runIDs, runID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return runIDs, nil
 }
 
-// ReapTerminalRunJournal is the retention store API scaffold.
-func (s *Store) ReapTerminalRunJournal(context.Context, uuid.UUID) (RetentionReapCounts, error) {
-	return RetentionReapCounts{}, nil
+// ReapTerminalRunJournal deletes a terminal run's engine journal atomically
+// and marks its retained platform projection as journal-expired.
+func (s *Store) ReapTerminalRunJournal(ctx context.Context, runID uuid.UUID) (RetentionReapCounts, error) {
+	tx, err := s.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return RetentionReapCounts{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if tx.projectFilter != nil {
+		_, err = tx.q.GetRunByProjectAndIDForUpdate(ctx, enginedb.GetRunByProjectAndIDForUpdateParams{
+			ProjectID: *tx.projectFilter,
+			ID:        runID,
+		})
+	} else {
+		_, err = tx.q.GetRunForUpdate(ctx, runID)
+	}
+	if err != nil {
+		return RetentionReapCounts{}, normalizeError(err)
+	}
+
+	var counts RetentionReapCounts
+	counts.ActivityTasks, err = tx.q.DeleteActivityTasksByRun(ctx, runID)
+	if err != nil {
+		return RetentionReapCounts{}, err
+	}
+	counts.Inbox, err = tx.q.DeleteInboxByRun(ctx, pgtype.UUID{Bytes: runID, Valid: true})
+	if err != nil {
+		return RetentionReapCounts{}, err
+	}
+	counts.History, err = tx.q.DeleteHistoryByRunCounted(ctx, runID)
+	if err != nil {
+		return RetentionReapCounts{}, err
+	}
+	if _, err := publicprojection.NewWriter(tx.Tx()).MarkProjectionJournalExpired(ctx, runID); err != nil {
+		return RetentionReapCounts{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return RetentionReapCounts{}, err
+	}
+	return counts, nil
 }

--- a/engine/internal/store/retention.go
+++ b/engine/internal/store/retention.go
@@ -1,0 +1,30 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// RetentionReapCounts reports journal rows deleted for a terminal run.
+type RetentionReapCounts struct {
+	History       int64
+	Inbox         int64
+	ActivityTasks int64
+}
+
+// ReapRequestDedupe is the retention store API scaffold.
+func (s *Store) ReapRequestDedupe(context.Context, time.Time, int32) (int64, error) {
+	return 0, nil
+}
+
+// ListRetainableTerminalRunIDs is the retention store API scaffold.
+func (s *Store) ListRetainableTerminalRunIDs(context.Context, time.Time, int32) ([]uuid.UUID, error) {
+	return nil, nil
+}
+
+// ReapTerminalRunJournal is the retention store API scaffold.
+func (s *Store) ReapTerminalRunJournal(context.Context, uuid.UUID) (RetentionReapCounts, error) {
+	return RetentionReapCounts{}, nil
+}

--- a/engine/internal/store/retention.go
+++ b/engine/internal/store/retention.go
@@ -44,38 +44,11 @@ func (s *Store) ListRetainableTerminalRunIDs(
 		projectFilter = pgtype.UUID{Bytes: *s.projectFilter, Valid: true}
 	}
 
-	rows, err := s.pool.Query(ctx, `
-		SELECT r.id
-		FROM engine.runs AS r
-		JOIN public.traces AS t ON t.engine_run_id = r.id
-		WHERE ($1::uuid IS NULL OR r.project_id = $1)
-		  AND r.status IN ('completed', 'failed', 'cancelled', 'terminated')
-		  AND r.completed_at IS NOT NULL
-		  AND r.completed_at < $2
-		  AND t.engine_latest_history_id IS NOT NULL
-		  AND t.engine_last_projected_history_id IS NOT NULL
-		  AND t.engine_last_projected_history_id >= t.engine_latest_history_id
-		  AND COALESCE(t.engine_projection_state, '') <> 'journal_expired'
-		ORDER BY r.completed_at ASC
-		LIMIT $3
-	`, projectFilter, cutoff, limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	runIDs := make([]uuid.UUID, 0, limit)
-	for rows.Next() {
-		var runID uuid.UUID
-		if err := rows.Scan(&runID); err != nil {
-			return nil, err
-		}
-		runIDs = append(runIDs, runID)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return runIDs, nil
+	return s.q.ListRetainableTerminalRunIDs(ctx, enginedb.ListRetainableTerminalRunIDsParams{
+		ProjectFilter: projectFilter,
+		Cutoff:        cutoff,
+		BatchSize:     limit,
+	})
 }
 
 // ReapTerminalRunJournal deletes a terminal run's engine journal atomically
@@ -87,14 +60,14 @@ func (s *Store) ReapTerminalRunJournal(ctx context.Context, runID uuid.UUID) (Re
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	projectFilter := pgtype.UUID{}
 	if tx.projectFilter != nil {
-		_, err = tx.q.GetRunByProjectAndIDForUpdate(ctx, enginedb.GetRunByProjectAndIDForUpdateParams{
-			ProjectID: *tx.projectFilter,
-			ID:        runID,
-		})
-	} else {
-		_, err = tx.q.GetRunForUpdate(ctx, runID)
+		projectFilter = pgtype.UUID{Bytes: *tx.projectFilter, Valid: true}
 	}
+	_, err = tx.q.GetRetainableTerminalRunForUpdate(ctx, enginedb.GetRetainableTerminalRunForUpdateParams{
+		RunID:         runID,
+		ProjectFilter: projectFilter,
+	})
 	if err != nil {
 		return RetentionReapCounts{}, normalizeError(err)
 	}

--- a/engine/internal/store/retention_test.go
+++ b/engine/internal/store/retention_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -215,6 +216,46 @@ func TestReapTerminalRunJournal_ProjectFilterMismatchLeavesData(t *testing.T) {
 	}
 }
 
+func TestReapTerminalRunJournal_RejectsActiveRun(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	fixture := seedRetentionJournal(t, ts, projectID, "active-run")
+	if _, err := ts.db.Pool.Exec(ts.ctx, `
+		UPDATE engine.runs
+		SET status = 'running', completed_at = NULL, updated_at = NOW()
+		WHERE id = $1
+	`, fixture.run.ID); err != nil {
+		t.Fatalf("mark run active: %v", err)
+	}
+
+	_, err := ts.store.ReapTerminalRunJournal(ts.ctx, fixture.run.ID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("ReapTerminalRunJournal() error = %v, want ErrNotFound", err)
+	}
+	assertRetentionRunRows(t, ts, fixture.run.ID, 2, 1, 1)
+	assertRetentionTraceNotExpired(t, ts, fixture.traceID)
+}
+
+func TestReapTerminalRunJournal_RejectsIncompleteProjection(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	fixture := seedRetentionJournal(t, ts, projectID, "incomplete-projection")
+	if _, err := ts.db.Pool.Exec(ts.ctx, `
+		UPDATE public.traces
+		SET engine_last_projected_history_id = engine_latest_history_id - 1
+		WHERE id = $1
+	`, fixture.traceID); err != nil {
+		t.Fatalf("mark trace projection incomplete: %v", err)
+	}
+
+	_, err := ts.store.ReapTerminalRunJournal(ts.ctx, fixture.run.ID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("ReapTerminalRunJournal() error = %v, want ErrNotFound", err)
+	}
+	assertRetentionRunRows(t, ts, fixture.run.ID, 2, 1, 1)
+	assertRetentionTraceNotExpired(t, ts, fixture.traceID)
+}
+
 type retentionJournalFixture struct {
 	instance   enginedb.EngineInstance
 	run        enginedb.EngineRun
@@ -377,5 +418,20 @@ func assertRetentionRunRows(t *testing.T, ts *testStore, runID uuid.UUID, wantHi
 		if got != check.want {
 			t.Errorf("%s rows for run = %d, want %d", check.name, got, check.want)
 		}
+	}
+}
+
+func assertRetentionTraceNotExpired(t *testing.T, ts *testStore, traceID uuid.UUID) {
+	t.Helper()
+	var traceState string
+	if err := ts.db.Pool.QueryRow(ts.ctx, `
+		SELECT COALESCE(engine_projection_state, '')
+		FROM public.traces
+		WHERE id = $1
+	`, traceID).Scan(&traceState); err != nil {
+		t.Fatalf("query trace projection state: %v", err)
+	}
+	if traceState == "journal_expired" {
+		t.Fatal("ineligible run marked trace journal_expired; want journal data and projection state untouched")
 	}
 }

--- a/engine/internal/store/retention_test.go
+++ b/engine/internal/store/retention_test.go
@@ -1,0 +1,381 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+)
+
+func TestReapRequestDedupe_DeletesFinalizedPastCutoff(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	now := time.Now()
+
+	seedRetentionDedupe(t, ts, projectID, "old-expired", "expired", now.Add(-48*time.Hour))
+	seedRetentionDedupe(t, ts, projectID, "old-completed", "completed", now.Add(-48*time.Hour))
+	seedRetentionDedupe(t, ts, projectID, "recent-expired", "expired", now.Add(time.Hour))
+	seedRetentionDedupe(t, ts, projectID, "old-in-progress", "in_progress", now.Add(-48*time.Hour))
+
+	reaped, err := ts.store.ReapRequestDedupe(ts.ctx, now.Add(-24*time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ReapRequestDedupe() error = %v", err)
+	}
+	if reaped != 2 {
+		t.Fatalf("ReapRequestDedupe() = %d, want 2", reaped)
+	}
+	if got, want := retentionDedupeKeys(t, ts, projectID), []string{"old-in-progress", "recent-expired"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("surviving request_dedupe keys = %v, want %v", got, want)
+	}
+}
+
+func TestReapRequestDedupe_HonorsBatchLimit(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		seedRetentionDedupe(t, ts, projectID, "eligible-"+string(rune('a'+i)), "expired", now.Add(-48*time.Hour))
+	}
+
+	reaped, err := ts.store.ReapRequestDedupe(ts.ctx, now.Add(-24*time.Hour), 2)
+	if err != nil {
+		t.Fatalf("ReapRequestDedupe() first call error = %v", err)
+	}
+	if reaped != 2 {
+		t.Fatalf("ReapRequestDedupe() first call = %d, want 2", reaped)
+	}
+	if remaining := retentionDedupeCount(t, ts, projectID); remaining != 3 {
+		t.Fatalf("request_dedupe rows after first call = %d, want 3", remaining)
+	}
+
+	reaped, err = ts.store.ReapRequestDedupe(ts.ctx, now.Add(-24*time.Hour), 2)
+	if err != nil {
+		t.Fatalf("ReapRequestDedupe() second call error = %v", err)
+	}
+	if reaped != 2 {
+		t.Fatalf("ReapRequestDedupe() second call = %d, want 2", reaped)
+	}
+	if remaining := retentionDedupeCount(t, ts, projectID); remaining != 1 {
+		t.Fatalf("request_dedupe rows after second call = %d, want 1", remaining)
+	}
+}
+
+func TestReapRequestDedupe_HonorsProjectFilter(t *testing.T) {
+	ts := newTestStore(t)
+	projectA := uuidOrFatal(t)
+	projectB := uuidOrFatal(t)
+	now := time.Now()
+	seedRetentionDedupe(t, ts, projectA, "project-a", "failed", now.Add(-48*time.Hour))
+	seedRetentionDedupe(t, ts, projectB, "project-b", "failed", now.Add(-48*time.Hour))
+
+	reaped, err := ts.store.WithProjectFilter(projectA).ReapRequestDedupe(ts.ctx, now.Add(-24*time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ReapRequestDedupe() error = %v", err)
+	}
+	if reaped != 1 {
+		t.Fatalf("ReapRequestDedupe() = %d, want 1", reaped)
+	}
+	if remaining := retentionDedupeCount(t, ts, projectA); remaining != 0 {
+		t.Fatalf("project A request_dedupe rows = %d, want 0", remaining)
+	}
+	if remaining := retentionDedupeCount(t, ts, projectB); remaining != 1 {
+		t.Fatalf("project B request_dedupe rows = %d, want 1", remaining)
+	}
+}
+
+func TestListRetainableTerminalRunIDs_RequiresProjectionComplete(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	enginetest.EnsurePlatformProject(t, ts.db.Pool, projectID)
+	completedAt := time.Now().Add(-48 * time.Hour)
+	incomplete := seedRetentionRun(t, ts, projectID, "projection-incomplete", "completed", completedAt)
+	complete := seedRetentionRun(t, ts, projectID, "projection-complete", "completed", completedAt.Add(time.Minute))
+	seedRetentionTrace(t, ts, incomplete, "completed", "up_to_date", 20, 19, false)
+	seedRetentionTrace(t, ts, complete, "completed", "up_to_date", 30, 30, false)
+
+	ids, err := ts.store.ListRetainableTerminalRunIDs(ts.ctx, time.Now().Add(-24*time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListRetainableTerminalRunIDs() error = %v", err)
+	}
+	if got, want := ids, []uuid.UUID{complete.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListRetainableTerminalRunIDs() = %v, want %v", got, want)
+	}
+}
+
+func TestListRetainableTerminalRunIDs_ExcludesIneligibleRuns(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	enginetest.EnsurePlatformProject(t, ts.db.Pool, projectID)
+	now := time.Now()
+	cutoff := now.Add(-24 * time.Hour)
+
+	recent := seedRetentionRun(t, ts, projectID, "recent-completed", "completed", now.Add(-time.Hour))
+	seedRetentionTrace(t, ts, recent, "completed", "up_to_date", 10, 10, false)
+	running := seedRetentionRun(t, ts, projectID, "running", "running", now.Add(-48*time.Hour))
+	seedRetentionTrace(t, ts, running, "running", "up_to_date", 10, 10, false)
+	quarantined := seedRetentionRun(t, ts, projectID, "quarantined", "quarantined", now.Add(-48*time.Hour))
+	seedRetentionTrace(t, ts, quarantined, "quarantined", "up_to_date", 10, 10, false)
+	continued := seedRetentionRun(t, ts, projectID, "continued", "continued_as_new", now.Add(-48*time.Hour))
+	seedRetentionTrace(t, ts, continued, "continued_as_new", "up_to_date", 10, 10, false)
+	seedRetentionRun(t, ts, projectID, "no-trace", "completed", now.Add(-48*time.Hour))
+	alreadyExpired := seedRetentionRun(t, ts, projectID, "already-expired", "completed", now.Add(-48*time.Hour))
+	seedRetentionTrace(t, ts, alreadyExpired, "completed", "journal_expired", 10, 10, false)
+	control := seedRetentionRun(t, ts, projectID, "included-control", "completed", now.Add(-72*time.Hour))
+	seedRetentionTrace(t, ts, control, "completed", "up_to_date", 10, 10, false)
+
+	ids, err := ts.store.ListRetainableTerminalRunIDs(ts.ctx, cutoff, 20)
+	if err != nil {
+		t.Fatalf("ListRetainableTerminalRunIDs() error = %v", err)
+	}
+	if got, want := ids, []uuid.UUID{control.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListRetainableTerminalRunIDs() = %v, want only control %v", got, want)
+	}
+}
+
+func TestListRetainableTerminalRunIDs_BatchLimitAndOrder(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	enginetest.EnsurePlatformProject(t, ts.db.Pool, projectID)
+	now := time.Now()
+	oldest := seedRetentionRun(t, ts, projectID, "oldest", "completed", now.Add(-72*time.Hour))
+	middle := seedRetentionRun(t, ts, projectID, "middle", "completed", now.Add(-48*time.Hour))
+	newest := seedRetentionRun(t, ts, projectID, "newest", "completed", now.Add(-36*time.Hour))
+	for _, run := range []enginedb.EngineRun{oldest, middle, newest} {
+		seedRetentionTrace(t, ts, run, "completed", "up_to_date", 10, 10, false)
+	}
+
+	ids, err := ts.store.ListRetainableTerminalRunIDs(ts.ctx, now.Add(-24*time.Hour), 2)
+	if err != nil {
+		t.Fatalf("ListRetainableTerminalRunIDs() error = %v", err)
+	}
+	if got, want := ids, []uuid.UUID{oldest.ID, middle.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListRetainableTerminalRunIDs() = %v, want oldest-first %v", got, want)
+	}
+}
+
+func TestReapTerminalRunJournal_DeletesJournalAndMarksExpired(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	fixture := seedRetentionJournal(t, ts, projectID, "reap-journal")
+
+	counts, err := ts.store.ReapTerminalRunJournal(ts.ctx, fixture.run.ID)
+	if err != nil {
+		t.Fatalf("ReapTerminalRunJournal() error = %v", err)
+	}
+	if counts != (RetentionReapCounts{History: 2, Inbox: 1, ActivityTasks: 1}) {
+		t.Fatalf("ReapTerminalRunJournal() counts = %+v, want history=2 inbox=1 activity_tasks=1", counts)
+	}
+	assertRetentionRunRows(t, ts, fixture.run.ID, 0, 0, 0)
+
+	var runExists, instanceExists, traceExists, rootSpanExists bool
+	var traceState, traceStatus string
+	if err := ts.db.Pool.QueryRow(ts.ctx, `SELECT EXISTS (SELECT 1 FROM engine.runs WHERE id = $1)`, fixture.run.ID).Scan(&runExists); err != nil {
+		t.Fatalf("query run existence: %v", err)
+	}
+	if err := ts.db.Pool.QueryRow(ts.ctx, `SELECT EXISTS (SELECT 1 FROM engine.instances WHERE id = $1)`, fixture.instance.ID).Scan(&instanceExists); err != nil {
+		t.Fatalf("query instance existence: %v", err)
+	}
+	if err := ts.db.Pool.QueryRow(ts.ctx, `
+		SELECT EXISTS (SELECT 1 FROM public.traces WHERE id = $1),
+		       COALESCE(engine_projection_state, ''), status
+		FROM public.traces WHERE id = $1
+	`, fixture.traceID).Scan(&traceExists, &traceState, &traceStatus); err != nil {
+		t.Fatalf("query retained trace: %v", err)
+	}
+	if err := ts.db.Pool.QueryRow(ts.ctx, `SELECT EXISTS (SELECT 1 FROM public.spans WHERE id = $1)`, fixture.rootSpanID).Scan(&rootSpanExists); err != nil {
+		t.Fatalf("query root span existence: %v", err)
+	}
+	if !runExists || !instanceExists || !traceExists || !rootSpanExists {
+		t.Fatalf("retained rows run=%t instance=%t trace=%t root_span=%t, want all true", runExists, instanceExists, traceExists, rootSpanExists)
+	}
+	if traceState != "journal_expired" || traceStatus != "completed" {
+		t.Fatalf("trace projection_state/status = %q/%q, want journal_expired/completed", traceState, traceStatus)
+	}
+}
+
+func TestReapTerminalRunJournal_ProjectFilterMismatchLeavesData(t *testing.T) {
+	ts := newTestStore(t)
+	projectA := uuidOrFatal(t)
+	projectB := uuidOrFatal(t)
+	fixture := seedRetentionJournal(t, ts, projectA, "project-filter-mismatch")
+
+	_, _ = ts.store.WithProjectFilter(projectB).ReapTerminalRunJournal(ts.ctx, fixture.run.ID)
+
+	assertRetentionRunRows(t, ts, fixture.run.ID, 2, 1, 1)
+	var traceState string
+	if err := ts.db.Pool.QueryRow(ts.ctx, `SELECT COALESCE(engine_projection_state, '') FROM public.traces WHERE id = $1`, fixture.traceID).Scan(&traceState); err != nil {
+		t.Fatalf("query trace projection state: %v", err)
+	}
+	if traceState == "journal_expired" {
+		t.Fatal("project-filter mismatch marked trace journal_expired; want journal data and projection state untouched")
+	}
+}
+
+type retentionJournalFixture struct {
+	instance   enginedb.EngineInstance
+	run        enginedb.EngineRun
+	traceID    uuid.UUID
+	rootSpanID uuid.UUID
+}
+
+func seedRetentionDedupe(t *testing.T, ts *testStore, projectID uuid.UUID, key, status string, expiresAt time.Time) {
+	t.Helper()
+	if _, err := ts.db.Pool.Exec(ts.ctx, `
+		INSERT INTO engine.request_dedupe (project_id, request_scope, request_key, status, expires_at)
+		VALUES ($1, 'engine.start', $2, $3::engine.request_dedupe_status, $4)
+	`, projectID, key, status, expiresAt); err != nil {
+		t.Fatalf("seed request_dedupe %q: %v", key, err)
+	}
+}
+
+func retentionDedupeKeys(t *testing.T, ts *testStore, projectID uuid.UUID) []string {
+	t.Helper()
+	rows, err := ts.db.Pool.Query(ts.ctx, `SELECT request_key FROM engine.request_dedupe WHERE project_id = $1 ORDER BY request_key`, projectID)
+	if err != nil {
+		t.Fatalf("query request_dedupe keys: %v", err)
+	}
+	defer rows.Close()
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			t.Fatalf("scan request_dedupe key: %v", err)
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate request_dedupe keys: %v", err)
+	}
+	return keys
+}
+
+func retentionDedupeCount(t *testing.T, ts *testStore, projectID uuid.UUID) int64 {
+	t.Helper()
+	var count int64
+	if err := ts.db.Pool.QueryRow(ts.ctx, `SELECT COUNT(*) FROM engine.request_dedupe WHERE project_id = $1`, projectID).Scan(&count); err != nil {
+		t.Fatalf("count request_dedupe rows: %v", err)
+	}
+	return count
+}
+
+func seedRetentionRun(t *testing.T, ts *testStore, projectID uuid.UUID, key, status string, completedAt time.Time) enginedb.EngineRun {
+	t.Helper()
+	instance := ts.createInstance(t, projectID, key+"-"+uuid.NewString()[:8])
+	run := ts.createRun(t, instance, 1)
+	if _, err := ts.db.Pool.Exec(ts.ctx, `
+		UPDATE engine.runs
+		SET status = $2::engine.run_lifecycle_status, completed_at = $3, updated_at = $3
+		WHERE id = $1
+	`, run.ID, status, completedAt); err != nil {
+		t.Fatalf("set run %s status %s: %v", run.ID, status, err)
+	}
+	run.Status = enginedb.EngineRunLifecycleStatus(status)
+	return run
+}
+
+func seedRetentionTrace(
+	t *testing.T,
+	ts *testStore,
+	run enginedb.EngineRun,
+	status, projectionState string,
+	latestHistoryID, lastProjectedHistoryID int64,
+	withRootSpan bool,
+) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	traceID := uuid.New()
+	if _, err := ts.db.Pool.Exec(ts.ctx, `
+		INSERT INTO public.traces (
+			id, project_id, trace_id, name, status, start_time, end_time,
+			engine_run_id, engine_run_status, engine_projection_state,
+			engine_latest_history_id, engine_last_projected_history_id, engine_projection_updated_at
+		)
+		VALUES ($1, $2, $3, 'Retention test', $4, NOW() - INTERVAL '2 days', NOW(),
+		        $5, $4, $6, $7, $8, NOW())
+	`, traceID, run.ProjectID, "engine:"+run.ID.String(), status, run.ID, projectionState, latestHistoryID, lastProjectedHistoryID); err != nil {
+		t.Fatalf("seed projected trace for run %s: %v", run.ID, err)
+	}
+	if !withRootSpan {
+		return traceID, uuid.Nil
+	}
+	rootSpanID := uuid.New()
+	if _, err := ts.db.Pool.Exec(ts.ctx, `
+		INSERT INTO public.spans (id, project_id, trace_id, span_id, name, type, status, level, start_time, end_time, depth)
+		VALUES ($1, $2, $3, $4, 'Retention root', 'chain', 'completed', 'default', NOW() - INTERVAL '2 days', NOW(), 0)
+	`, rootSpanID, run.ProjectID, traceID, "engine:run:"+run.ID.String()); err != nil {
+		t.Fatalf("seed root span for run %s: %v", run.ID, err)
+	}
+	return traceID, rootSpanID
+}
+
+func seedRetentionJournal(t *testing.T, ts *testStore, projectID uuid.UUID, key string) retentionJournalFixture {
+	t.Helper()
+	enginetest.EnsurePlatformProject(t, ts.db.Pool, projectID)
+	instance := ts.createInstance(t, projectID, key+"-"+uuid.NewString()[:8])
+	run := ts.createRun(t, instance, 1)
+	first := ts.createHistory(t, projectID, instance.ID, run.ID, 1, "workflow.started")
+	second := ts.createHistory(t, projectID, instance.ID, run.ID, 2, "workflow.completed")
+	if _, err := ts.store.CreateInboxItem(ts.ctx, enginedb.CreateInboxItemParams{
+		ProjectID:   projectID,
+		InstanceID:  instance.ID,
+		RunID:       enginetest.NullableUUID(run.ID),
+		HistoryID:   &first.ID,
+		Kind:        "signal",
+		Payload:     []byte(`{"signal":"done"}`),
+		AvailableAt: time.Now().Add(-48 * time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateInboxItem() error = %v", err)
+	}
+	if _, err := ts.db.Pool.Exec(ts.ctx, `UPDATE engine.inbox SET status = 'processed', resolved_at = NOW() WHERE run_id = $1`, run.ID); err != nil {
+		t.Fatalf("mark inbox processed: %v", err)
+	}
+	if _, err := ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &second.ID,
+		ActivityKey:     "retention-activity",
+		ActivityType:    "retention.test",
+		Input:           []byte(`{"value":1}`),
+		AvailableAt:     time.Now().Add(-48 * time.Hour),
+		ExecutionTarget: "local",
+		MaxAttempts:     1,
+	}); err != nil {
+		t.Fatalf("CreateActivityTask() error = %v", err)
+	}
+	if _, err := ts.db.Pool.Exec(ts.ctx, `UPDATE engine.activity_tasks SET status = 'completed', completed_at = NOW() WHERE run_id = $1`, run.ID); err != nil {
+		t.Fatalf("mark activity task completed: %v", err)
+	}
+	completedAt := time.Now().Add(-48 * time.Hour)
+	if _, err := ts.db.Pool.Exec(ts.ctx, `UPDATE engine.runs SET status = 'completed', completed_at = $2, updated_at = $2 WHERE id = $1`, run.ID, completedAt); err != nil {
+		t.Fatalf("mark run completed: %v", err)
+	}
+	run.Status = enginedb.EngineRunLifecycleStatusCompleted
+	traceID, rootSpanID := seedRetentionTrace(t, ts, run, "completed", "up_to_date", second.ID, second.ID, true)
+	return retentionJournalFixture{instance: instance, run: run, traceID: traceID, rootSpanID: rootSpanID}
+}
+
+func assertRetentionRunRows(t *testing.T, ts *testStore, runID uuid.UUID, wantHistory, wantInbox, wantTasks int64) {
+	t.Helper()
+	queries := []struct {
+		name  string
+		query string
+		want  int64
+	}{
+		{name: "history", query: `SELECT COUNT(*) FROM engine.history WHERE run_id = $1`, want: wantHistory},
+		{name: "inbox", query: `SELECT COUNT(*) FROM engine.inbox WHERE run_id = $1`, want: wantInbox},
+		{name: "activity_tasks", query: `SELECT COUNT(*) FROM engine.activity_tasks WHERE run_id = $1`, want: wantTasks},
+	}
+	for _, check := range queries {
+		var got int64
+		if err := ts.db.Pool.QueryRow(ts.ctx, check.query, runID).Scan(&got); err != nil {
+			t.Fatalf("count %s rows: %v", check.name, err)
+		}
+		if got != check.want {
+			t.Errorf("%s rows for run = %d, want %d", check.name, got, check.want)
+		}
+	}
+}

--- a/engine/internal/worker/retention.go
+++ b/engine/internal/worker/retention.go
@@ -20,12 +20,42 @@ type RetentionWorker struct {
 	cfg   RetentionConfig
 }
 
-// NewRetentionWorker constructs the retention worker API scaffold.
+// NewRetentionWorker constructs a retention worker.
 func NewRetentionWorker(engineStore *store.Store, cfg RetentionConfig) *RetentionWorker {
 	return &RetentionWorker{store: engineStore, cfg: cfg}
 }
 
-// PollOnce is the retention worker API scaffold.
-func (w *RetentionWorker) PollOnce(context.Context, string) error {
+// PollOnce reaps at most one configured batch from each retention class.
+func (w *RetentionWorker) PollOnce(ctx context.Context, _ string) error {
+	if w.cfg.BatchSize < 1 || (w.cfg.TerminalRuns <= 0 && w.cfg.DedupeGrace <= 0) {
+		return nil
+	}
+
+	now := time.Now()
+	metrics := w.store.Metrics()
+	if w.cfg.DedupeGrace > 0 {
+		reaped, err := w.store.ReapRequestDedupe(ctx, now.Add(-w.cfg.DedupeGrace), w.cfg.BatchSize)
+		if err != nil {
+			return err
+		}
+		metrics.AddRetentionReaped("request_dedupe", float64(reaped))
+	}
+
+	if w.cfg.TerminalRuns > 0 {
+		runIDs, err := w.store.ListRetainableTerminalRunIDs(ctx, now.Add(-w.cfg.TerminalRuns), w.cfg.BatchSize)
+		if err != nil {
+			return err
+		}
+		for _, runID := range runIDs {
+			counts, err := w.store.ReapTerminalRunJournal(ctx, runID)
+			if err != nil {
+				return err
+			}
+			metrics.AddRetentionReaped("history", float64(counts.History))
+			metrics.AddRetentionReaped("inbox", float64(counts.Inbox))
+			metrics.AddRetentionReaped("activity_tasks", float64(counts.ActivityTasks))
+		}
+	}
+
 	return nil
 }

--- a/engine/internal/worker/retention.go
+++ b/engine/internal/worker/retention.go
@@ -1,0 +1,31 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/continua-ai/continua/engine/internal/store"
+)
+
+// RetentionConfig configures terminal journal and request-dedupe retention.
+type RetentionConfig struct {
+	TerminalRuns time.Duration
+	DedupeGrace  time.Duration
+	BatchSize    int32
+}
+
+// RetentionWorker removes expired engine journal data.
+type RetentionWorker struct {
+	store *store.Store
+	cfg   RetentionConfig
+}
+
+// NewRetentionWorker constructs the retention worker API scaffold.
+func NewRetentionWorker(engineStore *store.Store, cfg RetentionConfig) *RetentionWorker {
+	return &RetentionWorker{store: engineStore, cfg: cfg}
+}
+
+// PollOnce is the retention worker API scaffold.
+func (w *RetentionWorker) PollOnce(context.Context, string) error {
+	return nil
+}

--- a/engine/internal/worker/retention_test.go
+++ b/engine/internal/worker/retention_test.go
@@ -1,0 +1,223 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginemetrics "github.com/continua-ai/continua/engine/internal/metrics"
+	"github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+)
+
+func TestRetentionWorkerPollOnce_DisabledIsNoop(t *testing.T) {
+	fixture := newRetentionWorkerFixture(t)
+	worker := NewRetentionWorker(fixture.store, RetentionConfig{
+		TerminalRuns: 0,
+		DedupeGrace:  0,
+		BatchSize:    10,
+	})
+
+	if err := worker.PollOnce(fixture.ctx, "retention-test"); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+	fixture.assertRows(t, 1, 2, 1, 1)
+	if state := fixture.traceProjectionState(t); state == "journal_expired" {
+		t.Fatal("disabled PollOnce() marked trace journal_expired")
+	}
+}
+
+func TestRetentionWorkerPollOnce_ReapsAndRecordsMetrics(t *testing.T) {
+	fixture := newRetentionWorkerFixture(t)
+	registry := prometheus.NewRegistry()
+	fixture.store = fixture.store.WithMetrics(enginemetrics.New(registry))
+	worker := NewRetentionWorker(fixture.store, RetentionConfig{
+		TerminalRuns: 24 * time.Hour,
+		DedupeGrace:  24 * time.Hour,
+		BatchSize:    10,
+	})
+
+	if err := worker.PollOnce(fixture.ctx, "retention-test"); err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+	fixture.assertRows(t, 0, 0, 0, 0)
+	if state := fixture.traceProjectionState(t); state != "journal_expired" {
+		t.Errorf("trace engine_projection_state = %q, want journal_expired", state)
+	}
+
+	got := gatherRetentionReaped(t, registry)
+	want := map[string]float64{
+		"request_dedupe": 1,
+		"history":        2,
+		"inbox":          1,
+		"activity_tasks": 1,
+	}
+	for table, wantValue := range want {
+		if gotValue := got[table]; gotValue != wantValue {
+			t.Errorf("continua_engine_retention_reaped_rows_total{table=%q} = %v, want %v", table, gotValue, wantValue)
+		}
+	}
+}
+
+type retentionWorkerFixture struct {
+	ctx     context.Context
+	db      *enginetest.TestDatabase
+	store   *store.Store
+	project uuid.UUID
+	runID   uuid.UUID
+	traceID uuid.UUID
+}
+
+func newRetentionWorkerFixture(t *testing.T) *retentionWorkerFixture {
+	t.Helper()
+	ctx := context.Background()
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.New()
+	enginetest.EnsurePlatformProject(t, db.Pool, projectID)
+	engineStore := store.New(db.Pool)
+	instance, err := engineStore.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "retention-worker-" + uuid.NewString()[:8],
+		DefinitionName: "retention.worker",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := engineStore.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now().Add(-48 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	first, err := engineStore.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID: projectID, InstanceID: instance.ID, RunID: run.ID,
+		SequenceNo: 1, EventType: "workflow.started", Payload: []byte(`{"event":"started"}`),
+	})
+	if err != nil {
+		t.Fatalf("AppendHistory(first) error = %v", err)
+	}
+	second, err := engineStore.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID: projectID, InstanceID: instance.ID, RunID: run.ID,
+		SequenceNo: 2, EventType: "workflow.completed", Payload: []byte(`{"event":"completed"}`),
+	})
+	if err != nil {
+		t.Fatalf("AppendHistory(second) error = %v", err)
+	}
+	if _, err := engineStore.CreateInboxItem(ctx, enginedb.CreateInboxItemParams{
+		ProjectID: projectID, InstanceID: instance.ID, RunID: enginetest.NullableUUID(run.ID),
+		HistoryID: &first.ID, Kind: "signal", Payload: []byte(`{"signal":"done"}`), AvailableAt: time.Now().Add(-48 * time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateInboxItem() error = %v", err)
+	}
+	if _, err := engineStore.CreateActivityTask(ctx, enginedb.CreateActivityTaskParams{
+		ProjectID: projectID, InstanceID: instance.ID, RunID: run.ID, HistoryID: &second.ID,
+		ActivityKey: "retention", ActivityType: "retention.test", Input: []byte(`{"value":1}`),
+		AvailableAt: time.Now().Add(-48 * time.Hour), ExecutionTarget: "local", MaxAttempts: 1,
+	}); err != nil {
+		t.Fatalf("CreateActivityTask() error = %v", err)
+	}
+	fixtureUpdates := []struct {
+		name  string
+		query string
+	}{
+		{name: "run", query: `UPDATE engine.runs SET status = 'completed', completed_at = NOW() - INTERVAL '48 hours' WHERE id = $1`},
+		{name: "inbox", query: `UPDATE engine.inbox SET status = 'processed', resolved_at = NOW() WHERE run_id = $1`},
+		{name: "activity task", query: `UPDATE engine.activity_tasks SET status = 'completed', completed_at = NOW() WHERE run_id = $1`},
+	}
+	for _, update := range fixtureUpdates {
+		if _, err := db.Pool.Exec(ctx, update.query, run.ID); err != nil {
+			t.Fatalf("finalize retention worker %s fixture: %v", update.name, err)
+		}
+	}
+	if _, err := db.Pool.Exec(ctx, `
+		INSERT INTO engine.request_dedupe (project_id, request_scope, request_key, status, expires_at)
+		VALUES ($1, 'engine.start', 'retention-worker', 'expired', NOW() - INTERVAL '48 hours')
+	`, projectID); err != nil {
+		t.Fatalf("seed request_dedupe: %v", err)
+	}
+	traceID := uuid.New()
+	if _, err := db.Pool.Exec(ctx, `
+		INSERT INTO public.traces (
+			id, project_id, trace_id, name, status, start_time, end_time,
+			engine_run_id, engine_run_status, engine_projection_state,
+			engine_latest_history_id, engine_last_projected_history_id, engine_projection_updated_at
+		)
+		VALUES ($1, $2, $3, 'Retention worker', 'completed', NOW() - INTERVAL '48 hours', NOW(),
+		        $4, 'completed', 'up_to_date', $5, $5, NOW())
+	`, traceID, projectID, "engine:"+run.ID.String(), run.ID, second.ID); err != nil {
+		t.Fatalf("seed projected trace: %v", err)
+	}
+	if _, err := db.Pool.Exec(ctx, `
+		INSERT INTO public.spans (project_id, trace_id, span_id, name, type, status, level, start_time, end_time, depth)
+		VALUES ($1, $2, $3, 'Retention root', 'chain', 'completed', 'default', NOW() - INTERVAL '48 hours', NOW(), 0)
+	`, projectID, traceID, "engine:run:"+run.ID.String()); err != nil {
+		t.Fatalf("seed projected root span: %v", err)
+	}
+
+	return &retentionWorkerFixture{ctx: ctx, db: db, store: engineStore, project: projectID, runID: run.ID, traceID: traceID}
+}
+
+func (f *retentionWorkerFixture) assertRows(t *testing.T, wantDedupe, wantHistory, wantInbox, wantTasks int64) {
+	t.Helper()
+	checks := []struct {
+		name  string
+		query string
+		arg   any
+		want  int64
+	}{
+		{name: "request_dedupe", query: `SELECT COUNT(*) FROM engine.request_dedupe WHERE project_id = $1`, arg: f.project, want: wantDedupe},
+		{name: "history", query: `SELECT COUNT(*) FROM engine.history WHERE run_id = $1`, arg: f.runID, want: wantHistory},
+		{name: "inbox", query: `SELECT COUNT(*) FROM engine.inbox WHERE run_id = $1`, arg: f.runID, want: wantInbox},
+		{name: "activity_tasks", query: `SELECT COUNT(*) FROM engine.activity_tasks WHERE run_id = $1`, arg: f.runID, want: wantTasks},
+	}
+	for _, check := range checks {
+		var got int64
+		if err := f.db.Pool.QueryRow(f.ctx, check.query, check.arg).Scan(&got); err != nil {
+			t.Fatalf("count %s rows: %v", check.name, err)
+		}
+		if got != check.want {
+			t.Errorf("%s rows = %d, want %d", check.name, got, check.want)
+		}
+	}
+}
+
+func (f *retentionWorkerFixture) traceProjectionState(t *testing.T) string {
+	t.Helper()
+	var state string
+	if err := f.db.Pool.QueryRow(f.ctx, `SELECT COALESCE(engine_projection_state, '') FROM public.traces WHERE id = $1`, f.traceID).Scan(&state); err != nil {
+		t.Fatalf("query trace projection state: %v", err)
+	}
+	return state
+}
+
+func gatherRetentionReaped(t *testing.T, registry *prometheus.Registry) map[string]float64 {
+	t.Helper()
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("registry.Gather() error = %v", err)
+	}
+	values := make(map[string]float64)
+	for _, family := range families {
+		if family.GetName() != "continua_engine_retention_reaped_rows_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			var table string
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "table" {
+					table = label.GetValue()
+				}
+			}
+			values[table] = metric.GetCounter().GetValue()
+		}
+	}
+	return values
+}

--- a/engine/pkg/runtime/options_test.go
+++ b/engine/pkg/runtime/options_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/continua-ai/continua/engine/internal/config"
 	"github.com/continua-ai/continua/engine/pkg/workflow"
 )
 
@@ -136,5 +137,26 @@ func TestRuntimeRunRejectsNilContext(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "context is required") {
 		t.Fatalf("Run(nil) error = %q, want context required error", err.Error())
+	}
+}
+
+func TestApplyRuntimeOverridesRetentionBatchSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		override int32
+		want     int32
+	}{
+		{name: "zero keeps default", override: 0, want: 500},
+		{name: "negative keeps default", override: -1, want: 500},
+		{name: "positive overrides default", override: 25, want: 25},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Defaults("postgres://example/db")
+			applyRuntimeOverrides(cfg, &Options{RetentionBatchSize: tt.override})
+			if cfg.Runtime.RetentionBatchSize != tt.want {
+				t.Fatalf("RetentionBatchSize = %d, want %d", cfg.Runtime.RetentionBatchSize, tt.want)
+			}
+		})
 	}
 }

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -57,8 +57,8 @@ type Options struct {
 	// zero; negative values disable the corresponding retention class.
 	RetentionTerminalRuns time.Duration
 	RetentionDedupeGrace  time.Duration
-	// RetentionBatchSize is the maximum rows or runs reaped per pass; zero uses
-	// the engine default.
+	// RetentionBatchSize is the maximum rows or runs reaped per pass;
+	// non-positive values use the engine default.
 	RetentionBatchSize int32
 	// MetricsRegistry receives engine Prometheus collectors when configured.
 	MetricsRegistry prometheus.Registerer
@@ -351,7 +351,7 @@ func applyRuntimeOverrides(cfg *config.Config, opts *Options) {
 	} else if opts.RetentionDedupeGrace != 0 {
 		cfg.Runtime.RetentionDedupeGrace = opts.RetentionDedupeGrace
 	}
-	if opts.RetentionBatchSize != 0 {
+	if opts.RetentionBatchSize > 0 {
 		cfg.Runtime.RetentionBatchSize = opts.RetentionBatchSize
 	}
 	if opts.LeaseCompletionGrace != 0 {

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -53,6 +53,9 @@ type Options struct {
 	MetricsSampleInterval   time.Duration
 	RunLeaseTTL             time.Duration
 	ActivityLeaseTTL        time.Duration
+	RetentionTerminalRuns   time.Duration
+	RetentionDedupeGrace    time.Duration
+	RetentionBatchSize      int32
 	// MetricsRegistry receives engine Prometheus collectors when configured.
 	MetricsRegistry prometheus.Registerer
 	// MetricsAddr configures the Prometheus HTTP listen address when non-empty.

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -53,9 +53,13 @@ type Options struct {
 	MetricsSampleInterval   time.Duration
 	RunLeaseTTL             time.Duration
 	ActivityLeaseTTL        time.Duration
-	RetentionTerminalRuns   time.Duration
-	RetentionDedupeGrace    time.Duration
-	RetentionBatchSize      int32
+	// RetentionTerminalRuns and RetentionDedupeGrace use engine defaults when
+	// zero; negative values disable the corresponding retention class.
+	RetentionTerminalRuns time.Duration
+	RetentionDedupeGrace  time.Duration
+	// RetentionBatchSize is the maximum rows or runs reaped per pass; zero uses
+	// the engine default.
+	RetentionBatchSize int32
 	// MetricsRegistry receives engine Prometheus collectors when configured.
 	MetricsRegistry prometheus.Registerer
 	// MetricsAddr configures the Prometheus HTTP listen address when non-empty.
@@ -153,6 +157,11 @@ func (r *Runtime) Run(ctx context.Context) error {
 	workflowWorker := engineworkflow.NewWorker(store, r.definitions, cfg.Runtime.RunLeaseTTL, r.options.Logger)
 	activityWorker := activity.NewWorker(store, r.activities, cfg.Runtime.ActivityLeaseTTL, r.options.Logger)
 	maintenanceWorker := engineworker.NewMaintenanceWorker(store)
+	retentionWorker := engineworker.NewRetentionWorker(store, engineworker.RetentionConfig{
+		TerminalRuns: cfg.Runtime.RetentionTerminalRuns,
+		DedupeGrace:  cfg.Runtime.RetentionDedupeGrace,
+		BatchSize:    cfg.Runtime.RetentionBatchSize,
+	})
 	projectorWorker := engineprojector.New(store)
 	metricsListener := r.options.MetricsListener
 	if metricsListener == nil && r.options.MetricsAddr != "" {
@@ -189,6 +198,16 @@ func (r *Runtime) Run(ctx context.Context) error {
 			observeIterations(recorder, "activity", activityWorker.PollOnce),
 		)
 	})
+	if cfg.Runtime.RetentionTerminalRuns > 0 || cfg.Runtime.RetentionDedupeGrace > 0 {
+		group.Go(func() error {
+			return engineworker.RunLoop(
+				groupCtx,
+				cfg.Runtime.MaintenancePollInterval,
+				"retention",
+				observeIterations(recorder, "retention", retentionWorker.PollOnce),
+			)
+		})
+	}
 	group.Go(func() error {
 		return engineworker.RunLoop(
 			groupCtx,
@@ -321,6 +340,19 @@ func applyRuntimeOverrides(cfg *config.Config, opts *Options) {
 	}
 	if opts.ActivityLeaseTTL != 0 {
 		cfg.Runtime.ActivityLeaseTTL = opts.ActivityLeaseTTL
+	}
+	if opts.RetentionTerminalRuns < 0 {
+		cfg.Runtime.RetentionTerminalRuns = 0
+	} else if opts.RetentionTerminalRuns != 0 {
+		cfg.Runtime.RetentionTerminalRuns = opts.RetentionTerminalRuns
+	}
+	if opts.RetentionDedupeGrace < 0 {
+		cfg.Runtime.RetentionDedupeGrace = 0
+	} else if opts.RetentionDedupeGrace != 0 {
+		cfg.Runtime.RetentionDedupeGrace = opts.RetentionDedupeGrace
+	}
+	if opts.RetentionBatchSize != 0 {
+		cfg.Runtime.RetentionBatchSize = opts.RetentionBatchSize
 	}
 	if opts.LeaseCompletionGrace != 0 {
 		cfg.Runtime.LeaseCompletionGrace = opts.LeaseCompletionGrace

--- a/engine/pkg/runtime/runtime_retention_e2e_test.go
+++ b/engine/pkg/runtime/runtime_retention_e2e_test.go
@@ -1,0 +1,152 @@
+package runtime_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestRuntimeRetentionGCsTerminalRun_E2E(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.New()
+	enginetest.EnsurePlatformProject(t, db.Pool, projectID)
+	definition := workflow.Definition{
+		Name:    "usertest.retention",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			return ctx.SetResult(map[string]bool{"completed": true})
+		},
+	}
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL:             db.DatabaseURL,
+		Workflows:               []workflow.Definition{definition},
+		ProjectID:               &projectID,
+		WorkflowPollInterval:    25 * time.Millisecond,
+		ActivityPollInterval:    25 * time.Millisecond,
+		MaintenancePollInterval: 25 * time.Millisecond,
+		RetentionTerminalRuns:   time.Millisecond,
+		RetentionDedupeGrace:    time.Millisecond,
+		RetentionBatchSize:      10,
+	})
+	if err != nil {
+		t.Fatalf("runtime.New() error = %v", err)
+	}
+
+	ctx := context.Background()
+	engineStore := enginestore.New(db.Pool)
+	instance, err := engineStore.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    "runtime-retention-e2e",
+		DefinitionName: definition.Name,
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := engineStore.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: definition.Version,
+		ReadyAt:           time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	input := mustJSON(t, map[string]string{"purpose": "retention-e2e"})
+	startedPayload, err := enginehistory.MarshalPayload(enginehistory.WorkflowStartedPayload{
+		DefinitionName:    definition.Name,
+		DefinitionVersion: definition.Version,
+		InstanceKey:       instance.InstanceKey,
+		Input:             input,
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(workflow started) error = %v", err)
+	}
+	started, err := engineStore.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID: projectID, InstanceID: instance.ID, RunID: run.ID,
+		SequenceNo: 1, EventType: enginehistory.EventWorkflowStarted, Payload: startedPayload,
+	})
+	if err != nil {
+		t.Fatalf("AppendHistory(workflow started) error = %v", err)
+	}
+	enginetest.SeedProjectionShell(t, db.Pool, &instance, &run, definition.Name, definition.Version, input, started.ID)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	stopped := false
+	go func() {
+		done <- rt.Run(runCtx)
+	}()
+	defer func() {
+		if stopped {
+			return
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runtime did not stop within 5s after test cleanup cancellation")
+		}
+	}()
+
+	completed := waitForCompletedRun(t, engineStore, instance.ID)
+	deadline := time.Now().Add(30 * time.Second)
+	remainingHistory := int64(-1)
+	for time.Now().Before(deadline) {
+		if err := db.Pool.QueryRow(ctx, `SELECT COUNT(*) FROM engine.history WHERE run_id = $1`, completed.ID).Scan(&remainingHistory); err != nil {
+			t.Fatalf("count retained history: %v", err)
+		}
+		if remainingHistory == 0 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if remainingHistory != 0 {
+		t.Fatalf("engine.history rows for terminal run = %d after retention deadline, want 0", remainingHistory)
+	}
+
+	var traceID uuid.UUID
+	var traceStatus, projectionState string
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT id, status, COALESCE(engine_projection_state, '')
+		FROM public.traces
+		WHERE engine_run_id = $1
+	`, completed.ID).Scan(&traceID, &traceStatus, &projectionState); err != nil {
+		t.Fatalf("query retained projected trace: %v", err)
+	}
+	if traceStatus != "completed" || projectionState != "journal_expired" {
+		t.Fatalf("retained trace status/projection_state = %q/%q, want completed/journal_expired", traceStatus, projectionState)
+	}
+	var rootSpanExists bool
+	if err := db.Pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM public.spans
+			WHERE trace_id = $1 AND depth = 0
+		)
+	`, traceID).Scan(&rootSpanExists); err != nil {
+		t.Fatalf("query retained root span: %v", err)
+	}
+	if !rootSpanExists {
+		t.Fatal("projected root span was deleted by terminal-run retention")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		stopped = true
+		if err != nil {
+			t.Fatalf("Runtime.Run() after cancellation error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Runtime.Run() did not stop within 5s after cancellation")
+	}
+}


### PR DESCRIPTION
## What / why

Closes #172.

No automated retention existed in the engine module: `engine.history`, processed/discarded `engine.inbox` rows, completed `engine.activity_tasks`, and finalized `engine.request_dedupe` rows accumulated forever, and the maintenance sweep only flipped dedupe rows to `expired` without ever deleting them. Unbounded growth on a single-node deployment degrades claim queries and disk — a GA blocker this PR removes.

## What's implemented

- **Config** (`engine/internal/config`): `ENGINE_RETENTION_TERMINAL_RUNS` (default `168h`), `ENGINE_RETENTION_DEDUPE_GRACE` (default `24h`), `ENGINE_RETENTION_BATCH_SIZE` (default `500`). `0` disables a window; negative durations and batch sizes < 1 are rejected.
- **Retention worker** (`engine/internal/worker/retention.go`): a new `retention` poll loop on the maintenance cadence. Per pass, batch-limited: (a) deletes finalized (`completed`/`failed`/`expired`) dedupe rows past the grace cutoff — `in_progress` rows are never touched; (b) deletes the journal (history, inbox, activity tasks) of terminal runs older than the window.
- **Projection-completeness guard** (`engine/internal/store/retention.go`): a run's journal is only GC'd when its projected trace shows `engine_last_projected_history_id >= engine_latest_history_id`. Only `completed`/`failed`/`cancelled`/`terminated` runs are eligible (matching the migration `000006` retention index) — never `quarantined`, `continued_as_new`, or non-terminal runs. Runs/instances rows are kept; only the journal is deleted, in FK-safe order, in one transaction that also flips the trace to `engine_projection_state = 'journal_expired'` via the existing projection `Writer`, so the debugger renders the existing expired-history state and the projected trace + root span survive intact.
- **Project scoping**: every new read/delete honors the store project filter (dark-launch runtime stays scoped to its project).
- **Metrics** (ties into #168): `continua_engine_retention_reaped_rows_total{table}` counters for `request_dedupe`, `history`, `inbox`, `activity_tasks`.
- **Migration `000015`**: supporting indexes — `engine.inbox(run_id)` partial and `engine.request_dedupe(expires_at)` partial for the reap scans.
- **Wiring**: `runtime.Options.RetentionTerminalRuns/RetentionDedupeGrace/RetentionBatchSize` (zero inherits defaults, negative disables) plus `continua-engine serve` env plumbing; the retention loop is skipped entirely when disabled.
- **Docs**: retention section in `docs-site/guides/embed-engine.mdx`; retention-window note for run-history reads in `docs-site/debugger/engine-runs.mdx`.

## Test evidence (TDD: tests authored and committed red first, implementation in a separate session)

Acceptance tests committed red in 082d545, implementation in a7e2d37 — the test files are byte-identical across both (tamper-checked).

- `engine/internal/config/config_retention_test.go` — defaults, env overrides, zero-disables, invalid-value rejection.
- `engine/internal/store/retention_test.go` (real Postgres) — dedupe reap correctness/batch-limit/project-filter; eligibility requires projection completeness and excludes recent, running, quarantined, continued-as-new, traceless, and already-expired runs; batch limit + oldest-first ordering; journal reap deletes history/inbox/tasks while retaining run, instance, trace (flipped to `journal_expired`) and root span; project-filter mismatch leaves data untouched.
- `engine/internal/worker/retention_test.go` (real Postgres) — disabled config is a strict no-op; enabled config reaps and records all four per-table counters.
- `engine/pkg/runtime/runtime_retention_e2e_test.go` — a real workflow runs to completion, its journal is GC'd by the live runtime, and the projected trace/root span survive with the expired-history state.

`cd engine && go test ./internal/config/... ./internal/store/... ./internal/worker/... ./pkg/runtime/...` — all pass; `make generate` leaves a clean tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable retention for completed engine runs and request-deduplication records.
  * Automatically removes expired journal data while preserving projected traces and root spans.
  * Added retention controls for embedded runtimes and server deployments.
  * Added metrics to track records removed by retention.
* **Documentation**
  * Documented retention settings, defaults, disabling behavior, and debugger behavior after journal expiration.
* **Bug Fixes**
  * Improved cleanup performance for retained engine and deduplication data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->