### PR TITLE
Fix branding icon consistency

### DIFF
--- a/docs-site/brand/continua-mark-dark.svg
+++ b/docs-site/brand/continua-mark-dark.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-grad-dark" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#ffc071"/>
-      <stop offset="1" stop-color="#efa051"/>
+      <stop offset="0" stop-color="#e99a4d"/>
+      <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
   <circle cx="32" cy="32" r="28" stroke="url(#cont-grad-dark)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>

--- a/docs-site/brand/continua-wordmark-dark.svg
+++ b/docs-site/brand/continua-wordmark-dark.svg
@@ -1,15 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 56" role="img" aria-label="Continua" fill="none">
   <defs>
     <linearGradient id="cont-grad-dark" x1="0" y1="0" x2="56" y2="56" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#ffc071"/>
-      <stop offset="1" stop-color="#efa051"/>
+      <stop offset="0" stop-color="#e99a4d"/>
+      <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
-  <g transform="translate(0, -4)">
-    <circle cx="32" cy="32" r="24" stroke="url(#cont-grad-dark)" stroke-width="3" stroke-linecap="round" stroke-dasharray="100 26 18 5" stroke-dashoffset="-28"/>
-    <path d="M 44 18 A 14.5 14.5 0 1 0 44 46" stroke="url(#cont-grad-dark)" stroke-width="3.75" stroke-linecap="round"/>
-    <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-dark)"/>
-    <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-dark)"/>
+  <g transform="scale(0.875)">
+    <circle cx="32" cy="32" r="28" stroke="url(#cont-grad-dark)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>
+    <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad-dark)" stroke-width="4.5" stroke-linecap="round"/>
+    <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad-dark)"/>
+    <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad-dark)"/>
   </g>
   <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#f4ede2">Continua</text>
 </svg>

--- a/docs-site/brand/continua-wordmark-light.svg
+++ b/docs-site/brand/continua-wordmark-light.svg
@@ -5,11 +5,11 @@
       <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
-  <g transform="translate(0, -4)">
-    <circle cx="32" cy="32" r="24" stroke="url(#cont-grad-light)" stroke-width="3" stroke-linecap="round" stroke-dasharray="100 26 18 5" stroke-dashoffset="-28"/>
-    <path d="M 44 18 A 14.5 14.5 0 1 0 44 46" stroke="url(#cont-grad-light)" stroke-width="3.75" stroke-linecap="round"/>
-    <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-light)"/>
-    <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-light)"/>
+  <g transform="scale(0.875)">
+    <circle cx="32" cy="32" r="28" stroke="url(#cont-grad-light)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>
+    <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad-light)" stroke-width="4.5" stroke-linecap="round"/>
+    <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad-light)"/>
+    <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad-light)"/>
   </g>
   <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" fill="#19140f">Continua</text>
 </svg>

--- a/docs-site/continua-favicon.svg
+++ b/docs-site/continua-favicon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
   <defs>
-    <linearGradient id="cont-favicon-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+    <linearGradient id="cont-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#e99a4d"/>
       <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="url(#cont-favicon-grad)"/>
-  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="#ffffff" stroke-width="6" stroke-linecap="round" fill="none"/>
-  <circle cx="46" cy="18" r="4" fill="#ffffff"/>
-  <circle cx="46" cy="46" r="4" fill="#ffffff"/>
+  <circle cx="32" cy="32" r="28" stroke="url(#cont-grad)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>
+  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad)" stroke-width="4.5" stroke-linecap="round"/>
+  <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad)"/>
+  <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad)"/>
 </svg>

--- a/web/public/assets/logo-wordmark.svg
+++ b/web/public/assets/logo-wordmark.svg
@@ -5,11 +5,11 @@
       <stop offset="1" stop-color="#c96a26"></stop>
     </linearGradient>
   </defs>
-  <g transform="translate(0, -4)">
-    <circle cx="32" cy="32" r="24" stroke="url(#cont-grad-w)" stroke-width="3" stroke-linecap="round" stroke-dasharray="100 26 18 5" stroke-dashoffset="-28"></circle>
-    <path d="M 44 18 A 14.5 14.5 0 1 0 44 46" stroke="url(#cont-grad-w)" stroke-width="3.75" stroke-linecap="round"></path>
-    <circle cx="44" cy="18" r="2.6" fill="url(#cont-grad-w)"></circle>
-    <circle cx="44" cy="46" r="2.6" fill="url(#cont-grad-w)"></circle>
+  <g transform="scale(0.875)">
+    <circle cx="32" cy="32" r="28" stroke="url(#cont-grad-w)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"></circle>
+    <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad-w)" stroke-width="4.5" stroke-linecap="round"></path>
+    <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad-w)"></circle>
+    <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad-w)"></circle>
   </g>
   <text x="68" y="36" font-family="Inter, system-ui, sans-serif" font-weight="800" font-size="26" letter-spacing="-1.2" fill="#19140f">Continua</text>
 </svg>

--- a/web/public/continua-favicon.svg
+++ b/web/public/continua-favicon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
   <defs>
-    <linearGradient id="cont-favicon-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+    <linearGradient id="cont-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#e99a4d"/>
       <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="url(#cont-favicon-grad)"/>
-  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="#ffffff" stroke-width="6" stroke-linecap="round" fill="none"/>
-  <circle cx="46" cy="18" r="4" fill="#ffffff"/>
-  <circle cx="46" cy="46" r="4" fill="#ffffff"/>
+  <circle cx="32" cy="32" r="28" stroke="url(#cont-grad)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>
+  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad)" stroke-width="4.5" stroke-linecap="round"/>
+  <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad)"/>
+  <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad)"/>
 </svg>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Continua" fill="none">
   <defs>
-    <linearGradient id="cont-favicon-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+    <linearGradient id="cont-grad" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#e99a4d"/>
       <stop offset="1" stop-color="#c96a26"/>
     </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="url(#cont-favicon-grad)"/>
-  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="#ffffff" stroke-width="6" stroke-linecap="round" fill="none"/>
-  <circle cx="46" cy="18" r="4" fill="#ffffff"/>
-  <circle cx="46" cy="46" r="4" fill="#ffffff"/>
+  <circle cx="32" cy="32" r="28" stroke="url(#cont-grad)" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="118 30 22 6" stroke-dashoffset="-32"/>
+  <path d="M 46 18 A 18 18 0 1 0 46 46" stroke="url(#cont-grad)" stroke-width="4.5" stroke-linecap="round"/>
+  <circle cx="46" cy="18" r="3.25" fill="url(#cont-grad)"/>
+  <circle cx="46" cy="46" r="3.25" fill="url(#cont-grad)"/>
 </svg>

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -259,10 +259,11 @@ describe('AppShell', () => {
     await renderShell('/sessions');
 
     expect(await screen.findByDisplayValue('Primary Project')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Go to landing page' })).toHaveAttribute(
-      'href',
-      '/'
-    );
+    const brandLink = screen.getByRole('link', { name: 'Go to landing page' });
+
+    expect(brandLink).toHaveAttribute('href', '/');
+    expect(brandLink.firstElementChild).toHaveAttribute('src', '/logo.svg');
+    expect(brandLink.firstElementChild).toHaveClass('h-6', 'w-6');
   });
 
   it('switches the active project and keeps the selected project in route state', async () => {

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -31,6 +31,7 @@ import {
 } from '../api/client';
 import { useOperatorAuth, useRuntimeAuth } from '../auth/runtime';
 import { useTheme } from '../hooks/useTheme';
+import { BrandMark } from './BrandMark';
 import { CommandPalette } from './CommandPalette';
 import {
   buildProjectPath,
@@ -482,13 +483,7 @@ function BrandBlock() {
       aria-label="Go to landing page"
       className="flex min-w-0 items-center gap-2.5 rounded-md outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-[var(--c-focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--c-sidebar-bg)]"
     >
-      <span className="console-brand-mark flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
-        <img
-          alt=""
-          className="h-[20px] w-[20px]"
-          src="/logo.svg"
-        />
-      </span>
+      <BrandMark />
       <div className="min-w-0 leading-none">
         <div className="truncate text-[13px] font-bold text-[var(--c-text-primary)]">
           Continua

--- a/web/src/components/BrandMark.tsx
+++ b/web/src/components/BrandMark.tsx
@@ -1,0 +1,3 @@
+export function BrandMark() {
+  return <img src="/logo.svg" alt="" className="h-6 w-6 shrink-0" />;
+}

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -21,6 +21,7 @@ import {
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { useRuntimeAuth } from '../auth/runtime';
+import { BrandMark } from '../components/BrandMark';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { useTheme } from '../hooks/useTheme';
 
@@ -281,7 +282,7 @@ function Nav({
     >
       <div className="mx-auto flex min-h-13 max-w-7xl items-center justify-between gap-3 px-4 py-2.5 sm:px-6">
         <a href="#" className="flex shrink-0 items-center gap-2.5">
-          <Logo />
+          <BrandMark />
           <span className="text-[14px] font-semibold tracking-tight">Continua</span>
         </a>
         <nav className="hidden items-center gap-7 text-[12.5px] font-medium text-[var(--c-text-secondary)] md:flex">
@@ -1274,7 +1275,7 @@ function Footer({
         <div className="grid gap-10 md:grid-cols-[1.4fr_1fr_1fr_1fr]">
           <div>
             <div className="flex items-center gap-2.5">
-              <Logo />
+              <BrandMark />
               <span className="text-[14px] font-semibold tracking-tight">Continua</span>
             </div>
             <p className="mt-4 max-w-xs text-[12px] leading-5 text-[var(--c-text-muted)]">Durable execution engine for AI agents, with built-in observability. MIT licensed.</p>
@@ -1361,12 +1362,6 @@ function SectionHeader({
       <h2 className="landing-display mt-4 text-[32px] font-semibold tracking-[-0.025em] text-[var(--c-text-primary)] sm:text-[44px]">{title}</h2>
       {copy ? <p className="mt-4 max-w-2xl text-[14px] leading-6 text-[var(--c-text-secondary)]">{copy}</p> : null}
     </div>
-  );
-}
-
-function Logo() {
-  return (
-    <img src="/logo.svg" alt="" className="h-6 w-6 shrink-0" />
   );
 }
 

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -468,12 +468,6 @@
     backdrop-filter: blur(18px);
   }
 
-  .console-brand-mark {
-    background: var(--c-accent-faint);
-    border: 1px solid var(--c-accent-border);
-    box-shadow: inset 0 1px 0 color-mix(in srgb, white 45%, transparent);
-  }
-
   .console-nav-link[aria-current='page'] {
     box-shadow: inset 2px 0 0 var(--c-accent);
     color: var(--c-text-primary);


### PR DESCRIPTION
## What changed
- reuse a shared 24px landing-page brand mark in the landing header, footer, and operator console
- remove the console-only framed badge treatment
- align docs light/dark wordmarks and standalone marks to the landing-page geometry and orange gradient
- align the web and docs favicons to the same mark

## Why
The console and docs each had separate treatments for the Continua icon, so the mark appeared framed, resized, or recolored compared with the landing page.

## Validation
- pnpm --filter web type-check
- pnpm --filter web lint
- focused AppShell and LandingPage tests: 24 passed
- SVG XML validation for all touched brand assets
- local visual comparison of landing, console, and docs variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the logo presentation across the landing page and console.
  * Removed outdated logo-specific visual styling for a cleaner, consistent appearance.

* **Tests**
  * Expanded coverage to verify the logo link destination, image source, and sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->