### PR TITLE
test(engine): drift guard for engine writes into public.traces (projection schema contract)

### DIFF
--- a/engine/pkg/projection/schema_contract.go
+++ b/engine/pkg/projection/schema_contract.go
@@ -1,6 +1,27 @@
 package projection
 
-// TraceEngineColumns declares the engine_* columns of public.traces that the
-// projection Writer's SQL depends on, mapped to their expected
-// information_schema.columns.data_type values.
-var TraceEngineColumns = map[string]string{}
+// TraceEngineColumns is the projection schema contract for the engine-to-platform
+// seam: the Writer in this package owns all engine writes into public.traces.
+// Migrations 000013, 000014, 000015 (as altered by 000016), and 000021 own these
+// columns. Any platform migration that adds, renames, or retypes an engine_*
+// column on traces must update this manifest; schema_guard_test.go enforces the
+// contract in both directions.
+var TraceEngineColumns = map[string]string{
+	"engine_run_id":                    "uuid",
+	"engine_definition_name":           "text",
+	"engine_definition_version":        "text",
+	"engine_projection_state":          "text",
+	"engine_latest_history_id":         "bigint",
+	"engine_last_projected_history_id": "bigint",
+	"engine_projection_updated_at":     "timestamp with time zone",
+	"engine_instance_key":              "text",
+	"engine_run_status":                "text",
+	"engine_custom_status":             "jsonb",
+	"engine_wait_state":                "jsonb",
+	"engine_pending_activity_tasks":    "bigint",
+	"engine_pending_inbox_items":       "bigint",
+	"engine_parent_run_id":             "uuid",
+	"engine_root_run_id":               "uuid",
+	"engine_child_key":                 "text",
+	"engine_child_depth":               "integer",
+}

--- a/engine/pkg/projection/schema_contract.go
+++ b/engine/pkg/projection/schema_contract.go
@@ -1,0 +1,6 @@
+package projection
+
+// TraceEngineColumns declares the engine_* columns of public.traces that the
+// projection Writer's SQL depends on, mapped to their expected
+// information_schema.columns.data_type values.
+var TraceEngineColumns = map[string]string{}

--- a/engine/pkg/projection/schema_guard_test.go
+++ b/engine/pkg/projection/schema_guard_test.go
@@ -1,0 +1,126 @@
+package projection_test
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	enginetest "github.com/continua-ai/continua/engine/internal/testutil"
+	"github.com/continua-ai/continua/engine/pkg/projection"
+)
+
+func TestTraceEngineColumnManifestMatchesDatabase(t *testing.T) {
+	db := enginetest.NewTestDatabase(t)
+
+	rows, err := db.Pool.Query(context.Background(), `
+		SELECT column_name, data_type
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND table_name = 'traces'
+		  AND column_name LIKE 'engine\_%'
+	`)
+	if err != nil {
+		t.Fatalf("query public.traces engine columns: %v", err)
+	}
+	defer rows.Close()
+
+	databaseColumns := make(map[string]string)
+	for rows.Next() {
+		var columnName string
+		var dataType string
+		if err := rows.Scan(&columnName, &dataType); err != nil {
+			t.Fatalf("scan public.traces engine column: %v", err)
+		}
+		databaseColumns[columnName] = dataType
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read public.traces engine columns: %v", err)
+	}
+
+	if len(projection.TraceEngineColumns) == 0 {
+		t.Error("the projection schema contract must declare the engine_* columns of public.traces")
+	}
+
+	for columnName, wantType := range projection.TraceEngineColumns {
+		gotType, ok := databaseColumns[columnName]
+		if !ok {
+			t.Errorf("manifest column %q does not exist in public.traces (want data_type %q)", columnName, wantType)
+			continue
+		}
+		if gotType != wantType {
+			t.Errorf("public.traces column %q data_type = %q, want %q", columnName, gotType, wantType)
+		}
+	}
+
+	for columnName, gotType := range databaseColumns {
+		_, ok := projection.TraceEngineColumns[columnName]
+		if !ok {
+			t.Errorf("public.traces column %q with data_type %q is not declared in projection.TraceEngineColumns", columnName, gotType)
+		}
+	}
+}
+
+func TestProjectionSQLReferencesOnlyManifestColumns(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	packageDir := filepath.Dir(testFile)
+
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		t.Fatalf("read projection package directory: %v", err)
+	}
+
+	engineColumnPattern := regexp.MustCompile(`(^|[^a-z0-9_])(engine_[a-z0-9_]+)`)
+	undeclared := make(map[string]struct{})
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+
+		path := filepath.Join(packageDir, entry.Name())
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", entry.Name(), err)
+		}
+
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			literal, ok := node.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				return true
+			}
+
+			value, err := strconv.Unquote(literal.Value)
+			if err != nil {
+				t.Fatalf("unquote string literal in %s: %v", entry.Name(), err)
+			}
+			for _, match := range engineColumnPattern.FindAllStringSubmatch(value, -1) {
+				columnName := match[2]
+				if _, declared := projection.TraceEngineColumns[columnName]; !declared {
+					undeclared[entry.Name()+": "+columnName] = struct{}{}
+				}
+			}
+			return true
+		})
+	}
+
+	if len(undeclared) > 0 {
+		found := make([]string, 0, len(undeclared))
+		for occurrence := range undeclared {
+			found = append(found, occurrence)
+		}
+		sort.Strings(found)
+		t.Fatalf("projection SQL references engine_* columns missing from projection.TraceEngineColumns:\n%s", strings.Join(found, "\n"))
+	}
+}


### PR DESCRIPTION
## What / why

The engine module writes the platform-owned `public.traces` table via raw SQL in
`engine/pkg/projection` (shell upserts, run-status updates, projection-state control), while that
table's schema is owned by platform migrations in a separate Go module with a separate sqlc config.
A platform migration renaming or retyping an `engine_*` column therefore produced no compile-time
or test signal inside the engine module — it failed at runtime in the projector. This PR turns that
implicit coupling into an explicit, CI-enforced contract.

## What was implemented

- `engine/pkg/projection/schema_contract.go` — `TraceEngineColumns`, an explicit manifest of all
  17 `engine_*` columns of `public.traces` mapped to their `information_schema` data types,
  documented with the owning migrations (000013, 000014, 000015 as altered by 000016, 000021) and
  the rule that any migration touching these columns must update the manifest.
- `engine/pkg/projection/schema_guard_test.go` —
  - `TestTraceEngineColumnManifestMatchesDatabase` provisions a fresh database with platform +
    engine migrations (via `engine/internal/testutil`) and checks manifest vs
    `information_schema.columns` in both directions: a missing column, an extra/renamed column, or
    a type mismatch each fail naming the exact column.
  - `TestProjectionSQLReferencesOnlyManifestColumns` parses the projection package's Go string
    literals (`go/ast`, literals only, boundary-aware matching so comments and constraint names
    cannot false-positive) and asserts every `engine_*` column the Writer SQL references is
    declared in the manifest.

No migrations, no generated-code changes, no writer SQL changes.

## Verification

- TDD with author/implementer separation: the tests landed first (7603a4c) and were verified red
  against the empty scaffold manifest (all 17 columns reported undeclared by a real database run);
  the implementation (6d41a33) turned them green without modifying the tests.
- Negative proof that the guard fires: temporarily adding a bogus manifest column and retyping
  `engine_child_depth` to `bigint` failed the DB-backed test naming exactly those columns;
  reverted and confirmed green.
- `make generate` clean; full `go test ./engine/...` green.

Closes #180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added contract tests to ensure every engine-generated `engine_*` trace column is present in `public.traces` with the expected SQL type.
  * Added checks to fail on any extra or missing `engine_*` columns in the database.
  * Added safeguards to ensure projection logic only references approved `engine_*` columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->