### PR TITLE
Align docs branding with warm theme

### DIFF
--- a/docs-site/brand/continua-mark-dark.svg
+++ b/docs-site/brand/continua-mark-dark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
+  <defs>
+    <linearGradient id="cont-grad-dark" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffc071"/>
+      <stop offset="1" stop-color="#efa051"/>
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="28" stroke="url(#cont-grad-dark)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>
+  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad-dark)" stroke-width="4.5" stroke-linecap="round"/>
+  <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad-dark)"/>
+  <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad-dark)"/>
+</svg>

--- a/docs-site/brand/continua-mark.svg
+++ b/docs-site/brand/continua-mark.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0075d6"/>
-      <stop offset="1" stop-color="#005cab"/>
+      <stop offset="0" stop-color="#e99a4d"/>
+      <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
   <circle cx="32" cy="32" r="28" stroke="url(#cont-grad)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>

--- a/docs-site/brand/continua-wordmark-dark.svg
+++ b/docs-site/brand/continua-wordmark-dark.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-grad-dark" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#38bdf8"/>
-      <stop offset="1" stop-color="#0ea5e9"/>
+      <stop offset="0" stop-color="#ffc071"/>
+      <stop offset="1" stop-color="#efa051"/>
     </linearGradient>
   </defs>
   <g transform="translate(0, -4)">
@@ -11,5 +11,5 @@
     <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-dark)"/>
     <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-dark)"/>
   </g>
-  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#f8fafc">Continua</text>
+  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#f4ede2">Continua</text>
 </svg>

--- a/docs-site/brand/continua-wordmark-light.svg
+++ b/docs-site/brand/continua-wordmark-light.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-grad-light" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0075d6"/>
-      <stop offset="1" stop-color="#005cab"/>
+      <stop offset="0" stop-color="#e99a4d"/>
+      <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
   <g transform="translate(0, -4)">
@@ -11,5 +11,5 @@
     <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-light)"/>
     <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-light)"/>
   </g>
-  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#0f172a">Continua</text>
+  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#19140f">Continua</text>
 </svg>

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -4,11 +4,23 @@
   "name": "Continua",
   "description": "Self-hosted durable execution engine with built-in observability for AI agent runs. Run agent workflows durably, then inspect every run as traces, spans, sessions, and events.",
   "colors": {
-    "primary": "#0075d6",
-    "light": "#7aaeff",
-    "dark": "#005cab"
+    "primary": "#c96a26",
+    "light": "#efa051",
+    "dark": "#9b4e18"
   },
-  "favicon": "/brand/continua-mark.svg",
+  "background": {
+    "color": {
+      "light": "#f3eee5",
+      "dark": "#0d0b08"
+    }
+  },
+  "fonts": {
+    "family": "Inter"
+  },
+  "favicon": {
+    "light": "/brand/continua-mark.svg",
+    "dark": "/brand/continua-mark-dark.svg"
+  },
   "appearance": {
     "default": "system"
   },

--- a/docs-site/favicon.svg
+++ b/docs-site/favicon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0075d6"/>
-      <stop offset="1" stop-color="#005cab"/>
+      <stop offset="0" stop-color="#e99a4d"/>
+      <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
   <circle cx="32" cy="32" r="28" stroke="url(#cont-grad)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>

--- a/docs-site/logo/dark.svg
+++ b/docs-site/logo/dark.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-grad-dark" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#38bdf8"/>
-      <stop offset="1" stop-color="#0ea5e9"/>
+      <stop offset="0" stop-color="#ffc071"/>
+      <stop offset="1" stop-color="#efa051"/>
     </linearGradient>
   </defs>
   <g transform="translate(0, -4)">
@@ -11,5 +11,5 @@
     <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-dark)"/>
     <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-dark)"/>
   </g>
-  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#f8fafc">Continua</text>
+  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#f4ede2">Continua</text>
 </svg>

--- a/docs-site/logo/light.svg
+++ b/docs-site/logo/light.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-grad-light" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0075d6"/>
-      <stop offset="1" stop-color="#005cab"/>
+      <stop offset="0" stop-color="#e99a4d"/>
+      <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
   <g transform="translate(0, -4)">
@@ -11,5 +11,5 @@
     <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-light)"/>
     <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-light)"/>
   </g>
-  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#0f172a">Continua</text>
+  <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#19140f">Continua</text>
 </svg>


### PR DESCRIPTION
## Summary

- align the Mintlify palette, backgrounds, and typography with Continua's warm product theme
- add theme-specific favicon artwork and update both light and dark wordmarks
- refresh duplicate docs logo and favicon assets so legacy blue branding cannot resurface

## Why

The documentation site still used the previous blue identity after the landing page and console moved to the warm amber, cream, and ink theme. This keeps the browser favicon, navigation branding, card icons, and interactive accents consistent across the full product experience.

## Impact

Docs content and navigation are unchanged. Readers get consistent light and dark branding, while the existing engine and observability documentation remains intact.

## Validation

- `make docs-check`
- JSON and SVG syntax validation
- light and dark browser preview with no console errors or error overlays


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the documentation site’s branding with a new orange color palette.
  * Added distinct light and dark background colors.
  * Changed the site font to Inter.
  * Added separate favicon assets for light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->