### PR TITLE
Pin and document the operator unbounded-read policy on engine GETs (#178)

### DIFF
--- a/docs-site/concepts/projects-and-auth.mdx
+++ b/docs-site/concepts/projects-and-auth.mdx
@@ -4,8 +4,8 @@ description: "How projects, API keys, Auth0 operator login, and demo mode fit to
 ---
 
 A **project** is the unit of multi-tenancy in Continua. Every trace, span, session, and
-ingest batch is scoped to exactly one project. Every authenticated request must resolve
-to a project.
+ingest batch is scoped to exactly one project. Authentication determines whether a read
+is bound to one project or available across projects to an instance operator.
 
 ## The three ways a request gets authenticated
 
@@ -37,13 +37,29 @@ See the [Managing projects guide](/guides/managing-projects) for end-to-end how-
 
 ## Project scoping on reads
 
-Every read endpoint applies a `WHERE project_id = ?` filter derived from the request
-context. There is no cross-project query API today. If you operate multiple projects, do
-the cross-project aggregation outside Continua (or in your data warehouse after export).
+API-key and public-demo requests are always **Bound** to their project. Every read,
+including all `/v1/engine/*` reads, is filtered to that project. Requesting an id that
+belongs to another project returns `404`.
 
-For Auth0 operators, the UI passes `selected_project_id` so an operator can move between
-projects without re-authenticating. The selected project is persisted in URL query
-params, so links remain shareable.
+Auth0 operators are instance administrators. Detail and run-scoped reads are
+**Unbounded** when an operator provides no `project_id`: the operator can read across all
+projects. This applies to platform trace and session detail, plus these engine surfaces:
+
+- `/v1/engine/runs/{id}`
+- `/v1/engine/runs/{id}/history`
+- `/v1/engine/runs/{id}/result`
+- `/v1/engine/runs/{id}/pending-work`
+- `/v1/engine/instances/{key}`
+
+This unbounded access is intentional operator convenience, not an authorization gap. On
+operator requests, `project_id` (or `selected_project_id`) is a selection filter rather
+than an authorization boundary: a mismatched project returns `404`. List endpoints still
+require a project id and return `400` without one. The UI persists the selected project
+in URL query params, so links remain shareable and operators can switch projects without
+re-authenticating.
+
+The `/v1/engine/activities/*` worker surface is API-key-bound only. Operator bearer
+tokens are rejected as unauthenticated.
 
 ## Demo mode in detail
 

--- a/internal/api/engine_boundary_test.go
+++ b/internal/api/engine_boundary_test.go
@@ -1,11 +1,23 @@
 package api
 
 import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	platformdb "github.com/continua-ai/continua/db/gen/go/platform"
+	publichistory "github.com/continua-ai/continua/engine/pkg/history"
+	"github.com/continua-ai/continua/internal/api/middleware"
 )
 
 func TestRootSideEngineStartPath_DoesNotImportEngineInternals(t *testing.T) {
@@ -25,4 +37,215 @@ func TestRootSideEngineStartPath_DoesNotImportEngineInternals(t *testing.T) {
 			t.Fatalf("expected %s to avoid engine/internal imports", file)
 		}
 	}
+}
+
+func TestEngineReadPolicy_OperatorUnboundedAcrossProjects(t *testing.T) {
+	fixture := seedEngineBoundaryRun(t)
+
+	runRec := invokeEngineBoundaryReadAsOperator(t, fixture.server, engineBoundaryRun, fixture.runID, fixture.instanceKey, nil)
+	require.Equal(t, http.StatusOK, runRec.Code, runRec.Body.String())
+	run := decodeJSONBody[EngineRunResponse](t, runRec)
+	assert.Equal(t, fixture.runID, run.RunId)
+	assert.Equal(t, fixture.instanceKey, run.InstanceKey)
+
+	historyRec := invokeEngineBoundaryReadAsOperator(t, fixture.server, engineBoundaryHistory, fixture.runID, fixture.instanceKey, nil)
+	require.Equal(t, http.StatusOK, historyRec.Code, historyRec.Body.String())
+	history := decodeJSONBody[EngineRunHistoryResponse](t, historyRec)
+	require.Len(t, history.Events, 1)
+	assert.Equal(t, publichistory.EventWorkflowStarted, history.Events[0].EventType)
+	require.NotNil(t, history.Events[0].Payload)
+	assert.Equal(t, fixture.instanceKey, (*history.Events[0].Payload)["instance_key"])
+
+	resultRec := invokeEngineBoundaryReadAsOperator(t, fixture.server, engineBoundaryResult, fixture.runID, fixture.instanceKey, nil)
+	require.Equal(t, http.StatusConflict, resultRec.Code, resultRec.Body.String())
+	assert.Equal(t, "run_not_terminal", decodeJSONBody[Error](t, resultRec).Code)
+
+	pendingRec := invokeEngineBoundaryReadAsOperator(t, fixture.server, engineBoundaryPendingWork, fixture.runID, fixture.instanceKey, nil)
+	require.Equal(t, http.StatusOK, pendingRec.Code, pendingRec.Body.String())
+	pending := decodeJSONBody[EnginePendingWorkResponse](t, pendingRec)
+	assert.Equal(t, fixture.runID, pending.RunId)
+
+	instanceRec := invokeEngineBoundaryReadAsOperator(t, fixture.server, engineBoundaryInstance, fixture.runID, fixture.instanceKey, nil)
+	require.Equal(t, http.StatusOK, instanceRec.Code, instanceRec.Body.String())
+	instance := decodeJSONBody[EngineInstanceResponse](t, instanceRec)
+	assert.Equal(t, fixture.instanceKey, instance.InstanceKey)
+	assert.Equal(t, fixture.runID, instance.CurrentRun.RunId)
+}
+
+func TestEngineReadPolicy_OperatorProjectIDActsAsFilter(t *testing.T) {
+	fixture := seedEngineBoundaryRun(t)
+
+	for _, read := range []engineBoundaryRead{engineBoundaryRun, engineBoundaryInstance} {
+		t.Run(string(read), func(t *testing.T) {
+			mismatch := invokeEngineBoundaryReadAsOperator(t, fixture.server, read, fixture.runID, fixture.instanceKey, &fixture.projectAID)
+			require.Equal(t, http.StatusNotFound, mismatch.Code, mismatch.Body.String())
+
+			selected := invokeEngineBoundaryReadAsOperator(t, fixture.server, read, fixture.runID, fixture.instanceKey, &fixture.projectBID)
+			require.Equal(t, http.StatusOK, selected.Code, selected.Body.String())
+			if read == engineBoundaryRun {
+				response := decodeJSONBody[EngineRunResponse](t, selected)
+				assert.Equal(t, fixture.runID, response.RunId)
+				assert.Equal(t, fixture.instanceKey, response.InstanceKey)
+				return
+			}
+			response := decodeJSONBody[EngineInstanceResponse](t, selected)
+			assert.Equal(t, fixture.instanceKey, response.InstanceKey)
+			assert.Equal(t, fixture.runID, response.CurrentRun.RunId)
+		})
+	}
+}
+
+func TestEngineReadPolicy_APIKeyBoundCrossProject(t *testing.T) {
+	fixture := seedEngineBoundaryRun(t)
+
+	paths := []struct {
+		name string
+		path string
+	}{
+		{name: "run", path: "/v1/engine/runs/" + fixture.runID.String()},
+		{name: "history", path: "/v1/engine/runs/" + fixture.runID.String() + "/history"},
+		{name: "result", path: "/v1/engine/runs/" + fixture.runID.String() + "/result"},
+		{name: "pending-work", path: "/v1/engine/runs/" + fixture.runID.String() + "/pending-work"},
+		{name: "instance", path: "/v1/engine/instances/" + fixture.instanceKey},
+	}
+
+	for _, target := range paths {
+		t.Run(target.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, target.path, nil)
+			req.Header.Set("X-API-Key", fixture.apiKeyA)
+			rec := httptest.NewRecorder()
+
+			fixture.router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
+		})
+	}
+}
+
+func TestEngineReadPolicy_ActivityRoutesRejectOperator(t *testing.T) {
+	_, platformStore, _, server, _ := setupEngineHandlerTest(t)
+	router := newAuthenticatedRouter(t, server, platformStore)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/engine/activities/claim",
+		bytes.NewBufferString(`{"worker_id":"operator","activity_types":["email.send"]}`),
+	)
+	req.Header.Set("Authorization", "Bearer operator.header.signature")
+	req.Header.Set(enginePreviewHeader, "1")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code, rec.Body.String())
+	assert.Equal(t, "invalid_api_key", decodeJSONBody[map[string]string](t, rec)["code"])
+}
+
+type engineBoundaryFixture struct {
+	server      *Server
+	router      http.Handler
+	projectAID  uuid.UUID
+	projectBID  uuid.UUID
+	apiKeyA     string
+	runID       uuid.UUID
+	instanceKey string
+}
+
+func seedEngineBoundaryRun(t *testing.T) engineBoundaryFixture {
+	t.Helper()
+
+	ctx, platformStore, engineQueries, server, projectAID := setupEngineHandlerTest(t)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	apiKeyA := "engine-boundary-a-" + uuid.NewString()
+	_, err := platformStore.Pool().Exec(ctx, `
+		UPDATE public.projects
+		SET api_key_hash = $2
+		WHERE id = $1
+	`, projectAID, hashTestAPIKey(apiKeyA))
+	require.NoError(t, err)
+
+	apiKeyB := "engine-boundary-b-" + uuid.NewString()
+	projectB, err := platformStore.Queries().CreateProject(ctx, platformdb.CreateProjectParams{
+		Name:       "engine-boundary-b-" + uuid.NewString()[:8],
+		ApiKeyHash: hashTestAPIKey(apiKeyB),
+	})
+	require.NoError(t, err)
+
+	router := newAuthenticatedRouter(t, server, platformStore)
+	suffix := uuid.NewString()
+	instanceKey := "operator-boundary-instance-" + suffix
+	start := startEngineRunThroughRouter(t, router, apiKeyB, EngineStartRunRequest{
+		DefinitionName:    "checkout",
+		DefinitionVersion: "v1",
+		InstanceKey:       instanceKey,
+		RequestKey:        "operator-boundary-request-" + suffix,
+	})
+
+	return engineBoundaryFixture{
+		server:      server,
+		router:      router,
+		projectAID:  projectAID,
+		projectBID:  projectB.ID,
+		apiKeyA:     apiKeyA,
+		runID:       start.RunId,
+		instanceKey: instanceKey,
+	}
+}
+
+type engineBoundaryRead string
+
+const (
+	engineBoundaryRun         engineBoundaryRead = "run"
+	engineBoundaryHistory     engineBoundaryRead = "history"
+	engineBoundaryResult      engineBoundaryRead = "result"
+	engineBoundaryPendingWork engineBoundaryRead = "pending-work"
+	engineBoundaryInstance    engineBoundaryRead = "instance"
+)
+
+func invokeEngineBoundaryReadAsOperator(
+	t *testing.T,
+	server *Server,
+	read engineBoundaryRead,
+	runID uuid.UUID,
+	instanceKey string,
+	projectID *uuid.UUID,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	path := "/v1/engine/runs/" + runID.String()
+	switch read {
+	case engineBoundaryHistory:
+		path += "/history"
+	case engineBoundaryResult:
+		path += "/result"
+	case engineBoundaryPendingWork:
+		path += "/pending-work"
+	case engineBoundaryInstance:
+		path = "/v1/engine/instances/" + instanceKey
+	}
+	if projectID != nil {
+		path += "?project_id=" + projectID.String()
+	}
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	reqCtx := context.WithValue(req.Context(), middleware.AuthModeKey, middleware.AuthModeOperator)
+	reqCtx = context.WithValue(reqCtx, middleware.OperatorEmailKey, "operator@example.com")
+	reqCtx = context.WithValue(reqCtx, middleware.OperatorSubjectKey, "google-oauth2|operator")
+	rec := httptest.NewRecorder()
+
+	switch read {
+	case engineBoundaryRun:
+		server.GetEngineRun(rec, req.WithContext(reqCtx), runID)
+	case engineBoundaryHistory:
+		server.GetEngineRunHistory(rec, req.WithContext(reqCtx), runID, GetEngineRunHistoryParams{})
+	case engineBoundaryResult:
+		server.GetEngineRunResult(rec, req.WithContext(reqCtx), runID)
+	case engineBoundaryPendingWork:
+		server.GetEngineRunPendingWork(rec, req.WithContext(reqCtx), runID)
+	case engineBoundaryInstance:
+		server.GetEngineInstance(rec, req.WithContext(reqCtx), instanceKey)
+	default:
+		t.Fatalf("unknown engine boundary read %q", read)
+	}
+	return rec
 }

--- a/internal/api/engine_boundary_test.go
+++ b/internal/api/engine_boundary_test.go
@@ -75,22 +75,42 @@ func TestEngineReadPolicy_OperatorUnboundedAcrossProjects(t *testing.T) {
 func TestEngineReadPolicy_OperatorProjectIDActsAsFilter(t *testing.T) {
 	fixture := seedEngineBoundaryRun(t)
 
-	for _, read := range []engineBoundaryRead{engineBoundaryRun, engineBoundaryInstance} {
+	for _, read := range []engineBoundaryRead{
+		engineBoundaryRun,
+		engineBoundaryHistory,
+		engineBoundaryResult,
+		engineBoundaryPendingWork,
+		engineBoundaryInstance,
+	} {
 		t.Run(string(read), func(t *testing.T) {
 			mismatch := invokeEngineBoundaryReadAsOperator(t, fixture.server, read, fixture.runID, fixture.instanceKey, &fixture.projectAID)
 			require.Equal(t, http.StatusNotFound, mismatch.Code, mismatch.Body.String())
 
 			selected := invokeEngineBoundaryReadAsOperator(t, fixture.server, read, fixture.runID, fixture.instanceKey, &fixture.projectBID)
-			require.Equal(t, http.StatusOK, selected.Code, selected.Body.String())
-			if read == engineBoundaryRun {
+			switch read {
+			case engineBoundaryRun:
+				require.Equal(t, http.StatusOK, selected.Code, selected.Body.String())
 				response := decodeJSONBody[EngineRunResponse](t, selected)
 				assert.Equal(t, fixture.runID, response.RunId)
 				assert.Equal(t, fixture.instanceKey, response.InstanceKey)
-				return
+			case engineBoundaryHistory:
+				require.Equal(t, http.StatusOK, selected.Code, selected.Body.String())
+				response := decodeJSONBody[EngineRunHistoryResponse](t, selected)
+				require.Len(t, response.Events, 1)
+				assert.Equal(t, publichistory.EventWorkflowStarted, response.Events[0].EventType)
+			case engineBoundaryResult:
+				require.Equal(t, http.StatusConflict, selected.Code, selected.Body.String())
+				assert.Equal(t, "run_not_terminal", decodeJSONBody[Error](t, selected).Code)
+			case engineBoundaryPendingWork:
+				require.Equal(t, http.StatusOK, selected.Code, selected.Body.String())
+				response := decodeJSONBody[EnginePendingWorkResponse](t, selected)
+				assert.Equal(t, fixture.runID, response.RunId)
+			case engineBoundaryInstance:
+				require.Equal(t, http.StatusOK, selected.Code, selected.Body.String())
+				response := decodeJSONBody[EngineInstanceResponse](t, selected)
+				assert.Equal(t, fixture.instanceKey, response.InstanceKey)
+				assert.Equal(t, fixture.runID, response.CurrentRun.RunId)
 			}
-			response := decodeJSONBody[EngineInstanceResponse](t, selected)
-			assert.Equal(t, fixture.instanceKey, response.InstanceKey)
-			assert.Equal(t, fixture.runID, response.CurrentRun.RunId)
 		})
 	}
 }


### PR DESCRIPTION
## What / why

Engine GET handlers resolve request scope with `scopePolicyAllowUnbounded`: an Auth0 operator
with no `project_id` can read any project's run. Issue #178 asked for this to become an
explicit, documented, test-pinned decision — either confirmed or reversed.

**Decision: confirmed.** The merged `add-project-scope-enforcement` scope rollout already
models operators as instance admins (`Unbounded`) on detail/run routes, with `project_id`
acting as a selection filter and list routes still requiring a project. Reversing would
contradict that shipped design and break operator console flows. This PR pins the policy in
tests and fixes the drifted docs; no runtime behavior changes.

## What's in the change

- **Tests** (`internal/api/engine_boundary_test.go`): four policy-pinning tests over the five
  engine read classes (`/v1/engine/runs/{id}`, `/history`, `/result`, `/pending-work`,
  `/v1/engine/instances/{key}`):
  - operator with no `project_id` reads a foreign project's run on every class (the
    non-terminal `/result` pins its actual `409 run_not_terminal` contract);
  - operator `?project_id=` acts as a filter — mismatch 404, match 200;
  - an API key is always bound — cross-project reads 404 on every class;
  - `/v1/engine/activities/*` stays API-key-bound — operator bearer tokens get
    `401 invalid_api_key`.
- **Docs** (`docs-site/concepts/projects-and-auth.mdx`): the 'Project scoping on reads'
  section claimed every read applies `WHERE project_id = ?` and 'There is no cross-project
  query API today' — both now false. Rewritten to document bound API-key/demo reads, unbounded
  operator detail/run reads (engine surfaces enumerated), filter-not-authz `project_id`
  semantics, 400-without-project list routes, and the API-key-only worker surface.

## Verification

- `go test ./internal/api/...` green on a real Postgres.
- Sensitivity-checked: temporarily flipping `GetEngineRun` to `scopePolicyRequireProject`
  makes the operator-unbounded test fail (`missing_project_id`), proving the tests pin the
  policy; the flip was reverted before committing.
- `make generate` is a no-op (no contract/SQL inputs changed).
- Real REST smoke: booted the server + engine worker against a fresh DB, created two projects,
  started a run in project B; `GET /v1/engine/runs/{id}` returned 404 with A's key and 200
  with B's key; platform trace/session reads unaffected. (The Auth0 operator path cannot be
  booted locally without an IdP; it is covered by the committed handler tests.)

Closes #178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how authentication and project scoping affect read access across projects, including API-key/public-demo project-bound behavior and cross-project `404`s.
  * Defined operator behavior when unbounded vs when `project_id` acts as a selection filter, including list endpoints requiring a project id (`400`) and `404` on mismatches.
  * Documented UI project selection via shareable URL query parameters.
  * Specified engine activity endpoint access rules, including rejection of operator activity claims (`401` with `invalid_api_key`).
* **Tests**
  * Added an HTTP test suite covering engine read authorization boundaries across projects, including expected `404`/`409` outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->