### PR TITLE
feat(web): surface and recover quarantined engine runs in the console

### DIFF
--- a/web/e2e/ui-smoke.spec.ts
+++ b/web/e2e/ui-smoke.spec.ts
@@ -671,7 +671,12 @@ test('covers the engine runs console smoke flows', async ({ page }, testInfo) =>
     .locator('xpath=ancestor::section[1]');
   await expect(quarantineBanner.getByText('replay_mismatch', { exact: true })).toBeVisible();
   await expect(quarantineBanner.getByText(QUARANTINE_ERROR_MESSAGE)).toBeVisible();
-  await expect(quarantineBanner.getByText(/activity_scheduled.*timer_started/)).toBeVisible();
+  await expect(
+    quarantineBanner.getByText(
+      'expected activity_scheduled · charge-card, got timer_started · timeout',
+      { exact: true }
+    )
+  ).toBeVisible();
   await expect(page.getByRole('button', { name: 'Resume', exact: true })).toBeEnabled();
 
   const quarantineScreenshot = await page.screenshot({

--- a/web/e2e/ui-smoke.spec.ts
+++ b/web/e2e/ui-smoke.spec.ts
@@ -19,7 +19,11 @@ const SECONDARY_PROJECT_ID = '22222222-2222-2222-2222-222222222222';
 const RUN_LOCALLY_DOCS_URL = 'https://www.continua.in/docs/guides/installation';
 const ENGINE_RUN_ID = '123e4567-e89b-12d3-a456-426614174100';
 const ENGINE_TRACE_ID = 'engine-trace-1';
+const QUARANTINED_ENGINE_RUN_ID = '123e4567-e89b-12d3-a456-426614174101';
+const QUARANTINED_ENGINE_TRACE_ID = 'engine-trace-quarantined';
 const STARTED_ENGINE_TRACE_ID = 'engine-trace-new';
+const QUARANTINE_ERROR_MESSAGE =
+  'expected activity_scheduled charge-card but history has timer_started timeout';
 
 const ENGINE_TRACE = {
   ...TRACE_ONE,
@@ -51,9 +55,42 @@ const ENGINE_TRACE_DETAIL = {
   output: { approved: true },
 };
 
+const QUARANTINED_ENGINE_TRACE = {
+  ...ENGINE_TRACE,
+  id: QUARANTINED_ENGINE_TRACE_ID,
+  name: 'Quarantined checkout workflow',
+  engine: {
+    ...ENGINE_TRACE.engine,
+    run_id: QUARANTINED_ENGINE_RUN_ID,
+    instance_key: 'checkout-quarantined',
+    status: 'QUARANTINED',
+    completed_at: undefined,
+    failure: {
+      error_code: 'replay_mismatch',
+      error_message: QUARANTINE_ERROR_MESSAGE,
+      status: 'QUARANTINED',
+    },
+    wait_state: {
+      kind: 'replay_mismatch',
+      expected_type: 'activity_scheduled',
+      expected_key: 'charge-card',
+      actual_type: 'timer_started',
+      actual_key: 'timeout',
+      detail: 'replay produced a different next event',
+    },
+  },
+};
+
+const QUARANTINED_ENGINE_TRACE_DETAIL = {
+  ...ENGINE_TRACE_DETAIL,
+  ...QUARANTINED_ENGINE_TRACE,
+  trace_id: 'engine-checkout-quarantined',
+};
+
 const TRACE_DETAILS = new Map([
   [TRACE_ONE.id, TRACE_DETAIL],
   [ENGINE_TRACE_ID, ENGINE_TRACE_DETAIL],
+  [QUARANTINED_ENGINE_TRACE_ID, QUARANTINED_ENGINE_TRACE_DETAIL],
   [STARTED_ENGINE_TRACE_ID, { ...ENGINE_TRACE_DETAIL, id: STARTED_ENGINE_TRACE_ID }],
   [
     TRACE_TWO.id,
@@ -302,7 +339,11 @@ async function mockApiRoutes(page: Page, mode: 'operator' | 'public-demo' = 'ope
             total: 1,
           });
         }
-        return fulfillJson(route, { traces: [ENGINE_TRACE], total: 1 });
+        const status = url.searchParams.get('engine_run_status');
+        const traces = [ENGINE_TRACE, QUARANTINED_ENGINE_TRACE].filter(
+          (trace) => !status || trace.engine.status.toLowerCase() === status
+        );
+        return fulfillJson(route, { traces, total: traces.length });
       }
       return fulfillJson(route, filterTraces(url));
     }
@@ -382,6 +423,18 @@ async function mockEngineRoutes(page: Page) {
       return fulfillJson(route, {
         run_id: ENGINE_RUN_ID,
         current_wait: null,
+        activities: [],
+        timers: [],
+        signals: [],
+        pending_activity_tasks: 0,
+        pending_inbox_items: 0,
+      });
+    }
+
+    if (url.pathname === `/v1/engine/runs/${QUARANTINED_ENGINE_RUN_ID}/pending-work`) {
+      return fulfillJson(route, {
+        run_id: QUARANTINED_ENGINE_RUN_ID,
+        current_wait: QUARANTINED_ENGINE_TRACE.engine.wait_state,
         activities: [],
         timers: [],
         signals: [],
@@ -588,8 +641,50 @@ test('covers the engine runs console smoke flows', async ({ page }, testInfo) =>
     `/engine/runs?project_id=${PRIMARY_PROJECT_ID}`
   );
   const engineRunRow = page.getByRole('row').filter({ hasText: 'checkout · v1' });
-  await expect(engineRunRow.getByText('checkout · v1', { exact: true })).toBeVisible();
   await expect(engineRunRow.getByText('Completed', { exact: true })).toBeVisible();
+  const quarantinedRow = page
+    .getByRole('row')
+    .filter({ hasText: 'checkout-quarantined' });
+  await expect(quarantinedRow.getByText('Quarantined', { exact: true })).toBeVisible();
+  await expect(quarantinedRow.getByText(/Replay mismatch/)).toBeVisible();
+
+  const statusFilter = page.getByRole('combobox', { name: 'Engine run status' });
+  const quarantinedRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return (
+      url.pathname === '/api/traces' &&
+      url.searchParams.get('engine_run_status') === 'quarantined'
+    );
+  });
+  await statusFilter.selectOption('quarantined');
+  expect(
+    new URL((await quarantinedRequest).url()).searchParams.get('engine_run_status')
+  ).toBe('quarantined');
+  await expect(page).toHaveURL(/engine_run_status=quarantined/);
+
+  await quarantinedRow
+    .getByRole('link', { name: `Open ${QUARANTINED_ENGINE_TRACE_ID}` })
+    .click();
+  await page.getByRole('button', { name: 'Engine state', exact: true }).click();
+  const quarantineBanner = page
+    .getByRole('heading', { name: 'Run quarantined' })
+    .locator('xpath=ancestor::section[1]');
+  await expect(quarantineBanner.getByText('replay_mismatch', { exact: true })).toBeVisible();
+  await expect(quarantineBanner.getByText(QUARANTINE_ERROR_MESSAGE)).toBeVisible();
+  await expect(quarantineBanner.getByText(/activity_scheduled.*timer_started/)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Resume', exact: true })).toBeEnabled();
+
+  const quarantineScreenshot = await page.screenshot({
+    fullPage: true,
+    animations: 'disabled',
+  });
+  await testInfo.attach(`${testInfo.project.name}-engine-quarantine`, {
+    body: quarantineScreenshot,
+    contentType: 'image/png',
+  });
+
+  await page.goto(`/engine/runs?project_id=${PRIMARY_PROJECT_ID}`);
+  await expect(page.getByRole('heading', { name: 'Engine Runs' })).toBeVisible();
 
   await page.getByRole('button', { name: 'Start run', exact: true }).click();
   const startForm = page

--- a/web/src/components/EngineQuarantineBanner.tsx
+++ b/web/src/components/EngineQuarantineBanner.tsx
@@ -1,0 +1,40 @@
+import type { EngineFailureSummary, EngineWaitState } from '../api/client';
+import { describeEngineWaitState } from '../pages/engineWaitState';
+
+export function EngineQuarantineBanner({
+  failure,
+  waitState,
+}: {
+  failure?: EngineFailureSummary;
+  waitState?: EngineWaitState | null;
+}) {
+  const mismatchSummary =
+    waitState?.kind === 'replay_mismatch'
+      ? describeEngineWaitState(waitState)
+      : null;
+
+  return (
+    <section className="rounded-[1rem] border border-[var(--c-red-border)] bg-[var(--c-red-faint)] px-4 py-3 text-[var(--c-text-primary)]">
+      <h2 className="text-sm font-semibold text-[var(--c-red-text)]">
+        Run quarantined
+      </h2>
+      {failure ? (
+        <div className="mt-2">
+          <div className="font-mono text-xs font-semibold text-[var(--c-red-text)]">
+            {failure.error_code}
+          </div>
+          <p className="mt-1 text-sm leading-6">{failure.error_message}</p>
+        </div>
+      ) : null}
+      {mismatchSummary ? (
+        <p className="mt-2 font-mono text-xs leading-5 text-[var(--c-red-text)]">
+          {mismatchSummary.detail}
+        </p>
+      ) : null}
+      <p className="mt-2 text-sm leading-6">
+        Recover by rolling back the workflow code to the version this run recorded, then use
+        Resume to retry replay. Terminate remains available if the run should not continue.
+      </p>
+    </section>
+  );
+}

--- a/web/src/pages/EngineRunsPage.test.tsx
+++ b/web/src/pages/EngineRunsPage.test.tsx
@@ -37,6 +37,23 @@ const ENGINE_TRACE: Trace = {
   },
 };
 
+const QUARANTINED_ENGINE_TRACE: Trace = {
+  ...ENGINE_TRACE,
+  id: 'engine-trace-quarantined',
+  engine: {
+    ...ENGINE_TRACE.engine!,
+    status: 'QUARANTINED',
+    wait_state: {
+      kind: 'replay_mismatch',
+      expected_type: 'activity_scheduled',
+      expected_key: 'charge-card',
+      actual_type: 'timer_started',
+      actual_key: 'timeout',
+      detail: 'replay produced a different next event',
+    },
+  },
+};
+
 function LocationProbe() {
   const location = useLocation();
   const state = location.state as { returnTo?: string } | null;
@@ -65,7 +82,15 @@ function renderEngineRunsPage(initialEntry = '/engine/runs') {
       <ThemeProvider>
         <MemoryRouter initialEntries={[initialEntry]}>
           <Routes>
-            <Route path="/engine/runs" element={<EngineRunsPage />} />
+            <Route
+              path="/engine/runs"
+              element={
+                <>
+                  <EngineRunsPage />
+                  <LocationProbe />
+                </>
+              }
+            />
             <Route path="/traces/:traceId" element={<LocationProbe />} />
           </Routes>
         </MemoryRouter>
@@ -76,10 +101,12 @@ function renderEngineRunsPage(initialEntry = '/engine/runs') {
 
 function mockEngineRequests({
   traces = [ENGINE_TRACE],
+  total = traces.length,
   instance,
   start,
 }: {
   traces?: Trace[];
+  total?: number;
   instance?: (url: URL, init?: RequestInit) => Promise<Response> | Response;
   start?: (url: URL, init?: RequestInit) => Promise<Response> | Response;
 } = {}) {
@@ -87,7 +114,7 @@ function mockEngineRequests({
     const url = new URL(readRequestUrl(input), 'http://localhost');
 
     if (url.pathname === '/api/traces') {
-      return jsonResponse({ traces, total: traces.length });
+      return jsonResponse({ traces, total });
     }
     if (/^\/v1\/engine\/instances\/[^/]+$/.test(url.pathname) && instance) {
       return instance(url, init);
@@ -136,6 +163,81 @@ describe('EngineRunsPage', () => {
       );
       expect(requestUrl.pathname).toBe('/api/traces');
       expect(requestUrl.searchParams.get('engine_only')).toBe('true');
+    });
+  });
+
+  it('renders quarantined runs with a quarantined status label and mismatch wait summary', async () => {
+    mockEngineRequests({ traces: [QUARANTINED_ENGINE_TRACE] });
+
+    renderEngineRunsPage();
+
+    const table = await screen.findByRole('table');
+    const status = await within(table).findByText('Quarantined');
+    const row = status.closest('tr');
+    expect(row).not.toBeNull();
+    expect(
+      within(row as HTMLTableRowElement).getByText(/Replay mismatch/)
+    ).toBeInTheDocument();
+    expect(
+      within(row as HTMLTableRowElement).queryByText(/Waiting on engine state/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('filters runs by engine status through the URL-driven quarantined filter', async () => {
+    const user = userEvent.setup();
+    mockEngineRequests({ total: DEFAULT_PAGE_SIZE + 1 });
+
+    const firstRender = renderEngineRunsPage();
+
+    await screen.findByText('darklaunch.demo · v1');
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) => {
+          const url = new URL(readRequestUrl(input as RequestInput), 'http://localhost');
+          return (
+            url.pathname === '/api/traces' &&
+            url.searchParams.get('offset') === String(DEFAULT_PAGE_SIZE)
+          );
+        })
+      ).toBe(true);
+    });
+
+    const statusFilter = screen.getByRole('combobox', { name: /status/i });
+    expect(statusFilter).toHaveDisplayValue('All statuses');
+    expect(
+      within(statusFilter).getByRole('option', { name: 'Quarantined' })
+    ).toHaveValue('quarantined');
+
+    await user.selectOptions(statusFilter, 'quarantined');
+
+    await waitFor(() => {
+      const filteredRequest = fetchMock.mock.calls
+        .map(
+          ([input]) =>
+            new URL(readRequestUrl(input as RequestInput), 'http://localhost')
+        )
+        .find((url) => url.searchParams.get('engine_run_status') === 'quarantined');
+      expect(filteredRequest).toBeDefined();
+      expect(['0', null]).toContain(filteredRequest?.searchParams.get('offset'));
+    });
+    expect(
+      new URLSearchParams(
+        screen.getByTestId('probe-search').textContent ?? ''
+      ).get('engine_run_status')
+    ).toBe('quarantined');
+
+    firstRender.unmount();
+    fetchMock.mockClear();
+
+    renderEngineRunsPage('/engine/runs?engine_run_status=quarantined');
+
+    await waitFor(() => {
+      const firstRequest = new URL(
+        readRequestUrl(fetchMock.mock.calls[0]?.[0] as RequestInput),
+        'http://localhost'
+      );
+      expect(firstRequest.searchParams.get('engine_run_status')).toBe('quarantined');
     });
   });
 

--- a/web/src/pages/EngineRunsPage.tsx
+++ b/web/src/pages/EngineRunsPage.tsx
@@ -32,6 +32,11 @@ import {
   buildProjectPath,
   getProjectIdFromSearchParams,
 } from '../utils/projectSearchParams';
+import {
+  ENGINE_RUN_STATUS_FILTER_VALUES,
+  formatEngineRunStatusLabel,
+  type EngineRunStatusFilter,
+} from '../utils/tracesSearchParams';
 
 const EMPTY_TRACES: Trace[] = [];
 
@@ -73,7 +78,14 @@ function formatEngineDefinitionLabel(engine: Trace['engine']): string {
 export function EngineRunsPage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const projectId = getProjectIdFromSearchParams(new URLSearchParams(location.search));
+  const searchParams = new URLSearchParams(location.search);
+  const projectId = getProjectIdFromSearchParams(searchParams);
+  const engineRunStatusCandidate = searchParams.get('engine_run_status');
+  const engineRunStatus = ENGINE_RUN_STATUS_FILTER_VALUES.includes(
+    engineRunStatusCandidate as EngineRunStatusFilter
+  )
+    ? (engineRunStatusCandidate as EngineRunStatusFilter)
+    : undefined;
   const [offset, setOffset] = useState(0);
   const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -81,9 +93,10 @@ export function EngineRunsPage() {
     engine_only: true,
     limit: pageSize,
     offset,
+    ...(engineRunStatus ? { engine_run_status: engineRunStatus } : {}),
   };
   const runsQuery = useQuery({
-    queryKey: ['engine-runs', projectId ?? null, offset, pageSize],
+    queryKey: ['engine-runs', projectId ?? null, engineRunStatus ?? null, offset, pageSize],
     queryFn: () => fetchTraces(queryParams),
     placeholderData: keepPreviousData,
     refetchInterval: 5000,
@@ -122,6 +135,45 @@ export function EngineRunsPage() {
         description={`${traces.length} of ${total} engine-backed traces · auto-refreshing every 5s`}
         title="Engine Runs"
       />
+
+      <div className="flex items-center gap-2 border-b border-[var(--c-border)] px-6 py-2">
+        <label
+          className="text-xs font-medium text-[var(--c-text-secondary)]"
+          htmlFor="engine-run-status"
+        >
+          Status
+        </label>
+        <select
+          id="engine-run-status"
+          aria-label="Engine run status"
+          className="h-7 rounded border border-[var(--c-border)] bg-[var(--c-app-bg)] px-2 text-xs text-[var(--c-text-primary)] outline-none"
+          value={engineRunStatus ?? ''}
+          onChange={(event) => {
+            const nextSearchParams = new URLSearchParams(location.search);
+            if (event.target.value) {
+              nextSearchParams.set('engine_run_status', event.target.value);
+            } else {
+              nextSearchParams.delete('engine_run_status');
+            }
+            nextSearchParams.delete('offset');
+            setOffset(0);
+            navigate({
+              pathname: location.pathname,
+              search: nextSearchParams.toString(),
+            });
+          }}
+        >
+          <option value="">All statuses</option>
+          {ENGINE_RUN_STATUS_FILTER_VALUES.map((value) => (
+            <option
+              key={value}
+              aria-label={formatEngineRunStatusLabel(value)}
+              label={formatEngineRunStatusLabel(value)}
+              value={value}
+            />
+          ))}
+        </select>
+      </div>
 
       {runsQuery.error ? (
         isAuthError(runsQuery.error) ? (

--- a/web/src/pages/TraceDetailPage.test.tsx
+++ b/web/src/pages/TraceDetailPage.test.tsx
@@ -394,6 +394,58 @@ describe('TraceDetailPage', () => {
     expect(screen.getAllByRole('button', { name: 'Signal' })).toHaveLength(1);
   });
 
+  it('explains a quarantined engine run and enables resume from the engine section', async () => {
+    const user = userEvent.setup();
+    const base = createEngineTraceDetail();
+    const errorMessage =
+      'expected activity_scheduled charge-card but history has timer_started timeout';
+    const detail = createEngineTraceDetail({
+      engine: {
+        ...base.engine!,
+        status: 'QUARANTINED',
+        failure: {
+          error_code: 'replay_mismatch',
+          error_message: errorMessage,
+          status: 'QUARANTINED',
+        },
+        wait_state: {
+          kind: 'replay_mismatch',
+          expected_type: 'activity_scheduled',
+          expected_key: 'charge-card',
+          actual_type: 'timer_started',
+          actual_key: 'timeout',
+          detail: 'replay produced a different next event',
+        },
+      },
+    });
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        detail: () => jsonResponse(detail),
+      })
+    );
+
+    renderTraceRoutes([`/traces/${TRACE_ONE.id}`]);
+
+    await user.click(await screen.findByRole('button', { name: 'Engine state' }));
+
+    const bannerHeading = screen.getByRole('heading', { name: 'Run quarantined' });
+    const quarantineBanner = bannerHeading.closest('section, [role="alert"]');
+    expect(quarantineBanner).not.toBeNull();
+    expect(
+      within(quarantineBanner as HTMLElement).getByText(/replay_mismatch/)
+    ).toBeInTheDocument();
+    expect(
+      within(quarantineBanner as HTMLElement).getByText(new RegExp(errorMessage))
+    ).toBeInTheDocument();
+    expect(
+      within(quarantineBanner as HTMLElement).getByText(
+        /rolling back the workflow code/i
+      )
+    ).toHaveTextContent(/Resume/i);
+    expect(screen.getByRole('button', { name: 'Resume' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Suspend' })).toBeDisabled();
+  });
+
   it('counts continued-as-new engine result panes and marks the state closed', async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(

--- a/web/src/pages/engineWaitState.test.ts
+++ b/web/src/pages/engineWaitState.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { describeEngineWaitState } from './engineWaitState';
+
+describe('describeEngineWaitState', () => {
+  it('describes replay mismatch waits with expected and actual event detail', () => {
+    const summary = describeEngineWaitState({
+      kind: 'replay_mismatch',
+      expected_type: 'activity_scheduled',
+      expected_key: 'charge-card',
+      actual_type: 'timer_started',
+      actual_key: 'timeout',
+      detail: 'replay produced a different next event',
+    });
+
+    expect(summary?.heading).toBe('Replay mismatch');
+    expect(summary?.detail).toContain('activity_scheduled');
+    expect(summary?.detail).toContain('timer_started');
+    expect(summary?.heading).not.toBe('Waiting on engine state');
+  });
+
+  it('describes engine invariant waits', () => {
+    const summary = describeEngineWaitState({
+      kind: 'engine_invariant',
+      detail: 'sequence gap detected',
+    });
+
+    expect(summary?.heading).toBe('Engine invariant');
+    expect(summary?.detail).toContain('sequence gap detected');
+  });
+
+  it('keeps the generic engine-state fallback for unknown kinds', () => {
+    const summary = describeEngineWaitState({ kind: 'mystery' });
+
+    expect(summary).toEqual({
+      heading: 'Waiting on engine state',
+      detail: 'mystery',
+    });
+  });
+});

--- a/web/src/pages/engineWaitState.ts
+++ b/web/src/pages/engineWaitState.ts
@@ -38,6 +38,33 @@ export function describeEngineWaitState(
         heading: 'Waiting on child workflow',
         detail: waitState.child_key ?? 'Child workflow completion',
       };
+    case 'replay_mismatch': {
+      const expectedType =
+        typeof waitState.expected_type === 'string' ? waitState.expected_type : null;
+      const expectedKey =
+        typeof waitState.expected_key === 'string' ? waitState.expected_key : null;
+      const actualType =
+        typeof waitState.actual_type === 'string' ? waitState.actual_type : null;
+      const actualKey =
+        typeof waitState.actual_key === 'string' ? waitState.actual_key : null;
+      const detail = typeof waitState.detail === 'string' ? waitState.detail : null;
+
+      return {
+        heading: 'Replay mismatch',
+        detail:
+          expectedType && expectedKey && actualType && actualKey
+            ? `expected ${expectedType} · ${expectedKey}, got ${actualType} · ${actualKey}`
+            : (detail ?? 'Replay produced a different event'),
+      };
+    }
+    case 'engine_invariant':
+      return {
+        heading: 'Engine invariant',
+        detail:
+          typeof waitState.detail === 'string'
+            ? waitState.detail
+            : 'Engine state invariant failed',
+      };
     default:
       return {
         heading: 'Waiting on engine state',

--- a/web/src/pages/traceDetail/TraceEngineSection.tsx
+++ b/web/src/pages/traceDetail/TraceEngineSection.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../api/client';
 import { Btn, Chip } from '../../components/DebuggerKit';
 import { EngineProjectionBanner } from '../../components/EngineProjectionBanner';
+import { EngineQuarantineBanner } from '../../components/EngineQuarantineBanner';
 import {
   buildEngineStateMachine,
   isTerminalEngineStatus,
@@ -142,6 +143,9 @@ export function TraceEngineSection() {
 
         <div className="mt-4 space-y-3">
           <EngineControlBar engine={engine} traceId={traceId} />
+          {engine.status === 'QUARANTINED' ? (
+            <EngineQuarantineBanner failure={engine.failure} waitState={waitState} />
+          ) : null}
           <EngineProjectionBanner projectionState={engine.projection_state} />
         </div>
 

--- a/web/src/utils/engineStateMachine.test.ts
+++ b/web/src/utils/engineStateMachine.test.ts
@@ -26,7 +26,12 @@ describe('buildEngineStateMachine', () => {
   it('flags waiting, suspended, and quarantined runs as a warned waiting step', () => {
     for (const status of ['WAITING', 'SUSPENDED', 'QUARANTINED'] as const) {
       const steps = buildEngineStateMachine(status as EngineRunStatus);
-      expect(steps[2]).toMatchObject({ current: true, warn: true, done: true });
+      expect(steps[2]).toMatchObject({
+        label: status === 'QUARANTINED' ? 'Quarantined' : 'Waiting',
+        current: true,
+        warn: true,
+        done: true,
+      });
     }
   });
 

--- a/web/src/utils/engineStateMachine.ts
+++ b/web/src/utils/engineStateMachine.ts
@@ -24,7 +24,7 @@ export function buildEngineStateMachine(status: EngineRunStatus): StateMachineSt
     },
     {
       id: 'waiting',
-      label: 'Waiting',
+      label: status === 'QUARANTINED' ? 'Quarantined' : 'Waiting',
       done: isClosed || isWaiting,
       current: isWaiting,
       warn: isWaiting,


### PR DESCRIPTION
## What / why

Closes #188.

#155 quarantines replay-mismatch runs instead of failing them terminally, but the debugger console had no way to see why a run was quarantined, filter for quarantined runs, or guide the operator to recovery. This PR makes that backend capability usable from the UI.

## What changed

- **Wait-state descriptions** (`web/src/pages/engineWaitState.ts`): `describeEngineWaitState` now understands the `replay_mismatch` wait payload (renders `expected <type> · <key>, got <type> · <key>`) and `engine_invariant` (renders the invariant detail), instead of falling back to the generic "Waiting on engine state" summary.
- **State machine** (`web/src/utils/engineStateMachine.ts`): a quarantined run's lifecycle step is now labeled **Quarantined** (still the warned waiting step) so it reads correctly at a glance.
- **Engine Runs page** (`web/src/pages/EngineRunsPage.tsx`): new URL-driven **status filter** (`?engine_run_status=...`) reusing the shared filter values/labels from `tracesSearchParams`; the selected status is sent to `GET /api/traces`, included in the query key, and resets pagination. Quarantined rows show the Quarantined status and the mismatch wait summary.
- **Quarantine banner** (`web/src/components/EngineQuarantineBanner.tsx`, rendered by `TraceEngineSection`): for quarantined runs, the Engine state tab shows the failure code + message, the expected-vs-actual mismatch line, and recovery guidance ("roll back the workflow code to the recorded version, then Resume; Terminate remains available"). Resume was already enabled for quarantined runs by #155's control-bar change.

No contract changes — the API already exposes `engine_run_status` filtering and the quarantine failure/wait payloads.

## How it was built and verified

- TDD with author/implementer separation: acceptance tests were written and committed red first (7af0584), then implemented by an independent session (dba204b) against them, unmodified (verified by diff).
- `pnpm --filter web test`: full suite green (64 files, 519 tests), including the new coverage: wait-state descriptions, quarantined state-machine label, runs-page badge + URL-driven filter (param sent, offset reset, URL hydration), and the trace-detail banner with Resume enabled / Suspend disabled.
- `pnpm --filter web lint` and type-check green.
- Playwright e2e (`web/e2e/ui-smoke.spec.ts`) extended with a quarantined-run scenario: runs-page row + filter request/URL assertions, trace-detail banner content, enabled Resume, plus a full-page screenshot attachment. Full suite passes 10/10 on desktop + mobile projects.
- Generated files untouched; `git status` clean of generated paths.