### PR TITLE
feat(engine): health/readiness HTTP endpoint for continua-engine serve (#170)

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -37,7 +37,8 @@
             "pages": [
               "guides/auth0-setup",
               "guides/managing-projects",
-              "guides/engine-metrics"
+              "guides/engine-metrics",
+              "guides/engine-health"
             ]
           },
           {

--- a/docs-site/guides/engine-health.mdx
+++ b/docs-site/guides/engine-health.mdx
@@ -1,0 +1,84 @@
+---
+title: "Engine health and readiness"
+description: "Expose and configure operational probes for the preview durable engine."
+---
+
+The preview engine runtime can expose liveness, readiness, and Prometheus
+metrics on one operational HTTP listener. Set `ENGINE_HTTP_ADDR` when running
+`continua-engine serve`:
+
+```bash
+ENGINE_HTTP_ADDR=0.0.0.0:9099 continua-engine serve
+```
+
+The listener is disabled when `ENGINE_HTTP_ADDR` is empty. Its endpoints have
+no authentication, so bind it to an internal interface or restrict access at
+the network layer. Embedded Go runtimes can set `runtime.Options.HTTPAddr` or
+provide a listener with `HTTPListener`; a supplied listener takes precedence.
+
+## Endpoint semantics
+
+- `GET /healthz` returns `200` while the process can serve HTTP. Use it for
+  liveness checks that decide whether to restart the process.
+- `GET /readyz` returns `200` only after every engine worker has completed an
+  iteration recently and the runtime can ping Postgres. It returns `503` and
+  names failed checks while the runtime is starting, Postgres is unavailable,
+  or a worker loop is stale. Use it to decide whether the instance should
+  receive work.
+- `GET /metrics` exposes the same Prometheus metrics described in
+  [Engine metrics](/guides/engine-metrics). It is mounted automatically on the
+  operational listener, even when `ENGINE_METRICS_ADDR` is unset.
+
+`ENGINE_METRICS_ADDR` continues to serve a dedicated metrics listener when
+configured. You can enable both listeners when metrics and health probes need
+different network policies.
+
+## Kubernetes probes
+
+Point both probes at the operational listener and allow readiness enough time
+for every worker's first database-backed iteration:
+
+```yaml
+containers:
+  - name: continua-engine
+    env:
+      - name: ENGINE_HTTP_ADDR
+        value: "0.0.0.0:9099"
+    ports:
+      - name: operations
+        containerPort: 9099
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: operations
+      periodSeconds: 10
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: operations
+      periodSeconds: 5
+      failureThreshold: 3
+```
+
+## systemd readiness check
+
+For a service that should not finish starting until the engine is ready, use
+an `ExecStartPost` loop. Keep `Restart=on-failure` for process failures; use an
+external monitor against `/healthz` if you also want HTTP-based restart
+decisions.
+
+```ini
+[Service]
+Environment=ENGINE_HTTP_ADDR=127.0.0.1:9099
+ExecStart=/usr/local/bin/continua-engine serve
+ExecStartPost=/bin/sh -c 'for i in $(seq 1 30); do curl --fail --silent http://127.0.0.1:9099/readyz && exit 0; sleep 1; done; exit 1'
+Restart=on-failure
+```
+
+For manual diagnosis, inspect both the status and JSON response:
+
+```bash
+curl --fail-with-body http://127.0.0.1:9099/healthz
+curl --fail-with-body http://127.0.0.1:9099/readyz
+```

--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -109,6 +109,7 @@ func serveCmd() *cobra.Command {
 				RunLeaseTTL:             cfg.Runtime.RunLeaseTTL,
 				ActivityLeaseTTL:        cfg.Runtime.ActivityLeaseTTL,
 				MetricsAddr:             cfg.Runtime.MetricsAddr,
+				HTTPAddr:                cfg.Runtime.HTTPAddr,
 				LeaseCompletionGrace:    cfg.Runtime.LeaseCompletionGrace,
 			})
 			if err != nil {

--- a/engine/cmd/continua-engine/runtime_http_health_e2e_test.go
+++ b/engine/cmd/continua-engine/runtime_http_health_e2e_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+)
+
+func TestServeExposesHealthEndpoints(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	configureRuntimeEnv(t, db.DatabaseURL)
+
+	lst, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+	addr := lst.Addr().String()
+	if err := lst.Close(); err != nil {
+		t.Fatalf("listener.Close() error = %v", err)
+	}
+	t.Setenv("ENGINE_HTTP_ADDR", addr)
+
+	serve := startServe(t)
+	defer serve.stop(t)
+
+	client := &http.Client{
+		Timeout: 250 * time.Millisecond,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+		},
+	}
+	baseURL := "http://" + addr
+	waitForServeHTTPStatus(t, client, baseURL+"/healthz", http.StatusOK, 10*time.Second)
+	waitForServeHTTPStatus(t, client, baseURL+"/readyz", http.StatusOK, 15*time.Second)
+
+	response, err := client.Get(baseURL + "/metrics")
+	if err != nil {
+		t.Fatalf("GET /metrics error = %v", err)
+	}
+	_, readErr := io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+	if readErr != nil {
+		t.Fatalf("read GET /metrics response: %v", readErr)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+}
+
+func waitForServeHTTPStatus(t *testing.T, client *http.Client, endpoint string, wantStatus int, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var lastStatus int
+	var lastBody string
+	var lastErr error
+	for time.Now().Before(deadline) {
+		response, err := client.Get(endpoint)
+		lastErr = err
+		if err == nil {
+			body, readErr := io.ReadAll(response.Body)
+			_ = response.Body.Close()
+			if readErr != nil {
+				lastErr = readErr
+			} else {
+				lastStatus = response.StatusCode
+				lastBody = string(body)
+				if response.StatusCode == wantStatus {
+					return
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("GET %s did not return %d within %s; last status=%d last error=%v last body=%q", endpoint, wantStatus, timeout, lastStatus, lastErr, lastBody)
+}

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -63,6 +63,7 @@ type RuntimeConfig struct {
 	RequestDedupeTTL        time.Duration
 	ProjectIDFilter         *uuid.UUID
 	MetricsAddr             string
+	HTTPAddr                string
 }
 
 // Defaults returns the engine runtime defaults for a database URL.

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -163,6 +163,7 @@ func Load() (*Config, error) {
 	cfg.Runtime.RequestDedupeTTL = requestDedupeTTL
 	cfg.Runtime.ProjectIDFilter = projectIDFilter
 	cfg.Runtime.MetricsAddr = os.Getenv("ENGINE_METRICS_ADDR")
+	cfg.Runtime.HTTPAddr = os.Getenv("ENGINE_HTTP_ADDR")
 	cfg.Logging.Level = logLevel
 	cfg.Logging.Format = logFormat
 	return cfg, nil

--- a/engine/internal/config/config_http_addr_test.go
+++ b/engine/internal/config/config_http_addr_test.go
@@ -1,0 +1,31 @@
+package config
+
+import "testing"
+
+func TestLoadHTTPAddrDefaultsEmpty(t *testing.T) {
+	t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("ENGINE_HTTP_ADDR", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Runtime.HTTPAddr != "" {
+		t.Fatalf("Runtime.HTTPAddr = %q, want empty string", cfg.Runtime.HTTPAddr)
+	}
+}
+
+func TestLoadHTTPAddrFromEnv(t *testing.T) {
+	t.Setenv("ENGINE_DATABASE_URL", "postgres://engine")
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("ENGINE_HTTP_ADDR", "127.0.0.1:9099")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Runtime.HTTPAddr != "127.0.0.1:9099" {
+		t.Fatalf("Runtime.HTTPAddr = %q, want %q", cfg.Runtime.HTTPAddr, "127.0.0.1:9099")
+	}
+}

--- a/engine/internal/health/health.go
+++ b/engine/internal/health/health.go
@@ -1,0 +1,46 @@
+// Package health provides operational health checks for the engine runtime.
+package health
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Pinger checks whether a dependency is reachable.
+type Pinger interface {
+	Ping(ctx context.Context) error
+}
+
+// Tracker tracks worker-loop iterations for readiness checks.
+type Tracker struct{}
+
+// NewTracker constructs a worker-loop readiness tracker.
+func NewTracker() *Tracker {
+	return &Tracker{}
+}
+
+// Register adds a worker and its maximum readiness age.
+func (t *Tracker) Register(worker string, staleAfter time.Duration) {}
+
+// MarkIteration records a worker iteration at the current time.
+func (t *Tracker) MarkIteration(worker string) {}
+
+// Check reports whether every registered worker has iterated recently.
+func (t *Tracker) Check(now time.Time) (ready bool, failing []string) {
+	return false, []string{"health tracker not implemented"}
+}
+
+// LivenessHandler returns the process liveness handler.
+func LivenessHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+}
+
+// ReadinessHandler returns the dependency and worker readiness handler.
+func ReadinessHandler(pinger Pinger, tracker *Tracker, pingTimeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+}

--- a/engine/internal/health/health.go
+++ b/engine/internal/health/health.go
@@ -3,7 +3,10 @@ package health
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"sort"
+	"sync"
 	"time"
 )
 
@@ -13,34 +16,90 @@ type Pinger interface {
 }
 
 // Tracker tracks worker-loop iterations for readiness checks.
-type Tracker struct{}
+type Tracker struct {
+	mu      sync.RWMutex
+	workers map[string]workerState
+}
+
+type workerState struct {
+	staleAfter    time.Duration
+	lastIteration time.Time
+}
 
 // NewTracker constructs a worker-loop readiness tracker.
 func NewTracker() *Tracker {
-	return &Tracker{}
+	return &Tracker{workers: make(map[string]workerState)}
 }
 
 // Register adds a worker and its maximum readiness age.
-func (t *Tracker) Register(worker string, staleAfter time.Duration) {}
+func (t *Tracker) Register(worker string, staleAfter time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.workers[worker] = workerState{staleAfter: staleAfter}
+}
 
 // MarkIteration records a worker iteration at the current time.
-func (t *Tracker) MarkIteration(worker string) {}
+func (t *Tracker) MarkIteration(worker string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state, ok := t.workers[worker]
+	if !ok {
+		return
+	}
+	state.lastIteration = time.Now()
+	t.workers[worker] = state
+}
 
 // Check reports whether every registered worker has iterated recently.
 func (t *Tracker) Check(now time.Time) (ready bool, failing []string) {
-	return false, []string{"health tracker not implemented"}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for worker, state := range t.workers {
+		if state.lastIteration.IsZero() || now.Sub(state.lastIteration) > state.staleAfter {
+			failing = append(failing, worker)
+		}
+	}
+	sort.Strings(failing)
+	return len(failing) == 0, failing
 }
 
 // LivenessHandler returns the process liveness handler.
 func LivenessHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, http.StatusOK, readinessResponse{Status: "ok"})
 	})
 }
 
 // ReadinessHandler returns the dependency and worker readiness handler.
 func ReadinessHandler(pinger Pinger, tracker *Tracker, pingTimeout time.Duration) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), pingTimeout)
+		defer cancel()
+
+		var failing []string
+		if err := pinger.Ping(ctx); err != nil {
+			failing = append(failing, "db")
+		}
+		_, failingWorkers := tracker.Check(time.Now())
+		failing = append(failing, failingWorkers...)
+		if len(failing) > 0 {
+			writeJSON(w, http.StatusServiceUnavailable, readinessResponse{
+				Status:  "unavailable",
+				Failing: failing,
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, readinessResponse{Status: "ready"})
 	})
+}
+
+type readinessResponse struct {
+	Status  string   `json:"status"`
+	Failing []string `json:"failing,omitempty"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, body readinessResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
 }

--- a/engine/internal/health/health_test.go
+++ b/engine/internal/health/health_test.go
@@ -1,0 +1,144 @@
+package health_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/continua-ai/continua/engine/internal/health"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+)
+
+func TestTrackerNotReadyBeforeFirstIteration(t *testing.T) {
+	tracker := health.NewTracker()
+	tracker.Register("workflow", time.Minute)
+
+	ready, failing := tracker.Check(time.Now())
+	if ready {
+		t.Fatal("Check() ready = true, want false before the first iteration")
+	}
+	if !slices.Contains(failing, "workflow") {
+		t.Fatalf("Check() failing = %v, want it to contain %q", failing, "workflow")
+	}
+}
+
+func TestTrackerReadyAfterRecentIteration(t *testing.T) {
+	tracker := health.NewTracker()
+	tracker.Register("workflow", time.Minute)
+	tracker.MarkIteration("workflow")
+
+	ready, failing := tracker.Check(time.Now())
+	if !ready {
+		t.Fatalf("Check() ready = false, want true; failing = %v", failing)
+	}
+	if len(failing) != 0 {
+		t.Fatalf("Check() failing = %v, want empty", failing)
+	}
+}
+
+func TestTrackerNotReadyWhenIterationStale(t *testing.T) {
+	tracker := health.NewTracker()
+	tracker.Register("workflow", 50*time.Millisecond)
+	tracker.MarkIteration("workflow")
+
+	ready, failing := tracker.Check(time.Now().Add(time.Second))
+	if ready {
+		t.Fatal("Check() ready = true, want false for a stale worker")
+	}
+	if !slices.Contains(failing, "workflow") {
+		t.Fatalf("Check() failing = %v, want it to contain %q", failing, "workflow")
+	}
+}
+
+func TestLivenessHandlerAlwaysOK(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+
+	health.LivenessHandler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET /healthz status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
+func TestReadinessHandlerOKWhenChecksPass(t *testing.T) {
+	tracker := health.NewTracker()
+	tracker.Register("workflow", time.Minute)
+	tracker.MarkIteration("workflow")
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+	health.ReadinessHandler(stubPinger{}, tracker, time.Second).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET /readyz status = %d, want %d; body = %q", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("GET /readyz body is not a JSON object: %v; body = %q", err, recorder.Body.String())
+	}
+	if body == nil {
+		t.Fatalf("GET /readyz body = %q, want a JSON object", recorder.Body.String())
+	}
+}
+
+func TestReadinessHandlerReportsStaleWorker(t *testing.T) {
+	tracker := health.NewTracker()
+	tracker.Register("workflow", time.Minute)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+	health.ReadinessHandler(stubPinger{}, tracker, time.Second).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /readyz status = %d, want %d; body = %q", recorder.Code, http.StatusServiceUnavailable, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "workflow") {
+		t.Fatalf("GET /readyz body = %q, want it to mention %q", recorder.Body.String(), "workflow")
+	}
+}
+
+func TestReadinessHandlerReportsDBFailureOnClosedPool(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	pool, err := pgxpool.New(context.Background(), db.DatabaseURL)
+	if err != nil {
+		t.Fatalf("pgxpool.New() error = %v", err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		pool.Close()
+		t.Fatalf("pool.Ping() before Close() error = %v", err)
+	}
+	pool.Close()
+
+	tracker := health.NewTracker()
+	tracker.Register("workflow", time.Minute)
+	tracker.MarkIteration("workflow")
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+
+	health.ReadinessHandler(pool, tracker, time.Second).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /readyz status = %d, want %d; body = %q", recorder.Code, http.StatusServiceUnavailable, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "db") {
+		t.Fatalf("GET /readyz body = %q, want it to mention %q", recorder.Body.String(), "db")
+	}
+}
+
+type stubPinger struct {
+	err error
+}
+
+func (p stubPinger) Ping(context.Context) error {
+	return p.err
+}
+
+var _ health.Pinger = stubPinger{}

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -166,16 +166,21 @@ func (r *Runtime) Run(ctx context.Context) error {
 		tracker.Register("metrics", workerStaleAfter(cfg.Runtime.MetricsSampleInterval))
 	}
 	metricsListener := r.options.MetricsListener
+	metricsListenerOwned := false
 	if metricsListener == nil && r.options.MetricsAddr != "" {
 		metricsListener, err = net.Listen("tcp", r.options.MetricsAddr)
 		if err != nil {
 			return fmt.Errorf("runtime: listen for metrics: %w", err)
 		}
+		metricsListenerOwned = true
 	}
 	httpListener := r.options.HTTPListener
 	if httpListener == nil && r.options.HTTPAddr != "" {
 		httpListener, err = net.Listen("tcp", r.options.HTTPAddr)
 		if err != nil {
+			if metricsListenerOwned {
+				_ = metricsListener.Close()
+			}
 			return fmt.Errorf("runtime: listen for operational HTTP: %w", err)
 		}
 	}

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -59,6 +59,10 @@ type Options struct {
 	MetricsAddr string
 	// MetricsListener supplies a caller-owned listener for the Prometheus endpoint.
 	MetricsListener net.Listener
+	// HTTPAddr configures the operational HTTP listen address when non-empty.
+	HTTPAddr string
+	// HTTPListener supplies a caller-owned listener for the operational HTTP endpoints.
+	HTTPListener net.Listener
 	// LeaseCompletionGrace allows the current remote activity owner to complete,
 	// fail, or retry briefly after lease expiry. It does not extend claims or heartbeats.
 	LeaseCompletionGrace time.Duration

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/continua-ai/continua/engine/internal/activity"
 	"github.com/continua-ai/continua/engine/internal/catalog"
 	"github.com/continua-ai/continua/engine/internal/config"
+	"github.com/continua-ai/continua/engine/internal/health"
 	enginemetrics "github.com/continua-ai/continua/engine/internal/metrics"
 	engineprojector "github.com/continua-ai/continua/engine/internal/projector"
 	enginestore "github.com/continua-ai/continua/engine/internal/store"
@@ -155,11 +156,27 @@ func (r *Runtime) Run(ctx context.Context) error {
 	activityWorker := activity.NewWorker(store, r.activities, cfg.Runtime.ActivityLeaseTTL, r.options.Logger)
 	maintenanceWorker := engineworker.NewMaintenanceWorker(store)
 	projectorWorker := engineprojector.New(store)
+	tracker := health.NewTracker()
+	tracker.Register("workflow", workerStaleAfter(cfg.Runtime.WorkflowPollInterval))
+	tracker.Register("activity", workerStaleAfter(cfg.Runtime.ActivityPollInterval))
+	tracker.Register("maintenance", workerStaleAfter(cfg.Runtime.MaintenancePollInterval))
+	tracker.Register("catalog-heartbeat", workerStaleAfter(cfg.Runtime.MaintenancePollInterval))
+	tracker.Register("projector", workerStaleAfter(cfg.Runtime.WorkflowPollInterval))
+	if recorder != nil {
+		tracker.Register("metrics", workerStaleAfter(cfg.Runtime.MetricsSampleInterval))
+	}
 	metricsListener := r.options.MetricsListener
 	if metricsListener == nil && r.options.MetricsAddr != "" {
 		metricsListener, err = net.Listen("tcp", r.options.MetricsAddr)
 		if err != nil {
 			return fmt.Errorf("runtime: listen for metrics: %w", err)
+		}
+	}
+	httpListener := r.options.HTTPListener
+	if httpListener == nil && r.options.HTTPAddr != "" {
+		httpListener, err = net.Listen("tcp", r.options.HTTPAddr)
+		if err != nil {
+			return fmt.Errorf("runtime: listen for operational HTTP: %w", err)
 		}
 	}
 
@@ -169,7 +186,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 			groupCtx,
 			cfg.Runtime.WorkflowPollInterval,
 			"workflow",
-			observeIterations(recorder, "workflow", workflowWorker.PollOnce),
+			trackIterations(tracker, "workflow", observeIterations(recorder, "workflow", workflowWorker.PollOnce)),
 		)
 	})
 	if recorder != nil {
@@ -178,7 +195,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 				groupCtx,
 				cfg.Runtime.MetricsSampleInterval,
 				"metrics",
-				observeIterations(recorder, "metrics", maintenanceWorker.PollMetricsOnce),
+				trackIterations(tracker, "metrics", observeIterations(recorder, "metrics", maintenanceWorker.PollMetricsOnce)),
 			)
 		})
 	}
@@ -187,7 +204,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 			groupCtx,
 			cfg.Runtime.ActivityPollInterval,
 			"activity",
-			observeIterations(recorder, "activity", activityWorker.PollOnce),
+			trackIterations(tracker, "activity", observeIterations(recorder, "activity", activityWorker.PollOnce)),
 		)
 	})
 	group.Go(func() error {
@@ -195,7 +212,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 			groupCtx,
 			cfg.Runtime.MaintenancePollInterval,
 			"maintenance",
-			observeIterations(recorder, "maintenance", maintenanceWorker.PollOnce),
+			trackIterations(tracker, "maintenance", observeIterations(recorder, "maintenance", maintenanceWorker.PollOnce)),
 		)
 	})
 	group.Go(func() error {
@@ -203,9 +220,9 @@ func (r *Runtime) Run(ctx context.Context) error {
 			groupCtx,
 			cfg.Runtime.MaintenancePollInterval,
 			"catalog-heartbeat",
-			observeIterations(recorder, "catalog-heartbeat", func(ctx context.Context, _ string) error {
+			trackIterations(tracker, "catalog-heartbeat", observeIterations(recorder, "catalog-heartbeat", func(ctx context.Context, _ string) error {
 				return catalog.HeartbeatStoreDefinitions(ctx, store, r.definitions.List())
-			}),
+			})),
 		)
 	})
 	group.Go(func() error {
@@ -213,7 +230,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 			groupCtx,
 			cfg.Runtime.WorkflowPollInterval,
 			"projector",
-			observeIterations(recorder, "projector", projectorWorker.PollOnce),
+			trackIterations(tracker, "projector", observeIterations(recorder, "projector", projectorWorker.PollOnce)),
 		)
 	})
 	if metricsListener != nil {
@@ -241,6 +258,31 @@ func (r *Runtime) Run(ctx context.Context) error {
 			return nil
 		})
 	}
+	if httpListener != nil {
+		httpServer := &http.Server{
+			Handler:           operationalMux(pool, tracker, metricsGatherer),
+			ReadHeaderTimeout: 5 * time.Second,
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      10 * time.Second,
+			IdleTimeout:       60 * time.Second,
+		}
+		group.Go(func() error {
+			err := httpServer.Serve(httpListener)
+			if errors.Is(err, http.ErrServerClosed) || groupCtx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("runtime: serve operational HTTP: %w", err)
+		})
+		group.Go(func() error {
+			<-groupCtx.Done()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := httpServer.Shutdown(shutdownCtx); err != nil {
+				_ = httpServer.Close()
+			}
+			return nil
+		})
+	}
 
 	return group.Wait()
 }
@@ -256,7 +298,7 @@ func (r *Runtime) beginRun() error {
 }
 
 func buildMetrics(opts *Options) (*enginemetrics.Metrics, prometheus.Gatherer, error) {
-	serving := opts.MetricsListener != nil || opts.MetricsAddr != ""
+	serving := opts.MetricsListener != nil || opts.MetricsAddr != "" || opts.HTTPListener != nil || opts.HTTPAddr != ""
 	registerer := opts.MetricsRegistry
 	var gatherer prometheus.Gatherer
 	if registerer == nil && serving {
@@ -298,9 +340,35 @@ func observeIterations(
 	}
 }
 
+func trackIterations(tracker *health.Tracker, worker string, fn engineworker.IterationFunc) engineworker.IterationFunc {
+	return func(ctx context.Context, workerID string) error {
+		err := fn(ctx, workerID)
+		tracker.MarkIteration(worker)
+		return err
+	}
+}
+
+func workerStaleAfter(pollInterval time.Duration) time.Duration {
+	staleAfter := 10 * pollInterval
+	if staleAfter < 10*time.Second {
+		return 10 * time.Second
+	}
+	return staleAfter
+}
+
 func metricsMux(gatherer prometheus.Gatherer) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", enginemetrics.Handler(gatherer))
+	return mux
+}
+
+func operationalMux(pool health.Pinger, tracker *health.Tracker, gatherer prometheus.Gatherer) http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("/healthz", health.LivenessHandler())
+	mux.Handle("/readyz", health.ReadinessHandler(pool, tracker, 2*time.Second))
+	if gatherer != nil {
+		mux.Handle("/metrics", enginemetrics.Handler(gatherer))
+	}
 	return mux
 }
 
@@ -328,4 +396,5 @@ func applyRuntimeOverrides(cfg *config.Config, opts *Options) {
 	}
 	cfg.Runtime.ProjectIDFilter = opts.ProjectID
 	cfg.Runtime.MetricsAddr = opts.MetricsAddr
+	cfg.Runtime.HTTPAddr = opts.HTTPAddr
 }

--- a/engine/pkg/runtime/runtime_health_e2e_test.go
+++ b/engine/pkg/runtime/runtime_health_e2e_test.go
@@ -1,0 +1,123 @@
+package runtime_test
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
+)
+
+func TestRuntimeServesHealthEndpointsOnListener(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.New()
+	enginetest.EnsurePlatformProject(t, db.Pool, projectID)
+	lst, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+	defer func() { _ = lst.Close() }()
+
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL:             db.DatabaseURL,
+		ProjectID:               &projectID,
+		HTTPListener:            lst,
+		WorkflowPollInterval:    25 * time.Millisecond,
+		ActivityPollInterval:    25 * time.Millisecond,
+		MaintenancePollInterval: 50 * time.Millisecond,
+		MetricsSampleInterval:   50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("runtime.New() error = %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	stopped := false
+	go func() {
+		done <- rt.Run(runCtx)
+	}()
+	defer func() {
+		if stopped {
+			return
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runtime did not stop within 5s after test cleanup cancellation")
+		}
+	}()
+
+	client := &http.Client{
+		Timeout: 250 * time.Millisecond,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+		},
+	}
+	baseURL := "http://" + lst.Addr().String()
+	waitForRuntimeHTTPStatus(t, client, baseURL+"/healthz", http.StatusOK, 10*time.Second)
+	waitForRuntimeHTTPStatus(t, client, baseURL+"/readyz", http.StatusOK, 15*time.Second)
+
+	response, err := client.Get(baseURL + "/metrics")
+	if err != nil {
+		t.Fatalf("GET /metrics error = %v", err)
+	}
+	body, readErr := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if readErr != nil {
+		t.Fatalf("read GET /metrics response: %v", readErr)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want %d; body = %q", response.StatusCode, http.StatusOK, body)
+	}
+	if !strings.Contains(string(body), "continua_engine_worker_iteration_duration_seconds") {
+		t.Fatalf("GET /metrics body does not contain worker iteration duration metric; body = %q", body)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		stopped = true
+		if err != nil {
+			t.Fatalf("Runtime.Run() after cancellation error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Runtime.Run() did not stop within 5s after cancellation")
+	}
+}
+
+func waitForRuntimeHTTPStatus(t *testing.T, client *http.Client, endpoint string, wantStatus int, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var lastStatus int
+	var lastBody string
+	var lastErr error
+	for time.Now().Before(deadline) {
+		response, err := client.Get(endpoint)
+		lastErr = err
+		if err == nil {
+			body, readErr := io.ReadAll(response.Body)
+			_ = response.Body.Close()
+			if readErr != nil {
+				lastErr = readErr
+			} else {
+				lastStatus = response.StatusCode
+				lastBody = string(body)
+				if response.StatusCode == wantStatus {
+					return
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("GET %s did not return %d within %s; last status=%d last error=%v last body=%q", endpoint, wantStatus, timeout, lastStatus, lastErr, lastBody)
+}


### PR DESCRIPTION
## What

Adds an operational HTTP listener to the engine runtime: set `ENGINE_HTTP_ADDR` (empty = disabled, unchanged default) and `continua-engine serve` exposes:

- `GET /healthz` — process liveness, always 200 while the process can serve HTTP
- `GET /readyz` — 200 only when Postgres pings OK **and** every worker loop (workflow, activity, maintenance, catalog-heartbeat, projector, metrics sampler) has iterated within its staleness window; otherwise 503 with a JSON body naming the failing checks
- `GET /metrics` — the same Prometheus metrics as `ENGINE_METRICS_ADDR` (#168), mounted on the operational listener even when no dedicated metrics listener is configured

Embedded runtimes get the same surface via `runtime.Options.HTTPAddr` / `Options.HTTPListener` (caller-owned listener takes precedence, mirroring the metrics pair).

Closes #170

## How

- `engine/internal/config`: `ENGINE_HTTP_ADDR` → `RuntimeConfig.HTTPAddr` (empty = disabled)
- `engine/internal/health` (new): mutex-guarded worker-iteration `Tracker` (per-worker staleness windows, deterministic failing list) plus `LivenessHandler`/`ReadinessHandler`; DB reachability via a `Pinger` interface satisfied by `*pgxpool.Pool`, pinged under a request-scoped timeout
- `engine/pkg/runtime`: each worker loop is wrapped to stamp the tracker every iteration (staleness window = max(10× poll interval, 10s), so readiness never flaps on a healthy runtime); the ops server reuses the metrics server's serve/graceful-shutdown errgroup pattern, so `serve` still exits cleanly on SIGINT/SIGTERM; the existing `ENGINE_METRICS_ADDR` listener is untouched and both can run together
- `engine/cmd/continua-engine`: `serve` passes the configured address through
- `docs-site/guides/engine-health.mdx`: runbook page (endpoint semantics, security note, Kubernetes probe and systemd readiness examples), registered in the docs nav

No contracts, migrations, or generated-code changes (`make generate` clean).

## Tests

Acceptance tests were authored first, committed red, and the implementation was written against them by an independent session (author/implementer split), verified on a real Postgres database:

- `engine/internal/config/config_http_addr_test.go` — env default + override
- `engine/internal/health/health_test.go` — tracker readiness transitions (never-iterated / recent / stale), liveness always-200, readiness 200 JSON, 503 naming a stale worker, and **readiness flips on DB loss via a closed `pgxpool.Pool`** (the issue's acceptance criterion)
- `engine/pkg/runtime/runtime_health_e2e_test.go` — full runtime on a caller-owned listener: `/healthz` → `/readyz` → `/metrics` (asserts worker metrics are served with no dedicated metrics listener), then graceful shutdown returns nil
- `engine/cmd/continua-engine/runtime_http_health_e2e_test.go` — `serve` with `ENGINE_HTTP_ADDR` set responds on all three endpoints

`go test ./internal/config/... ./internal/health/... ./pkg/runtime/... ./cmd/continua-engine/...` (engine module) green; engine lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operational health endpoints for engine liveness, readiness, and Prometheus metrics.
  * Added configuration through `ENGINE_HTTP_ADDR`, with the operational listener disabled when unset.
  * Readiness checks now report worker freshness and database connectivity.
  * Added Kubernetes and systemd setup guidance, troubleshooting examples, and documentation navigation.

* **Tests**
  * Added coverage confirming health, readiness, and metrics endpoints behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->