### PR TITLE
docs: clarify engine preview header scope and Python SDK role

### DIFF
--- a/docs-site/api-reference/auth-and-headers.mdx
+++ b/docs-site/api-reference/auth-and-headers.mdx
@@ -52,7 +52,7 @@ Some endpoints are behind preview flags and require an explicit opt-in header:
 | Header | Required by | Notes |
 | --- | --- | --- |
 | `X-Continua-Async-Version: 2` | `POST /v1/ingest` for true-async durable ingest | Without it, the server may run sync or fall back to legacy async behaviour |
-| `X-Continua-Engine-Preview: 1` | All `/v1/engine/*` endpoints | Also requires `ENGINE_PUBLIC_API_ENABLED=true` server-side |
+| `X-Continua-Engine-Preview: 1` | Mutating (POST) `/v1/engine/*` endpoints | GET reads need only `ENGINE_PUBLIC_API_ENABLED=true` server-side |
 
 Preview headers exist so we can ship surfaces under iteration without breaking
 non-preview clients. They will be relaxed or removed as those surfaces stabilise.

--- a/docs-site/concepts/engine-foundation.mdx
+++ b/docs-site/concepts/engine-foundation.mdx
@@ -12,9 +12,10 @@ store, control endpoints, and runs console UI around it are real too.
 This page draws the line between what runs today and what's still preview-limited.
 
 <Warning>
-  The engine is preview. Endpoints require `X-Continua-Engine-Preview` and
-  `ENGINE_PUBLIC_API_ENABLED=true` on the server. Don't depend on engine workflow
-  execution for production work yet. See [Roadmap](/roadmap).
+  The engine is preview. Mutating (POST) endpoints require
+  `X-Continua-Engine-Preview: 1`; all `/v1/engine/*` endpoints require
+  `ENGINE_PUBLIC_API_ENABLED=true` on the server, while reads need only the env flag. Don't
+  depend on engine workflow execution for production work yet. See [Roadmap](/roadmap).
 </Warning>
 
 ## What's implemented
@@ -111,10 +112,9 @@ the control bar. Polling-based.
 
 ## What's still limited in preview
 
-- **Go-only authoring.** Workflows and activities are written as Go functions registered
-  with the runtime. There is no TypeScript/Python SDK for *authoring* workflows yet (the
-  Python SDK's `ActivityWorker` / `@activity` / `EngineControlClient` target this surface
-  but aren't a full authoring runtime).
+- **Go-only authoring.** Workflow logic and authoring remain Go-only; the Python SDK's
+  `ActivityWorker` / `@activity` and `EngineControlClient` support remote activity
+  execution and run control only.
 - **No production definition loading.** The runtime today registers definitions from the
   Go process that starts workers; the bundled dark-launch CLI is still only a demo
   consumer. There's no supported path yet to dynamically register and version arbitrary
@@ -122,9 +122,9 @@ the control bar. Polling-based.
 - **Explicit project provisioning.** Scoped workers must point at an existing platform
   project with `ENGINE_PROJECT_ID` or `runtime.Options.ProjectID`; missing projects fail
   startup. See [Engine project provisioning](/guides/engine-project-provisioning).
-- **Preview-gated REST control plane.** The `/v1/engine/*` endpoints require
-  `X-Continua-Engine-Preview` + `ENGINE_PUBLIC_API_ENABLED`, and shapes may change
-  before GA.
+- **Preview-gated REST control plane.** Mutating (POST) endpoints require
+  `X-Continua-Engine-Preview: 1`; all `/v1/engine/*` endpoints require
+  `ENGINE_PUBLIC_API_ENABLED=true`, and shapes may change before GA.
 
 ## When to use the engine today
 

--- a/docs-site/debugger/engine-runs.mdx
+++ b/docs-site/debugger/engine-runs.mdx
@@ -8,11 +8,12 @@ Use it to inspect run state, see what work is still pending, and (in operator wo
 repair projection state.
 
 <Warning>
-  The engine surface is in preview. Endpoints require `X-Continua-Engine-Preview` and
-  `ENGINE_PUBLIC_API_ENABLED=true` on the server. Workflow execution works (Go-defined
-  workflows), but it's preview, not production-hardened, so don't put it on a
-  production-critical path yet. See [Engine foundation](/concepts/engine-foundation) and
-  [Roadmap](/roadmap).
+  The engine surface is in preview. Mutating (POST) endpoints require
+  `X-Continua-Engine-Preview: 1`; all `/v1/engine/*` endpoints require
+  `ENGINE_PUBLIC_API_ENABLED=true` on the server, while reads need only the env flag. Workflow
+  execution works (Go-defined workflows), but it's preview, not production-hardened, so don't
+  put it on a production-critical path yet. See [Engine foundation](/concepts/engine-foundation)
+  and [Roadmap](/roadmap).
 </Warning>
 
 ## Runs list

--- a/docs-site/guides/installation.mdx
+++ b/docs-site/guides/installation.mdx
@@ -142,7 +142,7 @@ Engine surface (preview: see [Roadmap](/roadmap) for status):
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `ENGINE_PUBLIC_API_ENABLED` | `false` | Expose `/v1/engine/*` endpoints. Requires `X-Continua-Engine-Preview` on requests |
+| `ENGINE_PUBLIC_API_ENABLED` | `false` | Expose `/v1/engine/*` endpoints. Mutating (POST) requests also require `X-Continua-Engine-Preview: 1` |
 | `ENGINE_DATABASE_URL` | falls back to `DATABASE_URL` | Optional separate Postgres for the engine schema |
 | `ENGINE_LEASE_COMPLETION_GRACE` | `0` | Optional clock-skew grace for remote activity complete, fail, and retry fences only |
 | `ENGINE_PROJECTION_RETENTION_AFTER` | unset | How long to retain projection state after a run reaches terminal state |

--- a/docs-site/guides/self-hosting.mdx
+++ b/docs-site/guides/self-hosting.mdx
@@ -58,7 +58,7 @@ The durable engine surface ships behind a preview flag. See
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `ENGINE_PUBLIC_API_ENABLED` | `false` | Expose `/v1/engine/*` endpoints. Requires `X-Continua-Engine-Preview` on requests |
+| `ENGINE_PUBLIC_API_ENABLED` | `false` | Expose `/v1/engine/*` endpoints. Mutating (POST) requests also require `X-Continua-Engine-Preview: 1` |
 | `ENGINE_DATABASE_URL` | falls back to `DATABASE_URL` | Optional separate Postgres for the engine schema |
 | `ENGINE_PROJECTION_RETENTION_AFTER` | unset | How long to retain projection state after a run reaches terminal state |
 | `ENGINE_HISTORY_RETENTION_AFTER` | unset | Retention window for run history. Must be greater than `ENGINE_PROJECTION_RETENTION_AFTER` |

--- a/docs-site/roadmap.mdx
+++ b/docs-site/roadmap.mdx
@@ -48,8 +48,7 @@ Preview caveats:
 - **Go-only authoring**: no TypeScript/Python SDK for authoring workflows yet.
 - **No production definition loading**: definitions register through the Go runtime that
   starts workers; there's no multi-tenant register-and-version path yet.
-- **Preview-gated REST**: `/v1/engine/*` requires `X-Continua-Engine-Preview` +
-  `ENGINE_PUBLIC_API_ENABLED`, and shapes may change before GA.
+- **Preview-gated REST**: mutating (POST) endpoints require `X-Continua-Engine-Preview: 1`; all `/v1/engine/*` endpoints require `ENGINE_PUBLIC_API_ENABLED=true`, and shapes may change before GA.
 
 See [Engine foundation](/concepts/engine-foundation) for the full picture.
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -3,6 +3,8 @@
 Python SDK for Continua — the self-hosted durable execution engine with built-in
 observability for AI agents. Sends traces, spans, sessions, events, and engine-control
 requests to a Continua server.
+The SDK's engine surface covers remote activity execution (`ActivityWorker`/`@activity`)
+and run control (`EngineControlClient`) only; workflow authoring remains in Go.
 
 ## Installation
 


### PR DESCRIPTION
## What / why

Two documentation drifts around the engine preview surface (#177):

1. **Preview header scope.** The docs claimed `X-Continua-Engine-Preview` is required on all `/v1/engine/*` endpoints. The middleware (`internal/api/engine_middleware.go`) enforces the header on **POSTs only**; GET reads need only `ENGINE_PUBLIC_API_ENABLED=true`. The OpenAPI contract already agrees (the header parameter exists only on the 13 mutating operations), so this fixes prose docs to match code — the middleware asymmetry is intentional and kept as-is.
2. **Python SDK positioning.** The docs' Go-only-authoring caveat was vague about what the Python SDK's `ActivityWorker` / `@activity` / `EngineControlClient` are for. They now state crisply: remote activity execution and run control only — workflow authoring stays Go.

## Changes

Consistent phrasing applied everywhere ('mutating (POST) endpoints require `X-Continua-Engine-Preview: 1`; all `/v1/engine/*` endpoints require `ENGINE_PUBLIC_API_ENABLED=true`'):

- `docs-site/concepts/engine-foundation.mdx` — preview `<Warning>`, the 'Preview-gated REST control plane' bullet, and the sharpened 'Go-only authoring' bullet
- `docs-site/api-reference/auth-and-headers.mdx` — preview-headers table row
- `docs-site/debugger/engine-runs.mdx` — preview `<Warning>`
- `docs-site/roadmap.mdx` — 'Preview-gated REST' caveat
- `docs-site/guides/installation.mdx`, `docs-site/guides/self-hosting.mdx` — `ENGINE_PUBLIC_API_ENABLED` env-table rows
- `sdks/python/README.md` — one sentence scoping the SDK's engine surface

Docs-only: no code, contracts, migrations, or generated files touched; `make generate` not needed.

## Verification

- Every edited claim was mapped against `internal/api/engine_middleware.go` (flag gates all engine routes; header check is POST-only) and `internal/api/engine_handlers_test.go` (disabled GET → 404, POST without header → 400 `preview_header_required`, GET without header → passes).
- `rg` sweep of `docs-site/` confirms no remaining prose claims that reads require the header (generated `openapi.yaml` mirrors untouched).
- `jq empty docs-site/docs.json` and `git diff --check` clean.

Closes #177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified engine API preview access requirements across documentation.
  - Mutating `POST /v1/engine/*` requests require `X-Continua-Engine-Preview: 1`; read requests require only the server-side feature setting.
  - Updated preview limitations, installation, self-hosting, and roadmap guidance.
  - Clarified Python SDK support for remote activity execution and run control, while workflow authoring remains available through Go.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->