### PR TITLE
feat(web): pick live registered definitions in the Start Run dialog

### DIFF
--- a/web/e2e/ui-smoke.spec.ts
+++ b/web/e2e/ui-smoke.spec.ts
@@ -354,6 +354,29 @@ async function mockEngineRoutes(page: Page) {
     const url = new URL(request.url());
     expectOperatorAuthHeader(route);
 
+    if (url.pathname === '/v1/engine/definitions' && request.method() === 'GET') {
+      return fulfillJson(route, {
+        definitions: [
+          {
+            definition_name: 'checkout',
+            definition_version: 'v1',
+            enabled: true,
+            live: true,
+            runtime_published_at: '2026-03-14T09:00:00.000Z',
+            published_at: '2026-03-14T08:00:00.000Z',
+          },
+          {
+            definition_name: 'legacy-checkout',
+            definition_version: 'v0',
+            enabled: true,
+            live: false,
+            runtime_published_at: '2026-03-01T09:00:00.000Z',
+            published_at: '2026-03-01T08:00:00.000Z',
+          },
+        ],
+      });
+    }
+
     if (/^\/v1\/engine\/instances\/[^/]+$/.test(url.pathname)) {
       return fulfillJson(route, { code: 'not_found', message: 'Instance not found' }, 404);
     }
@@ -589,6 +612,7 @@ test('covers the engine runs console smoke flows', async ({ page }, testInfo) =>
   const startForm = page
     .getByRole('heading', { name: 'Start run', exact: true })
     .locator('xpath=ancestor::form');
+  await startForm.getByRole('button', { name: 'Enter manually', exact: true }).click();
   await startForm.getByLabel(/^Instance key/).fill('checkout-42');
   await startForm.getByLabel(/^Definition name/).fill('checkout');
   await startForm.getByLabel(/^Definition version/).fill('v1');
@@ -635,6 +659,47 @@ test('covers the engine runs console smoke flows', async ({ page }, testInfo) =>
     body: screenshot,
     contentType: 'image/png',
   });
+});
+
+test('starts an engine run from the live definition picker', async ({ page }, testInfo) => {
+  await bootstrapOperatorSession(page);
+  await mockApiRoutes(page, 'operator');
+  await mockEngineRoutes(page);
+  await page.goto(`/engine/runs?project_id=${PRIMARY_PROJECT_ID}`);
+
+  await page.getByRole('button', { name: 'Start run', exact: true }).click();
+  const startForm = page
+    .getByRole('heading', { name: 'Start run', exact: true })
+    .locator('xpath=ancestor::form');
+  await startForm.getByLabel(/^Instance key/).fill('checkout-42');
+  await startForm.getByRole('button', { name: 'Check', exact: true }).click();
+  await expect(startForm.getByText('Instance key is available.')).toBeVisible();
+  await startForm.getByLabel(/^Definition name/).selectOption('checkout');
+  await startForm.getByLabel(/^Definition version/).selectOption('v1');
+  await expect(
+    startForm.getByRole('option', { name: /legacy-checkout.*not live/i })
+  ).toHaveJSProperty('disabled', true);
+
+  const screenshot = await page.screenshot({ fullPage: true, animations: 'disabled' });
+  await testInfo.attach(`${testInfo.project.name}-engine-definition-picker`, {
+    body: screenshot,
+    contentType: 'image/png',
+  });
+
+  const startRequest = page.waitForRequest(
+    (request) =>
+      new URL(request.url()).pathname === '/v1/engine/runs' &&
+      request.method() === 'POST'
+  );
+  await startForm.getByRole('button', { name: 'Start run', exact: true }).click();
+  expect((await startRequest).postDataJSON()).toMatchObject({
+    instance_key: 'checkout-42',
+    definition_name: 'checkout',
+    definition_version: 'v1',
+  });
+  await expect(page).toHaveURL(
+    new RegExp(String.raw`/traces/${STARTED_ENGINE_TRACE_ID}\?project_id=${PRIMARY_PROJECT_ID}`)
+  );
 });
 
 test('walks the public demo flow from landing through debugger reads', async ({ page }, testInfo) => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -370,6 +370,19 @@ export type EngineProjectionBackfillAction =
 
 export type EnginePurgeMode = 'projection_only' | 'full';
 
+export interface EngineDefinition {
+  definition_name: string;
+  definition_version: string;
+  enabled: boolean;
+  live: boolean;
+  runtime_published_at: string;
+  published_at: string;
+}
+
+export interface EngineDefinitionListResponse {
+  definitions: EngineDefinition[];
+}
+
 export interface EngineTraceInfo {
   run_id: string;
   definition_name: string;
@@ -1138,6 +1151,10 @@ export async function fetchEngineInstance(
   return fetchAPI<EngineInstanceResponse>(
     `/v1/engine/instances/${encodeURIComponent(instanceKey)}`
   );
+}
+
+export async function listEngineDefinitions(): Promise<EngineDefinitionListResponse> {
+  return fetchAPI<EngineDefinitionListResponse>('/v1/engine/definitions');
 }
 
 export async function startEngineRun(

--- a/web/src/pages/EngineRunsPage.test.tsx
+++ b/web/src/pages/EngineRunsPage.test.tsx
@@ -497,12 +497,23 @@ describe('StartEngineRunDialog definition picker', () => {
 
   it('builds the start payload from the picker selection', async () => {
     const user = userEvent.setup();
+    const startedRunId = '123e4567-e89b-12d3-a456-426614174102';
+    const startedTrace: Trace = {
+      ...ENGINE_TRACE,
+      id: 'trace-picker-1',
+      engine: {
+        ...ENGINE_TRACE.engine!,
+        run_id: startedRunId,
+        instance_key: 'picker-instance',
+      },
+    };
     mockEngineRequests({
+      traces: [ENGINE_TRACE, startedTrace],
       instance: () =>
         jsonResponse({ code: 'not_found', message: 'Instance not found' }, 404),
       start: () =>
         jsonResponse({
-          run_id: '123e4567-e89b-12d3-a456-426614174102',
+          run_id: startedRunId,
           instance_key: 'picker-instance',
           trace_id: 'trace-picker-1',
         }),
@@ -584,12 +595,23 @@ describe('StartEngineRunDialog definition picker', () => {
 
   it('manual entry fallback still allows free-text definitions', async () => {
     const user = userEvent.setup();
+    const startedRunId = '123e4567-e89b-12d3-a456-426614174103';
+    const startedTrace: Trace = {
+      ...ENGINE_TRACE,
+      id: 'trace-manual-1',
+      engine: {
+        ...ENGINE_TRACE.engine!,
+        run_id: startedRunId,
+        instance_key: 'manual-instance',
+      },
+    };
     mockEngineRequests({
+      traces: [ENGINE_TRACE, startedTrace],
       instance: () =>
         jsonResponse({ code: 'not_found', message: 'Instance not found' }, 404),
       start: () =>
         jsonResponse({
-          run_id: '123e4567-e89b-12d3-a456-426614174103',
+          run_id: startedRunId,
           instance_key: 'manual-instance',
           trace_id: 'trace-manual-1',
         }),

--- a/web/src/pages/EngineRunsPage.test.tsx
+++ b/web/src/pages/EngineRunsPage.test.tsx
@@ -55,6 +55,14 @@ const DEFINITIONS = [
     published_at: '2026-03-11T09:00:00.000Z',
   },
   {
+    definition_name: 'defA',
+    definition_version: 'v0',
+    enabled: true,
+    live: false,
+    runtime_published_at: '2026-03-09T10:00:00.000Z',
+    published_at: '2026-03-09T09:00:00.000Z',
+  },
+  {
     definition_name: 'defB',
     definition_version: 'v9',
     enabled: true,
@@ -464,6 +472,22 @@ describe('StartEngineRunDialog definition picker', () => {
     expect(picker.getByRole('option', { name: /legacy.*not live/i })).toBeDisabled();
   });
 
+  it('disables picker submission while definitions are loading', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({
+      definitions: () => new Promise<Response>(() => undefined),
+    });
+    renderEngineRunsPage();
+
+    const dialogHeading = await openStartDialog(user);
+    const form = dialogHeading.closest('form');
+    expect(form).not.toBeNull();
+    const dialog = within(form as HTMLFormElement);
+
+    expect(dialog.getByText('Loading registered definitions…')).toBeInTheDocument();
+    expect(dialog.getByRole('button', { name: 'Start run' })).toBeDisabled();
+  });
+
   it('scopes the version dropdown to the selected definition and resets it on change', async () => {
     const user = userEvent.setup();
     mockEngineRequests();
@@ -475,12 +499,17 @@ describe('StartEngineRunDialog definition picker', () => {
     await user.selectOptions(definitionName, 'defA');
 
     const definitionVersion = screen.getByLabelText(/^Definition version/);
+    const defAVersionOptions = within(definitionVersion).getAllByRole('option');
     expect(
-      within(definitionVersion)
-        .getAllByRole('option')
+      defAVersionOptions
         .map((option) => (option as HTMLOptionElement).value)
         .filter(Boolean)
-    ).toEqual(['v1', 'v2']);
+    ).toEqual(['v1', 'v2', 'v0']);
+    expect(
+      defAVersionOptions.find(
+        (option) => (option as HTMLOptionElement).value === 'v0'
+      )
+    ).toBeDisabled();
 
     await user.selectOptions(definitionVersion, 'v2');
     expect(definitionVersion).toHaveValue('v2');
@@ -534,24 +563,27 @@ describe('StartEngineRunDialog definition picker', () => {
       .value;
     await user.click(dialog.getByRole('button', { name: 'Start run' }));
 
+    let postCall: ReturnType<typeof fetchMock>['mock']['calls'][number] | undefined;
     await waitFor(() => {
-      expect(screen.getByTestId('probe-pathname')).toHaveTextContent(
-        '/traces/trace-picker-1'
-      );
+      postCall = fetchMock.mock.calls.find(([input, init]) => {
+        const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+        return (
+          url.pathname === '/v1/engine/runs' &&
+          (init as RequestInit | undefined)?.method === 'POST'
+        );
+      });
+      expect(postCall).toBeDefined();
     });
-    const postCall = fetchMock.mock.calls.find(([input, init]) => {
-      const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
-      return (
-        url.pathname === '/v1/engine/runs' &&
-        (init as RequestInit | undefined)?.method === 'POST'
-      );
-    });
-    expect(postCall).toBeDefined();
     expect(JSON.parse((postCall?.[1] as RequestInit).body as string)).toEqual({
       instance_key: 'picker-instance',
       definition_name: 'defA',
       definition_version: 'v2',
       request_key: requestKey,
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-pathname')).toHaveTextContent(
+        '/traces/trace-picker-1'
+      );
     });
     expect(screen.getByTestId('probe-return-to')).toHaveTextContent('/engine/runs');
   });
@@ -634,33 +666,43 @@ describe('StartEngineRunDialog definition picker', () => {
       .value;
     await user.click(dialog.getByRole('button', { name: 'Start run' }));
 
+    let postCall: ReturnType<typeof fetchMock>['mock']['calls'][number] | undefined;
     await waitFor(() => {
-      expect(screen.getByTestId('probe-pathname')).toHaveTextContent(
-        '/traces/trace-manual-1'
-      );
+      postCall = fetchMock.mock.calls.find(([input, init]) => {
+        const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+        return (
+          url.pathname === '/v1/engine/runs' &&
+          (init as RequestInit | undefined)?.method === 'POST'
+        );
+      });
+      expect(postCall).toBeDefined();
     });
-    const postCall = fetchMock.mock.calls.find(([input, init]) => {
-      const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
-      return (
-        url.pathname === '/v1/engine/runs' &&
-        (init as RequestInit | undefined)?.method === 'POST'
-      );
-    });
-    expect(postCall).toBeDefined();
     expect(JSON.parse((postCall?.[1] as RequestInit).body as string)).toEqual({
       instance_key: 'manual-instance',
       definition_name: 'custom-def',
       definition_version: 'v42',
       request_key: requestKey,
     });
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-pathname')).toHaveTextContent(
+        '/traces/trace-manual-1'
+      );
+    });
   });
 
-  it('falls back to manual entry when the definitions endpoint fails', async () => {
-    const user = userEvent.setup();
-    mockEngineRequests({
+  it.each([
+    {
+      scenario: 'the definitions endpoint fails',
       definitions: () =>
         jsonResponse({ code: 'server_error', message: 'boom' }, 500),
-    });
+    },
+    {
+      scenario: 'the definitions catalog is empty',
+      definitions: () => jsonResponse({ definitions: [] }),
+    },
+  ])('falls back to manual entry when $scenario', async ({ definitions }) => {
+    const user = userEvent.setup();
+    mockEngineRequests({ definitions });
     renderEngineRunsPage();
 
     await openStartDialog(user);

--- a/web/src/pages/EngineRunsPage.test.tsx
+++ b/web/src/pages/EngineRunsPage.test.tsx
@@ -37,6 +37,41 @@ const ENGINE_TRACE: Trace = {
   },
 };
 
+const DEFINITIONS = [
+  {
+    definition_name: 'defA',
+    definition_version: 'v1',
+    enabled: true,
+    live: true,
+    runtime_published_at: '2026-03-10T10:00:00.000Z',
+    published_at: '2026-03-10T09:00:00.000Z',
+  },
+  {
+    definition_name: 'defA',
+    definition_version: 'v2',
+    enabled: true,
+    live: true,
+    runtime_published_at: '2026-03-11T10:00:00.000Z',
+    published_at: '2026-03-11T09:00:00.000Z',
+  },
+  {
+    definition_name: 'defB',
+    definition_version: 'v9',
+    enabled: true,
+    live: true,
+    runtime_published_at: '2026-03-12T10:00:00.000Z',
+    published_at: '2026-03-12T09:00:00.000Z',
+  },
+  {
+    definition_name: 'legacy',
+    definition_version: 'v0',
+    enabled: true,
+    live: false,
+    runtime_published_at: '2026-03-09T10:00:00.000Z',
+    published_at: '2026-03-09T09:00:00.000Z',
+  },
+];
+
 function LocationProbe() {
   const location = useLocation();
   const state = location.state as { returnTo?: string } | null;
@@ -76,10 +111,12 @@ function renderEngineRunsPage(initialEntry = '/engine/runs') {
 
 function mockEngineRequests({
   traces = [ENGINE_TRACE],
+  definitions = () => jsonResponse({ definitions: DEFINITIONS }),
   instance,
   start,
 }: {
   traces?: Trace[];
+  definitions?: (url: URL, init?: RequestInit) => Promise<Response> | Response;
   instance?: (url: URL, init?: RequestInit) => Promise<Response> | Response;
   start?: (url: URL, init?: RequestInit) => Promise<Response> | Response;
 } = {}) {
@@ -88,6 +125,12 @@ function mockEngineRequests({
 
     if (url.pathname === '/api/traces') {
       return jsonResponse({ traces, total: traces.length });
+    }
+    if (
+      url.pathname === '/v1/engine/definitions' &&
+      (init?.method ?? 'GET') === 'GET'
+    ) {
+      return definitions(url, init);
     }
     if (/^\/v1\/engine\/instances\/[^/]+$/.test(url.pathname) && instance) {
       return instance(url, init);
@@ -318,6 +361,7 @@ describe('StartEngineRunDialog', () => {
     renderEngineRunsPage();
 
     await openStartDialog(user);
+    await user.click(screen.getByRole('button', { name: 'Enter manually' }));
     const definitionName = screen.getByLabelText(/^Definition name/);
     const definitionVersion = screen.getByLabelText(/^Definition version/);
     await user.type(definitionName, 'defA');
@@ -356,6 +400,7 @@ describe('StartEngineRunDialog', () => {
     renderEngineRunsPage();
 
     const dialogHeading = await openStartDialog(user);
+    await user.click(screen.getByRole('button', { name: 'Enter manually' }));
     const form = dialogHeading.closest('form');
     expect(form).not.toBeNull();
     const dialog = within(form as HTMLFormElement);
@@ -386,5 +431,230 @@ describe('StartEngineRunDialog', () => {
       request_key: requestKey,
     });
     expect(screen.getByTestId('probe-return-to')).toHaveTextContent('/engine/runs');
+  });
+});
+
+describe('StartEngineRunDialog definition picker', () => {
+  it('fetches live definitions when the dialog opens and lists them in the picker', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests();
+    renderEngineRunsPage();
+
+    await openStartDialog(user);
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input, init]) => {
+          const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+          return (
+            url.pathname === '/v1/engine/definitions' &&
+            ((init as RequestInit | undefined)?.method ?? 'GET') === 'GET'
+          );
+        })
+      ).toBe(true);
+    });
+
+    const definitionName = await screen.findByRole('combobox', {
+      name: /^Definition name/,
+    });
+    expect(definitionName.tagName).toBe('SELECT');
+    const picker = within(definitionName);
+    expect(picker.getByRole('option', { name: /^defA(?:\s|$)/ })).toBeEnabled();
+    expect(picker.getByRole('option', { name: /^defB(?:\s|$)/ })).toBeEnabled();
+    expect(picker.getByRole('option', { name: /legacy.*not live/i })).toBeDisabled();
+  });
+
+  it('scopes the version dropdown to the selected definition and resets it on change', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests();
+    renderEngineRunsPage();
+
+    await openStartDialog(user);
+    const definitionName = screen.getByLabelText(/^Definition name/);
+    await screen.findByRole('option', { name: /^defA(?:\s|$)/ });
+    await user.selectOptions(definitionName, 'defA');
+
+    const definitionVersion = screen.getByLabelText(/^Definition version/);
+    expect(
+      within(definitionVersion)
+        .getAllByRole('option')
+        .map((option) => (option as HTMLOptionElement).value)
+        .filter(Boolean)
+    ).toEqual(['v1', 'v2']);
+
+    await user.selectOptions(definitionVersion, 'v2');
+    expect(definitionVersion).toHaveValue('v2');
+    await user.selectOptions(definitionName, 'defB');
+
+    expect(definitionVersion).toHaveValue('');
+    expect(
+      within(definitionVersion)
+        .getAllByRole('option')
+        .map((option) => (option as HTMLOptionElement).value)
+        .filter(Boolean)
+    ).toEqual(['v9']);
+  });
+
+  it('builds the start payload from the picker selection', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({
+      instance: () =>
+        jsonResponse({ code: 'not_found', message: 'Instance not found' }, 404),
+      start: () =>
+        jsonResponse({
+          run_id: '123e4567-e89b-12d3-a456-426614174102',
+          instance_key: 'picker-instance',
+          trace_id: 'trace-picker-1',
+        }),
+    });
+    renderEngineRunsPage();
+
+    const dialogHeading = await openStartDialog(user);
+    const form = dialogHeading.closest('form');
+    expect(form).not.toBeNull();
+    const dialog = within(form as HTMLFormElement);
+    await screen.findByRole('option', { name: /^defA(?:\s|$)/ });
+    await user.selectOptions(dialog.getByLabelText(/^Definition name/), 'defA');
+    await user.selectOptions(dialog.getByLabelText(/^Definition version/), 'v2');
+    await user.type(dialog.getByLabelText(/^Instance key/), 'picker-instance');
+    await user.click(dialog.getByRole('button', { name: 'Check' }));
+    expect(await screen.findByText('Instance key is available.')).toBeInTheDocument();
+    const requestKey = (dialog.getByLabelText(/^Idempotency key/) as HTMLInputElement)
+      .value;
+    await user.click(dialog.getByRole('button', { name: 'Start run' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-pathname')).toHaveTextContent(
+        '/traces/trace-picker-1'
+      );
+    });
+    const postCall = fetchMock.mock.calls.find(([input, init]) => {
+      const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+      return (
+        url.pathname === '/v1/engine/runs' &&
+        (init as RequestInit | undefined)?.method === 'POST'
+      );
+    });
+    expect(postCall).toBeDefined();
+    expect(JSON.parse((postCall?.[1] as RequestInit).body as string)).toEqual({
+      instance_key: 'picker-instance',
+      definition_name: 'defA',
+      definition_version: 'v2',
+      request_key: requestKey,
+    });
+    expect(screen.getByTestId('probe-return-to')).toHaveTextContent('/engine/runs');
+  });
+
+  it('cannot start a non-live definition through the picker', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests();
+    renderEngineRunsPage();
+
+    const dialogHeading = await openStartDialog(user);
+    const form = dialogHeading.closest('form');
+    expect(form).not.toBeNull();
+    const dialog = within(form as HTMLFormElement);
+    expect(
+      await dialog.findByRole('option', { name: /legacy.*not live/i })
+    ).toBeDisabled();
+    await user.type(dialog.getByLabelText(/^Instance key/), 'blocked-instance');
+    await user.click(dialog.getByRole('button', { name: 'Start run' }));
+
+    expect(
+      await dialog.findByText(/(?:select|choose) a live definition/i)
+    ).toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(([input, init]) => {
+        const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+        return url.pathname === '/v1/engine/runs' && init?.method === 'POST';
+      })
+    ).toBe(false);
+  });
+
+  it('shows liveness and last-published metadata for stale definitions', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests();
+    renderEngineRunsPage();
+
+    await openStartDialog(user);
+
+    expect(await screen.findByText(/legacy.*not live/i)).toBeInTheDocument();
+    expect(await screen.findAllByText(/last published/i)).not.toHaveLength(0);
+  });
+
+  it('manual entry fallback still allows free-text definitions', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({
+      instance: () =>
+        jsonResponse({ code: 'not_found', message: 'Instance not found' }, 404),
+      start: () =>
+        jsonResponse({
+          run_id: '123e4567-e89b-12d3-a456-426614174103',
+          instance_key: 'manual-instance',
+          trace_id: 'trace-manual-1',
+        }),
+    });
+    renderEngineRunsPage();
+
+    const dialogHeading = await openStartDialog(user);
+    await user.click(screen.getByRole('button', { name: 'Enter manually' }));
+    const form = dialogHeading.closest('form');
+    expect(form).not.toBeNull();
+    const dialog = within(form as HTMLFormElement);
+    const definitionName = dialog.getByLabelText(/^Definition name/);
+    const definitionVersion = dialog.getByLabelText(/^Definition version/);
+    expect(definitionName.tagName).toBe('INPUT');
+    expect(definitionVersion.tagName).toBe('INPUT');
+    await user.type(dialog.getByLabelText(/^Instance key/), 'manual-instance');
+    await user.type(definitionName, 'custom-def');
+    await user.type(definitionVersion, 'v42');
+    const requestKey = (dialog.getByLabelText(/^Idempotency key/) as HTMLInputElement)
+      .value;
+    await user.click(dialog.getByRole('button', { name: 'Start run' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-pathname')).toHaveTextContent(
+        '/traces/trace-manual-1'
+      );
+    });
+    const postCall = fetchMock.mock.calls.find(([input, init]) => {
+      const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+      return (
+        url.pathname === '/v1/engine/runs' &&
+        (init as RequestInit | undefined)?.method === 'POST'
+      );
+    });
+    expect(postCall).toBeDefined();
+    expect(JSON.parse((postCall?.[1] as RequestInit).body as string)).toEqual({
+      instance_key: 'manual-instance',
+      definition_name: 'custom-def',
+      definition_version: 'v42',
+      request_key: requestKey,
+    });
+  });
+
+  it('falls back to manual entry when the definitions endpoint fails', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({
+      definitions: () =>
+        jsonResponse({ code: 'server_error', message: 'boom' }, 500),
+    });
+    renderEngineRunsPage();
+
+    await openStartDialog(user);
+
+    expect(
+      await screen.findByText(
+        /definitions.*(?:unavailable|failed)|(?:could not|unable to) load.*definitions/i
+      )
+    ).toBeInTheDocument();
+    const definitionName = screen.getByLabelText(/^Definition name/);
+    const definitionVersion = screen.getByLabelText(/^Definition version/);
+    expect(definitionName.tagName).toBe('INPUT');
+    expect(definitionVersion.tagName).toBe('INPUT');
+    await user.type(definitionName, 'fallback-def');
+    await user.type(definitionVersion, 'v7');
+    expect(definitionName).toHaveValue('fallback-def');
+    expect(definitionVersion).toHaveValue('v7');
   });
 });

--- a/web/src/pages/EngineRunsPage.tsx
+++ b/web/src/pages/EngineRunsPage.tsx
@@ -309,7 +309,10 @@ function StartEngineRunDialog({
   const versionSuggestions = definitionName
     ? Array.from(definitionVersions.get(definitionName) ?? [])
     : [];
-  const manualOnly = definitionsQuery.isError || definitionsQuery.data?.definitions.length === 0;
+  const definitionsLoading = definitionsQuery.isPending;
+  const manualOnly =
+    !definitionsLoading &&
+    (definitionsQuery.isError || definitionsQuery.data?.definitions.length === 0);
   const manualMode = definitionMode === 'manual' || manualOnly;
   const staleDefinitions = definitions.filter((definition) => !definition.live);
 
@@ -457,7 +460,11 @@ function StartEngineRunDialog({
             <PreflightNotice state={preflight} />
           </FormField>
 
-          {manualOnly ? (
+          {definitionsLoading ? (
+            <div className="text-sm text-[var(--c-text-secondary)]">
+              Loading registered definitions…
+            </div>
+          ) : manualOnly ? (
             <div className="app-alert-warning">
               Definitions unavailable. Enter the definition and version manually.
             </div>
@@ -556,7 +563,7 @@ function StartEngineRunDialog({
                   key={`${definition.definition_name}:${definition.definition_version}`}
                   className="text-xs text-[var(--c-text-muted)]"
                 >
-                  {definition.definition_name} — last published{' '}
+                  {definition.definition_name} · {definition.definition_version} — last published{' '}
                   {formatTimestamp(definition.runtime_published_at)}
                 </p>
               ))}
@@ -588,7 +595,7 @@ function StartEngineRunDialog({
           <Btn kind="secondary" type="button" onClick={onClose}>
             Cancel
           </Btn>
-          <Btn kind="primary" type="submit" disabled={submitting}>
+          <Btn kind="primary" type="submit" disabled={submitting || definitionsLoading}>
             {submitting ? 'Starting…' : 'Start run'}
           </Btn>
         </div>

--- a/web/src/pages/EngineRunsPage.tsx
+++ b/web/src/pages/EngineRunsPage.tsx
@@ -7,6 +7,7 @@ import {
   fetchEngineInstance,
   fetchTraces,
   isAuthError,
+  listEngineDefinitions,
   startEngineRun,
   type EngineRunStatus,
   type JsonValue,
@@ -280,6 +281,7 @@ function StartEngineRunDialog({
   const [instanceKey, setInstanceKey] = useState('');
   const [definitionName, setDefinitionName] = useState('');
   const [definitionVersion, setDefinitionVersion] = useState('');
+  const [definitionMode, setDefinitionMode] = useState<'picker' | 'manual'>('picker');
   const [requestKey, setRequestKey] = useState(generateRequestKey);
   const [inputText, setInputText] = useState('');
   const [fieldError, setFieldError] = useState<string | null>(null);
@@ -293,9 +295,23 @@ function StartEngineRunDialog({
     | { state: 'unknown'; message: string }
   >({ state: 'idle' });
   const [submitting, setSubmitting] = useState(false);
+  const definitionsQuery = useQuery({
+    queryKey: ['engine-definitions', projectId ?? null],
+    queryFn: listEngineDefinitions,
+  });
+  const definitions = definitionsQuery.data?.definitions ?? [];
+  const definitionNames = Array.from(
+    new Set(definitions.map((definition) => definition.definition_name))
+  );
+  const pickerVersions = definitions.filter(
+    (definition) => definition.definition_name === definitionName
+  );
   const versionSuggestions = definitionName
     ? Array.from(definitionVersions.get(definitionName) ?? [])
     : [];
+  const manualOnly = definitionsQuery.isError || definitionsQuery.data?.definitions.length === 0;
+  const manualMode = definitionMode === 'manual' || manualOnly;
+  const staleDefinitions = definitions.filter((definition) => !definition.live);
 
   const runPreflight = async (): Promise<void> => {
     const key = instanceKey.trim();
@@ -346,6 +362,19 @@ function StartEngineRunDialog({
     setFieldError(null);
     setSubmitError(null);
     setDefinitionError(false);
+
+    if (
+      !manualMode &&
+      !definitions.some(
+        (definition) =>
+          definition.live &&
+          definition.definition_name === definitionName &&
+          definition.definition_version === definitionVersion
+      )
+    ) {
+      setFieldError('Select a live definition and version.');
+      return;
+    }
 
     let input: JsonValue | undefined;
     try {
@@ -428,35 +457,111 @@ function StartEngineRunDialog({
             <PreflightNotice state={preflight} />
           </FormField>
 
+          {manualOnly ? (
+            <div className="app-alert-warning">
+              Definitions unavailable. Enter the definition and version manually.
+            </div>
+          ) : (
+            <div>
+              <Btn
+                kind="secondary"
+                size="sm"
+                type="button"
+                onClick={() => setDefinitionMode(manualMode ? 'picker' : 'manual')}
+              >
+                {manualMode ? 'Use picker' : 'Enter manually'}
+              </Btn>
+            </div>
+          )}
+
           <div className="grid gap-4 sm:grid-cols-2">
             <FormField label="Definition name">
-              <input
-                aria-invalid={definitionError}
-                className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
-                value={definitionName}
-                onChange={(event) => handleDefinitionNameChange(event.target.value)}
-                list="engine-definition-names"
-              />
-              <datalist id="engine-definition-names">
-                {Array.from(definitionVersions.keys()).map((name) => (
-                  <option key={name} value={name} />
-                ))}
-              </datalist>
+              {manualMode ? (
+                <>
+                  <input
+                    aria-invalid={definitionError}
+                    className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+                    value={definitionName}
+                    onChange={(event) => handleDefinitionNameChange(event.target.value)}
+                    list="engine-definition-names"
+                  />
+                  <datalist id="engine-definition-names">
+                    {Array.from(definitionVersions.keys()).map((name) => (
+                      <option key={name} value={name} />
+                    ))}
+                  </datalist>
+                </>
+              ) : (
+                <select
+                  aria-invalid={definitionError}
+                  className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+                  value={definitionName}
+                  onChange={(event) => handleDefinitionNameChange(event.target.value)}
+                >
+                  <option value="">Select a definition</option>
+                  {definitionNames.map((name) => {
+                    const live = definitions.some(
+                      (definition) =>
+                        definition.definition_name === name && definition.live
+                    );
+                    return (
+                      <option key={name} value={name} disabled={!live}>
+                        {live ? name : `${name} — not live`}
+                      </option>
+                    );
+                  })}
+                </select>
+              )}
             </FormField>
             <FormField label="Definition version">
-              <input
-                className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
-                value={definitionVersion}
-                onChange={(event) => setDefinitionVersion(event.target.value)}
-                list="engine-definition-versions"
-              />
-              <datalist id="engine-definition-versions">
-                {versionSuggestions.map((version) => (
-                  <option key={version} value={version} />
-                ))}
-              </datalist>
+              {manualMode ? (
+                <>
+                  <input
+                    className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+                    value={definitionVersion}
+                    onChange={(event) => setDefinitionVersion(event.target.value)}
+                    list="engine-definition-versions"
+                  />
+                  <datalist id="engine-definition-versions">
+                    {versionSuggestions.map((version) => (
+                      <option key={version} value={version} />
+                    ))}
+                  </datalist>
+                </>
+              ) : (
+                <select
+                  className="app-input h-9 w-full rounded-md border border-[var(--c-border)] bg-[var(--c-surface)] px-3 text-sm"
+                  value={definitionVersion}
+                  onChange={(event) => setDefinitionVersion(event.target.value)}
+                >
+                  <option value="">Select a version</option>
+                  {pickerVersions.map((definition) => (
+                    <option
+                      key={definition.definition_version}
+                      value={definition.definition_version}
+                      disabled={!definition.live}
+                    >
+                      {definition.definition_version}
+                    </option>
+                  ))}
+                </select>
+              )}
             </FormField>
           </div>
+
+          {!manualMode && staleDefinitions.length > 0 ? (
+            <div className="grid gap-1">
+              {staleDefinitions.map((definition) => (
+                <p
+                  key={`${definition.definition_name}:${definition.definition_version}`}
+                  className="text-xs text-[var(--c-text-muted)]"
+                >
+                  {definition.definition_name} — last published{' '}
+                  {formatTimestamp(definition.runtime_published_at)}
+                </p>
+              ))}
+            </div>
+          ) : null}
 
           <FormField label="Idempotency key" helper="Idempotency key — change only when retrying a prior start.">
             <input


### PR DESCRIPTION
## What / why

The Start Run dialog on the Engine Runs page took `definition_name` / `definition_version` as free text, so users could type a definition the live runtime cannot execute — the exact gap behind the "queued forever" bug (#152). Now that #163 exposes registry truth via `GET /v1/engine/definitions`, the dialog offers a picker over live registered definitions and versions, making start-a-run pick-from-live-list instead of guess-and-type.

## What changed

- `web/src/api/client.ts`: typed `listEngineDefinitions()` plus `EngineDefinition` / `EngineDefinitionListResponse` interfaces mirroring the generated contract types. Plain GET — no engine-preview header, matching the other engine read calls.
- `web/src/pages/EngineRunsPage.tsx` (`StartEngineRunDialog`):
  - Fetches the definition catalog when the dialog opens (`['engine-definitions', projectId]` query).
  - Default mode is a picker: a Definition name `<select>` (one option per registered name; names with no live version are disabled and labeled "— not live") and a Definition version `<select>` scoped to the selected name (non-live versions disabled). Changing the definition resets the version.
  - Stale definitions are visibly distinct: disabled "not live" options plus a per-stale-definition "last published" line from `runtime_published_at`.
  - Picker-mode submit validates that a live definition + version pair is selected before firing the request, so a non-live definition cannot be started through the picker.
  - "Enter manually" / "Use picker" toggle preserves the previous free-text path (with the existing trace-derived datalist suggestions) for advanced users; the dialog auto-falls back to manual entry with a notice when the catalog request fails or returns no definitions.
  - Instance-key preflight, idempotency key, input JSON, and error handling are unchanged.
- `web/e2e/ui-smoke.spec.ts`: mocks `GET /v1/engine/definitions` (live + stale catalog), adds a picker E2E scenario (select live definition/version, assert stale option disabled, assert the POST body uses the picked values, assert navigation to the projected trace), and routes the existing manual-flow smoke through the new toggle.

## Verification

- Acceptance tests were written first and committed red (5a3114e), then implemented against by an independent session: 7 new dialog tests + 2 existing tests updated for the new default mode, all in `web/src/pages/EngineRunsPage.test.tsx`.
- `pnpm --filter web test`: 520/520 pass; `pnpm --filter web lint` and `pnpm --filter web type-check` clean.
- `make generate`: no diff (no contract changes — this consumes #163's endpoint as-is).
- Playwright E2E: 12/12 pass on desktop-chromium and mobile-chromium, including the new picker scenario. One real flake was found and fixed during review: the picker test now settles the instance-key preflight ("Check" + await notice) before submitting, because the blur-triggered preflight notice could shift the footer mid-click and swallow the submit on mobile.

Closes #189


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a definition picker to the “Start run” dialog for selecting live engine definitions and versions.
  * Non-live definitions are clearly labeled and cannot be selected.
  * Added a manual entry option with suggestions when definitions are unavailable or need to be entered directly.
  * Added status details, including last-published information for stale definitions.
  * Added validation to prevent starting runs with unavailable definitions or versions.

* **Bug Fixes**
  * Improved fallback behavior when definition loading fails, allowing runs to be started manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->