### PR TITLE
feat(api): sunset the engine preview header and define the GA path for /v1/engine/*

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -1457,44 +1457,44 @@ type ListSpansByTraceParams struct {
 
 // ClaimRemoteActivityTasksParams defines parameters for ClaimRemoteActivityTasks.
 type ClaimRemoteActivityTasksParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // CompleteRemoteActivityTaskParams defines parameters for CompleteRemoteActivityTask.
 type CompleteRemoteActivityTaskParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // FailRemoteActivityTaskParams defines parameters for FailRemoteActivityTask.
 type FailRemoteActivityTaskParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // HeartbeatRemoteActivityTaskParams defines parameters for HeartbeatRemoteActivityTask.
 type HeartbeatRemoteActivityTaskParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // BackfillEngineProjectionsParams defines parameters for BackfillEngineProjections.
 type BackfillEngineProjectionsParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // StartEngineRunParams defines parameters for StartEngineRun.
 type StartEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // CancelEngineRunParams defines parameters for CancelEngineRun.
 type CancelEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // GetEngineRunHistoryParams defines parameters for GetEngineRunHistory.
@@ -1505,38 +1505,38 @@ type GetEngineRunHistoryParams struct {
 
 // PurgeEngineRunParams defines parameters for PurgeEngineRun.
 type PurgeEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // RepairEngineRunParams defines parameters for RepairEngineRun.
 type RepairEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // ResumeEngineRunParams defines parameters for ResumeEngineRun.
 type ResumeEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // SignalEngineRunParams defines parameters for SignalEngineRun.
 type SignalEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // SuspendEngineRunParams defines parameters for SuspendEngineRun.
 type SuspendEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // TerminateEngineRunParams defines parameters for TerminateEngineRun.
 type TerminateEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // IngestParams defines parameters for Ingest.
@@ -2858,7 +2858,7 @@ func (siw *ServerInterfaceWrapper) ClaimRemoteActivityTasks(w http.ResponseWrite
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2867,18 +2867,14 @@ func (siw *ServerInterfaceWrapper) ClaimRemoteActivityTasks(w http.ResponseWrite
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2917,7 +2913,7 @@ func (siw *ServerInterfaceWrapper) CompleteRemoteActivityTask(w http.ResponseWri
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2926,18 +2922,14 @@ func (siw *ServerInterfaceWrapper) CompleteRemoteActivityTask(w http.ResponseWri
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2976,7 +2968,7 @@ func (siw *ServerInterfaceWrapper) FailRemoteActivityTask(w http.ResponseWriter,
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2985,18 +2977,14 @@ func (siw *ServerInterfaceWrapper) FailRemoteActivityTask(w http.ResponseWriter,
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3035,7 +3023,7 @@ func (siw *ServerInterfaceWrapper) HeartbeatRemoteActivityTask(w http.ResponseWr
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3044,18 +3032,14 @@ func (siw *ServerInterfaceWrapper) HeartbeatRemoteActivityTask(w http.ResponseWr
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3142,7 +3126,7 @@ func (siw *ServerInterfaceWrapper) BackfillEngineProjections(w http.ResponseWrit
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3151,18 +3135,14 @@ func (siw *ServerInterfaceWrapper) BackfillEngineProjections(w http.ResponseWrit
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3194,7 +3174,7 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3203,18 +3183,14 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3288,7 +3264,7 @@ func (siw *ServerInterfaceWrapper) CancelEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3297,18 +3273,14 @@ func (siw *ServerInterfaceWrapper) CancelEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3434,7 +3406,7 @@ func (siw *ServerInterfaceWrapper) PurgeEngineRun(w http.ResponseWriter, r *http
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3443,18 +3415,14 @@ func (siw *ServerInterfaceWrapper) PurgeEngineRun(w http.ResponseWriter, r *http
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3495,7 +3463,7 @@ func (siw *ServerInterfaceWrapper) RepairEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3504,18 +3472,14 @@ func (siw *ServerInterfaceWrapper) RepairEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3589,7 +3553,7 @@ func (siw *ServerInterfaceWrapper) ResumeEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3598,18 +3562,14 @@ func (siw *ServerInterfaceWrapper) ResumeEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3650,7 +3610,7 @@ func (siw *ServerInterfaceWrapper) SignalEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3659,18 +3619,14 @@ func (siw *ServerInterfaceWrapper) SignalEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3711,7 +3667,7 @@ func (siw *ServerInterfaceWrapper) SuspendEngineRun(w http.ResponseWriter, r *ht
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3720,18 +3676,14 @@ func (siw *ServerInterfaceWrapper) SuspendEngineRun(w http.ResponseWriter, r *ht
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3772,7 +3724,7 @@ func (siw *ServerInterfaceWrapper) TerminateEngineRun(w http.ResponseWriter, r *
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3781,18 +3733,14 @@ func (siw *ServerInterfaceWrapper) TerminateEngineRun(w http.ResponseWriter, r *
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -1664,9 +1664,12 @@ export interface operations {
     startEngineRun: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path?: never;
             cookie?: never;
@@ -1686,7 +1689,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineStartRunResponse"];
                 };
             };
-            /** @description Invalid request or missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -1727,9 +1730,12 @@ export interface operations {
     claimRemoteActivityTasks: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path?: never;
             cookie?: never;
@@ -1749,7 +1755,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineRemoteActivityClaimResponse"];
                 };
             };
-            /** @description Invalid request or missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -1772,9 +1778,12 @@ export interface operations {
     heartbeatRemoteActivityTask: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 id: string;
@@ -1796,7 +1805,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineRemoteActivityHeartbeatResponse"];
                 };
             };
-            /** @description Invalid request or missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -1837,9 +1846,12 @@ export interface operations {
     completeRemoteActivityTask: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 id: string;
@@ -1859,7 +1871,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Invalid request or missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -1900,9 +1912,12 @@ export interface operations {
     failRemoteActivityTask: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 id: string;
@@ -1922,7 +1937,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Invalid request or missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -2175,9 +2190,12 @@ export interface operations {
     purgeEngineRun: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 run_id: string;
@@ -2199,7 +2217,7 @@ export interface operations {
                     "application/json": components["schemas"]["EnginePurgeResponse"];
                 };
             };
-            /** @description Invalid request body or missing preview header */
+            /** @description Invalid request body */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -2240,9 +2258,12 @@ export interface operations {
     repairEngineRun: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 run_id: string;
@@ -2260,7 +2281,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineRepairResponse"];
                 };
             };
-            /** @description Missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -2292,9 +2313,12 @@ export interface operations {
     backfillEngineProjections: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path?: never;
             cookie?: never;
@@ -2314,7 +2338,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineProjectionBackfillResponse"];
                 };
             };
-            /** @description Invalid request body, limit above 100, or missing preview header */
+            /** @description Invalid request body or limit above 100 */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -2346,9 +2370,12 @@ export interface operations {
     signalEngineRun: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 run_id: string;
@@ -2370,7 +2397,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineControlResponse"];
                 };
             };
-            /** @description Invalid request or missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -2411,9 +2438,12 @@ export interface operations {
     suspendEngineRun: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 run_id: string;
@@ -2431,7 +2461,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineRunResponse"];
                 };
             };
-            /** @description Missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -2472,9 +2502,12 @@ export interface operations {
     resumeEngineRun: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 run_id: string;
@@ -2492,7 +2525,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineRunResponse"];
                 };
             };
-            /** @description Missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -2533,9 +2566,12 @@ export interface operations {
     cancelEngineRun: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 run_id: string;
@@ -2553,7 +2589,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineControlResponse"];
                 };
             };
-            /** @description Missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -2594,9 +2630,12 @@ export interface operations {
     terminateEngineRun: {
         parameters: {
             query?: never;
-            header: {
-                /** @description Required preview header for mutating engine routes. */
-                "X-Continua-Engine-Preview": string;
+            header?: {
+                /**
+                 * @deprecated
+                 * @description Deprecated and no longer required; this header will be removed at GA.
+                 */
+                "X-Continua-Engine-Preview"?: string;
             };
             path: {
                 run_id: string;
@@ -2614,7 +2653,7 @@ export interface operations {
                     "application/json": components["schemas"]["EngineRunResultResponse"];
                 };
             };
-            /** @description Missing preview header */
+            /** @description Invalid request */
             400: {
                 headers: {
                     [name: string]: unknown;

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -146,8 +146,9 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -164,7 +165,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineStartRunResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -198,8 +199,9 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -216,7 +218,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRemoteActivityClaimResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -244,8 +246,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -262,7 +265,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRemoteActivityHeartbeatResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -302,8 +305,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -316,7 +320,7 @@ paths:
         '204':
           description: Activity task completed
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -356,8 +360,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -370,7 +375,7 @@ paths:
         '204':
           description: Activity task failed or requeued
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -594,8 +599,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -612,7 +618,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnginePurgeResponse'
         '400':
-          description: Invalid request body or missing preview header
+          description: Invalid request body
           content:
             application/json:
               schema:
@@ -654,8 +660,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -666,7 +673,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRepairResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -699,8 +706,9 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -717,7 +725,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineProjectionBackfillResponse'
         '400':
-          description: Invalid request body, limit above 100, or missing preview header
+          description: Invalid request body or limit above 100
           content:
             application/json:
               schema:
@@ -749,8 +757,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -767,7 +776,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineControlResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -805,8 +814,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -817,7 +827,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRunResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -855,8 +865,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -867,7 +878,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRunResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -909,8 +920,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -921,7 +933,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineControlResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -959,8 +971,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -971,7 +984,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRunResultResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -151,8 +151,9 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -169,7 +170,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineStartRunResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -203,8 +204,9 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -221,7 +223,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRemoteActivityClaimResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -249,8 +251,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -267,7 +270,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRemoteActivityHeartbeatResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -307,8 +310,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -321,7 +325,7 @@ paths:
         '204':
           description: Activity task completed
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -361,8 +365,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -375,7 +380,7 @@ paths:
         '204':
           description: Activity task failed or requeued
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -599,8 +604,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -617,7 +623,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnginePurgeResponse'
         '400':
-          description: Invalid request body or missing preview header
+          description: Invalid request body
           content:
             application/json:
               schema:
@@ -659,8 +665,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -671,7 +678,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRepairResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -704,8 +711,9 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -722,7 +730,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineProjectionBackfillResponse'
         '400':
-          description: Invalid request body, limit above 100, or missing preview header
+          description: Invalid request body or limit above 100
           content:
             application/json:
               schema:
@@ -754,8 +762,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -772,7 +781,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineControlResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -810,8 +819,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -822,7 +832,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRunResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -860,8 +870,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -872,7 +883,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRunResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -914,8 +925,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -926,7 +938,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineControlResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -964,8 +976,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -976,7 +989,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRunResultResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:

--- a/docs-site/api-reference/auth-and-headers.mdx
+++ b/docs-site/api-reference/auth-and-headers.mdx
@@ -47,15 +47,16 @@ cross-project read endpoint today.
 
 ## Preview headers
 
-Some endpoints are behind preview flags and require an explicit opt-in header:
+Some endpoints use preview headers while their contracts stabilise:
 
 | Header | Required by | Notes |
 | --- | --- | --- |
 | `X-Continua-Async-Version: 2` | `POST /v1/ingest` for true-async durable ingest | Without it, the server may run sync or fall back to legacy async behaviour |
-| `X-Continua-Engine-Preview: 1` | Mutating (POST) `/v1/engine/*` endpoints | GET reads need only `ENGINE_PUBLIC_API_ENABLED=true` server-side |
+| `X-Continua-Engine-Preview: 1` | Optional for mutating (POST) `/v1/engine/*` endpoints | Deprecated during the sunset window; all engine routes still need `ENGINE_PUBLIC_API_ENABLED=true` server-side |
 
 Preview headers exist so we can ship surfaces under iteration without breaking
-non-preview clients. They will be relaxed or removed as those surfaces stabilise.
+non-preview clients. The engine header is no longer required and will be removed in a
+following release. See the [path to GA for `/v1/engine/*`](/concepts/engine-foundation#path-to-ga-for-v1engine).
 
 ## Response codes
 

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -146,8 +146,9 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -164,7 +165,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineStartRunResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -198,8 +199,9 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -216,7 +218,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRemoteActivityClaimResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -244,8 +246,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -262,7 +265,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRemoteActivityHeartbeatResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -302,8 +305,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -316,7 +320,7 @@ paths:
         '204':
           description: Activity task completed
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -356,8 +360,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -370,7 +375,7 @@ paths:
         '204':
           description: Activity task failed or requeued
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -594,8 +599,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -612,7 +618,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnginePurgeResponse'
         '400':
-          description: Invalid request body or missing preview header
+          description: Invalid request body
           content:
             application/json:
               schema:
@@ -654,8 +660,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -666,7 +673,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRepairResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -699,8 +706,9 @@ paths:
       parameters:
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -717,7 +725,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineProjectionBackfillResponse'
         '400':
-          description: Invalid request body, limit above 100, or missing preview header
+          description: Invalid request body or limit above 100
           content:
             application/json:
               schema:
@@ -749,8 +757,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       requestBody:
@@ -767,7 +776,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineControlResponse'
         '400':
-          description: Invalid request or missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -805,8 +814,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -817,7 +827,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRunResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -855,8 +865,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -867,7 +878,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRunResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -909,8 +920,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -921,7 +933,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineControlResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:
@@ -959,8 +971,9 @@ paths:
             format: uuid
         - name: X-Continua-Engine-Preview
           in: header
-          required: true
-          description: Required preview header for mutating engine routes.
+          required: false
+          deprecated: true
+          description: Deprecated and no longer required; this header will be removed at GA.
           schema:
             type: string
       responses:
@@ -971,7 +984,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EngineRunResultResponse'
         '400':
-          description: Missing preview header
+          description: Invalid request
           content:
             application/json:
               schema:

--- a/docs-site/concepts/engine-foundation.mdx
+++ b/docs-site/concepts/engine-foundation.mdx
@@ -12,10 +12,10 @@ store, control endpoints, and runs console UI around it are real too.
 This page draws the line between what runs today and what's still preview-limited.
 
 <Warning>
-  The engine is preview. Mutating (POST) endpoints require
-  `X-Continua-Engine-Preview: 1`; all `/v1/engine/*` endpoints require
-  `ENGINE_PUBLIC_API_ENABLED=true` on the server, while reads need only the env flag. Don't
-  depend on engine workflow execution for production work yet. See [Roadmap](/roadmap).
+  The engine is preview. `X-Continua-Engine-Preview: 1` is optional and deprecated for
+  mutating (POST) endpoints during the sunset window. All `/v1/engine/*` endpoints still
+  require `ENGINE_PUBLIC_API_ENABLED=true` on the server. Don't depend on engine workflow
+  execution for production work yet. See [Roadmap](/roadmap).
 </Warning>
 
 ## What's implemented
@@ -122,9 +122,25 @@ the control bar. Polling-based.
 - **Explicit project provisioning.** Scoped workers must point at an existing platform
   project with `ENGINE_PROJECT_ID` or `runtime.Options.ProjectID`; missing projects fail
   startup. See [Engine project provisioning](/guides/engine-project-provisioning).
-- **Preview-gated REST control plane.** Mutating (POST) endpoints require
-  `X-Continua-Engine-Preview: 1`; all `/v1/engine/*` endpoints require
-  `ENGINE_PUBLIC_API_ENABLED=true`, and shapes may change before GA.
+- **Preview REST control plane.** `X-Continua-Engine-Preview: 1` is optional and
+  deprecated for mutating (POST) endpoints during the sunset window. All
+  `/v1/engine/*` endpoints still require `ENGINE_PUBLIC_API_ENABLED=true`.
+
+## Path to GA for `/v1/engine/*`
+
+The control plane graduates when these gates are complete:
+
+1. **Prerequisites.** The run/timer/signal correctness spine (#152–#155), library
+   entrypoint (#161), Prometheus metrics (#168), and retention/GC (#172) are all merged.
+2. **Contract freeze.** The `/v1/engine/*` shapes and error-code taxonomy in
+   `contracts/openapi/openapi.yaml` are frozen. Further changes must be additive and pass
+   explicit contract review.
+3. **Header sunset.** This release accepts mutating requests without
+   `X-Continua-Engine-Preview` and logs a deprecation warning. A following release removes
+   the header parameter from the contract, and SDKs stop sending it.
+4. **Deployment opt-in.** `ENGINE_PUBLIC_API_ENABLED` remains default-off through the
+   sunset window. After the header is removed, the default flips to enabled and
+   `ENGINE_PUBLIC_API_ENABLED=false` remains the documented off-switch.
 
 ## When to use the engine today
 

--- a/docs-site/debugger/engine-runs.mdx
+++ b/docs-site/debugger/engine-runs.mdx
@@ -8,12 +8,12 @@ Use it to inspect run state, see what work is still pending, and (in operator wo
 repair projection state.
 
 <Warning>
-  The engine surface is in preview. Mutating (POST) endpoints require
-  `X-Continua-Engine-Preview: 1`; all `/v1/engine/*` endpoints require
-  `ENGINE_PUBLIC_API_ENABLED=true` on the server, while reads need only the env flag. Workflow
-  execution works (Go-defined workflows), but it's preview, not production-hardened, so don't
-  put it on a production-critical path yet. See [Engine foundation](/concepts/engine-foundation)
-  and [Roadmap](/roadmap).
+  The engine surface is in preview. `X-Continua-Engine-Preview: 1` is optional and
+  deprecated for mutating (POST) endpoints during the sunset window. All
+  `/v1/engine/*` endpoints still require `ENGINE_PUBLIC_API_ENABLED=true` on the server.
+  Workflow execution works (Go-defined workflows), but it's preview, not
+  production-hardened, so don't put it on a production-critical path yet. See
+  [Engine foundation](/concepts/engine-foundation) and [Roadmap](/roadmap).
 </Warning>
 
 ## Runs list

--- a/docs-site/guides/installation.mdx
+++ b/docs-site/guides/installation.mdx
@@ -142,7 +142,7 @@ Engine surface (preview: see [Roadmap](/roadmap) for status):
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `ENGINE_PUBLIC_API_ENABLED` | `false` | Expose `/v1/engine/*` endpoints. Mutating (POST) requests also require `X-Continua-Engine-Preview: 1` |
+| `ENGINE_PUBLIC_API_ENABLED` | `false` | Expose `/v1/engine/*` endpoints. `X-Continua-Engine-Preview: 1` is optional and deprecated for mutating (POST) requests during the sunset window |
 | `ENGINE_DATABASE_URL` | falls back to `DATABASE_URL` | Optional separate Postgres for the engine schema |
 | `ENGINE_LEASE_COMPLETION_GRACE` | `0` | Optional clock-skew grace for remote activity complete, fail, and retry fences only |
 | `ENGINE_PROJECTION_RETENTION_AFTER` | unset | How long to retain projection state after a run reaches terminal state |

--- a/docs-site/guides/self-hosting.mdx
+++ b/docs-site/guides/self-hosting.mdx
@@ -58,7 +58,7 @@ The durable engine surface ships behind a preview flag. See
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `ENGINE_PUBLIC_API_ENABLED` | `false` | Expose `/v1/engine/*` endpoints. Mutating (POST) requests also require `X-Continua-Engine-Preview: 1` |
+| `ENGINE_PUBLIC_API_ENABLED` | `false` | Expose `/v1/engine/*` endpoints. `X-Continua-Engine-Preview: 1` is optional and deprecated for mutating (POST) requests during the sunset window |
 | `ENGINE_DATABASE_URL` | falls back to `DATABASE_URL` | Optional separate Postgres for the engine schema |
 | `ENGINE_PROJECTION_RETENTION_AFTER` | unset | How long to retain projection state after a run reaches terminal state |
 | `ENGINE_HISTORY_RETENTION_AFTER` | unset | Retention window for run history. Must be greater than `ENGINE_PROJECTION_RETENTION_AFTER` |

--- a/docs-site/roadmap.mdx
+++ b/docs-site/roadmap.mdx
@@ -48,7 +48,7 @@ Preview caveats:
 - **Go-only authoring**: no TypeScript/Python SDK for authoring workflows yet.
 - **No production definition loading**: definitions register through the Go runtime that
   starts workers; there's no multi-tenant register-and-version path yet.
-- **Preview-gated REST**: mutating (POST) endpoints require `X-Continua-Engine-Preview: 1`; all `/v1/engine/*` endpoints require `ENGINE_PUBLIC_API_ENABLED=true`, and shapes may change before GA.
+- **Preview REST sunset**: `X-Continua-Engine-Preview: 1` is optional and deprecated for mutating (POST) endpoints; all `/v1/engine/*` endpoints still require `ENGINE_PUBLIC_API_ENABLED=true`. See the [documented GA path](/concepts/engine-foundation#path-to-ga-for-v1engine).
 
 See [Engine foundation](/concepts/engine-foundation) for the full picture.
 
@@ -94,7 +94,7 @@ Rough ordering, subject to change as feedback comes in:
 
 1. Finish the TypeScript SDK to parity with Python for trace / span / session instrumentation.
 2. WebSocket runtime so the trace detail page can drop polling.
-3. Graduate the durable engine from preview: multi-tenant workflow definition loading, non-Go (TypeScript/Python) workflow authoring, and a GA `/v1/engine/*` control plane.
+3. Graduate the durable engine from preview: multi-tenant workflow definition loading, non-Go (TypeScript/Python) workflow authoring, and the [documented GA path for `/v1/engine/*`](/concepts/engine-foundation#path-to-ga-for-v1engine).
 4. Proxy capture for zero-code instrumentation.
 5. Replay execution as a layer on top of durable engine workflows.
 

--- a/internal/api/engine_activities_test.go
+++ b/internal/api/engine_activities_test.go
@@ -245,15 +245,15 @@ func TestRemoteActivityRoutesRequireAuthAndPreview(t *testing.T) {
 		assert.Equal(t, "missing_api_key", decodeJSONBody[map[string]string](t, rec)["code"])
 	})
 
-	t.Run("preview header is required", func(t *testing.T) {
+	t.Run("authenticated request without preview header reaches claim handler", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/v1/engine/activities/claim", bytes.NewReader(body))
 		req.Header.Set("X-API-Key", apiKey)
 		rec := httptest.NewRecorder()
 
 		handler.ServeHTTP(rec, req)
 
-		require.Equal(t, http.StatusBadRequest, rec.Code)
-		assert.Equal(t, "preview_header_required", decodeJSONBody[Error](t, rec).Code)
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Empty(t, decodeJSONBody[EngineRemoteActivityClaimResponse](t, rec).Tasks)
 	})
 
 	t.Run("authenticated preview request reaches claim handler", func(t *testing.T) {
@@ -615,7 +615,7 @@ func invokeClaimRemoteActivityTasks(
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.ClaimRemoteActivityTasks(rec, req, ClaimRemoteActivityTasksParams{XContinuaEnginePreview: "1"})
+	server.ClaimRemoteActivityTasks(rec, req, ClaimRemoteActivityTasksParams{})
 	return rec
 }
 
@@ -635,7 +635,7 @@ func invokeHeartbeatRemoteActivityTask(
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.HeartbeatRemoteActivityTask(rec, req, taskID, HeartbeatRemoteActivityTaskParams{XContinuaEnginePreview: "1"})
+	server.HeartbeatRemoteActivityTask(rec, req, taskID, HeartbeatRemoteActivityTaskParams{})
 	return rec
 }
 
@@ -655,7 +655,7 @@ func invokeCompleteRemoteActivityTask(
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.CompleteRemoteActivityTask(rec, req, taskID, CompleteRemoteActivityTaskParams{XContinuaEnginePreview: "1"})
+	server.CompleteRemoteActivityTask(rec, req, taskID, CompleteRemoteActivityTaskParams{})
 	return rec
 }
 
@@ -675,6 +675,6 @@ func invokeFailRemoteActivityTask(
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.FailRemoteActivityTask(rec, req, taskID, FailRemoteActivityTaskParams{XContinuaEnginePreview: "1"})
+	server.FailRemoteActivityTask(rec, req, taskID, FailRemoteActivityTaskParams{})
 	return rec
 }

--- a/internal/api/engine_handlers_test.go
+++ b/internal/api/engine_handlers_test.go
@@ -57,16 +57,14 @@ func TestEnginePreviewHeaderMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	t.Run("preview header is required on mutating routes", func(t *testing.T) {
+	t.Run("mutating routes pass through without preview header", func(t *testing.T) {
 		handler := enginePreviewHeaderMiddleware()(next)
 		req := httptest.NewRequest(http.MethodPost, "/v1/engine/runs", bytes.NewReader([]byte(`{}`)))
 		rec := httptest.NewRecorder()
 
 		handler.ServeHTTP(rec, req)
 
-		require.Equal(t, http.StatusBadRequest, rec.Code)
-		resp := decodeJSONBody[Error](t, rec)
-		assert.Equal(t, "preview_header_required", resp.Code)
+		require.Equal(t, http.StatusNoContent, rec.Code)
 	})
 
 	t.Run("get routes pass through without preview header", func(t *testing.T) {
@@ -1189,7 +1187,7 @@ func TestTerminateEngineRun_ProjectorEventuallyProjectsTerminalCleanup(t *testin
 	assert.Len(t, waitState, 0)
 }
 
-func TestTerminateEngineRun_RouterEnforcesPreviewHeaderAndAvailability(t *testing.T) {
+func TestTerminateEngineRun_RouterAcceptsHeaderlessAndEnforcesAvailability(t *testing.T) {
 	ctx := context.Background()
 	platformStore := store.New(testutil.TestDB(t))
 	engineQueries := enginedb.New(platformStore.Pool())
@@ -1220,8 +1218,7 @@ func TestTerminateEngineRun_RouterEnforcesPreviewHeaderAndAvailability(t *testin
 
 	router.ServeHTTP(rec, req)
 
-	require.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Equal(t, "preview_header_required", decodeJSONBody[Error](t, rec).Code)
+	require.Equal(t, http.StatusOK, rec.Code)
 
 	server.enginePublicAPIEnabled = false
 	router = newAuthenticatedRouter(t, server, platformStore)
@@ -1540,7 +1537,7 @@ func TestEngineRunTerminateQuarantinedRun(t *testing.T) {
 	assert.Len(t, run.WaitingFor, 0)
 }
 
-func TestSuspendResumeEngineRun_RouterEnforcesPreviewHeaderAndAvailability(t *testing.T) {
+func TestSuspendResumeEngineRun_RouterAcceptsHeaderlessAndEnforcesAvailability(t *testing.T) {
 	ctx := context.Background()
 	platformStore := store.New(testutil.TestDB(t))
 	engineQueries := enginedb.New(platformStore.Pool())
@@ -1569,8 +1566,7 @@ func TestSuspendResumeEngineRun_RouterEnforcesPreviewHeaderAndAvailability(t *te
 	req.Header.Set("X-API-Key", apiKey)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Equal(t, "preview_header_required", decodeJSONBody[Error](t, rec).Code)
+	require.Equal(t, http.StatusOK, rec.Code)
 
 	server.enginePublicAPIEnabled = false
 	router = newAuthenticatedRouter(t, server, platformStore)
@@ -3429,7 +3425,7 @@ func invokeStartEngineRun(t *testing.T, server *Server, projectID uuid.UUID, req
 	httpReq = httpReq.WithContext(context.WithValue(httpReq.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.StartEngineRun(rec, httpReq, StartEngineRunParams{XContinuaEnginePreview: "1"})
+	server.StartEngineRun(rec, httpReq, StartEngineRunParams{})
 	return rec
 }
 
@@ -3533,7 +3529,7 @@ func invokePurgeEngineRun(
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.PurgeEngineRun(rec, req, runID, PurgeEngineRunParams{XContinuaEnginePreview: "1"})
+	server.PurgeEngineRun(rec, req, runID, PurgeEngineRunParams{})
 	return rec
 }
 
@@ -3545,7 +3541,7 @@ func invokeRepairEngineRun(t *testing.T, server *Server, projectID, runID uuid.U
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.RepairEngineRun(rec, req, runID, RepairEngineRunParams{XContinuaEnginePreview: "1"})
+	server.RepairEngineRun(rec, req, runID, RepairEngineRunParams{})
 	return rec
 }
 
@@ -3586,7 +3582,7 @@ func invokeBackfillEngineProjectionsWithAuthMode(
 	}
 	rec := httptest.NewRecorder()
 
-	server.BackfillEngineProjections(rec, req, BackfillEngineProjectionsParams{XContinuaEnginePreview: "1"})
+	server.BackfillEngineProjections(rec, req, BackfillEngineProjectionsParams{})
 	return rec
 }
 
@@ -3606,7 +3602,7 @@ func invokeSignalEngineRun(
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.SignalEngineRun(rec, req, runID, SignalEngineRunParams{XContinuaEnginePreview: "1"})
+	server.SignalEngineRun(rec, req, runID, SignalEngineRunParams{})
 	return rec
 }
 
@@ -3618,7 +3614,7 @@ func invokeCancelEngineRun(t *testing.T, server *Server, projectID, runID uuid.U
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.CancelEngineRun(rec, req, runID, CancelEngineRunParams{XContinuaEnginePreview: "1"})
+	server.CancelEngineRun(rec, req, runID, CancelEngineRunParams{})
 	return rec
 }
 
@@ -3641,7 +3637,7 @@ func invokeTerminateEngineRun(t *testing.T, server *Server, projectID, runID uui
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.TerminateEngineRun(rec, req, runID, TerminateEngineRunParams{XContinuaEnginePreview: "1"})
+	server.TerminateEngineRun(rec, req, runID, TerminateEngineRunParams{})
 	return rec
 }
 
@@ -3653,7 +3649,7 @@ func invokeSuspendEngineRun(t *testing.T, server *Server, projectID, runID uuid.
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.SuspendEngineRun(rec, req, runID, SuspendEngineRunParams{XContinuaEnginePreview: "1"})
+	server.SuspendEngineRun(rec, req, runID, SuspendEngineRunParams{})
 	return rec
 }
 
@@ -3665,7 +3661,7 @@ func invokeResumeEngineRun(t *testing.T, server *Server, projectID, runID uuid.U
 	req = req.WithContext(context.WithValue(req.Context(), middleware.ProjectIDKey, projectID))
 	rec := httptest.NewRecorder()
 
-	server.ResumeEngineRun(rec, req, runID, ResumeEngineRunParams{XContinuaEnginePreview: "1"})
+	server.ResumeEngineRun(rec, req, runID, ResumeEngineRunParams{})
 	return rec
 }
 

--- a/internal/api/engine_middleware.go
+++ b/internal/api/engine_middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
 )
@@ -33,9 +34,8 @@ func enginePreviewHeaderMiddleware() func(http.Handler) http.Handler {
 				return
 			}
 
-			if r.Method == http.MethodPost && r.Header.Get(enginePreviewHeader) != "1" {
-				writeError(w, http.StatusBadRequest, "preview_header_required", "X-Continua-Engine-Preview: 1 header is required")
-				return
+			if r.Method == http.MethodPost && len(r.Header.Values(enginePreviewHeader)) == 0 {
+				slog.Warn(enginePreviewHeader+" requirement is deprecated and removed during the sunset window", "path", r.URL.Path)
 			}
 
 			next.ServeHTTP(w, r)

--- a/internal/api/engine_preview_header_sunset_test.go
+++ b/internal/api/engine_preview_header_sunset_test.go
@@ -1,0 +1,356 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	platformdb "github.com/continua-ai/continua/db/gen/go/platform"
+	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+func TestEngineMutations_AcceptRequestsWithoutPreviewHeader(t *testing.T) {
+	router, apiKey := setupEnginePreviewSunsetRouter(t)
+
+	startRec := postEngineStartRunThroughRouter(
+		t,
+		router,
+		apiKey,
+		"sunset-headerless-instance-"+uuid.NewString(),
+		"sunset-headerless-request-"+uuid.NewString(),
+		false,
+	)
+	require.Equal(t, http.StatusOK, startRec.Code, startRec.Body.String())
+	started := decodeJSONBody[EngineStartRunResponse](t, startRec)
+	require.NotEqual(t, uuid.Nil, started.RunId)
+
+	cancelReq := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/engine/runs/"+started.RunId.String()+"/cancel",
+		nil,
+	)
+	cancelReq.Header.Set("X-API-Key", apiKey)
+	cancelRec := httptest.NewRecorder()
+	router.ServeHTTP(cancelRec, cancelReq)
+
+	assert.NotEqual(t, http.StatusBadRequest, cancelRec.Code, cancelRec.Body.String())
+	var cancelBody map[string]any
+	require.NoError(t, json.Unmarshal(cancelRec.Body.Bytes(), &cancelBody))
+	assert.NotEqual(t, "preview_header_required", cancelBody["code"])
+}
+
+func TestEngineMutations_PreviewHeaderStillAcceptedDuringSunset(t *testing.T) {
+	router, apiKey := setupEnginePreviewSunsetRouter(t)
+
+	startRec := postEngineStartRunThroughRouter(
+		t,
+		router,
+		apiKey,
+		"sunset-present-instance-"+uuid.NewString(),
+		"sunset-present-request-"+uuid.NewString(),
+		true,
+	)
+	require.Equal(t, http.StatusOK, startRec.Code, startRec.Body.String())
+	started := decodeJSONBody[EngineStartRunResponse](t, startRec)
+	assert.NotEqual(t, uuid.Nil, started.RunId)
+}
+
+func TestEngineMutations_HeaderlessPostLogsDeprecationWarning(t *testing.T) {
+	previousLogger := slog.Default()
+	capture := newEnginePreviewSunsetCaptureHandler()
+	slog.SetDefault(slog.New(capture))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	router, apiKey := setupEnginePreviewSunsetRouter(t)
+	capture.clear()
+
+	postEngineStartRunThroughRouter(
+		t,
+		router,
+		apiKey,
+		"sunset-warning-instance-"+uuid.NewString(),
+		"sunset-warning-request-"+uuid.NewString(),
+		false,
+	)
+
+	assert.Truef(
+		t,
+		capture.hasWarningMentioning(enginePreviewHeader),
+		"expected a warn-level slog record mentioning %s",
+		enginePreviewHeader,
+	)
+
+	capture.clear()
+	withHeaderRec := postEngineStartRunThroughRouter(
+		t,
+		router,
+		apiKey,
+		"sunset-no-warning-instance-"+uuid.NewString(),
+		"sunset-no-warning-request-"+uuid.NewString(),
+		true,
+	)
+	require.Equal(t, http.StatusOK, withHeaderRec.Code, withHeaderRec.Body.String())
+	assert.Falsef(
+		t,
+		capture.hasWarningMentioning(enginePreviewHeader),
+		"did not expect a warn-level slog record mentioning %s when the header is present",
+		enginePreviewHeader,
+	)
+}
+
+func TestEngineRoutes_AvailabilityFlagStillGates(t *testing.T) {
+	ctx := context.Background()
+	platformStore := store.New(testutil.TestDB(t))
+	apiKey := "engine-sunset-disabled-" + uuid.NewString()
+	_, err := platformStore.Queries().CreateProject(ctx, platformdb.CreateProjectParams{
+		Name:       "engine-sunset-disabled-" + uuid.NewString()[:8],
+		ApiKeyHash: hashTestAPIKey(apiKey),
+	})
+	require.NoError(t, err)
+
+	server := NewServer(platformStore, nil)
+	router := newAuthenticatedRouter(t, server, platformStore)
+
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/engine/runs/"+uuid.NewString(), nil)
+	getReq.Header.Set("X-API-Key", apiKey)
+	getRec := httptest.NewRecorder()
+	router.ServeHTTP(getRec, getReq)
+	require.Equal(t, http.StatusNotFound, getRec.Code)
+
+	postRec := postEngineStartRunThroughRouter(
+		t,
+		router,
+		apiKey,
+		"sunset-disabled-instance-"+uuid.NewString(),
+		"sunset-disabled-request-"+uuid.NewString(),
+		false,
+	)
+	require.Equal(t, http.StatusNotFound, postRec.Code)
+}
+
+func TestOpenAPIContract_PreviewHeaderDeprecatedAndOptional(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", ".."))
+	contractPath := filepath.Join(repoRoot, "contracts", "openapi", "openapi.yaml")
+	contents, err := os.ReadFile(contractPath)
+	require.NoError(t, err)
+
+	lines := strings.Split(string(contents), "\n")
+	const headerParameterName = "name: X-Continua-Engine-Preview"
+	found := 0
+	for lineIndex, line := range lines {
+		if !strings.Contains(line, headerParameterName) {
+			continue
+		}
+
+		found++
+		headerIndent := len(line) - len(strings.TrimLeft(line, " "))
+		end := lineIndex + 1
+		for end < len(lines) {
+			if strings.TrimSpace(lines[end]) != "" && len(lines[end])-len(strings.TrimLeft(lines[end], " ")) <= headerIndent {
+				break
+			}
+			end++
+		}
+		block := strings.Join(lines[lineIndex:end], "\n")
+		assert.NotContainsf(
+			t,
+			block,
+			"required: true",
+			"preview header parameter block %d must be optional:\n%s",
+			found,
+			block,
+		)
+		assert.Containsf(
+			t,
+			block,
+			"deprecated: true",
+			"preview header parameter block %d must be deprecated:\n%s",
+			found,
+			block,
+		)
+	}
+
+	assert.GreaterOrEqual(t, found, 10, "expected at least 10 preview header parameter blocks")
+}
+
+func setupEnginePreviewSunsetRouter(t *testing.T) (http.Handler, string) {
+	t.Helper()
+
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	platformStore := store.New(pool)
+	engineQueries := enginedb.New(pool)
+
+	apiKey := "engine-sunset-" + uuid.NewString()
+	_, err := platformStore.Queries().CreateProject(ctx, platformdb.CreateProjectParams{
+		Name:       "engine-sunset-" + uuid.NewString()[:8],
+		ApiKeyHash: hashTestAPIKey(apiKey),
+	})
+	require.NoError(t, err)
+	require.NoError(t, publishCheckoutDefinition(ctx, engineQueries))
+
+	server := NewServer(platformStore, nil)
+	server.engineControl = newEngineControlService(platformStore)
+	server.enginePublicAPIEnabled = true
+
+	return newAuthenticatedRouter(t, server, platformStore), apiKey
+}
+
+func postEngineStartRunThroughRouter(
+	t *testing.T,
+	router http.Handler,
+	apiKey, instanceKey, requestKey string,
+	withPreviewHeader bool,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{
+		"definition_name":    "checkout",
+		"definition_version": "v1",
+		"instance_key":       instanceKey,
+		"request_key":        requestKey,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/engine/runs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	if withPreviewHeader {
+		req.Header.Set(enginePreviewHeader, "1")
+	}
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+type enginePreviewSunsetCapturedRecord struct {
+	record       slog.Record
+	handlerAttrs []slog.Attr
+	groups       []string
+}
+
+type enginePreviewSunsetCaptureState struct {
+	mu      sync.Mutex
+	records []enginePreviewSunsetCapturedRecord
+}
+
+type enginePreviewSunsetCaptureHandler struct {
+	state  *enginePreviewSunsetCaptureState
+	attrs  []slog.Attr
+	groups []string
+}
+
+func newEnginePreviewSunsetCaptureHandler() *enginePreviewSunsetCaptureHandler {
+	return &enginePreviewSunsetCaptureHandler{state: &enginePreviewSunsetCaptureState{}}
+}
+
+func (h *enginePreviewSunsetCaptureHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *enginePreviewSunsetCaptureHandler) Handle(_ context.Context, record slog.Record) error {
+	h.state.mu.Lock()
+	defer h.state.mu.Unlock()
+
+	h.state.records = append(h.state.records, enginePreviewSunsetCapturedRecord{
+		record:       record.Clone(),
+		handlerAttrs: append([]slog.Attr(nil), h.attrs...),
+		groups:       append([]string(nil), h.groups...),
+	})
+	return nil
+}
+
+func (h *enginePreviewSunsetCaptureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &enginePreviewSunsetCaptureHandler{
+		state:  h.state,
+		attrs:  append(append([]slog.Attr(nil), h.attrs...), attrs...),
+		groups: append([]string(nil), h.groups...),
+	}
+}
+
+func (h *enginePreviewSunsetCaptureHandler) WithGroup(name string) slog.Handler {
+	return &enginePreviewSunsetCaptureHandler{
+		state:  h.state,
+		attrs:  append([]slog.Attr(nil), h.attrs...),
+		groups: append(append([]string(nil), h.groups...), name),
+	}
+}
+
+func (h *enginePreviewSunsetCaptureHandler) clear() {
+	h.state.mu.Lock()
+	defer h.state.mu.Unlock()
+	h.state.records = nil
+}
+
+func (h *enginePreviewSunsetCaptureHandler) hasWarningMentioning(needle string) bool {
+	h.state.mu.Lock()
+	defer h.state.mu.Unlock()
+
+	for _, captured := range h.state.records {
+		if captured.record.Level < slog.LevelWarn {
+			continue
+		}
+		if strings.Contains(captured.record.Message, needle) || slicesContainString(captured.groups, needle) {
+			return true
+		}
+		for _, attr := range captured.handlerAttrs {
+			if slogAttrMentions(attr, needle) {
+				return true
+			}
+		}
+		mentioned := false
+		captured.record.Attrs(func(attr slog.Attr) bool {
+			mentioned = slogAttrMentions(attr, needle)
+			return !mentioned
+		})
+		if mentioned {
+			return true
+		}
+	}
+	return false
+}
+
+func slogAttrMentions(attr slog.Attr, needle string) bool {
+	if strings.Contains(attr.Key, needle) {
+		return true
+	}
+
+	value := attr.Value.Resolve()
+	if value.Kind() == slog.KindGroup {
+		for _, child := range value.Group() {
+			if slogAttrMentions(child, needle) {
+				return true
+			}
+		}
+		return false
+	}
+	return strings.Contains(value.String(), needle)
+}
+
+func slicesContainString(values []string, needle string) bool {
+	for _, value := range values {
+		if strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -1457,44 +1457,44 @@ type ListSpansByTraceParams struct {
 
 // ClaimRemoteActivityTasksParams defines parameters for ClaimRemoteActivityTasks.
 type ClaimRemoteActivityTasksParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // CompleteRemoteActivityTaskParams defines parameters for CompleteRemoteActivityTask.
 type CompleteRemoteActivityTaskParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // FailRemoteActivityTaskParams defines parameters for FailRemoteActivityTask.
 type FailRemoteActivityTaskParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // HeartbeatRemoteActivityTaskParams defines parameters for HeartbeatRemoteActivityTask.
 type HeartbeatRemoteActivityTaskParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // BackfillEngineProjectionsParams defines parameters for BackfillEngineProjections.
 type BackfillEngineProjectionsParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // StartEngineRunParams defines parameters for StartEngineRun.
 type StartEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // CancelEngineRunParams defines parameters for CancelEngineRun.
 type CancelEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // GetEngineRunHistoryParams defines parameters for GetEngineRunHistory.
@@ -1505,38 +1505,38 @@ type GetEngineRunHistoryParams struct {
 
 // PurgeEngineRunParams defines parameters for PurgeEngineRun.
 type PurgeEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // RepairEngineRunParams defines parameters for RepairEngineRun.
 type RepairEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // ResumeEngineRunParams defines parameters for ResumeEngineRun.
 type ResumeEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // SignalEngineRunParams defines parameters for SignalEngineRun.
 type SignalEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // SuspendEngineRunParams defines parameters for SuspendEngineRun.
 type SuspendEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // TerminateEngineRunParams defines parameters for TerminateEngineRun.
 type TerminateEngineRunParams struct {
-	// XContinuaEnginePreview Required preview header for mutating engine routes.
-	XContinuaEnginePreview string `json:"X-Continua-Engine-Preview"`
+	// XContinuaEnginePreview Deprecated and no longer required; this header will be removed at GA.
+	XContinuaEnginePreview *string `json:"X-Continua-Engine-Preview,omitempty"`
 }
 
 // IngestParams defines parameters for Ingest.
@@ -2858,7 +2858,7 @@ func (siw *ServerInterfaceWrapper) ClaimRemoteActivityTasks(w http.ResponseWrite
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2867,18 +2867,14 @@ func (siw *ServerInterfaceWrapper) ClaimRemoteActivityTasks(w http.ResponseWrite
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2917,7 +2913,7 @@ func (siw *ServerInterfaceWrapper) CompleteRemoteActivityTask(w http.ResponseWri
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2926,18 +2922,14 @@ func (siw *ServerInterfaceWrapper) CompleteRemoteActivityTask(w http.ResponseWri
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2976,7 +2968,7 @@ func (siw *ServerInterfaceWrapper) FailRemoteActivityTask(w http.ResponseWriter,
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -2985,18 +2977,14 @@ func (siw *ServerInterfaceWrapper) FailRemoteActivityTask(w http.ResponseWriter,
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3035,7 +3023,7 @@ func (siw *ServerInterfaceWrapper) HeartbeatRemoteActivityTask(w http.ResponseWr
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3044,18 +3032,14 @@ func (siw *ServerInterfaceWrapper) HeartbeatRemoteActivityTask(w http.ResponseWr
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3142,7 +3126,7 @@ func (siw *ServerInterfaceWrapper) BackfillEngineProjections(w http.ResponseWrit
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3151,18 +3135,14 @@ func (siw *ServerInterfaceWrapper) BackfillEngineProjections(w http.ResponseWrit
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3194,7 +3174,7 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3203,18 +3183,14 @@ func (siw *ServerInterfaceWrapper) StartEngineRun(w http.ResponseWriter, r *http
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3288,7 +3264,7 @@ func (siw *ServerInterfaceWrapper) CancelEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3297,18 +3273,14 @@ func (siw *ServerInterfaceWrapper) CancelEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3434,7 +3406,7 @@ func (siw *ServerInterfaceWrapper) PurgeEngineRun(w http.ResponseWriter, r *http
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3443,18 +3415,14 @@ func (siw *ServerInterfaceWrapper) PurgeEngineRun(w http.ResponseWriter, r *http
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3495,7 +3463,7 @@ func (siw *ServerInterfaceWrapper) RepairEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3504,18 +3472,14 @@ func (siw *ServerInterfaceWrapper) RepairEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3589,7 +3553,7 @@ func (siw *ServerInterfaceWrapper) ResumeEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3598,18 +3562,14 @@ func (siw *ServerInterfaceWrapper) ResumeEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3650,7 +3610,7 @@ func (siw *ServerInterfaceWrapper) SignalEngineRun(w http.ResponseWriter, r *htt
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3659,18 +3619,14 @@ func (siw *ServerInterfaceWrapper) SignalEngineRun(w http.ResponseWriter, r *htt
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3711,7 +3667,7 @@ func (siw *ServerInterfaceWrapper) SuspendEngineRun(w http.ResponseWriter, r *ht
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3720,18 +3676,14 @@ func (siw *ServerInterfaceWrapper) SuspendEngineRun(w http.ResponseWriter, r *ht
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3772,7 +3724,7 @@ func (siw *ServerInterfaceWrapper) TerminateEngineRun(w http.ResponseWriter, r *
 
 	headers := r.Header
 
-	// ------------- Required header parameter "X-Continua-Engine-Preview" -------------
+	// ------------- Optional header parameter "X-Continua-Engine-Preview" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Continua-Engine-Preview")]; found {
 		var XContinuaEnginePreview string
 		n := len(valueList)
@@ -3781,18 +3733,14 @@ func (siw *ServerInterfaceWrapper) TerminateEngineRun(w http.ResponseWriter, r *
 			return
 		}
 
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Continua-Engine-Preview", valueList[0], &XContinuaEnginePreview, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false})
 		if err != nil {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Continua-Engine-Preview", Err: err})
 			return
 		}
 
-		params.XContinuaEnginePreview = XContinuaEnginePreview
+		params.XContinuaEnginePreview = &XContinuaEnginePreview
 
-	} else {
-		err := fmt.Errorf("Header parameter X-Continua-Engine-Preview is required, but not found")
-		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Continua-Engine-Preview", Err: err})
-		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What / why

`/v1/engine/*` was double-gated — `ENGINE_PUBLIC_API_ENABLED` plus a hard `X-Continua-Engine-Preview: 1` requirement on every mutating route — with no written criteria for how the surface graduates to GA. This PR defines that path and executes its first step, the preview-header sunset. Its prerequisites (#152–#155 correctness spine, #161 library entrypoint, #168 metrics, #172 retention) are all merged.

## What changed

- **Header sunset, step 1**: mutating `/v1/engine/*` requests without `X-Continua-Engine-Preview` are now accepted. The `preview_header_required` 400 rejection is removed from `internal/api/engine_middleware.go`; a warn-level slog record (naming the header and request path) is emitted for headerless mutations during the sunset window. Requests that still send the header behave identically and log nothing.
- **Contract freeze review**: all 13 `X-Continua-Engine-Preview` parameters in `contracts/openapi/openapi.yaml` flipped to `required: false` + `deprecated: true`; 400 descriptions no longer mention the missing header. Generated artifacts (`server_gen.go`, bundle, TS client, docs-site OpenAPI copy) regenerated via `make generate`.
- **GA criteria doc**: new "Path to GA for `/v1/engine/*`" section in `docs-site/concepts/engine-foundation.mdx` defining the graduation gates — prerequisites (merged), contract freeze + error-code taxonomy stability, the two-release header sunset schedule, and the `ENGINE_PUBLIC_API_ENABLED` default-flip plan with a documented off-switch. `auth-and-headers.mdx`, `roadmap.mdx`, `engine-runs.mdx`, and the self-hosting/installation guides updated to match.
- **Unchanged**: `ENGINE_PUBLIC_API_ENABLED` stays the deployment opt-in (404 when off, before auth). The Python SDK keeps sending the header during the window; no SDK changes.

## Test evidence

Acceptance tests were written first and committed red (`cae47ae`), then implemented against by an independent session:

- `TestEngineMutations_AcceptRequestsWithoutPreviewHeader` — headerless start + cancel through the real router succeed.
- `TestEngineMutations_PreviewHeaderStillAcceptedDuringSunset` — header-present parity.
- `TestEngineMutations_HeaderlessPostLogsDeprecationWarning` — warn record present headerless, absent with header.
- `TestEngineRoutes_AvailabilityFlagStillGates` — flag off still 404s GET and POST before auth.
- `TestOpenAPIContract_PreviewHeaderDeprecatedAndOptional` — contract scan: no `required: true`, all `deprecated: true`.

`go test ./internal/api/...` green on a real Postgres; existing 400-asserting tests converted to the new behavior (availability coverage kept). `make generate` run twice with zero residual drift. Feature verified end-to-end on a booted server: headerless `POST /v1/engine/runs` → 200 with one WARN log; with header → 200, no log; `/api/health`, traces/sessions reads, and the engine CLI (`start`/`inspect`) all regression-checked.

Closes #176
