### PR TITLE
Extend the warm theme across the Continua console

### DIFF
--- a/web/public/assets/logo-wordmark.svg
+++ b/web/public/assets/logo-wordmark.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" fill="none">
   <defs>
     <linearGradient id="cont-grad-w" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0075d6"></stop>
-      <stop offset="1" stop-color="#005cab"></stop>
+      <stop offset="0" stop-color="#e99a4d"></stop>
+      <stop offset="1" stop-color="#c96a26"></stop>
     </linearGradient>
   </defs>
   <g transform="translate(0, -4)">
@@ -11,5 +11,5 @@
     <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-w)"></circle>
     <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-w)"></circle>
   </g>
-  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" letter-spacing="-1.2" fill="#0f172a">Continua</text>
+  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" letter-spacing="-1.2" fill="#19140f">Continua</text>
 </svg>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-favicon-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0075d6"/>
-      <stop offset="1" stop-color="#005cab"/>
+      <stop offset="0" stop-color="#e99a4d"/>
+      <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
   <rect width="64" height="64" rx="14" fill="url(#cont-favicon-grad)"/>

--- a/web/public/logo.svg
+++ b/web/public/logo.svg
@@ -2,8 +2,8 @@
 
   <defs>
     <linearGradient id="cont-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0075d6"></stop>
-      <stop offset="1" stop-color="#005cab"></stop>
+      <stop offset="0" stop-color="#e99a4d"></stop>
+      <stop offset="1" stop-color="#c96a26"></stop>
     </linearGradient>
   </defs>
 

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -217,6 +217,7 @@ describe('AppShell', () => {
     expect(await screen.findByDisplayValue('Primary Project')).toBeInTheDocument();
     expect(screen.getByText('operator@continua.dev')).toBeInTheDocument();
     expect(screen.getByText('Session list content')).toBeInTheDocument();
+    expect(screen.getByText('Session list content').closest('.console-theme')).not.toBeNull();
 
     const primaryNav = screen.getByRole('navigation', { name: 'Primary' });
     expect(within(primaryNav).getByText('Overview').closest('a')).toHaveAttribute(

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -349,7 +349,7 @@ export function AppShell() {
   );
 
   return (
-    <div className="app-shell-enter min-h-screen bg-[var(--c-app-bg)] text-[var(--c-text-primary)]">
+    <div className="console-theme app-shell-enter min-h-screen bg-[var(--c-app-bg)] text-[var(--c-text-primary)]">
       <ConsoleSidebar
         email={user?.email}
         isPublicDemo={isPublicDemo}
@@ -387,7 +387,7 @@ export function AppShell() {
             className="absolute inset-0 bg-slate-950/40 backdrop-blur-sm"
             onClick={() => setMobileOpen(false)}
           />
-          <aside className="app-drawer-enter relative flex h-full w-[19rem] max-w-[88vw] flex-col border-r border-[var(--c-border)] bg-[var(--c-sidebar-bg)]">
+          <aside className="console-sidebar app-drawer-enter relative flex h-full w-[19rem] max-w-[88vw] flex-col border-r border-[var(--c-border)]">
             <div className="flex items-center justify-between border-b border-[var(--c-border)] p-4">
               <BrandBlock />
               <button
@@ -450,7 +450,7 @@ function ConsoleSidebar({
   selectedProjectName?: string;
 }) {
   return (
-    <aside className="fixed inset-y-0 left-0 z-50 hidden w-56 flex-col border-r border-[var(--c-border)] bg-[var(--c-sidebar-bg)] md:flex">
+    <aside className="console-sidebar fixed inset-y-0 left-0 z-50 hidden w-56 flex-col border-r border-[var(--c-border)] md:flex">
       <div className="border-b border-[var(--c-border)] px-4 py-3.5">
         <BrandBlock />
       </div>
@@ -482,11 +482,13 @@ function BrandBlock() {
       aria-label="Go to landing page"
       className="flex min-w-0 items-center gap-2.5 rounded-md outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-[var(--c-focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--c-sidebar-bg)]"
     >
-      <img
-        alt=""
-        className="h-[22px] w-[22px] shrink-0"
-        src="/logo.svg"
-      />
+      <span className="console-brand-mark flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
+        <img
+          alt=""
+          className="h-[20px] w-[20px]"
+          src="/logo.svg"
+        />
+      </span>
       <div className="min-w-0 leading-none">
         <div className="truncate text-[13px] font-bold text-[var(--c-text-primary)]">
           Continua
@@ -546,7 +548,7 @@ function SidebarProjectSwitcher({
           </option>
         ))}
       </select>
-      <span className="absolute left-2 top-2 h-4 w-4 rounded-[3px] bg-gradient-to-br from-[#0075d6] to-[#79b4f5]" />
+      <span className="absolute left-2 top-2 h-4 w-4 rounded-[3px] border border-[var(--c-accent-border)] bg-[var(--c-accent)]" />
       <ChevronDown className="pointer-events-none absolute right-2 top-2 h-4 w-4 text-[var(--c-text-muted)]" />
       {!selectedProjectName && projectsQueryPending ? null : null}
     </label>
@@ -609,7 +611,7 @@ function SidebarNavLink({
       to={buildProjectPath(item.path, projectId)}
       end={item.path === '/dashboard'}
       className={({ isActive }) =>
-        `mb-0.5 flex items-center gap-2.5 rounded-[5px] px-2.5 py-1.5 text-[13px] font-medium transition ${
+        `console-nav-link mb-0.5 flex items-center gap-2.5 rounded-[5px] px-2.5 py-1.5 text-[13px] font-medium transition ${
           isActive
             ? 'bg-[var(--c-nav-active-bg)] font-semibold text-[var(--c-text-primary)]'
             : 'text-[var(--c-text-secondary)] hover:bg-[var(--c-nav-hover-bg)] hover:text-[var(--c-text-primary)]'
@@ -660,7 +662,7 @@ function ConsoleTopBar({
   toggleTheme: () => void;
 }) {
   return (
-    <header className="sticky top-0 z-40 flex h-11 items-center justify-between border-b border-[var(--c-border)] bg-[var(--c-app-bg)] px-3 md:px-4">
+    <header className="console-topbar sticky top-0 z-40 flex h-11 items-center justify-between border-b border-[var(--c-border)] px-3 md:px-4">
       <div className="flex min-w-0 items-center gap-1.5 text-[13px] text-[var(--c-text-secondary)]">
         <button
           type="button"

--- a/web/src/components/DebuggerKit.tsx
+++ b/web/src/components/DebuggerKit.tsx
@@ -89,7 +89,7 @@ const buttonKindClasses: Record<ButtonKind, string> = {
   primary: 'border-transparent bg-[var(--c-text-primary)] text-[var(--c-app-bg)] font-semibold',
   secondary: 'border-[var(--c-border)] bg-[var(--c-surface)] text-[var(--c-text-primary)] font-medium',
   ghost: 'border-transparent bg-transparent text-[var(--c-text-secondary)] font-medium hover:bg-[var(--c-nav-hover-bg)]',
-  accent: 'border-transparent bg-[var(--c-accent)] text-[var(--c-text-inverse)] font-semibold',
+  accent: 'border-transparent bg-[var(--c-accent)] text-[var(--continua-accent-contrast)] font-semibold',
 };
 
 const buttonSizeClasses: Record<ButtonSize, string> = {

--- a/web/src/components/DebuggerKit.tsx
+++ b/web/src/components/DebuggerKit.tsx
@@ -89,7 +89,7 @@ const buttonKindClasses: Record<ButtonKind, string> = {
   primary: 'border-transparent bg-[var(--c-text-primary)] text-[var(--c-app-bg)] font-semibold',
   secondary: 'border-[var(--c-border)] bg-[var(--c-surface)] text-[var(--c-text-primary)] font-medium',
   ghost: 'border-transparent bg-transparent text-[var(--c-text-secondary)] font-medium hover:bg-[var(--c-nav-hover-bg)]',
-  accent: 'border-transparent bg-[var(--c-accent)] text-white font-semibold',
+  accent: 'border-transparent bg-[var(--c-accent)] text-[var(--c-text-inverse)] font-semibold',
 };
 
 const buttonSizeClasses: Record<ButtonSize, string> = {
@@ -184,7 +184,7 @@ export function PageHeader({
   title: ReactNode;
 }) {
   return (
-    <header className={`border-b border-[var(--c-border)] px-6 pt-5 ${tabs ? 'pb-0' : 'pb-4'}`}>
+    <header className={`console-page-header border-b border-[var(--c-border)] px-6 pt-5 ${tabs ? 'pb-0' : 'pb-4'}`}>
       <div className="flex items-start justify-between gap-6">
         <div className="min-w-0">
           {eyebrow ? (

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -186,7 +186,31 @@
     --c-bar-tick: rgba(255, 255, 255, 0.08);
   }
 
-  .landing-theme {
+  :is(.landing-theme, .console-theme) {
+    --continua-app-bg: #f3eee5;
+    --continua-shell-rail: rgba(233, 224, 210, 0.94);
+    --continua-shell-topbar: rgba(243, 238, 229, 0.9);
+    --continua-surface: rgba(251, 247, 239, 0.86);
+    --continua-surface-elevated: rgba(255, 250, 242, 0.96);
+    --continua-surface-muted: rgba(233, 225, 213, 0.88);
+    --continua-border-soft: rgba(65, 43, 24, 0.075);
+    --continua-border-strong: rgba(65, 43, 24, 0.24);
+    --continua-text-primary: #19140f;
+    --continua-text-secondary: #63584c;
+    --continua-text-muted: #948778;
+    --continua-accent: #c96a26;
+    --continua-accent-strong: #e99a4d;
+    --continua-accent-contrast: #fffaf2;
+    --continua-accent-faint: rgba(201, 105, 34, 0.11);
+    --continua-shadow-soft: 0 24px 60px -28px rgba(65, 43, 24, 0.28);
+    --continua-panel-separator: rgba(65, 43, 24, 0.13);
+    --continua-error: #bd4d3e;
+    --continua-error-faint: rgba(189, 77, 62, 0.1);
+    --continua-error-border: rgba(189, 77, 62, 0.25);
+    --continua-secondary: #8e620f;
+    --continua-secondary-container: rgba(201, 144, 36, 0.16);
+    --continua-tertiary: #4f6d24;
+    --continua-tertiary-container: rgba(110, 141, 57, 0.16);
     --c-app-bg: #f3eee5;
     --c-sidebar-bg: #e9e0d2;
     --c-surface: #fbf7ef;
@@ -197,6 +221,7 @@
     --c-row-selected-bg: rgba(195, 103, 35, 0.09);
     --c-nav-active-bg: rgba(102, 63, 25, 0.07);
     --c-nav-hover-bg: rgba(102, 63, 25, 0.045);
+    --c-kbd-bg: rgba(102, 63, 25, 0.055);
     --c-border: rgba(65, 43, 24, 0.13);
     --c-border-subtle: rgba(65, 43, 24, 0.075);
     --c-border-strong: rgba(65, 43, 24, 0.24);
@@ -208,6 +233,7 @@
     --c-accent-text: #9b4e18;
     --c-accent-faint: rgba(201, 105, 34, 0.11);
     --c-accent-border: rgba(201, 105, 34, 0.3);
+    --c-focus: rgba(201, 105, 34, 0.5);
     --c-blue: #c96a26;
     --c-blue-text: #9b4e18;
     --c-blue-faint: rgba(201, 106, 38, 0.1);
@@ -233,7 +259,31 @@
     --c-bar-tick: rgba(65, 43, 24, 0.09);
   }
 
-  html.dark .landing-theme {
+  html.dark :is(.landing-theme, .console-theme) {
+    --continua-app-bg: #0d0b08;
+    --continua-shell-rail: rgba(18, 15, 11, 0.95);
+    --continua-shell-topbar: rgba(13, 11, 8, 0.9);
+    --continua-surface: rgba(23, 18, 13, 0.86);
+    --continua-surface-elevated: rgba(29, 23, 17, 0.96);
+    --continua-surface-muted: rgba(28, 22, 16, 0.9);
+    --continua-border-soft: rgba(255, 224, 188, 0.06);
+    --continua-border-strong: rgba(255, 224, 188, 0.2);
+    --continua-text-primary: #f4ede2;
+    --continua-text-secondary: #b9ad9c;
+    --continua-text-muted: #786d60;
+    --continua-accent: #efa051;
+    --continua-accent-strong: #ffc071;
+    --continua-accent-contrast: #17100a;
+    --continua-accent-faint: rgba(239, 160, 81, 0.12);
+    --continua-shadow-soft: 0 28px 64px -26px rgba(0, 0, 0, 0.72);
+    --continua-panel-separator: rgba(255, 224, 188, 0.11);
+    --continua-error: #db7766;
+    --continua-error-faint: rgba(219, 119, 102, 0.11);
+    --continua-error-border: rgba(219, 119, 102, 0.25);
+    --continua-secondary: #f4cc72;
+    --continua-secondary-container: rgba(227, 182, 83, 0.13);
+    --continua-tertiary: #bfd98b;
+    --continua-tertiary-container: rgba(155, 183, 104, 0.14);
     --c-app-bg: #0d0b08;
     --c-sidebar-bg: #120f0b;
     --c-surface: #17120d;
@@ -244,6 +294,7 @@
     --c-row-selected-bg: rgba(238, 160, 81, 0.09);
     --c-nav-active-bg: rgba(255, 224, 188, 0.07);
     --c-nav-hover-bg: rgba(255, 224, 188, 0.04);
+    --c-kbd-bg: rgba(255, 224, 188, 0.055);
     --c-border: rgba(255, 224, 188, 0.11);
     --c-border-subtle: rgba(255, 224, 188, 0.06);
     --c-border-strong: rgba(255, 224, 188, 0.2);
@@ -255,6 +306,7 @@
     --c-accent-text: #ffc071;
     --c-accent-faint: rgba(239, 160, 81, 0.12);
     --c-accent-border: rgba(239, 160, 81, 0.28);
+    --c-focus: rgba(239, 160, 81, 0.5);
     --c-blue: #efa051;
     --c-blue-text: #ffc071;
     --c-blue-faint: rgba(239, 160, 81, 0.11);
@@ -401,6 +453,40 @@
     animation: continua-shell-enter 240ms ease-out;
   }
 
+  .console-theme {
+    background: var(--c-app-bg);
+  }
+
+  .console-sidebar {
+    background: color-mix(in srgb, var(--c-sidebar-bg) 94%, transparent);
+    box-shadow: 12px 0 36px -30px rgba(65, 43, 24, 0.48);
+    backdrop-filter: blur(18px);
+  }
+
+  .console-topbar {
+    background: color-mix(in srgb, var(--c-app-bg) 88%, transparent);
+    backdrop-filter: blur(18px);
+  }
+
+  .console-brand-mark {
+    background: var(--c-accent-faint);
+    border: 1px solid var(--c-accent-border);
+    box-shadow: inset 0 1px 0 color-mix(in srgb, white 45%, transparent);
+  }
+
+  .console-nav-link[aria-current='page'] {
+    box-shadow: inset 2px 0 0 var(--c-accent);
+    color: var(--c-text-primary);
+  }
+
+  .console-nav-link[aria-current='page'] svg {
+    color: var(--c-accent-text);
+  }
+
+  .console-page-header {
+    background: color-mix(in srgb, var(--c-surface) 54%, transparent);
+  }
+
   .app-overlay-enter {
     animation: continua-overlay-enter 180ms ease-out;
   }
@@ -420,14 +506,14 @@
   .app-surface {
     background: var(--c-surface);
     border: 1px solid var(--c-border);
-    box-shadow: none;
-    @apply rounded-md p-6;
+    box-shadow: 0 1px 0 color-mix(in srgb, white 35%, transparent);
+    @apply rounded-lg p-6;
   }
 
   .app-surface-muted {
     background: var(--c-surface-muted);
     border: 1px solid var(--c-border);
-    @apply rounded-md;
+    @apply rounded-lg;
   }
 
   .app-metric-panel {
@@ -505,7 +591,7 @@
   }
 
   .app-overline {
-    color: var(--c-text-muted);
+    color: var(--c-accent-text);
     @apply text-[10px] font-black uppercase tracking-widest;
   }
 
@@ -519,8 +605,8 @@
   }
 
   .app-button-primary {
-    background: var(--c-text-primary);
-    color: var(--c-app-bg);
+    background: var(--c-accent);
+    color: var(--c-text-inverse);
     @apply inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-semibold transition hover:opacity-90 active:scale-95 focus:outline-none focus:ring-2;
   }
 
@@ -528,7 +614,7 @@
     background: var(--c-surface);
     border: 1px solid var(--c-border);
     color: var(--c-text-primary);
-    @apply inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium transition hover:border-[var(--c-border-strong)] hover:text-[var(--c-accent-text)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)];
+    @apply inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium transition hover:border-[var(--c-accent-border)] hover:bg-[var(--c-accent-faint)] hover:text-[var(--c-accent-text)] focus:outline-none focus:ring-2 focus:ring-[var(--c-accent-faint)];
   }
 
   .app-button-ghost {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -200,7 +200,7 @@
     --continua-text-muted: #948778;
     --continua-accent: #c96a26;
     --continua-accent-strong: #e99a4d;
-    --continua-accent-contrast: #fffaf2;
+    --continua-accent-contrast: #2b190d;
     --continua-accent-faint: rgba(201, 105, 34, 0.11);
     --continua-shadow-soft: 0 24px 60px -28px rgba(65, 43, 24, 0.28);
     --continua-panel-separator: rgba(65, 43, 24, 0.13);
@@ -606,7 +606,7 @@
 
   .app-button-primary {
     background: var(--c-accent);
-    color: var(--c-text-inverse);
+    color: var(--continua-accent-contrast);
     @apply inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-semibold transition hover:opacity-90 active:scale-95 focus:outline-none focus:ring-2;
   }
 


### PR DESCRIPTION
## What changed

- promotes the landing page’s warm paper-and-coral palette into the shared console theme
- updates the sidebar, top bar, navigation, page headers, controls, and reusable surfaces across observability and engine screens
- keeps semantic success, warning, and failure colors distinct for operator clarity
- recolors the shared logo, favicon, and wordmark to the same amber-to-coral brand gradient

## Impact

The overview, traces, trace debugger, engine runs, engine tools, sessions, projects, and settings now feel like one coherent product while preserving existing routing and behavior.

## Validation

- `pnpm --filter web test`
- `pnpm --filter web test:e2e` (12 desktop/mobile flows)
- `pnpm --filter web lint`
- `pnpm --filter web type-check`
- production Vite build
- live light/dark and responsive browser verification with no console errors or horizontal overflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refreshed the console interface with consistent light and dark themes.
  - Updated navigation, sidebars, top bar, page headers, branding, buttons, and project switcher accents.
  - Improved focus states, status colors, surface rounding, shadows, and translucent background treatments.
  - Enhanced secondary-button hover styling and overall theme consistency across landing and console pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->