### PR TITLE
Fix engine run trace navigation

### DIFF
--- a/web/e2e/ui-smoke.spec.ts
+++ b/web/e2e/ui-smoke.spec.ts
@@ -296,6 +296,12 @@ async function mockApiRoutes(page: Page, mode: 'operator' | 'public-demo' = 'ope
 
     if (url.pathname === '/api/traces') {
       if (url.searchParams.get('engine_only') === 'true') {
+        if (url.searchParams.get('engine_run_id') === ENGINE_RUN_ID) {
+          return fulfillJson(route, {
+            traces: [{ ...ENGINE_TRACE, id: STARTED_ENGINE_TRACE_ID }],
+            total: 1,
+          });
+        }
         return fulfillJson(route, { traces: [ENGINE_TRACE], total: 1 });
       }
       return fulfillJson(route, filterTraces(url));

--- a/web/src/pages/EngineRunsPage.test.tsx
+++ b/web/src/pages/EngineRunsPage.test.tsx
@@ -343,12 +343,23 @@ describe('StartEngineRunDialog', () => {
 
   it('submits the start request and navigates to the projected trace', async () => {
     const user = userEvent.setup();
+    const startedRunId = '123e4567-e89b-12d3-a456-426614174102';
+    const startedTrace: Trace = {
+      ...ENGINE_TRACE,
+      id: 'trace-uuid-new-1',
+      engine: {
+        ...ENGINE_TRACE.engine!,
+        run_id: startedRunId,
+        instance_key: 'checkout-42',
+      },
+    };
     mockEngineRequests({
+      traces: [ENGINE_TRACE, startedTrace],
       instance: () =>
         jsonResponse({ code: 'not_found', message: 'Instance not found' }, 404),
       start: () =>
         jsonResponse({
-          run_id: '123e4567-e89b-12d3-a456-426614174102',
+          run_id: startedRunId,
           instance_key: 'checkout-42',
           trace_id: 'trace-new-1',
         }),
@@ -366,7 +377,9 @@ describe('StartEngineRunDialog', () => {
     await user.click(dialog.getByRole('button', { name: 'Start run' }));
 
     await waitFor(() => {
-      expect(screen.getByTestId('probe-pathname')).toHaveTextContent('/traces/trace-new-1');
+      expect(screen.getByTestId('probe-pathname')).toHaveTextContent(
+        '/traces/trace-uuid-new-1'
+      );
     });
     const postCall = fetchMock.mock.calls.find(([input, init]) => {
       const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
@@ -385,6 +398,11 @@ describe('StartEngineRunDialog', () => {
       definition_version: 'v3',
       request_key: requestKey,
     });
+    const resolutionCall = fetchMock.mock.calls.find(([input]) => {
+      const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+      return url.searchParams.get('engine_run_id') === startedRunId;
+    });
+    expect(resolutionCall).toBeDefined();
     expect(screen.getByTestId('probe-return-to')).toHaveTextContent('/engine/runs');
   });
 });

--- a/web/src/pages/EngineRunsPage.tsx
+++ b/web/src/pages/EngineRunsPage.tsx
@@ -370,8 +370,20 @@ function StartEngineRunDialog({
         request_key: requestKey.trim(),
         ...(input !== undefined ? { input } : {}),
       });
+      const projectedTraces = await fetchTraces({
+        engine_only: true,
+        engine_run_id: response.run_id,
+        limit: 1,
+        ...(projectId ? { project_id: projectId } : {}),
+      });
+      const projectedTrace = projectedTraces.traces.find(
+        (trace) => trace.engine?.run_id === response.run_id
+      );
+      if (!projectedTrace) {
+        throw new Error('Run started, but its projected trace could not be resolved.');
+      }
       await queryClient.invalidateQueries({ queryKey: ['engine-runs', projectId ?? null] });
-      onSuccess(response.trace_id);
+      onSuccess(projectedTrace.id);
     } catch (error) {
       if (error instanceof ApiError && error.status === 409 && error.code === 'instance_conflict') {
         setSubmitError('Instance conflict. Recheck the durable workflow identity and run preflight again.');


### PR DESCRIPTION
## What changed

- resolve the projected trace by `engine_run_id` after starting an engine run
- navigate to the debugger's internal trace UUID instead of the external engine trace identifier
- add unit and desktop/mobile browser regression coverage

## Why

The engine start response exposes an external trace identifier such as `engine:<run-id>`, while the trace-detail API route requires the internal projected trace UUID. The engine runs console therefore navigated to a route that returned HTTP 400 immediately after a successful start.

## Impact

Operators now land on the newly started workflow's trace workspace, with project scope and return navigation preserved. If projection cannot be resolved, the dialog presents an actionable error instead of navigating to a broken route.

## Validation

- Phase 1 focused engine/API acceptance tests
- full engine suite with race detection
- API suite with race detection
- frontend unit tests: 513 passed
- Playwright desktop/mobile smoke suite: 10 passed
- frontend lint and type-check
- live browser verification of start, restart, quarantine, resume, and recovery flows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved engine-run startup navigation by resolving the correct projected trace before opening it.
  * Added validation to prevent navigation when a matching projected trace cannot be found.
  * Ensured engine-run data refreshes after a successful start.

* **Tests**
  * Expanded coverage for engine-run trace resolution and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->