### PR TITLE
test(web): close the engine runs console test debt

### DIFF
--- a/web/e2e/ui-smoke.spec.ts
+++ b/web/e2e/ui-smoke.spec.ts
@@ -17,9 +17,44 @@ const E2E_OPERATOR_TOKEN = 'e2e-operator-token';
 const PRIMARY_PROJECT_ID = '11111111-1111-1111-1111-111111111111';
 const SECONDARY_PROJECT_ID = '22222222-2222-2222-2222-222222222222';
 const RUN_LOCALLY_DOCS_URL = 'https://www.continua.in/docs/guides/installation';
+const ENGINE_RUN_ID = '123e4567-e89b-12d3-a456-426614174100';
+const ENGINE_TRACE_ID = 'engine-trace-1';
+const STARTED_ENGINE_TRACE_ID = 'engine-trace-new';
+
+const ENGINE_TRACE = {
+  ...TRACE_ONE,
+  id: ENGINE_TRACE_ID,
+  name: 'Checkout workflow',
+  status: 'COMPLETED',
+  error_count: 0,
+  engine: {
+    run_id: ENGINE_RUN_ID,
+    definition_name: 'checkout',
+    definition_version: 'v1',
+    projection_state: 'up_to_date',
+    instance_key: 'checkout-42',
+    status: 'COMPLETED',
+    pending_work: {
+      pending_activity_tasks: 0,
+      pending_inbox_items: 0,
+    },
+    created_at: '2026-03-14T10:00:00.000Z',
+    updated_at: '2026-03-14T10:00:03.000Z',
+    completed_at: '2026-03-14T10:00:03.000Z',
+  },
+};
+
+const ENGINE_TRACE_DETAIL = {
+  ...TRACE_DETAIL,
+  ...ENGINE_TRACE,
+  trace_id: 'engine-checkout-42',
+  output: { approved: true },
+};
 
 const TRACE_DETAILS = new Map([
   [TRACE_ONE.id, TRACE_DETAIL],
+  [ENGINE_TRACE_ID, ENGINE_TRACE_DETAIL],
+  [STARTED_ENGINE_TRACE_ID, { ...ENGINE_TRACE_DETAIL, id: STARTED_ENGINE_TRACE_ID }],
   [
     TRACE_TWO.id,
     {
@@ -260,6 +295,9 @@ async function mockApiRoutes(page: Page, mode: 'operator' | 'public-demo' = 'ope
     }
 
     if (url.pathname === '/api/traces') {
+      if (url.searchParams.get('engine_only') === 'true') {
+        return fulfillJson(route, { traces: [ENGINE_TRACE], total: 1 });
+      }
       return fulfillJson(route, filterTraces(url));
     }
 
@@ -304,6 +342,86 @@ async function mockApiRoutes(page: Page, mode: 'operator' | 'public-demo' = 'ope
         return fulfillJson(route, SESSION_TWO);
       }
       return fulfillJson(route, { code: 'not_found', message: 'Resource not found' }, 404);
+    }
+
+    return fulfillJson(route, { code: 'not_found', message: 'Resource not found' }, 404);
+  });
+}
+
+async function mockEngineRoutes(page: Page) {
+  await page.route('**/v1/engine/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    expectOperatorAuthHeader(route);
+
+    if (/^\/v1\/engine\/instances\/[^/]+$/.test(url.pathname)) {
+      return fulfillJson(route, { code: 'not_found', message: 'Instance not found' }, 404);
+    }
+
+    if (url.pathname === '/v1/engine/runs' && request.method() === 'POST') {
+      expect(request.headers()['x-continua-engine-preview']).toBe('1');
+      expect(request.postDataJSON()).toMatchObject({
+        instance_key: 'checkout-42',
+        definition_name: 'checkout',
+        definition_version: 'v1',
+      });
+      return fulfillJson(route, {
+        run_id: ENGINE_RUN_ID,
+        instance_key: 'checkout-42',
+        trace_id: STARTED_ENGINE_TRACE_ID,
+      });
+    }
+
+    if (url.pathname === `/v1/engine/runs/${ENGINE_RUN_ID}/pending-work`) {
+      return fulfillJson(route, {
+        run_id: ENGINE_RUN_ID,
+        current_wait: null,
+        activities: [],
+        timers: [],
+        signals: [],
+        pending_activity_tasks: 0,
+        pending_inbox_items: 0,
+      });
+    }
+
+    if (url.pathname === `/v1/engine/runs/${ENGINE_RUN_ID}/history`) {
+      return fulfillJson(route, { events: [], has_more: false, expired: false });
+    }
+
+    if (url.pathname === `/v1/engine/runs/${ENGINE_RUN_ID}/result`) {
+      return fulfillJson(route, {
+        run_id: ENGINE_RUN_ID,
+        status: 'COMPLETED',
+        result: { approved: true },
+      });
+    }
+
+    if (
+      url.pathname === '/v1/engine/projections/backfill' &&
+      request.method() === 'POST'
+    ) {
+      expect(request.headers()['x-continua-engine-preview']).toBe('1');
+      expect(request.postDataJSON()).toEqual({
+        dry_run: true,
+        limit: 50,
+        engine_projection_state: 'summary_only',
+      });
+      return fulfillJson(route, {
+        dry_run: true,
+        limit: 50,
+        eligible_count: 1,
+        repair_requested_count: 0,
+        skipped_count: 0,
+        results: [
+          {
+            run_id: ENGINE_RUN_ID,
+            trace_id: ENGINE_TRACE_ID,
+            projection_state: 'summary_only',
+            action: 'would_repair',
+            reason: 'repair_requested',
+          },
+        ],
+      });
     }
 
     return fulfillJson(route, { code: 'not_found', message: 'Resource not found' }, 404);
@@ -435,6 +553,88 @@ test('captures trace, session, and compare workspaces', async ({ page }, testInf
     () => expect(page.getByRole('heading', { name: 'Span Diff' })).toBeVisible(),
     `${prefix}-session-compare`
   );
+});
+
+test('covers the engine runs console smoke flows', async ({ page }, testInfo) => {
+  const isMobile = testInfo.project.name === 'mobile-chromium';
+  await bootstrapOperatorSession(page);
+  await mockApiRoutes(page, 'operator');
+  await mockEngineRoutes(page);
+  await page.goto(`/traces?project_id=${PRIMARY_PROJECT_ID}`);
+
+  if (isMobile) {
+    await page.getByRole('button', { name: 'Open navigation', exact: true }).click();
+  }
+  const navigation = page.getByRole('navigation', {
+    name: isMobile ? 'Mobile primary' : 'Primary',
+    exact: true,
+  });
+  expect((await navigation.getByRole('link').allTextContents()).map((text) => text.trim()))
+    .toEqual(['Overview', 'Traces', 'Engine Runs', 'Sessions', 'Projects', 'Settings']);
+
+  const engineRunsRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/traces' && url.searchParams.get('engine_only') === 'true';
+  });
+  await navigation.getByRole('link', { name: 'Engine Runs', exact: true }).click();
+  expect(new URL((await engineRunsRequest).url()).searchParams.get('engine_only')).toBe('true');
+  await expect(page).toHaveURL(
+    `/engine/runs?project_id=${PRIMARY_PROJECT_ID}`
+  );
+  const engineRunRow = page.getByRole('row').filter({ hasText: 'checkout · v1' });
+  await expect(engineRunRow.getByText('checkout · v1', { exact: true })).toBeVisible();
+  await expect(engineRunRow.getByText('Completed', { exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Start run', exact: true }).click();
+  const startForm = page
+    .getByRole('heading', { name: 'Start run', exact: true })
+    .locator('xpath=ancestor::form');
+  await startForm.getByLabel(/^Instance key/).fill('checkout-42');
+  await startForm.getByLabel(/^Definition name/).fill('checkout');
+  await startForm.getByLabel(/^Definition version/).fill('v1');
+  const startRequest = page.waitForRequest(
+    (request) =>
+      new URL(request.url()).pathname === '/v1/engine/runs' &&
+      request.method() === 'POST'
+  );
+  await startForm.getByRole('button', { name: 'Start run', exact: true }).click();
+  await startRequest;
+  await expect(page).toHaveURL(
+    new RegExp(String.raw`/traces/${STARTED_ENGINE_TRACE_ID}\?project_id=${PRIMARY_PROJECT_ID}`)
+  );
+
+  await page.getByRole('button', { name: 'Engine state', exact: true }).click();
+  await expect(page.getByRole('button', { name: /^Overview \d+$/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /^Pending \d+$/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /^Engine history \d+$/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /^Result \d+$/ })).toBeVisible();
+
+  await page.goto(`/settings?project_id=${PRIMARY_PROJECT_ID}`);
+  const operationsSection = page
+    .getByRole('heading', { name: 'Operations', exact: true })
+    .locator('xpath=ancestor::section[1]');
+  await expect(operationsSection).toBeVisible();
+  await operationsSection
+    .getByRole('link', { name: /^Engine projection repair/ })
+    .click();
+  await expect(page).toHaveURL(
+    `/tools/engine-projections?project_id=${PRIMARY_PROJECT_ID}`
+  );
+  await expect(
+    page.getByRole('heading', { name: 'Engine projection repair', exact: true })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Apply repair', exact: true })
+  ).toHaveCount(0);
+  await page.getByRole('button', { name: 'Run dry run', exact: true }).click();
+  await expect(page.getByText(ENGINE_RUN_ID, { exact: true })).toBeVisible();
+  await expect(page.getByText('Dry run', { exact: true })).toBeVisible();
+
+  const screenshot = await page.screenshot({ fullPage: true, animations: 'disabled' });
+  await testInfo.attach(`${testInfo.project.name}-engine-projection-dry-run`, {
+    body: screenshot,
+    contentType: 'image/png',
+  });
 });
 
 test('walks the public demo flow from landing through debugger reads', async ({ page }, testInfo) => {

--- a/web/src/pages/EngineProjectionRepairPage.test.tsx
+++ b/web/src/pages/EngineProjectionRepairPage.test.tsx
@@ -1,0 +1,356 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { clearApiKey, setApiKey } from '../api/client';
+import { ThemeProvider } from '../hooks/ThemeProvider';
+import {
+  createDeferredResponse,
+  jsonResponse,
+  readRequestUrl,
+  type RequestInput,
+} from './testUtils';
+import { EngineProjectionRepairPage } from './EngineProjectionRepairPage';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+const RESULT_ROWS = [
+  {
+    run_id: 'run-repair-1',
+    trace_id: 'trace-repair-1',
+    projection_state: 'summary_only',
+    action: 'would_repair',
+    reason: 'repair_requested',
+  },
+  {
+    run_id: 'run-repair-2',
+    trace_id: 'trace-repair-2',
+    projection_state: 'summary_only',
+    action: 'would_repair',
+    reason: 'no_events_to_project',
+  },
+];
+
+function backfillResponse({
+  dryRun = true,
+  eligibleCount = 2,
+  results = RESULT_ROWS,
+}: {
+  dryRun?: boolean;
+  eligibleCount?: number;
+  results?: typeof RESULT_ROWS;
+} = {}) {
+  return {
+    dry_run: dryRun,
+    limit: 50,
+    eligible_count: eligibleCount,
+    repair_requested_count: dryRun ? 0 : eligibleCount,
+    skipped_count: 0,
+    results,
+  };
+}
+
+function renderRepairPage(initialEntry = '/tools/engine-projections') {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path="/tools/engine-projections"
+            element={<EngineProjectionRepairPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+}
+
+function backfillCalls(): Array<[RequestInput, RequestInit]> {
+  return fetchMock.mock.calls.filter(([input, init]) => {
+    const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+    return (
+      url.pathname === '/v1/engine/projections/backfill' &&
+      (init as RequestInit | undefined)?.method === 'POST'
+    );
+  }) as Array<[RequestInput, RequestInit]>;
+}
+
+function requestBody(call: [RequestInput, RequestInit]) {
+  return JSON.parse(call[1].body as string) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  localStorage.clear();
+  setApiKey('test-key');
+});
+
+afterEach(() => {
+  clearApiKey();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe('EngineProjectionRepairPage', () => {
+  it('renders the form with the summary_only default and helper copy', () => {
+    renderRepairPage();
+
+    expect(
+      screen.getByRole('heading', { name: 'Engine projection repair' })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Projection state/)).toHaveValue('summary_only');
+    expect(
+      screen.getByText(
+        'Default repair target is summary_only. up_to_date, catching_up, and journal_expired return zero eligible rows.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Apply repair' })).not.toBeInTheDocument();
+  });
+
+  it('posts an exact dry-run body then an exact apply body through the confirmation modal', async () => {
+    const user = userEvent.setup();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(backfillResponse()))
+      .mockResolvedValueOnce(
+        jsonResponse(backfillResponse({ dryRun: false }))
+      );
+    renderRepairPage();
+
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+
+    expect(await screen.findByText('run-repair-1')).toBeInTheDocument();
+    expect(backfillCalls()).toHaveLength(1);
+    expect(requestBody(backfillCalls()[0])).toEqual({
+      dry_run: true,
+      limit: 50,
+      engine_projection_state: 'summary_only',
+    });
+
+    const applyButton = screen.getByRole('button', { name: 'Apply repair' });
+    expect(applyButton).toBeEnabled();
+    await user.click(applyButton);
+
+    expect(
+      screen.getByText(/^Last dry run found 2 eligible runs\./)
+    ).toBeInTheDocument();
+    const modal = screen
+      .getByRole('heading', { name: 'Apply projection repair' })
+      .closest('.fixed');
+    expect(modal).not.toBeNull();
+    await user.click(
+      within(modal as HTMLElement).getByRole('button', { name: 'Apply repair' })
+    );
+
+    await waitFor(() => expect(backfillCalls()).toHaveLength(2));
+    expect(requestBody(backfillCalls()[1])).toEqual({
+      dry_run: false,
+      limit: 50,
+      engine_projection_state: 'summary_only',
+    });
+  });
+
+  it('renders a successful empty result when zero runs are eligible', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(backfillResponse({ eligibleCount: 0, results: [] }))
+    );
+    renderRepairPage();
+
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+
+    expect(await screen.findByRole('heading', { name: 'No eligible runs' })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The dry run completed successfully and found no repair targets.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply repair' })).toBeDisabled();
+    expect(screen.getByText('No eligible runs to repair.')).toBeInTheDocument();
+    expect(screen.queryByText('Backend failure')).not.toBeInTheDocument();
+  });
+
+  it('converts older_than local input to a UTC ISO-8601 string', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(backfillResponse({ eligibleCount: 0, results: [] }))
+    );
+    renderRepairPage();
+    const localValue = '2026-03-14T10:00';
+
+    fireEvent.change(screen.getByLabelText(/^Older than/), {
+      target: { value: localValue },
+    });
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+
+    await waitFor(() => expect(backfillCalls()).toHaveLength(1));
+    expect(requestBody(backfillCalls()[0]).older_than).toBe(
+      new Date(localValue).toISOString()
+    );
+  });
+
+  it('blocks submission client-side when limit exceeds 100', async () => {
+    const user = userEvent.setup();
+    renderRepairPage();
+    const limit = screen.getByLabelText(/^Limit/);
+
+    await user.clear(limit);
+    await user.type(limit, '150');
+
+    expect(screen.getByText('Limit must be 100 or less.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('clears results and disables apply when a filter changes after a dry run', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(jsonResponse(backfillResponse()));
+    renderRepairPage();
+
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+    expect(await screen.findByText('run-repair-1')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/^Instance key/), 'instance-filter');
+
+    expect(screen.queryByText('run-repair-1')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply repair' })).toBeDisabled();
+    expect(screen.getByText('Run a fresh dry run to apply.')).toBeInTheDocument();
+  });
+
+  it('prevents double submission and locks the form during apply', async () => {
+    const user = userEvent.setup();
+    const dryRunDeferred = createDeferredResponse();
+    const applyDeferred = createDeferredResponse();
+    fetchMock
+      .mockImplementationOnce(() => dryRunDeferred.promise)
+      .mockImplementationOnce(() => applyDeferred.promise);
+    renderRepairPage();
+
+    const dryRunButton = screen.getByRole('button', { name: 'Run dry run' });
+    await user.click(dryRunButton);
+    await user.click(dryRunButton);
+
+    expect(backfillCalls()).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Running…' })).toBeDisabled();
+
+    await act(async () => {
+      dryRunDeferred.resolve(jsonResponse(backfillResponse()));
+    });
+    expect(await screen.findByText('run-repair-1')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Apply repair' }));
+    const modal = screen
+      .getByRole('heading', { name: 'Apply projection repair' })
+      .closest('.fixed');
+    expect(modal).not.toBeNull();
+    await user.click(
+      within(modal as HTMLElement).getByRole('button', { name: 'Apply repair' })
+    );
+
+    expect(screen.getByLabelText(/^Instance key/)).toBeDisabled();
+    expect(screen.getByLabelText(/^Definition name/)).toBeDisabled();
+    expect(screen.getByLabelText(/^Projection state/)).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Run dry run' })).toBeDisabled();
+    const applyingButtons = screen.getAllByRole('button', { name: 'Applying…' });
+    expect(applyingButtons).toHaveLength(2);
+    applyingButtons.forEach((button) => expect(button).toBeDisabled());
+
+    await act(async () => {
+      applyDeferred.resolve(
+        jsonResponse(backfillResponse({ dryRun: false }))
+      );
+    });
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('heading', { name: 'Apply projection repair' })
+      ).not.toBeInTheDocument()
+    );
+    expect(backfillCalls().filter((call) => requestBody(call).dry_run === false)).toHaveLength(1);
+  });
+
+  it('maps backend 400 failures to a correction error without retrying or clearing form values', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ code: 'invalid_request', message: 'Choose a supported filter.' }, 400)
+    );
+    renderRepairPage();
+    const instanceKey = screen.getByLabelText(/^Instance key/);
+    const definitionName = screen.getByLabelText(/^Definition name/);
+
+    await user.type(instanceKey, 'instance-400');
+    await user.type(definitionName, 'definition-400');
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+
+    expect(await screen.findByText('Request needs correction')).toBeInTheDocument();
+    expect(screen.getByText(/Choose a supported filter\./)).toBeInTheDocument();
+    expect(instanceKey).toHaveValue('instance-400');
+    expect(definitionName).toHaveValue('definition-400');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps backend 401 failures to the authentication banner', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ code: 'invalid_api_key', message: 'Invalid API key' }, 401)
+    );
+    renderRepairPage();
+
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Authentication required');
+    expect(alert).toHaveTextContent('Invalid API key');
+  });
+
+  it('maps backend 404 failures to the engine-disabled state', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ code: 'not_found', message: 'Not found' }, 404)
+    );
+    renderRepairPage();
+
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+
+    expect(await screen.findByText('Engine API disabled')).toBeInTheDocument();
+    expect(
+      screen.getByText(/The projection repair endpoint is not available on this server\./)
+    ).toBeInTheDocument();
+  });
+
+  it('maps backend 500 failures to the backend-failure state', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ code: 'internal', message: 'Database unavailable' }, 500)
+    );
+    renderRepairPage();
+
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+
+    expect(await screen.findByText('Backend failure')).toBeInTheDocument();
+  });
+
+  it('links result rows to project-scoped trace URLs', async () => {
+    const user = userEvent.setup();
+    const projectId = '123e4567-e89b-12d3-a456-426614174999';
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ...backfillResponse({ eligibleCount: 1, results: [RESULT_ROWS[0]] }),
+        results: [
+          {
+            ...RESULT_ROWS[0],
+            run_id: 'run-x',
+            trace_id: 'trace-x',
+          },
+        ],
+      })
+    );
+    renderRepairPage(`/tools/engine-projections?project_id=${projectId}`);
+
+    await user.click(screen.getByRole('button', { name: 'Run dry run' }));
+
+    expect(await screen.findByRole('link', { name: 'trace-x' })).toHaveAttribute(
+      'href',
+      `/traces/trace-x?project_id=${projectId}`
+    );
+  });
+});

--- a/web/src/pages/EngineRunsPage.test.tsx
+++ b/web/src/pages/EngineRunsPage.test.tsx
@@ -1,16 +1,56 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
-import { clearApiKey, setApiKey } from '../api/client';
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+} from 'react-router-dom';
+import { clearApiKey, setApiKey, type Trace } from '../api/client';
 import { TRACE_ONE } from '../test/traceFixtures';
 import { ThemeProvider } from '../hooks/ThemeProvider';
+import { DEFAULT_PAGE_SIZE } from '../utils/pagination';
 import { jsonResponse, readRequestUrl, type RequestInput } from './testUtils';
 import { EngineRunsPage } from './EngineRunsPage';
 
 let fetchMock: ReturnType<typeof vi.fn>;
 
-function renderEngineRunsPage() {
+const ENGINE_TRACE: Trace = {
+  ...TRACE_ONE,
+  id: 'engine-trace-1',
+  name: 'Darklaunch run',
+  error_count: 0,
+  engine: {
+    run_id: '123e4567-e89b-12d3-a456-426614174100',
+    definition_name: 'darklaunch.demo',
+    definition_version: 'v1',
+    projection_state: 'up_to_date',
+    instance_key: 'darklaunch-1',
+    status: 'QUEUED',
+    pending_work: {
+      pending_activity_tasks: 0,
+      pending_inbox_items: 0,
+    },
+    updated_at: '2026-03-14T10:00:03.000Z',
+  },
+};
+
+function LocationProbe() {
+  const location = useLocation();
+  const state = location.state as { returnTo?: string } | null;
+
+  return (
+    <>
+      <div data-testid="probe-pathname">{location.pathname}</div>
+      <div data-testid="probe-search">{location.search}</div>
+      <div data-testid="probe-return-to">{state?.returnTo}</div>
+    </>
+  );
+}
+
+function renderEngineRunsPage(initialEntry = '/engine/runs') {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -23,12 +63,47 @@ function renderEngineRunsPage() {
   return render(
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
-        <MemoryRouter initialEntries={['/engine/runs']}>
-          <EngineRunsPage />
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path="/engine/runs" element={<EngineRunsPage />} />
+            <Route path="/traces/:traceId" element={<LocationProbe />} />
+          </Routes>
         </MemoryRouter>
       </ThemeProvider>
     </QueryClientProvider>
   );
+}
+
+function mockEngineRequests({
+  traces = [ENGINE_TRACE],
+  instance,
+  start,
+}: {
+  traces?: Trace[];
+  instance?: (url: URL, init?: RequestInit) => Promise<Response> | Response;
+  start?: (url: URL, init?: RequestInit) => Promise<Response> | Response;
+} = {}) {
+  fetchMock.mockImplementation((input: RequestInput, init?: RequestInit) => {
+    const url = new URL(readRequestUrl(input), 'http://localhost');
+
+    if (url.pathname === '/api/traces') {
+      return jsonResponse({ traces, total: traces.length });
+    }
+    if (/^\/v1\/engine\/instances\/[^/]+$/.test(url.pathname) && instance) {
+      return instance(url, init);
+    }
+    if (url.pathname === '/v1/engine/runs' && init?.method === 'POST' && start) {
+      return start(url, init);
+    }
+
+    throw new Error(`Unhandled request: ${init?.method ?? 'GET'} ${url.pathname}`);
+  });
+}
+
+async function openStartDialog(user: ReturnType<typeof userEvent.setup>) {
+  await screen.findByRole('table');
+  await user.click(screen.getByRole('button', { name: 'Start run' }));
+  return screen.findByRole('heading', { name: 'Start run' });
 }
 
 beforeEach(() => {
@@ -46,37 +121,7 @@ afterEach(() => {
 
 describe('EngineRunsPage', () => {
   it('requests engine-only traces and renders engine status labels', async () => {
-    fetchMock.mockImplementation((input: RequestInput) => {
-      const url = new URL(readRequestUrl(input), 'http://localhost');
-      if (url.pathname !== '/api/traces') {
-        throw new Error(`Unhandled request: ${url.pathname}`);
-      }
-
-      return jsonResponse({
-        traces: [
-          {
-            ...TRACE_ONE,
-            id: 'engine-trace-1',
-            name: 'Darklaunch run',
-            error_count: 0,
-            engine: {
-              run_id: '123e4567-e89b-12d3-a456-426614174100',
-              definition_name: 'darklaunch.demo',
-              definition_version: 'v1',
-              projection_state: 'up_to_date',
-              instance_key: 'darklaunch-1',
-              status: 'QUEUED',
-              pending_work: {
-                pending_activity_tasks: 0,
-                pending_inbox_items: 0,
-              },
-              updated_at: '2026-03-14T10:00:03.000Z',
-            },
-          },
-        ],
-        total: 1,
-      });
-    });
+    mockEngineRequests();
 
     renderEngineRunsPage();
 
@@ -92,5 +137,254 @@ describe('EngineRunsPage', () => {
       expect(requestUrl.pathname).toBe('/api/traces');
       expect(requestUrl.searchParams.get('engine_only')).toBe('true');
     });
+  });
+
+  it('sends engine_only with pagination params and renders the locked column order', async () => {
+    mockEngineRequests();
+
+    renderEngineRunsPage();
+
+    expect(await screen.findByText('darklaunch.demo · v1')).toBeInTheDocument();
+    const requestUrl = new URL(
+      readRequestUrl(fetchMock.mock.calls[0]?.[0] as RequestInput),
+      'http://localhost'
+    );
+    expect(requestUrl.searchParams.get('engine_only')).toBe('true');
+    expect(requestUrl.searchParams.get('limit')).toBe(String(DEFAULT_PAGE_SIZE));
+    expect(requestUrl.searchParams.get('offset')).toBeNull();
+    expect(
+      screen.getAllByRole('columnheader').map((header) => header.textContent?.trim())
+    ).toEqual([
+      'Status',
+      'Definition',
+      'Instance key',
+      'Wait',
+      'Pending',
+      'Projection',
+      'Updated',
+      '→',
+    ]);
+  });
+
+  it('navigates rows through project-scoped links carrying returnTo state', async () => {
+    const user = userEvent.setup();
+    const projectId = '123e4567-e89b-12d3-a456-426614174999';
+    mockEngineRequests();
+
+    renderEngineRunsPage(`/engine/runs?project_id=${projectId}`);
+
+    const rowLink = await screen.findByRole('link', { name: `Open ${ENGINE_TRACE.id}` });
+    expect(rowLink).toHaveAttribute(
+      'href',
+      `/traces/${ENGINE_TRACE.id}?project_id=${projectId}`
+    );
+
+    await user.click(rowLink);
+
+    expect(screen.getByTestId('probe-pathname')).toHaveTextContent(
+      `/traces/${ENGINE_TRACE.id}`
+    );
+    expect(screen.getByTestId('probe-search')).toHaveTextContent(`project_id=${projectId}`);
+    expect(screen.getByTestId('probe-return-to')).toHaveTextContent(
+      `/engine/runs?project_id=${projectId}`
+    );
+  });
+
+  it('shows the empty state and opens the start dialog from it', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({ traces: [] });
+
+    renderEngineRunsPage();
+
+    const emptyHeading = await screen.findByRole('heading', { name: 'No engine runs yet' });
+    const emptyState = emptyHeading.closest('.app-empty-state');
+    expect(emptyState).not.toBeNull();
+    await user.click(within(emptyState as HTMLElement).getByRole('button', { name: 'Start run' }));
+
+    expect(await screen.findByRole('heading', { name: 'Start run' })).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Instance key/)).toBeInTheDocument();
+  });
+});
+
+describe('StartEngineRunDialog', () => {
+  it('generates an editable UUID idempotency key', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests();
+    renderEngineRunsPage();
+
+    await openStartDialog(user);
+    const requestKey = screen.getByLabelText(/^Idempotency key/) as HTMLInputElement;
+    expect(requestKey.value).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+
+    await user.clear(requestKey);
+    await user.type(requestKey, 'custom-request-key');
+    expect(requestKey).toHaveValue('custom-request-key');
+  });
+
+  it('treats instance preflight 404 as available', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({
+      instance: () =>
+        jsonResponse({ code: 'not_found', message: 'Instance not found' }, 404),
+    });
+    renderEngineRunsPage();
+
+    await openStartDialog(user);
+    await user.type(screen.getByLabelText(/^Instance key/), 'available-key');
+    await user.click(screen.getByRole('button', { name: 'Check' }));
+
+    expect(await screen.findByText('Instance key is available.')).toBeInTheDocument();
+  });
+
+  it('warns when preflight finds an active instance', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({
+      instance: () =>
+        jsonResponse({
+          instance_id: 'instance-id-1',
+          instance_key: 'active-key',
+          definition_name: 'checkout',
+          status: 'active',
+          current_run: {
+            run_id: '123e4567-e89b-12d3-a456-426614174101',
+            instance_key: 'active-key',
+            definition_name: 'checkout',
+            definition_version: 'v1',
+            projection_state: 'up_to_date',
+            status: 'RUNNING',
+            created_at: '2026-03-14T10:00:00.000Z',
+            updated_at: '2026-03-14T10:00:03.000Z',
+            pending_work: {
+              pending_activity_tasks: 0,
+              pending_inbox_items: 0,
+            },
+          },
+        }),
+    });
+    renderEngineRunsPage();
+
+    await openStartDialog(user);
+    await user.type(screen.getByLabelText(/^Instance key/), 'active-key');
+    await user.click(screen.getByRole('button', { name: 'Check' }));
+
+    expect(
+      await screen.findByText('Active instance exists for checkout (RUNNING).')
+    ).toBeInTheDocument();
+  });
+
+  it('keeps submit enabled when preflight fails', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({
+      instance: () => jsonResponse({ code: 'server_error', message: 'Unavailable' }, 500),
+    });
+    renderEngineRunsPage();
+
+    const dialogHeading = await openStartDialog(user);
+    await user.type(screen.getByLabelText(/^Instance key/), 'unknown-key');
+    await user.click(screen.getByRole('button', { name: 'Check' }));
+
+    expect(
+      await screen.findByText(/^Preflight unavailable\. Submit remains enabled\./)
+    ).toBeInTheDocument();
+    const form = dialogHeading.closest('form');
+    expect(form).not.toBeNull();
+    expect(
+      within(form as HTMLFormElement).getByRole('button', { name: 'Start run' })
+    ).not.toBeDisabled();
+  });
+
+  it('scopes version suggestions to the selected definition and resets version on name change', async () => {
+    const user = userEvent.setup();
+    const traces: Trace[] = [
+      {
+        ...ENGINE_TRACE,
+        id: 'trace-def-a-v1',
+        engine: { ...ENGINE_TRACE.engine!, definition_name: 'defA', definition_version: 'v1' },
+      },
+      {
+        ...ENGINE_TRACE,
+        id: 'trace-def-a-v2',
+        engine: { ...ENGINE_TRACE.engine!, definition_name: 'defA', definition_version: 'v2' },
+      },
+      {
+        ...ENGINE_TRACE,
+        id: 'trace-def-b-v9',
+        engine: { ...ENGINE_TRACE.engine!, definition_name: 'defB', definition_version: 'v9' },
+      },
+    ];
+    mockEngineRequests({ traces });
+    renderEngineRunsPage();
+
+    await openStartDialog(user);
+    const definitionName = screen.getByLabelText(/^Definition name/);
+    const definitionVersion = screen.getByLabelText(/^Definition version/);
+    await user.type(definitionName, 'defA');
+
+    expect(
+      Array.from(document.querySelectorAll('#engine-definition-versions option')).map(
+        (option) => (option as HTMLOptionElement).value
+      )
+    ).toEqual(expect.arrayContaining(['v1', 'v2']));
+    expect(document.querySelectorAll('#engine-definition-versions option')).toHaveLength(2);
+
+    await user.type(definitionVersion, 'v1');
+    await user.clear(definitionName);
+    await user.type(definitionName, 'defB');
+
+    expect(definitionVersion).toHaveValue('');
+    expect(
+      Array.from(document.querySelectorAll('#engine-definition-versions option')).map(
+        (option) => (option as HTMLOptionElement).value
+      )
+    ).toEqual(['v9']);
+  });
+
+  it('submits the start request and navigates to the projected trace', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({
+      instance: () =>
+        jsonResponse({ code: 'not_found', message: 'Instance not found' }, 404),
+      start: () =>
+        jsonResponse({
+          run_id: '123e4567-e89b-12d3-a456-426614174102',
+          instance_key: 'checkout-42',
+          trace_id: 'trace-new-1',
+        }),
+    });
+    renderEngineRunsPage();
+
+    const dialogHeading = await openStartDialog(user);
+    const form = dialogHeading.closest('form');
+    expect(form).not.toBeNull();
+    const dialog = within(form as HTMLFormElement);
+    const requestKey = (dialog.getByLabelText(/^Idempotency key/) as HTMLInputElement).value;
+    await user.type(dialog.getByLabelText(/^Instance key/), 'checkout-42');
+    await user.type(dialog.getByLabelText(/^Definition name/), 'checkout');
+    await user.type(dialog.getByLabelText(/^Definition version/), 'v3');
+    await user.click(dialog.getByRole('button', { name: 'Start run' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-pathname')).toHaveTextContent('/traces/trace-new-1');
+    });
+    const postCall = fetchMock.mock.calls.find(([input, init]) => {
+      const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+      return url.pathname === '/v1/engine/runs' && (init as RequestInit | undefined)?.method === 'POST';
+    });
+    expect(postCall).toBeDefined();
+    const [postInput, postInit] = postCall as [RequestInput, RequestInit];
+    expect((postInit.method ?? 'GET').toUpperCase()).toBe('POST');
+    expect(new URL(readRequestUrl(postInput), 'http://localhost').pathname).toBe(
+      '/v1/engine/runs'
+    );
+    expect(new Headers(postInit.headers).get('X-Continua-Engine-Preview')).not.toBeNull();
+    expect(JSON.parse(postInit.body as string)).toEqual({
+      instance_key: 'checkout-42',
+      definition_name: 'checkout',
+      definition_version: 'v3',
+      request_key: requestKey,
+    });
+    expect(screen.getByTestId('probe-return-to')).toHaveTextContent('/engine/runs');
   });
 });

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -419,6 +419,126 @@ describe('TraceDetailPage', () => {
     expect(screen.queryAllByText('Closing')).toHaveLength(0);
   });
 
+  it('renders expired engine history in the Engine history tab', async () => {
+    const user = userEvent.setup();
+    const detail = createEngineTraceDetail();
+    const runId = detail.engine!.run_id;
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(detail),
+        engineHistory: () =>
+          jsonResponse({ events: [], has_more: false, expired: true }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await user.click(await screen.findByRole('button', { name: 'Engine state' }));
+    await user.click(screen.getByRole('button', { name: 'Engine history 0' }));
+
+    expect(
+      await screen.findByText(
+        'History expired. Retained history for this run has been purged.'
+      )
+    ).toBeInTheDocument();
+    const historyRequests = getRequests(fetchMock, `/v1/engine/runs/${runId}/history`);
+    expect(historyRequests).toHaveLength(1);
+    expect(historyRequests[0].searchParams.get('limit')).toBe('50');
+  });
+
+  it('renders the completed result payload in the Result tab', async () => {
+    const user = userEvent.setup();
+    const base = createEngineTraceDetail();
+    const detail = createEngineTraceDetail({
+      status: 'COMPLETED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      engine: {
+        ...base.engine!,
+        status: 'COMPLETED',
+        completed_at: '2026-03-14T10:00:10.000Z',
+      },
+    });
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(detail),
+        engineResult: () =>
+          jsonResponse({
+            run_id: detail.engine!.run_id,
+            status: 'COMPLETED',
+            result: { output: 42 },
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await user.click(await screen.findByRole('button', { name: 'Engine state' }));
+    await user.click(screen.getByRole('button', { name: 'Result 1' }));
+
+    expect(await screen.findByText('Completed result')).toBeInTheDocument();
+    expect(screen.getByText('"output"')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('renders the failure shell for failed runs', async () => {
+    const user = userEvent.setup();
+    const base = createEngineTraceDetail();
+    const detail = createEngineTraceDetail({
+      status: 'FAILED',
+      ended_at: '2026-03-14T10:00:10.000Z',
+      engine: {
+        ...base.engine!,
+        status: 'FAILED',
+        completed_at: '2026-03-14T10:00:10.000Z',
+      },
+    });
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(detail),
+        engineResult: () =>
+          jsonResponse({
+            run_id: detail.engine!.run_id,
+            status: 'FAILED',
+            result: null,
+            failure: { error_code: 'boom', error_message: 'exploded' },
+          }),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await user.click(await screen.findByRole('button', { name: 'Engine state' }));
+    await user.click(screen.getByRole('button', { name: 'Result 1' }));
+
+    expect(await screen.findByText('FAILED result shell')).toBeInTheDocument();
+    expect(screen.getByText('boom')).toBeInTheDocument();
+    expect(screen.getByText('exploded')).toBeInTheDocument();
+  });
+
+  it('keeps the result unavailable for non-terminal runs', async () => {
+    const user = userEvent.setup();
+    const detail = createEngineTraceDetail();
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(detail),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await user.click(await screen.findByRole('button', { name: 'Engine state' }));
+    await user.click(screen.getByRole('button', { name: 'Result 0' }));
+
+    expect(
+      screen.getByText(
+        'Result is not available until the run reaches a terminal state.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      getRequests(fetchMock, `/v1/engine/runs/${detail.engine!.run_id}/result`)
+    ).toHaveLength(0);
+  });
+
   it('shows pending engine work in the mobile summary workspace', async () => {
     setMatchMediaMatches(false);
     fetchMock.mockImplementation(

--- a/web/src/pages/testUtils.tsx
+++ b/web/src/pages/testUtils.tsx
@@ -80,7 +80,9 @@ export function buildFetchHandler({
   sessionNarrative,
   spans,
   timeline,
+  engineHistory,
   enginePendingWork,
+  engineResult,
   engineAction,
 }: {
   list?: JsonHandler;
@@ -91,7 +93,9 @@ export function buildFetchHandler({
   sessionNarrative?: JsonHandler;
   spans?: JsonHandler;
   timeline?: JsonHandler;
+  engineHistory?: JsonHandler;
   enginePendingWork?: JsonHandler;
+  engineResult?: JsonHandler;
   engineAction?: JsonHandler;
 } = {}) {
   return async (input: RequestInput, init?: RequestInit) => {
@@ -216,6 +220,22 @@ export function buildFetchHandler({
         pending_activity_tasks: 0,
         pending_inbox_items: 0,
       });
+    }
+
+    if (/^\/v1\/engine\/runs\/[^/]+\/history$/.test(url.pathname)) {
+      return (
+        engineHistory?.(url, init) ??
+        jsonResponse({ events: [], has_more: false, expired: false })
+      );
+    }
+
+    if (/^\/v1\/engine\/runs\/[^/]+\/result$/.test(url.pathname)) {
+      if (engineResult) {
+        return engineResult(url, init);
+      }
+
+      const runId = url.pathname.split('/').at(-2);
+      return jsonResponse({ run_id: runId, status: 'COMPLETED', result: null });
     }
 
     if (


### PR DESCRIPTION
## What / why

The engine runs console (openspec change `add-engine-runs-console`) shipped ~90% complete;
its test tasks (4.5, 5.8, 6.8, 7.14, 8.5) were open debt. This PR closes that debt so the
operator console is regression-protected ahead of the GA push. No product code changes —
the diff is Vitest suites, a small test-infra extension, and an E2E smoke extension.

## What's covered

**`EngineRunsPage.test.tsx` (task 4.5)** — `engine_only=true` + pagination query params
(canonical omission of `offset=0`), the locked column order
`Status | Definition | Instance key | Wait | Pending | Projection | Updated | →`,
project-scoped row navigation carrying `returnTo` state, and the empty state opening the
Start-run dialog.

**`StartEngineRunDialog` (task 5.8, tested through the page)** — editable auto-generated UUID
idempotency key; instance preflight 404 → available, 200 → active-instance warning,
error → non-blocking notice; version datalist scoped to the selected definition and reset on
name change; submit posts the exact body with the `X-Continua-Engine-Preview` header and
navigates to the projected trace with `returnTo` state.

**`TraceDetailPage.test.tsx` (task 6.8)** — expired-history rendering in the Engine history tab
(with `limit=50` request assertion), completed-result payload, FAILED result shell with error
code/message, and result-unavailable (no fetch) for non-terminal runs. The tab set and default
tab were already covered by existing tests.

**`EngineProjectionRepairPage.test.tsx` (task 7.14, new suite)** — direct navigation with the
`summary_only` default and helper copy; exact request-body assertions for `dry_run: true` and
`dry_run: false` through the destructive confirmation modal (`Last dry run found N eligible
runs.`); zero-eligible successful empty state; `older_than` local→UTC ISO-8601 conversion;
client-side `limit > 100` blocking; stale-form apply disablement; double-submit protection and
apply-time form lock; 400/401/404 (`Engine API disabled`)/5xx error states with preserved form
values and no auto-retry; project-scoped trace links from result rows. Per the spec, the
preview header is asserted at the client-wrapper level only (existing `client.test.ts`
coverage), and the Settings `Operations` link is already covered in `SettingsPage.test.tsx`.

**`web/e2e/ui-smoke.spec.ts` (task 8.5)** — a browser smoke walk of the dev-verification
checklist: sidebar shows `Engine Runs` between `Traces` and `Sessions`; `/engine/runs` lists
engine-only rows (asserting the `engine_only=true` request); the Start-run flow lands on the
projected trace detail; the Engine state section shows the Overview / Pending / Engine history /
Result tabs; `/tools/engine-projections` is reachable from the Settings Operations link with
dry-run-first UX.

**Test infra** — `buildFetchHandler` in `testUtils.tsx` gained optional `engineHistory` /
`engineResult` handlers (defaults preserve existing behavior).

## Verification

- `pnpm --filter web test`: 63 files, 513 tests, green (includes the 25 new tests).
- `pnpm --filter web test:e2e`: 10/10 green (desktop + mobile Chromium), executed in a real
  browser.
- `pnpm --filter web type-check` and `pnpm --filter web lint`: pass.
- `make generate`: no drift (no contract changes in this PR).
- Real-stack verification against a throwaway Postgres DB: platform + engine migrations, the
  `darklaunch.demo` workflow driven end-to-end via `continua-engine serve/start/signal/inspect`;
  `GET /api/traces?engine_only=true` → 200 with the projected run (`up_to_date`, `COMPLETED`);
  projection backfill dry-run → 200 with count fields; run history → 200 (11 events); run
  result → 200 (`COMPLETED` with payload); trace/session read surfaces and sync ingest all 200.

Closes #175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for Engine Runs, including filtering, starting runs, navigation, and projection repair.
  * Expanded coverage for history, result, expired data, failures, validation, permissions, and backend errors.
  * Added checks for request parameters, headers, pagination, idempotency keys, and form behavior.
  * Improved test mocks for engine history, results, pending work, and repair workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->