### PR TITLE
feat(engine): graceful drain on shutdown — finish in-flight work and release leases

### DIFF
--- a/engine/cmd/continua-engine/runtime_commands.go
+++ b/engine/cmd/continua-engine/runtime_commands.go
@@ -117,6 +117,7 @@ func serveCmd() *cobra.Command {
 				MetricsSampleInterval:      cfg.Runtime.MetricsSampleInterval,
 				RunLeaseTTL:                cfg.Runtime.RunLeaseTTL,
 				ActivityLeaseTTL:           cfg.Runtime.ActivityLeaseTTL,
+				ShutdownGrace:              shutdownGraceOption(cfg.Runtime.ShutdownGrace),
 				RetentionTerminalRuns:      retentionWindowOption(cfg.Runtime.RetentionTerminalRuns),
 				RetentionDedupeGrace:       retentionWindowOption(cfg.Runtime.RetentionDedupeGrace),
 				RetentionBatchSize:         cfg.Runtime.RetentionBatchSize,
@@ -141,6 +142,13 @@ func serveCmd() *cobra.Command {
 }
 
 func retentionWindowOption(configured time.Duration) time.Duration {
+	if configured == 0 {
+		return -1
+	}
+	return configured
+}
+
+func shutdownGraceOption(configured time.Duration) time.Duration {
 	if configured == 0 {
 		return -1
 	}

--- a/engine/cmd/continua-engine/runtime_commands_unit_test.go
+++ b/engine/cmd/continua-engine/runtime_commands_unit_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	enginestore "github.com/continua-ai/continua/engine/internal/store"
 	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
@@ -11,6 +12,15 @@ import (
 
 	"github.com/jackc/pgx/v5"
 )
+
+func TestShutdownGraceOption(t *testing.T) {
+	if got := shutdownGraceOption(0); got >= 0 {
+		t.Fatalf("shutdownGraceOption(0) = %s, want negative sentinel", got)
+	}
+	if got := shutdownGraceOption(2 * time.Second); got != 2*time.Second {
+		t.Fatalf("shutdownGraceOption(2s) = %s, want 2s", got)
+	}
+}
 
 func TestResolveStartDefinitionVersionOmittedUsesLatestRegisteredVersion(t *testing.T) {
 	run := func(publicworkflow.Context) error { return nil }

--- a/engine/db/gen/go/activity_tasks.sql.go
+++ b/engine/db/gen/go/activity_tasks.sql.go
@@ -1111,6 +1111,65 @@ func (q *Queries) ListOpenActivityTasksByRun(ctx context.Context, runID uuid.UUI
 	return items, nil
 }
 
+const releaseActivityTasksByClaimant = `-- name: ReleaseActivityTasksByClaimant :many
+UPDATE engine.activity_tasks
+SET status = 'queued',
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE claimed_by = $1
+  AND status = 'claimed'
+RETURNING id, project_id, instance_id, run_id, history_id, activity_key, activity_type, input, output, status, available_at, attempt_count, claimed_by, claimed_at, lease_expires_at, last_error_code, last_error_message, completed_at, created_at, updated_at, max_attempts, initial_backoff_ms, max_backoff_ms, backoff_multiplier, execution_target, lease_duration_ms
+`
+
+func (q *Queries) ReleaseActivityTasksByClaimant(ctx context.Context, claimedBy *string) ([]EngineActivityTask, error) {
+	rows, err := q.db.Query(ctx, releaseActivityTasksByClaimant, claimedBy)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineActivityTask{}
+	for rows.Next() {
+		var i EngineActivityTask
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunID,
+			&i.HistoryID,
+			&i.ActivityKey,
+			&i.ActivityType,
+			&i.Input,
+			&i.Output,
+			&i.Status,
+			&i.AvailableAt,
+			&i.AttemptCount,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.LastErrorCode,
+			&i.LastErrorMessage,
+			&i.CompletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.MaxAttempts,
+			&i.InitialBackoffMs,
+			&i.MaxBackoffMs,
+			&i.BackoffMultiplier,
+			&i.ExecutionTarget,
+			&i.LeaseDurationMs,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const retryActivityTask = `-- name: RetryActivityTask :one
 UPDATE engine.activity_tasks
 SET status = 'queued',

--- a/engine/db/gen/go/runs.sql.go
+++ b/engine/db/gen/go/runs.sql.go
@@ -615,6 +615,64 @@ func (q *Queries) ListRunsByInstance(ctx context.Context, arg ListRunsByInstance
 	return items, nil
 }
 
+const releaseRunsByClaimant = `-- name: ReleaseRunsByClaimant :many
+UPDATE engine.runs
+SET status = 'queued',
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE claimed_by = $1
+  AND status = 'running'
+RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id, parent_run_id, root_run_id, child_key, child_depth
+`
+
+func (q *Queries) ReleaseRunsByClaimant(ctx context.Context, claimedBy *string) ([]EngineRun, error) {
+	rows, err := q.db.Query(ctx, releaseRunsByClaimant, claimedBy)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []EngineRun{}
+	for rows.Next() {
+		var i EngineRun
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.InstanceID,
+			&i.RunNumber,
+			&i.DefinitionVersion,
+			&i.Status,
+			&i.ReadyAt,
+			&i.AttemptCount,
+			&i.LastErrorCode,
+			&i.LastErrorMessage,
+			&i.ClaimedBy,
+			&i.ClaimedAt,
+			&i.LeaseExpiresAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Result,
+			&i.CustomStatus,
+			&i.WaitingFor,
+			&i.CompletedAt,
+			&i.ContinuedFromRunID,
+			&i.ContinuedToRunID,
+			&i.ParentRunID,
+			&i.RootRunID,
+			&i.ChildKey,
+			&i.ChildDepth,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const transitionRunToCancelled = `-- name: TransitionRunToCancelled :one
 UPDATE engine.runs
 SET status = 'cancelled',

--- a/engine/db/queries/activity_tasks.sql
+++ b/engine/db/queries/activity_tasks.sql
@@ -97,6 +97,17 @@ WHERE id = (
 )
 RETURNING *;
 
+-- name: ReleaseActivityTasksByClaimant :many
+UPDATE engine.activity_tasks
+SET status = 'queued',
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE claimed_by = $1
+  AND status = 'claimed'
+RETURNING *;
+
 -- name: ClaimRemoteActivityTasks :many
 WITH candidates AS (
     SELECT candidate.id

--- a/engine/db/queries/runs.sql
+++ b/engine/db/queries/runs.sql
@@ -337,3 +337,14 @@ WHERE id = (
     FOR UPDATE SKIP LOCKED
 )
 RETURNING *;
+
+-- name: ReleaseRunsByClaimant :many
+UPDATE engine.runs
+SET status = 'queued',
+    claimed_by = NULL,
+    claimed_at = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE claimed_by = $1
+  AND status = 'running'
+RETURNING *;

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -69,6 +69,7 @@ type RuntimeConfig struct {
 	MetricsSampleInterval      time.Duration
 	RunLeaseTTL                time.Duration
 	ActivityLeaseTTL           time.Duration
+	ShutdownGrace              time.Duration
 	LeaseCompletionGrace       time.Duration
 	RequestDedupeTTL           time.Duration
 	RetentionTerminalRuns      time.Duration

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -24,6 +24,7 @@ const (
 	defaultMetricsSample   = 30 * time.Second
 	defaultRunLeaseTTL     = 30 * time.Second
 	defaultActivityLease   = 5 * time.Minute
+	defaultShutdownGrace   = 30 * time.Second
 	defaultRequestDedupe   = time.Hour
 	defaultRetentionRuns   = 168 * time.Hour
 	defaultRetentionDedupe = 24 * time.Hour
@@ -101,6 +102,7 @@ func Defaults(databaseURL string) *Config {
 			MetricsSampleInterval:      defaultMetricsSample,
 			RunLeaseTTL:                defaultRunLeaseTTL,
 			ActivityLeaseTTL:           defaultActivityLease,
+			ShutdownGrace:              defaultShutdownGrace,
 			RequestDedupeTTL:           defaultRequestDedupe,
 			RetentionTerminalRuns:      defaultRetentionRuns,
 			RetentionDedupeGrace:       defaultRetentionDedupe,
@@ -190,6 +192,13 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	shutdownGrace, err := durationFromEnv("ENGINE_SHUTDOWN_GRACE", cfg.Runtime.ShutdownGrace)
+	if err != nil {
+		return nil, err
+	}
+	if shutdownGrace < 0 {
+		return nil, errors.New("ENGINE_SHUTDOWN_GRACE must be non-negative")
+	}
 	leaseCompletionGrace, err := durationFromEnv("ENGINE_LEASE_COMPLETION_GRACE", cfg.Runtime.LeaseCompletionGrace)
 	if err != nil {
 		return nil, err
@@ -267,6 +276,7 @@ func Load() (*Config, error) {
 	cfg.Runtime.MetricsSampleInterval = metricsSampleInterval
 	cfg.Runtime.RunLeaseTTL = runLeaseTTL
 	cfg.Runtime.ActivityLeaseTTL = activityLeaseTTL
+	cfg.Runtime.ShutdownGrace = shutdownGrace
 	cfg.Runtime.LeaseCompletionGrace = leaseCompletionGrace
 	cfg.Runtime.RequestDedupeTTL = requestDedupeTTL
 	cfg.Runtime.RetentionTerminalRuns = retentionTerminalRuns

--- a/engine/internal/config/config_shutdown_grace_test.go
+++ b/engine/internal/config/config_shutdown_grace_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadShutdownGraceDefault(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_DATABASE_URL", "")
+	t.Setenv("ENGINE_SHUTDOWN_GRACE", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Runtime.ShutdownGrace != 30*time.Second {
+		t.Fatalf("ShutdownGrace = %s, want %s", cfg.Runtime.ShutdownGrace, 30*time.Second)
+	}
+}
+
+func TestLoadShutdownGraceFromEnv(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://engine")
+	t.Setenv("ENGINE_DATABASE_URL", "")
+	t.Setenv("ENGINE_SHUTDOWN_GRACE", "5s")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Runtime.ShutdownGrace != 5*time.Second {
+		t.Fatalf("ShutdownGrace = %s, want %s", cfg.Runtime.ShutdownGrace, 5*time.Second)
+	}
+}
+
+func TestLoadShutdownGraceInvalid(t *testing.T) {
+	t.Run("malformed", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://engine")
+		t.Setenv("ENGINE_DATABASE_URL", "")
+		t.Setenv("ENGINE_SHUTDOWN_GRACE", "nope")
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("Load() error = nil, want invalid ENGINE_SHUTDOWN_GRACE error")
+		}
+		if !strings.Contains(err.Error(), "ENGINE_SHUTDOWN_GRACE") {
+			t.Fatalf("Load() error = %q, want mention of ENGINE_SHUTDOWN_GRACE", err)
+		}
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://engine")
+		t.Setenv("ENGINE_DATABASE_URL", "")
+		t.Setenv("ENGINE_SHUTDOWN_GRACE", "-1s")
+
+		if _, err := Load(); err == nil {
+			t.Fatal("Load() error = nil, want non-negative ENGINE_SHUTDOWN_GRACE validation error")
+		}
+	})
+}

--- a/engine/internal/store/activity_tasks.go
+++ b/engine/internal/store/activity_tasks.go
@@ -73,7 +73,7 @@ func (o *storeOps) ReleaseActivityTasksByClaimant(
 	ctx context.Context,
 	claimant string,
 ) ([]enginedb.EngineActivityTask, error) {
-	return nil, errors.New("not implemented")
+	return o.q.ReleaseActivityTasksByClaimant(ctx, &claimant)
 }
 
 func (o *storeOps) ClaimRemoteActivityTasks(

--- a/engine/internal/store/activity_tasks.go
+++ b/engine/internal/store/activity_tasks.go
@@ -69,6 +69,13 @@ func (o *storeOps) ClaimNextActivityTask(
 	}))
 }
 
+func (o *storeOps) ReleaseActivityTasksByClaimant(
+	ctx context.Context,
+	claimant string,
+) ([]enginedb.EngineActivityTask, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (o *storeOps) ClaimRemoteActivityTasks(
 	ctx context.Context,
 	projectID uuid.UUID,

--- a/engine/internal/store/release_claims_test.go
+++ b/engine/internal/store/release_claims_test.go
@@ -184,7 +184,7 @@ func TestReleaseActivityTasksByClaimantReleasesOnlyOwnClaimedTasks(t *testing.T)
 		t.Fatalf("ReleaseActivityTasksByClaimant() task ID = %s, want %s", released[0].ID, task1.ID)
 	}
 	if released[0].Status != enginedb.EngineActivityTaskStatusQueued ||
-		released[0].ClaimedBy != nil || released[0].LeaseExpiresAt.Valid {
+		released[0].ClaimedBy != nil || released[0].ClaimedAt.Valid || released[0].LeaseExpiresAt.Valid {
 		t.Fatalf("released task has stale claim state: %+v", released[0])
 	}
 	if released[0].AttemptCount != 1 {
@@ -196,7 +196,8 @@ func TestReleaseActivityTasksByClaimantReleasesOnlyOwnClaimedTasks(t *testing.T)
 		t.Fatalf("GetActivityTask(task 1) error = %v", err)
 	}
 	if refetched1.Status != enginedb.EngineActivityTaskStatusQueued ||
-		refetched1.ClaimedBy != nil || refetched1.LeaseExpiresAt.Valid || refetched1.AttemptCount != 1 {
+		refetched1.ClaimedBy != nil || refetched1.ClaimedAt.Valid ||
+		refetched1.LeaseExpiresAt.Valid || refetched1.AttemptCount != 1 {
 		t.Fatalf("persisted task 1 has wrong released state: %+v", refetched1)
 	}
 

--- a/engine/internal/store/release_claims_test.go
+++ b/engine/internal/store/release_claims_test.go
@@ -1,0 +1,219 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+)
+
+func TestReleaseRunsByClaimantReleasesOnlyOwnRunningClaims(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	instanceA := ts.createInstance(t, projectID, "release-run-a")
+	runA := ts.createRun(t, instanceA, 1)
+
+	claimedA, err := ts.store.ClaimNextRun(ts.ctx, "drain-worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun(worker-a) error = %v", err)
+	}
+	if claimedA.ID != runA.ID {
+		t.Fatalf("ClaimNextRun(worker-a) ID = %s, want %s", claimedA.ID, runA.ID)
+	}
+
+	instanceB := ts.createInstance(t, projectID, "release-run-b")
+	runB := ts.createRun(t, instanceB, 1)
+	claimedB, err := ts.store.ClaimNextRun(ts.ctx, "drain-worker-b", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun(worker-b) error = %v", err)
+	}
+	if claimedB.ID != runB.ID {
+		t.Fatalf("ClaimNextRun(worker-b) ID = %s, want %s", claimedB.ID, runB.ID)
+	}
+
+	released, err := ts.store.ReleaseRunsByClaimant(ts.ctx, "drain-worker-a")
+	if err != nil {
+		t.Fatalf("ReleaseRunsByClaimant() error = %v", err)
+	}
+	if len(released) != 1 {
+		t.Fatalf("ReleaseRunsByClaimant() returned %d runs, want 1", len(released))
+	}
+	if released[0].ID != runA.ID {
+		t.Fatalf("ReleaseRunsByClaimant() run ID = %s, want %s", released[0].ID, runA.ID)
+	}
+	if released[0].Status != enginedb.EngineRunLifecycleStatusQueued ||
+		released[0].ClaimedBy != nil || released[0].ClaimedAt.Valid || released[0].LeaseExpiresAt.Valid {
+		t.Fatalf("released run has stale claim state: %+v", released[0])
+	}
+	if released[0].AttemptCount != 1 {
+		t.Fatalf("released run attempt_count = %d, want unchanged value 1", released[0].AttemptCount)
+	}
+
+	refetchedA, err := ts.store.GetRun(ts.ctx, runA.ID)
+	if err != nil {
+		t.Fatalf("GetRun(run A) error = %v", err)
+	}
+	if refetchedA.Status != enginedb.EngineRunLifecycleStatusQueued ||
+		refetchedA.ClaimedBy != nil || refetchedA.ClaimedAt.Valid || refetchedA.LeaseExpiresAt.Valid {
+		t.Fatalf("persisted run A has stale claim state: %+v", refetchedA)
+	}
+	if refetchedA.AttemptCount != 1 {
+		t.Fatalf("persisted run A attempt_count = %d, want unchanged value 1", refetchedA.AttemptCount)
+	}
+
+	refetchedB, err := ts.store.GetRun(ts.ctx, runB.ID)
+	if err != nil {
+		t.Fatalf("GetRun(run B) error = %v", err)
+	}
+	if refetchedB.Status != enginedb.EngineRunLifecycleStatusRunning ||
+		refetchedB.ClaimedBy == nil || *refetchedB.ClaimedBy != "drain-worker-b" {
+		t.Fatalf("run B changed while releasing worker A claims: %+v", refetchedB)
+	}
+
+	reclaimed, err := ts.store.ClaimNextRun(ts.ctx, "post-drain-worker", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun(post-drain-worker) error = %v", err)
+	}
+	if reclaimed.ID != runA.ID {
+		t.Fatalf("ClaimNextRun(post-drain-worker) ID = %s, want immediately released run %s", reclaimed.ID, runA.ID)
+	}
+}
+
+func TestReleaseRunsByClaimantSkipsTerminalRuns(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	instance := ts.createInstance(t, projectID, "release-terminal-run")
+	run := ts.createRun(t, instance, 1)
+
+	claimed, err := ts.store.ClaimNextRun(ts.ctx, "drain-worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun() error = %v", err)
+	}
+	claimant := "drain-worker-a"
+	completed, err := ts.store.TransitionRunToCompleted(ts.ctx, enginedb.TransitionRunToCompletedParams{
+		ID:           claimed.ID,
+		ClaimedBy:    &claimant,
+		Result:       []byte(`{"status":"done"}`),
+		CustomStatus: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("TransitionRunToCompleted() error = %v", err)
+	}
+	if completed.Status != enginedb.EngineRunLifecycleStatusCompleted {
+		t.Fatalf("TransitionRunToCompleted() status = %s, want completed", completed.Status)
+	}
+
+	released, err := ts.store.ReleaseRunsByClaimant(ts.ctx, "drain-worker-a")
+	if err != nil {
+		t.Fatalf("ReleaseRunsByClaimant() error = %v", err)
+	}
+	if len(released) != 0 {
+		t.Fatalf("ReleaseRunsByClaimant() returned %d terminal runs, want 0", len(released))
+	}
+	refetched, err := ts.store.GetRun(ts.ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if refetched.Status != enginedb.EngineRunLifecycleStatusCompleted {
+		t.Fatalf("terminal run status = %s after release, want completed", refetched.Status)
+	}
+}
+
+func TestReleaseActivityTasksByClaimantReleasesOnlyOwnClaimedTasks(t *testing.T) {
+	ts := newTestStore(t)
+	projectID := uuidOrFatal(t)
+	instance := ts.createInstance(t, projectID, "release-activity-tasks")
+	run := ts.createRun(t, instance, 1)
+	history := ts.createHistory(t, projectID, instance.ID, run.ID, 1, "activity.scheduled")
+
+	availableAt := time.Now().Add(-2 * time.Minute)
+	task1, err := ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &history.ID,
+		ActivityKey:     "release-activity-1",
+		ActivityType:    "draintest.block",
+		Input:           []byte(`{}`),
+		AvailableAt:     availableAt,
+		ExecutionTarget: "local",
+		MaxAttempts:     3,
+	})
+	if err != nil {
+		t.Fatalf("CreateActivityTask(task 1) error = %v", err)
+	}
+	task2, err := ts.store.CreateActivityTask(ts.ctx, enginedb.CreateActivityTaskParams{
+		ProjectID:       projectID,
+		InstanceID:      instance.ID,
+		RunID:           run.ID,
+		HistoryID:       &history.ID,
+		ActivityKey:     "release-activity-2",
+		ActivityType:    "draintest.block",
+		Input:           []byte(`{}`),
+		AvailableAt:     availableAt.Add(time.Second),
+		ExecutionTarget: "local",
+		MaxAttempts:     3,
+	})
+	if err != nil {
+		t.Fatalf("CreateActivityTask(task 2) error = %v", err)
+	}
+
+	claimed1, err := ts.store.ClaimNextActivityTask(ts.ctx, "drain-worker-a", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextActivityTask(worker-a) error = %v", err)
+	}
+	if claimed1.ID != task1.ID {
+		t.Fatalf("ClaimNextActivityTask(worker-a) ID = %s, want %s", claimed1.ID, task1.ID)
+	}
+	claimed2, err := ts.store.ClaimNextActivityTask(ts.ctx, "drain-worker-b", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextActivityTask(worker-b) error = %v", err)
+	}
+	if claimed2.ID != task2.ID {
+		t.Fatalf("ClaimNextActivityTask(worker-b) ID = %s, want %s", claimed2.ID, task2.ID)
+	}
+
+	released, err := ts.store.ReleaseActivityTasksByClaimant(ts.ctx, "drain-worker-a")
+	if err != nil {
+		t.Fatalf("ReleaseActivityTasksByClaimant() error = %v", err)
+	}
+	if len(released) != 1 {
+		t.Fatalf("ReleaseActivityTasksByClaimant() returned %d tasks, want 1", len(released))
+	}
+	if released[0].ID != task1.ID {
+		t.Fatalf("ReleaseActivityTasksByClaimant() task ID = %s, want %s", released[0].ID, task1.ID)
+	}
+	if released[0].Status != enginedb.EngineActivityTaskStatusQueued ||
+		released[0].ClaimedBy != nil || released[0].LeaseExpiresAt.Valid {
+		t.Fatalf("released task has stale claim state: %+v", released[0])
+	}
+	if released[0].AttemptCount != 1 {
+		t.Fatalf("released task attempt_count = %d, want unchanged value 1", released[0].AttemptCount)
+	}
+
+	refetched1, err := ts.store.GetActivityTask(ts.ctx, task1.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask(task 1) error = %v", err)
+	}
+	if refetched1.Status != enginedb.EngineActivityTaskStatusQueued ||
+		refetched1.ClaimedBy != nil || refetched1.LeaseExpiresAt.Valid || refetched1.AttemptCount != 1 {
+		t.Fatalf("persisted task 1 has wrong released state: %+v", refetched1)
+	}
+
+	refetched2, err := ts.store.GetActivityTask(ts.ctx, task2.ID)
+	if err != nil {
+		t.Fatalf("GetActivityTask(task 2) error = %v", err)
+	}
+	if refetched2.Status != enginedb.EngineActivityTaskStatusClaimed ||
+		refetched2.ClaimedBy == nil || *refetched2.ClaimedBy != "drain-worker-b" {
+		t.Fatalf("task 2 changed while releasing worker A claims: %+v", refetched2)
+	}
+
+	reclaimed, err := ts.store.ClaimNextActivityTask(ts.ctx, "post-drain-worker", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextActivityTask(post-drain-worker) error = %v", err)
+	}
+	if reclaimed.ID != task1.ID {
+		t.Fatalf("ClaimNextActivityTask(post-drain-worker) ID = %s, want immediately released task %s", reclaimed.ID, task1.ID)
+	}
+}

--- a/engine/internal/store/runs.go
+++ b/engine/internal/store/runs.go
@@ -190,6 +190,13 @@ func (o *storeOps) ClaimNextRun(
 	}))
 }
 
+func (o *storeOps) ReleaseRunsByClaimant(
+	ctx context.Context,
+	claimant string,
+) ([]enginedb.EngineRun, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (o *storeOps) classifyRunCASMiss(ctx context.Context, id uuid.UUID, err error) error {
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return normalizeError(err)

--- a/engine/internal/store/runs.go
+++ b/engine/internal/store/runs.go
@@ -194,7 +194,7 @@ func (o *storeOps) ReleaseRunsByClaimant(
 	ctx context.Context,
 	claimant string,
 ) ([]enginedb.EngineRun, error) {
-	return nil, errors.New("not implemented")
+	return o.q.ReleaseRunsByClaimant(ctx, &claimant)
 }
 
 func (o *storeOps) classifyRunCASMiss(ctx context.Context, id uuid.UUID, err error) error {

--- a/engine/internal/worker/loop.go
+++ b/engine/internal/worker/loop.go
@@ -3,14 +3,12 @@ package worker
 import (
 	"context"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type IterationFunc func(context.Context, string) error
 
-func RunLoop(ctx context.Context, pollInterval time.Duration, prefix string, fn IterationFunc) error {
-	if err := fn(ctx, workerID(prefix)); err != nil {
+func RunLoop(ctx context.Context, pollInterval time.Duration, workerID string, fn IterationFunc) error {
+	if err := fn(ctx, workerID); err != nil {
 		if ctx.Err() != nil {
 			return nil
 		}
@@ -25,7 +23,7 @@ func RunLoop(ctx context.Context, pollInterval time.Duration, prefix string, fn 
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := fn(ctx, workerID(prefix)); err != nil {
+			if err := fn(ctx, workerID); err != nil {
 				if ctx.Err() != nil {
 					return nil
 				}
@@ -33,8 +31,4 @@ func RunLoop(ctx context.Context, pollInterval time.Duration, prefix string, fn 
 			}
 		}
 	}
-}
-
-func workerID(prefix string) string {
-	return prefix + ":" + uuid.NewString()
 }

--- a/engine/internal/worker/loop_test.go
+++ b/engine/internal/worker/loop_test.go
@@ -11,7 +11,7 @@ func TestRunLoopSuppressesIterationErrorAfterCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	iterationErr := errors.New("write failed after cancellation")
 
-	err := RunLoop(ctx, time.Hour, "test", func(context.Context, string) error {
+	err := RunLoop(ctx, time.Hour, "test:fixed", func(context.Context, string) error {
 		cancel()
 		return iterationErr
 	})
@@ -23,10 +23,30 @@ func TestRunLoopSuppressesIterationErrorAfterCancellation(t *testing.T) {
 func TestRunLoopReturnsIterationErrorBeforeCancellation(t *testing.T) {
 	iterationErr := errors.New("poll failed")
 
-	err := RunLoop(context.Background(), time.Hour, "test", func(context.Context, string) error {
+	err := RunLoop(context.Background(), time.Hour, "test:fixed", func(context.Context, string) error {
 		return iterationErr
 	})
 	if !errors.Is(err, iterationErr) {
 		t.Fatalf("RunLoop() error = %v, want %v", err, iterationErr)
+	}
+}
+
+func TestRunLoopUsesStableWorkerID(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	const workerID = "test:fixed"
+	iterations := 0
+
+	err := RunLoop(ctx, time.Millisecond, workerID, func(_ context.Context, got string) error {
+		iterations++
+		if got != workerID {
+			t.Fatalf("iteration worker ID = %q, want %q", got, workerID)
+		}
+		if iterations == 2 {
+			cancel()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunLoop() error = %v, want nil", err)
 	}
 }

--- a/engine/pkg/runtime/options_test.go
+++ b/engine/pkg/runtime/options_test.go
@@ -162,6 +162,27 @@ func TestApplyRuntimeOverridesRetentionBatchSize(t *testing.T) {
 	}
 }
 
+func TestApplyRuntimeOverridesShutdownGrace(t *testing.T) {
+	tests := []struct {
+		name     string
+		override time.Duration
+		want     time.Duration
+	}{
+		{name: "zero keeps default", want: 30 * time.Second},
+		{name: "negative disables grace", override: -1, want: 0},
+		{name: "positive overrides default", override: 5 * time.Second, want: 5 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Defaults("postgres://example/db")
+			applyRuntimeOverrides(cfg, &Options{ShutdownGrace: tt.override})
+			if cfg.Runtime.ShutdownGrace != tt.want {
+				t.Fatalf("ShutdownGrace = %s, want %s", cfg.Runtime.ShutdownGrace, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyRuntimeOverridesPoolAndLimits(t *testing.T) {
 	t.Run("positive values override engine defaults", func(t *testing.T) {
 		cfg := config.Defaults("postgres://example/db")

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -72,6 +72,8 @@ type Options struct {
 	MetricsSampleInterval   time.Duration
 	RunLeaseTTL             time.Duration
 	ActivityLeaseTTL        time.Duration
+	// ShutdownGrace is the maximum time allowed for in-flight work to finish during shutdown.
+	ShutdownGrace time.Duration
 	// RetentionTerminalRuns and RetentionDedupeGrace use engine defaults when
 	// zero; negative values disable the corresponding retention class.
 	RetentionTerminalRuns time.Duration

--- a/engine/pkg/runtime/runtime.go
+++ b/engine/pkg/runtime/runtime.go
@@ -220,13 +220,36 @@ func (r *Runtime) Run(ctx context.Context) error {
 		}
 	}
 
-	group, groupCtx := errgroup.WithContext(ctx)
+	logger := r.options.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	runtimeID := uuid.NewString()
+	workflowWorkerID := "workflow:" + runtimeID
+	activityWorkerID := "activity:" + runtimeID
+
+	workersCtx, cancelWorkers := context.WithCancel(ctx)
+	defer cancelWorkers()
+	group, groupCtx := errgroup.WithContext(workersCtx)
+	workCtx, cancelWork := context.WithCancel(context.WithoutCancel(ctx))
+	defer cancelWork()
+	go func() {
+		<-groupCtx.Done()
+		timer := time.NewTimer(cfg.Runtime.ShutdownGrace)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			cancelWork()
+		case <-workCtx.Done():
+		}
+	}()
+
 	group.Go(func() error {
 		return engineworker.RunLoop(
 			groupCtx,
 			cfg.Runtime.WorkflowPollInterval,
-			"workflow",
-			trackIterations(tracker, "workflow", observeIterations(recorder, "workflow", workflowWorker.PollOnce)),
+			workflowWorkerID,
+			withIterationContext(workCtx, trackIterations(tracker, "workflow", observeIterations(recorder, "workflow", workflowWorker.PollOnce))),
 		)
 	})
 	if recorder != nil {
@@ -234,7 +257,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 			return engineworker.RunLoop(
 				groupCtx,
 				cfg.Runtime.MetricsSampleInterval,
-				"metrics",
+				"metrics:"+runtimeID,
 				trackIterations(tracker, "metrics", observeIterations(recorder, "metrics", maintenanceWorker.PollMetricsOnce)),
 			)
 		})
@@ -243,8 +266,8 @@ func (r *Runtime) Run(ctx context.Context) error {
 		return engineworker.RunLoop(
 			groupCtx,
 			cfg.Runtime.ActivityPollInterval,
-			"activity",
-			trackIterations(tracker, "activity", observeIterations(recorder, "activity", activityWorker.PollOnce)),
+			activityWorkerID,
+			withIterationContext(workCtx, trackIterations(tracker, "activity", observeIterations(recorder, "activity", activityWorker.PollOnce))),
 		)
 	})
 	if cfg.Runtime.RetentionTerminalRuns > 0 || cfg.Runtime.RetentionDedupeGrace > 0 {
@@ -252,7 +275,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 			return engineworker.RunLoop(
 				groupCtx,
 				cfg.Runtime.MaintenancePollInterval,
-				"retention",
+				"retention:"+runtimeID,
 				observeIterations(recorder, "retention", retentionWorker.PollOnce),
 			)
 		})
@@ -261,7 +284,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 		return engineworker.RunLoop(
 			groupCtx,
 			cfg.Runtime.MaintenancePollInterval,
-			"maintenance",
+			"maintenance:"+runtimeID,
 			trackIterations(tracker, "maintenance", observeIterations(recorder, "maintenance", maintenanceWorker.PollOnce)),
 		)
 	})
@@ -269,7 +292,7 @@ func (r *Runtime) Run(ctx context.Context) error {
 		return engineworker.RunLoop(
 			groupCtx,
 			cfg.Runtime.MaintenancePollInterval,
-			"catalog-heartbeat",
+			"catalog-heartbeat:"+runtimeID,
 			trackIterations(tracker, "catalog-heartbeat", observeIterations(recorder, "catalog-heartbeat", func(ctx context.Context, _ string) error {
 				return catalog.HeartbeatStoreDefinitions(ctx, store, r.definitions.List())
 			})),
@@ -279,62 +302,85 @@ func (r *Runtime) Run(ctx context.Context) error {
 		return engineworker.RunLoop(
 			groupCtx,
 			cfg.Runtime.WorkflowPollInterval,
-			"projector",
+			"projector:"+runtimeID,
 			trackIterations(tracker, "projector", observeIterations(recorder, "projector", projectorWorker.PollOnce)),
 		)
 	})
+	var serverGroup errgroup.Group
+	serverCount := 0
+	var metricsServer *http.Server
 	if metricsListener != nil {
-		metricsServer := &http.Server{
+		metricsServer = &http.Server{
 			Handler:           metricsMux(metricsGatherer),
 			ReadHeaderTimeout: 5 * time.Second,
 			ReadTimeout:       10 * time.Second,
 			WriteTimeout:      10 * time.Second,
 			IdleTimeout:       60 * time.Second,
 		}
-		group.Go(func() error {
+		serverGroup.Go(func() error {
 			err := metricsServer.Serve(metricsListener)
-			if errors.Is(err, http.ErrServerClosed) || groupCtx.Err() != nil {
+			if errors.Is(err, http.ErrServerClosed) {
 				return nil
 			}
 			return fmt.Errorf("runtime: serve metrics: %w", err)
 		})
-		group.Go(func() error {
-			<-groupCtx.Done()
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err := metricsServer.Shutdown(shutdownCtx); err != nil {
-				_ = metricsServer.Close()
-			}
-			return nil
-		})
+		serverCount++
 	}
+	var httpServer *http.Server
 	if httpListener != nil {
-		httpServer := &http.Server{
+		httpServer = &http.Server{
 			Handler:           operationalMux(pool, tracker, metricsGatherer),
 			ReadHeaderTimeout: 5 * time.Second,
 			ReadTimeout:       10 * time.Second,
 			WriteTimeout:      10 * time.Second,
 			IdleTimeout:       60 * time.Second,
 		}
-		group.Go(func() error {
+		serverGroup.Go(func() error {
 			err := httpServer.Serve(httpListener)
-			if errors.Is(err, http.ErrServerClosed) || groupCtx.Err() != nil {
+			if errors.Is(err, http.ErrServerClosed) {
 				return nil
 			}
 			return fmt.Errorf("runtime: serve operational HTTP: %w", err)
 		})
-		group.Go(func() error {
-			<-groupCtx.Done()
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err := httpServer.Shutdown(shutdownCtx); err != nil {
-				_ = httpServer.Close()
-			}
-			return nil
-		})
+		serverCount++
 	}
 
-	return group.Wait()
+	workerDone := make(chan error, 1)
+	go func() { workerDone <- group.Wait() }()
+	var serverDone <-chan error
+	if serverCount > 0 {
+		done := make(chan error, 1)
+		serverDone = done
+		go func() { done <- serverGroup.Wait() }()
+	}
+
+	var workerErr, serverErr error
+	if serverDone == nil {
+		workerErr = <-workerDone
+	} else {
+		select {
+		case workerErr = <-workerDone:
+		case serverErr = <-serverDone:
+			serverDone = nil
+			cancelWorkers()
+			workerErr = <-workerDone
+		}
+	}
+
+	releaseWorkerClaims(ctx, store, logger, activityWorkerID, workflowWorkerID)
+	shutdownRuntimeServer(ctx, metricsServer)
+	shutdownRuntimeServer(ctx, httpServer)
+	if serverDone != nil {
+		serverErr = <-serverDone
+	}
+
+	if workerErr != nil {
+		return workerErr
+	}
+	if ctx.Err() == nil {
+		return serverErr
+	}
+	return nil
 }
 
 func (r *Runtime) beginRun() error {
@@ -395,6 +441,48 @@ func trackIterations(tracker *health.Tracker, worker string, fn engineworker.Ite
 		err := fn(ctx, workerID)
 		tracker.MarkIteration(worker)
 		return err
+	}
+}
+
+func withIterationContext(ctx context.Context, fn engineworker.IterationFunc) engineworker.IterationFunc {
+	return func(_ context.Context, workerID string) error {
+		return fn(ctx, workerID)
+	}
+}
+
+func releaseWorkerClaims(
+	ctx context.Context,
+	store *enginestore.Store,
+	logger *slog.Logger,
+	activityWorkerID string,
+	workflowWorkerID string,
+) {
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	tasks, err := store.ReleaseActivityTasksByClaimant(releaseCtx, activityWorkerID)
+	if err != nil {
+		logger.Error("failed to release activity worker claims", "event", "shutdown_claim_release_failed", "worker", "activity", "worker_id", activityWorkerID, "err", err)
+	} else {
+		logger.Info("released activity worker claims", "event", "shutdown_claims_released", "worker", "activity", "worker_id", activityWorkerID, "released_count", len(tasks))
+	}
+
+	runs, err := store.ReleaseRunsByClaimant(releaseCtx, workflowWorkerID)
+	if err != nil {
+		logger.Error("failed to release workflow worker claims", "event", "shutdown_claim_release_failed", "worker", "workflow", "worker_id", workflowWorkerID, "err", err)
+	} else {
+		logger.Info("released workflow worker claims", "event", "shutdown_claims_released", "worker", "workflow", "worker_id", workflowWorkerID, "released_count", len(runs))
+	}
+}
+
+func shutdownRuntimeServer(ctx context.Context, server *http.Server) {
+	if server == nil {
+		return
+	}
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		_ = server.Close()
 	}
 }
 
@@ -464,6 +552,11 @@ func applyRuntimeOverrides(cfg *config.Config, opts *Options) {
 	}
 	if opts.ActivityLeaseTTL != 0 {
 		cfg.Runtime.ActivityLeaseTTL = opts.ActivityLeaseTTL
+	}
+	if opts.ShutdownGrace < 0 {
+		cfg.Runtime.ShutdownGrace = 0
+	} else if opts.ShutdownGrace != 0 {
+		cfg.Runtime.ShutdownGrace = opts.ShutdownGrace
 	}
 	if opts.RetentionTerminalRuns < 0 {
 		cfg.Runtime.RetentionTerminalRuns = 0

--- a/engine/pkg/runtime/runtime_drain_e2e_test.go
+++ b/engine/pkg/runtime/runtime_drain_e2e_test.go
@@ -1,0 +1,372 @@
+package runtime_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	enginehistory "github.com/continua-ai/continua/engine/internal/history"
+	enginestore "github.com/continua-ai/continua/engine/internal/store"
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
+	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
+	"github.com/continua-ai/continua/engine/pkg/workflow"
+)
+
+func TestRuntimeDrainCompletesInFlightActivityWithinGrace(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.New()
+	enginetest.EnsurePlatformProject(t, db.Pool, projectID)
+
+	definition := drainWorkflowDefinition()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var handlerCancelled atomic.Bool
+	activities := map[string]engineruntime.ActivityHandler{
+		"draintest.block": func(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+			startedOnce.Do(func() { close(started) })
+			select {
+			case <-release:
+				return json.RawMessage(`{"value":"released"}`), nil
+			case <-ctx.Done():
+				handlerCancelled.Store(true)
+				return nil, ctx.Err()
+			}
+		},
+	}
+	store, instance, run := seedDrainRun(t, db, projectID, "drain-completes-within-grace")
+
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL:             db.DatabaseURL,
+		Workflows:               []workflow.Definition{definition},
+		Activities:              activities,
+		ProjectID:               &projectID,
+		WorkflowPollInterval:    25 * time.Millisecond,
+		ActivityPollInterval:    25 * time.Millisecond,
+		MaintenancePollInterval: 100 * time.Millisecond,
+		ShutdownGrace:           5 * time.Second,
+		RunLeaseTTL:             time.Minute,
+		ActivityLeaseTTL:        5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("runtime.New() error = %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- rt.Run(runCtx) }()
+	stopped := false
+	defer func() {
+		if stopped {
+			return
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runtime did not stop within 5s during test cleanup")
+		}
+	}()
+
+	waitForDrainActivityStart(t, started)
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	select {
+	case err := <-done:
+		stopped = true
+		if err != nil {
+			t.Fatalf("Runtime.Run() after drain cancellation error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Runtime.Run() did not finish draining within 5s")
+	}
+	if handlerCancelled.Load() {
+		t.Fatal("in-flight activity handler observed context cancellation before voluntary completion")
+	}
+
+	tasks, err := store.ListActivityTasksByRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("ListActivityTasksByRun() error = %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("ListActivityTasksByRun() returned %d tasks, want 1", len(tasks))
+	}
+	if tasks[0].Status != enginedb.EngineActivityTaskStatusCompleted {
+		t.Fatalf("activity task status after drain = %s, want completed", tasks[0].Status)
+	}
+
+	secondRuntime, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL:             db.DatabaseURL,
+		Workflows:               []workflow.Definition{definition},
+		Activities:              activities,
+		ProjectID:               &projectID,
+		WorkflowPollInterval:    25 * time.Millisecond,
+		ActivityPollInterval:    25 * time.Millisecond,
+		MaintenancePollInterval: 100 * time.Millisecond,
+		ShutdownGrace:           5 * time.Second,
+		RunLeaseTTL:             time.Minute,
+		ActivityLeaseTTL:        5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("runtime.New(second runtime) error = %v", err)
+	}
+	secondCtx, secondCancel := context.WithCancel(context.Background())
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- secondRuntime.Run(secondCtx) }()
+	secondStopped := false
+	defer func() {
+		if secondStopped {
+			return
+		}
+		secondCancel()
+		select {
+		case <-secondDone:
+		case <-time.After(5 * time.Second):
+			t.Error("second runtime did not stop within 5s during test cleanup")
+		}
+	}()
+
+	completedRun := waitForDrainCompletedRun(t, store, instance.ID, 10*time.Second)
+	var result struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(completedRun.Result, &result); err != nil {
+		t.Fatalf("json.Unmarshal(run.Result) error = %v; raw = %s", err, string(completedRun.Result))
+	}
+	if result.Value != "released" {
+		t.Fatalf("completed run result value = %q, want %q", result.Value, "released")
+	}
+
+	secondCancel()
+	select {
+	case err := <-secondDone:
+		secondStopped = true
+		if err != nil {
+			t.Fatalf("second Runtime.Run() after cancellation error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("second Runtime.Run() did not stop within 5s")
+	}
+}
+
+func TestRuntimeDrainReleasesLeasesAtGraceExpiry(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.New()
+	enginetest.EnsurePlatformProject(t, db.Pool, projectID)
+
+	started := make(chan struct{})
+	activities := map[string]engineruntime.ActivityHandler{
+		"draintest.block": func(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	store, _, run := seedDrainRun(t, db, projectID, "drain-releases-at-expiry")
+
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL:             db.DatabaseURL,
+		Workflows:               []workflow.Definition{drainWorkflowDefinition()},
+		Activities:              activities,
+		ProjectID:               &projectID,
+		WorkflowPollInterval:    25 * time.Millisecond,
+		ActivityPollInterval:    25 * time.Millisecond,
+		MaintenancePollInterval: 100 * time.Millisecond,
+		ShutdownGrace:           200 * time.Millisecond,
+		RunLeaseTTL:             time.Minute,
+		ActivityLeaseTTL:        5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("runtime.New() error = %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- rt.Run(runCtx) }()
+	stopped := false
+	defer func() {
+		if stopped {
+			return
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runtime did not stop within 5s during test cleanup")
+		}
+	}()
+
+	waitForDrainActivityStart(t, started)
+	cancel()
+	select {
+	case err := <-done:
+		stopped = true
+		if err != nil {
+			t.Fatalf("Runtime.Run() after grace expiry error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Runtime.Run() did not return within 5s after grace expiry")
+	}
+
+	tasks, err := store.ListActivityTasksByRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("ListActivityTasksByRun() error = %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("ListActivityTasksByRun() returned %d tasks, want 1", len(tasks))
+	}
+	task := tasks[0]
+	if task.Status != enginedb.EngineActivityTaskStatusQueued || task.ClaimedBy != nil || task.LeaseExpiresAt.Valid {
+		t.Fatalf("activity task was not released at grace expiry: %+v", task)
+	}
+
+	reclaimed, err := enginestore.New(db.Pool).ClaimNextActivityTask(
+		context.Background(),
+		"post-drain-worker",
+		time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("ClaimNextActivityTask(post-drain-worker) error = %v", err)
+	}
+	if reclaimed.ID != task.ID {
+		t.Fatalf("ClaimNextActivityTask(post-drain-worker) ID = %s, want released task %s", reclaimed.ID, task.ID)
+	}
+}
+
+func drainWorkflowDefinition() workflow.Definition {
+	return workflow.Definition{
+		Name:    "draintest.wf",
+		Version: "v1",
+		Run: func(ctx workflow.Context) error {
+			var output struct {
+				Value string `json:"value"`
+			}
+			if err := ctx.Activity("block", "draintest.block", struct{}{}, &output); err != nil {
+				return err
+			}
+			return ctx.SetResult(output)
+		},
+	}
+}
+
+func seedDrainRun(
+	t *testing.T,
+	db *enginetest.TestDatabase,
+	projectID uuid.UUID,
+	instanceKey string,
+) (*enginestore.Store, enginedb.EngineInstance, enginedb.EngineRun) {
+	t.Helper()
+
+	ctx := context.Background()
+	store := enginestore.New(db.Pool)
+	instance, err := store.CreateInstance(ctx, enginedb.CreateInstanceParams{
+		ProjectID:      projectID,
+		InstanceKey:    instanceKey,
+		DefinitionName: "draintest.wf",
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance() error = %v", err)
+	}
+	run, err := store.CreateRun(ctx, enginedb.CreateRunParams{
+		ProjectID:         projectID,
+		InstanceID:        instance.ID,
+		RunNumber:         1,
+		DefinitionVersion: "v1",
+		ReadyAt:           time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	input := json.RawMessage(`{}`)
+	startedPayload, err := enginehistory.MarshalPayload(enginehistory.WorkflowStartedPayload{
+		DefinitionName:    "draintest.wf",
+		DefinitionVersion: "v1",
+		InstanceKey:       instanceKey,
+		Input:             input,
+	})
+	if err != nil {
+		t.Fatalf("MarshalPayload(workflow started) error = %v", err)
+	}
+	startedEvent, err := store.AppendHistory(ctx, enginedb.AppendHistoryParams{
+		ProjectID:  projectID,
+		InstanceID: instance.ID,
+		RunID:      run.ID,
+		SequenceNo: 1,
+		EventType:  enginehistory.EventWorkflowStarted,
+		Payload:    startedPayload,
+	})
+	if err != nil {
+		t.Fatalf("AppendHistory(workflow started) error = %v", err)
+	}
+
+	tx, err := store.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	traceName := "draintest.wf"
+	if err := publicprojection.NewWriter(tx.Tx()).CreateTraceShell(
+		ctx,
+		&instance,
+		&run,
+		&publicprojection.TraceShellSeed{},
+		&startedEvent,
+		input,
+		&traceName,
+	); err != nil {
+		t.Fatalf("CreateTraceShell() error = %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store, instance, run
+}
+
+func waitForDrainActivityStart(t *testing.T, started <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("activity handler did not start within 10s")
+	}
+}
+
+func waitForDrainCompletedRun(
+	t *testing.T,
+	store *enginestore.Store,
+	instanceID uuid.UUID,
+	timeout time.Duration,
+) enginedb.EngineRun {
+	t.Helper()
+
+	ctx := context.Background()
+	deadline := time.Now().Add(timeout)
+	var lastStatus enginedb.EngineRunLifecycleStatus
+	for time.Now().Before(deadline) {
+		runs, err := store.ListRunsByInstance(ctx, enginedb.ListRunsByInstanceParams{
+			InstanceID: instanceID,
+			Limit:      1,
+		})
+		if err != nil {
+			t.Fatalf("ListRunsByInstance() error = %v", err)
+		}
+		if len(runs) > 0 {
+			lastStatus = runs[0].Status
+			if runs[0].Status == enginedb.EngineRunLifecycleStatusCompleted {
+				return runs[0]
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("run did not complete within %s; last observed status = %s", timeout, lastStatus)
+	return enginedb.EngineRun{}
+}

--- a/engine/pkg/runtime/runtime_drain_e2e_test.go
+++ b/engine/pkg/runtime/runtime_drain_e2e_test.go
@@ -3,6 +3,8 @@ package runtime_test
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,6 +17,7 @@ import (
 	enginehistory "github.com/continua-ai/continua/engine/internal/history"
 	enginestore "github.com/continua-ai/continua/engine/internal/store"
 	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	engineworkflow "github.com/continua-ai/continua/engine/internal/workflow"
 	publicprojection "github.com/continua-ai/continua/engine/pkg/projection"
 	engineruntime "github.com/continua-ai/continua/engine/pkg/runtime"
 	"github.com/continua-ai/continua/engine/pkg/workflow"
@@ -225,7 +228,8 @@ func TestRuntimeDrainReleasesLeasesAtGraceExpiry(t *testing.T) {
 		t.Fatalf("ListActivityTasksByRun() returned %d tasks, want 1", len(tasks))
 	}
 	task := tasks[0]
-	if task.Status != enginedb.EngineActivityTaskStatusQueued || task.ClaimedBy != nil || task.LeaseExpiresAt.Valid {
+	if task.Status != enginedb.EngineActivityTaskStatusQueued ||
+		task.ClaimedBy != nil || task.ClaimedAt.Valid || task.LeaseExpiresAt.Valid {
 		t.Fatalf("activity task was not released at grace expiry: %+v", task)
 	}
 
@@ -239,6 +243,79 @@ func TestRuntimeDrainReleasesLeasesAtGraceExpiry(t *testing.T) {
 	}
 	if reclaimed.ID != task.ID {
 		t.Fatalf("ClaimNextActivityTask(post-drain-worker) ID = %s, want released task %s", reclaimed.ID, task.ID)
+	}
+}
+
+func TestRuntimeDrainReleasesWorkflowLeaseAtGraceExpiry(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+	projectID := uuid.New()
+	enginetest.EnsurePlatformProject(t, db.Pool, projectID)
+
+	tempDir := t.TempDir()
+	claimMarker := filepath.Join(tempDir, "workflow-claim.marker")
+	claimRelease := filepath.Join(tempDir, "workflow-claim.release")
+	t.Setenv(engineworkflow.TestWorkflowClaimMarkerEnv, claimMarker)
+	t.Setenv(engineworkflow.TestWorkflowClaimReleaseEnv, claimRelease)
+
+	store, _, run := seedDrainRun(t, db, projectID, "drain-releases-workflow-at-expiry")
+	rt, err := engineruntime.New(engineruntime.Options{
+		DatabaseURL:             db.DatabaseURL,
+		Workflows:               []workflow.Definition{drainWorkflowDefinition()},
+		ProjectID:               &projectID,
+		WorkflowPollInterval:    25 * time.Millisecond,
+		ActivityPollInterval:    25 * time.Millisecond,
+		MaintenancePollInterval: 100 * time.Millisecond,
+		ShutdownGrace:           200 * time.Millisecond,
+		RunLeaseTTL:             time.Minute,
+		ActivityLeaseTTL:        5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("runtime.New() error = %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- rt.Run(runCtx) }()
+	stopped := false
+	defer func() {
+		if stopped {
+			return
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runtime did not stop within 5s during test cleanup")
+		}
+	}()
+
+	waitForDrainFile(t, claimMarker)
+	cancel()
+	select {
+	case err := <-done:
+		stopped = true
+		if err != nil {
+			t.Fatalf("Runtime.Run() after workflow grace expiry error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Runtime.Run() did not return within 5s after workflow grace expiry")
+	}
+
+	released, err := store.GetRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if released.Status != enginedb.EngineRunLifecycleStatusQueued ||
+		released.ClaimedBy != nil || released.ClaimedAt.Valid || released.LeaseExpiresAt.Valid {
+		t.Fatalf("workflow run was not released at grace expiry: %+v", released)
+	}
+
+	reclaimed, err := store.ClaimNextRun(context.Background(), "post-drain-workflow-worker", time.Minute)
+	if err != nil {
+		t.Fatalf("ClaimNextRun(post-drain-workflow-worker) error = %v", err)
+	}
+	if reclaimed.ID != run.ID {
+		t.Fatalf("ClaimNextRun(post-drain-workflow-worker) ID = %s, want released run %s", reclaimed.ID, run.ID)
 	}
 }
 
@@ -338,6 +415,21 @@ func waitForDrainActivityStart(t *testing.T, started <-chan struct{}) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("activity handler did not start within 10s")
 	}
+}
+
+func waitForDrainFile(t *testing.T, path string) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat drain marker %q: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("drain marker %q did not appear within 10s", path)
 }
 
 func waitForDrainCompletedRun(


### PR DESCRIPTION
## What / why

Shutdown today is `signal.NotifyContext` cancelling the worker contexts: in-flight activity handlers are killed mid-execution and their claims are abandoned to lease expiry, so after every deploy/restart interrupted work waits out `ENGINE_RUN_LEASE_TTL` (30s) or `ENGINE_ACTIVITY_LEASE_TTL` (5m) before any worker picks it up again.

This PR makes deploys cheap: on SIGTERM the runtime stops claiming, gives in-flight work a bounded grace to commit, and explicitly releases anything still held so a restarted process resumes immediately instead of waiting out TTLs.

## How

- **Stable claimant IDs** — `RunLoop` previously minted a fresh `prefix:uuid` worker ID *per iteration*, so nothing could identify "my" claims at shutdown. It now takes a stable per-loop worker ID (`workflow:<runtime-uuid>`, `activity:<runtime-uuid>`, …) generated once in `Runtime.Run`. Safe because each loop processes one claim at a time and all completion/retry/fail paths are already guarded per-row by `claimed_by`.
- **Drain sequence** in `Runtime.Run` — on ctx cancellation the loops stop scheduling new iterations; in-flight workflow/activity iterations run under a work context detached from the signal context, cancelled by a watchdog `ShutdownGrace` after shutdown begins (`ENGINE_SHUTDOWN_GRACE`, default 30s; explicit `0` via the CLI maps to zero grace).
- **Final sweep** — after all worker loops exit (on every exit path), new claimant-guarded sqlc queries `ReleaseRunsByClaimant` / `ReleaseActivityTasksByClaimant` flip still-held rows back to `queued` with cleared `claimed_by`/`claimed_at`/`lease_expires_at` (attempt counts preserved), under a fresh 10s-bounded context. Sweep failures are logged, never turned into a shutdown error. Remote-activity leases (#166) are untouched.
- **HTTP ordering (#170)** — the operational HTTP and metrics servers now serve through the drain and shut down after the sweep, so `/healthz` answers while in-flight work finishes.

No schema migration: the claim columns already exist. `make generate` regenerated the sqlc output.

## Test evidence

Acceptance tests were written first and committed red (author/implementer separation; implementation was done by an independent session against the committed tests):

- `engine/internal/store/release_claims_test.go` — claimant-scoped release for runs and activity tasks: only the claimant's non-terminal claims are released, attempt counts preserved, released rows immediately re-claimable with **no** lease manipulation, other workers' claims untouched.
- `engine/internal/config/config_shutdown_grace_test.go` — `ENGINE_SHUTDOWN_GRACE` default 30s, env parsing, malformed/negative rejection.
- `engine/pkg/runtime/runtime_drain_e2e_test.go` —
  - in-flight activity completes voluntarily during drain (handler provably not ctx-cancelled), its output is committed, and a fresh runtime completes the run immediately;
  - with a blocking activity and 200ms grace vs a 5-minute activity lease TTL, `Run` returns promptly and the task is instantly `queued`/re-claimable — the codified acceptance criterion ("no TTL wait").

Verification: full `cd engine && go test ./...` green against real Postgres; platform `go test ./internal/...` green; `make generate` clean; `make lint-go` clean. Feature exercised end-to-end through the real CLI: `continua-engine serve` with a gated dark-launch activity received SIGTERM mid-activity, exited ~2s later (grace 2s), left the task `queued` with null claimant/lease, and a restarted process reclaimed and completed the run.

Closes #173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable shutdown grace period, including `ENGINE_SHUTDOWN_GRACE`, plus a runtime option to control it.
  * During graceful shutdown, the runtime allows in-flight work to finish and releases eligible activity/workflow leases so they can be reclaimed promptly.

* **Bug Fixes**
  * Improved shutdown coordination and server cleanup to ensure predictable drain behavior.
  * Ensured only non-terminal (non-completed) work is released, preventing accidental release of completed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->