### PR TITLE
refactor(engine): remove dead inbox claim path and unguarded UpdateRunStatus wrapper

### DIFF
--- a/engine/db/gen/go/inbox.sql.go
+++ b/engine/db/gen/go/inbox.sql.go
@@ -13,55 +13,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const claimNextInboxItem = `-- name: ClaimNextInboxItem :one
-UPDATE engine.inbox
-SET status = 'claimed',
-    claimed_by = $1,
-    claimed_at = NOW(),
-    lease_expires_at = NOW() + ($2::bigint * INTERVAL '1 microsecond'),
-    updated_at = NOW()
-WHERE id = (
-    SELECT id
-    FROM engine.inbox
-    WHERE (status = 'pending' AND available_at <= NOW())
-       OR (status = 'claimed' AND lease_expires_at IS NOT NULL AND lease_expires_at < NOW())
-    ORDER BY available_at ASC, ordinal ASC
-    LIMIT 1
-    FOR UPDATE SKIP LOCKED
-)
-RETURNING id, project_id, instance_id, run_id, history_id, kind, payload, status, available_at, claimed_by, claimed_at, lease_expires_at, dedupe_key, resolved_at, created_at, updated_at, ordinal
-`
-
-type ClaimNextInboxItemParams struct {
-	ClaimedBy           *string `json:"claimed_by"`
-	LeaseDurationMicros int64   `json:"lease_duration_micros"`
-}
-
-func (q *Queries) ClaimNextInboxItem(ctx context.Context, arg ClaimNextInboxItemParams) (EngineInbox, error) {
-	row := q.db.QueryRow(ctx, claimNextInboxItem, arg.ClaimedBy, arg.LeaseDurationMicros)
-	var i EngineInbox
-	err := row.Scan(
-		&i.ID,
-		&i.ProjectID,
-		&i.InstanceID,
-		&i.RunID,
-		&i.HistoryID,
-		&i.Kind,
-		&i.Payload,
-		&i.Status,
-		&i.AvailableAt,
-		&i.ClaimedBy,
-		&i.ClaimedAt,
-		&i.LeaseExpiresAt,
-		&i.DedupeKey,
-		&i.ResolvedAt,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.Ordinal,
-	)
-	return i, err
-}
-
 const clearInboxHistoryByRun = `-- name: ClearInboxHistoryByRun :execrows
 UPDATE engine.inbox
 SET history_id = NULL,

--- a/engine/db/gen/go/runs.sql.go
+++ b/engine/db/gen/go/runs.sql.go
@@ -1244,61 +1244,6 @@ func (q *Queries) TransitionRunToWaiting(ctx context.Context, arg TransitionRunT
 	return i, err
 }
 
-const updateRunStatus = `-- name: UpdateRunStatus :one
-UPDATE engine.runs
-SET status = $2,
-    last_error_code = $3,
-    last_error_message = $4,
-    updated_at = NOW()
-WHERE id = $1
-RETURNING id, project_id, instance_id, run_number, definition_version, status, ready_at, attempt_count, last_error_code, last_error_message, claimed_by, claimed_at, lease_expires_at, created_at, updated_at, result, custom_status, waiting_for, completed_at, continued_from_run_id, continued_to_run_id, parent_run_id, root_run_id, child_key, child_depth
-`
-
-type UpdateRunStatusParams struct {
-	ID               uuid.UUID                `json:"id"`
-	Status           EngineRunLifecycleStatus `json:"status"`
-	LastErrorCode    *string                  `json:"last_error_code"`
-	LastErrorMessage *string                  `json:"last_error_message"`
-}
-
-func (q *Queries) UpdateRunStatus(ctx context.Context, arg UpdateRunStatusParams) (EngineRun, error) {
-	row := q.db.QueryRow(ctx, updateRunStatus,
-		arg.ID,
-		arg.Status,
-		arg.LastErrorCode,
-		arg.LastErrorMessage,
-	)
-	var i EngineRun
-	err := row.Scan(
-		&i.ID,
-		&i.ProjectID,
-		&i.InstanceID,
-		&i.RunNumber,
-		&i.DefinitionVersion,
-		&i.Status,
-		&i.ReadyAt,
-		&i.AttemptCount,
-		&i.LastErrorCode,
-		&i.LastErrorMessage,
-		&i.ClaimedBy,
-		&i.ClaimedAt,
-		&i.LeaseExpiresAt,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.Result,
-		&i.CustomStatus,
-		&i.WaitingFor,
-		&i.CompletedAt,
-		&i.ContinuedFromRunID,
-		&i.ContinuedToRunID,
-		&i.ParentRunID,
-		&i.RootRunID,
-		&i.ChildKey,
-		&i.ChildDepth,
-	)
-	return i, err
-}
-
 const wakeWaitingChildWorkflowRun = `-- name: WakeWaitingChildWorkflowRun :one
 UPDATE engine.runs
 SET status = 'queued',

--- a/engine/db/queries/inbox.sql
+++ b/engine/db/queries/inbox.sql
@@ -12,24 +12,6 @@ INSERT INTO engine.inbox (
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING *;
 
--- name: ClaimNextInboxItem :one
-UPDATE engine.inbox
-SET status = 'claimed',
-    claimed_by = sqlc.arg(claimed_by),
-    claimed_at = NOW(),
-    lease_expires_at = NOW() + (sqlc.arg(lease_duration_micros)::bigint * INTERVAL '1 microsecond'),
-    updated_at = NOW()
-WHERE id = (
-    SELECT id
-    FROM engine.inbox
-    WHERE (status = 'pending' AND available_at <= NOW())
-       OR (status = 'claimed' AND lease_expires_at IS NOT NULL AND lease_expires_at < NOW())
-    ORDER BY available_at ASC, ordinal ASC
-    LIMIT 1
-    FOR UPDATE SKIP LOCKED
-)
-RETURNING *;
-
 -- name: ListPendingInboxByRun :many
 SELECT *
 FROM engine.inbox

--- a/engine/db/queries/runs.sql
+++ b/engine/db/queries/runs.sql
@@ -101,15 +101,6 @@ WHERE instance_id = $1
 ORDER BY run_number DESC, id DESC
 LIMIT 1;
 
--- name: UpdateRunStatus :one
-UPDATE engine.runs
-SET status = $2,
-    last_error_code = $3,
-    last_error_message = $4,
-    updated_at = NOW()
-WHERE id = $1
-RETURNING *;
-
 -- name: TransitionRunToWaiting :one
 UPDATE engine.runs
 SET status = 'waiting',

--- a/engine/internal/store/inbox.go
+++ b/engine/internal/store/inbox.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -20,17 +19,6 @@ func (o *storeOps) CreateInboxItem(ctx context.Context, arg enginedb.CreateInbox
 		return err
 	})
 	return mapResult(inbox, err)
-}
-
-func (o *storeOps) ClaimNextInboxItem(
-	ctx context.Context,
-	workerID string,
-	leaseDuration time.Duration,
-) (enginedb.EngineInbox, error) {
-	return mapResult(o.q.ClaimNextInboxItem(ctx, enginedb.ClaimNextInboxItemParams{
-		ClaimedBy:           nullableWorkerID(workerID),
-		LeaseDurationMicros: leaseDurationMicros(leaseDuration),
-	}))
 }
 
 func (o *storeOps) ListPendingInboxByRun(

--- a/engine/internal/store/inbox_ordering_test.go
+++ b/engine/internal/store/inbox_ordering_test.go
@@ -23,23 +23,6 @@ func TestListPendingInboxByRunFIFOOnAvailableAtTie(t *testing.T) {
 	assertInboxPayloadIdxSequence(t, "ListPendingInboxByRun", items)
 }
 
-func TestClaimNextInboxItemFIFOOnAvailableAtTie(t *testing.T) {
-	ts := newTestStore(t)
-	run := createInboxOrderingRun(t, ts, "claim-next")
-	insertInboxOrderingItems(t, ts, run, "signal")
-
-	items := make([]enginedb.EngineInbox, 0, inboxOrderingItemCount)
-	for range inboxOrderingItemCount {
-		item, err := ts.store.ClaimNextInboxItem(ts.ctx, "worker-fifo", time.Minute)
-		if err != nil {
-			t.Fatalf("ClaimNextInboxItem() error = %v", err)
-		}
-		items = append(items, item)
-	}
-
-	assertInboxPayloadIdxSequence(t, "ClaimNextInboxItem", items)
-}
-
 func TestListOpenInboxItemsByRunAndKindFIFOOnAvailableAtTie(t *testing.T) {
 	ts := newTestStore(t)
 	run := createInboxOrderingRun(t, ts, "list-open-kind")

--- a/engine/internal/store/leases_test.go
+++ b/engine/internal/store/leases_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 
 	enginedb "github.com/continua-ai/continua/engine/db/gen/go"
-	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
 )
 
 func TestClaimNextRunLeaseLifecycle(t *testing.T) {
@@ -412,56 +411,5 @@ func (ts *testStore) expireRemoteLeaseTestTask(t *testing.T, taskID uuid.UUID) {
 		WHERE id = $1
 	`, taskID); err != nil {
 		t.Fatalf("expire remote activity lease: %v", err)
-	}
-}
-
-func TestClaimNextInboxItemLeaseLifecycle(t *testing.T) {
-	ts := newTestStore(t)
-	projectID := uuidOrFatal(t)
-	instance := ts.createInstance(t, projectID, "instance-inbox")
-	run := ts.createRun(t, instance, 1)
-	history := ts.createHistory(t, projectID, instance.ID, run.ID, 1, "signal.received")
-
-	inbox, err := ts.store.CreateInboxItem(ts.ctx, enginedb.CreateInboxItemParams{
-		ProjectID:   projectID,
-		InstanceID:  instance.ID,
-		RunID:       enginetest.NullableUUID(run.ID),
-		HistoryID:   &history.ID,
-		Kind:        "signal",
-		Payload:     []byte(`{"name":"wake"}`),
-		AvailableAt: time.Now().Add(-time.Minute),
-		DedupeKey:   enginetest.Ptr("signal-1"),
-	})
-	if err != nil {
-		t.Fatalf("CreateInboxItem() error = %v", err)
-	}
-
-	claimed, err := ts.store.ClaimNextInboxItem(ts.ctx, "worker-a", time.Minute)
-	if err != nil {
-		t.Fatalf("ClaimNextInboxItem() error = %v", err)
-	}
-	if claimed.ID != inbox.ID || claimed.Status != enginedb.EngineInboxStatusClaimed {
-		t.Fatalf("expected claimed inbox item %s in claimed status, got %+v", inbox.ID, claimed)
-	}
-
-	_, err = ts.store.ClaimNextInboxItem(ts.ctx, "worker-b", time.Minute)
-	if !errors.Is(err, ErrNotFound) {
-		t.Fatalf("expected active lease to block duplicate inbox claim, got %v", err)
-	}
-
-	if _, err := ts.db.Pool.Exec(ts.ctx, `
-		UPDATE engine.inbox
-		SET lease_expires_at = NOW() - INTERVAL '1 minute'
-		WHERE id = $1
-	`, inbox.ID); err != nil {
-		t.Fatalf("expire inbox lease: %v", err)
-	}
-
-	reclaimed, err := ts.store.ClaimNextInboxItem(ts.ctx, "worker-c", time.Minute)
-	if err != nil {
-		t.Fatalf("ClaimNextInboxItem() reclaim error = %v", err)
-	}
-	if reclaimed.ID != inbox.ID {
-		t.Fatalf("expected reclaimed inbox item %s, got %s", inbox.ID, reclaimed.ID)
 	}
 }

--- a/engine/internal/store/runs.go
+++ b/engine/internal/store/runs.go
@@ -55,13 +55,6 @@ func (o *storeOps) ListRunsByInstance(
 	return o.q.ListRunsByInstance(ctx, arg)
 }
 
-func (o *storeOps) UpdateRunStatus(
-	ctx context.Context,
-	arg enginedb.UpdateRunStatusParams,
-) (enginedb.EngineRun, error) {
-	return mapResult(o.q.UpdateRunStatus(ctx, arg))
-}
-
 func (o *storeOps) TransitionRunToWaiting(
 	ctx context.Context,
 	arg enginedb.TransitionRunToWaitingParams,

--- a/engine/internal/store/store_surface_test.go
+++ b/engine/internal/store/store_surface_test.go
@@ -1,0 +1,37 @@
+package store
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRunsQueriesHaveNoUnguardedStatusWrite(t *testing.T) {
+	assertQueryMarkerAbsent(
+		t,
+		"../../db/queries/runs.sql",
+		"-- name: UpdateRunStatus",
+		"every run-state mutation must go through the CAS-guarded Transition*/Wake*/Claim* queries; an unguarded status write bypasses the claimed_by/status CAS discipline",
+	)
+}
+
+func TestInboxQueriesHaveNoDeadClaimPath(t *testing.T) {
+	assertQueryMarkerAbsent(
+		t,
+		"../../db/queries/inbox.sql",
+		"-- name: ClaimNextInboxItem",
+		"inbox consumption happens via ListPendingInboxByRun inside workflow activations; the standalone claim/lease path is dead surface",
+	)
+}
+
+func assertQueryMarkerAbsent(t *testing.T, path, marker, invariant string) {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if strings.Contains(string(contents), marker) {
+		t.Fatalf("%s contains %q: %s", path, marker, invariant)
+	}
+}


### PR DESCRIPTION
## What / why

Removes two dead pieces of engine store surface identified in the GA gap analysis (#179):

- **`ClaimNextInboxItem`** (query + store wrapper): no runtime callers. Inbox consumption
  actually happens via `ListPendingInboxByRun` inside workflow activations; the standalone
  claim/lease path was never wired in.
- **`UpdateRunStatus`** (query + store wrapper): an unguarded status write with no status
  precondition and no `claimed_by` CAS — unlike every real transition. Zero callers, and a
  foot-gun if future code ever picked it up.

After this change, the store surface only contains operations the runtime actually uses, and
every run-state mutation goes through the CAS-guarded `Transition*`/`Wake*`/`Claim*` queries.

## Scope decision

The inbox claim/lease **columns stay**: they are referenced by live queries
(`MarkInboxProcessed`, `CountOpenInboxByRun`, …) and an index in the immutable foundation
migration, so dropping them would turn a size:S code removal into schema surgery. The issue
explicitly allows the leave-columns-remove-code branch.

## Changes

- Delete the `ClaimNextInboxItem` query from `engine/db/queries/inbox.sql` and its wrapper in `engine/internal/store/inbox.go`.
- Delete the `UpdateRunStatus` query from `engine/db/queries/runs.sql` and its wrapper in `engine/internal/store/runs.go`.
- `make generate` regenerates `engine/db/gen/go` (no hand edits).
- Remove the two tests whose sole subject was the deleted claim path (`TestClaimNextInboxItemLeaseLifecycle`, `TestClaimNextInboxItemFIFOOnAvailableAtTie`); live-path FIFO coverage (`TestListPendingInboxByRunFIFOOnAvailableAtTie`) is untouched.
- Add `engine/internal/store/store_surface_test.go`: two absence-guard tests that fail if the `UpdateRunStatus` / `ClaimNextInboxItem` query markers ever reappear in the sqlc sources — committed red first (TDD), green after the removal.

## Verification

- `make generate` leaves a clean tree.
- `go test ./engine/...` green against a real Postgres (full engine suite exercises real workflow runs through the store).
- `make lint` clean.
- Grep confirms zero references to either symbol outside the guard tests.
- Net −182 lines; pure deletion, no behavior change to any live path.

Closes #179
