### PR TITLE
fix(api,web): scope debugger reads to the selected project

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -1354,7 +1354,7 @@ type SelectedProjectId = openapi_types.UUID
 
 // ListSessionsParams defines parameters for ListSessions.
 type ListSessionsParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 	Limit     *int               `form:"limit,omitempty" json:"limit,omitempty"`
 	Offset    *int               `form:"offset,omitempty" json:"offset,omitempty"`
@@ -1380,13 +1380,13 @@ type ListSessionsParamsSortDir string
 
 // GetSessionParams defines parameters for GetSession.
 type GetSessionParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 }
 
 // GetSessionCompareParams defines parameters for GetSessionCompare.
 type GetSessionCompareParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId        *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 	BaselineTraceId  openapi_types.UUID `form:"baseline_trace_id" json:"baseline_trace_id"`
 	CandidateTraceId openapi_types.UUID `form:"candidate_trace_id" json:"candidate_trace_id"`
@@ -1394,13 +1394,13 @@ type GetSessionCompareParams struct {
 
 // GetSessionNarrativeParams defines parameters for GetSessionNarrative.
 type GetSessionNarrativeParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 }
 
 // ListTracesParams defines parameters for ListTraces.
 type ListTracesParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId  `form:"project_id,omitempty" json:"project_id,omitempty"`
 	Limit     *int                `form:"limit,omitempty" json:"limit,omitempty"`
 	Offset    *int                `form:"offset,omitempty" json:"offset,omitempty"`
@@ -1481,13 +1481,13 @@ type ListTracesParamsEngineRunStatus string
 
 // GetTraceParams defines parameters for GetTrace.
 type GetTraceParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 }
 
 // GetTraceEventsParams defines parameters for GetTraceEvents.
 type GetTraceEventsParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 
 	// After Opaque cursor returned by a previous timeline response
@@ -1499,7 +1499,7 @@ type GetTraceEventsParams struct {
 
 // ListSpansByTraceParams defines parameters for ListSpansByTrace.
 type ListSpansByTraceParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 }
 

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -1559,7 +1559,7 @@ export interface components {
     };
     responses: never;
     parameters: {
-        /** @description Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key. */
+        /** @description Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch. */
         SelectedProjectId: string;
     };
     requestBodies: never;
@@ -3026,7 +3026,7 @@ export interface operations {
     listTraces: {
         parameters: {
             query?: {
-                /** @description Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key. */
+                /** @description Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch. */
                 project_id?: components["parameters"]["SelectedProjectId"];
                 limit?: number;
                 offset?: number;
@@ -3101,7 +3101,7 @@ export interface operations {
     getTrace: {
         parameters: {
             query?: {
-                /** @description Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key. */
+                /** @description Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch. */
                 project_id?: components["parameters"]["SelectedProjectId"];
             };
             header?: never;
@@ -3144,7 +3144,7 @@ export interface operations {
     listSpansByTrace: {
         parameters: {
             query?: {
-                /** @description Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key. */
+                /** @description Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch. */
                 project_id?: components["parameters"]["SelectedProjectId"];
             };
             header?: never;
@@ -3187,7 +3187,7 @@ export interface operations {
     getTraceEvents: {
         parameters: {
             query?: {
-                /** @description Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key. */
+                /** @description Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch. */
                 project_id?: components["parameters"]["SelectedProjectId"];
                 /** @description Opaque cursor returned by a previous timeline response */
                 after?: string;
@@ -3243,7 +3243,7 @@ export interface operations {
     listSessions: {
         parameters: {
             query?: {
-                /** @description Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key. */
+                /** @description Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch. */
                 project_id?: components["parameters"]["SelectedProjectId"];
                 limit?: number;
                 offset?: number;
@@ -3285,7 +3285,7 @@ export interface operations {
     getSession: {
         parameters: {
             query?: {
-                /** @description Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key. */
+                /** @description Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch. */
                 project_id?: components["parameters"]["SelectedProjectId"];
             };
             header?: never;
@@ -3328,7 +3328,7 @@ export interface operations {
     getSessionNarrative: {
         parameters: {
             query?: {
-                /** @description Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key. */
+                /** @description Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch. */
                 project_id?: components["parameters"]["SelectedProjectId"];
             };
             header?: never;
@@ -3371,7 +3371,7 @@ export interface operations {
     getSessionCompare: {
         parameters: {
             query: {
-                /** @description Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key. */
+                /** @description Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch. */
                 project_id?: components["parameters"]["SelectedProjectId"];
                 baseline_trace_id: string;
                 candidate_trace_id: string;

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -3096,6 +3096,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Project selection does not match the authenticated API key */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     getTrace: {
@@ -3123,6 +3132,15 @@ export interface operations {
             };
             /** @description Unauthorized - missing or invalid credentials */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Project selection does not match the authenticated API key */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3166,6 +3184,15 @@ export interface operations {
             };
             /** @description Unauthorized - missing or invalid credentials */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Project selection does not match the authenticated API key */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3229,6 +3256,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Project selection does not match the authenticated API key */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Trace not found */
             404: {
                 headers: {
@@ -3280,6 +3316,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description Project selection does not match the authenticated API key */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     getSession: {
@@ -3307,6 +3352,15 @@ export interface operations {
             };
             /** @description Unauthorized - missing or invalid credentials */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Project selection does not match the authenticated API key */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3350,6 +3404,15 @@ export interface operations {
             };
             /** @description Unauthorized - missing or invalid credentials */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Project selection does not match the authenticated API key */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3404,6 +3467,15 @@ export interface operations {
             };
             /** @description Unauthorized - missing or invalid credentials */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Project selection does not match the authenticated API key */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -1690,7 +1690,7 @@ components:
     SelectedProjectId:
       name: project_id
       in: query
-      description: Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+      description: Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
       schema:
         type: string
         format: uuid

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -1387,6 +1387,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/traces/{id}:
     get:
       operationId: getTrace
@@ -1410,6 +1416,12 @@ paths:
                 $ref: '#/components/schemas/TraceDetail'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1443,6 +1455,12 @@ paths:
                 $ref: '#/components/schemas/SpanList'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1495,6 +1513,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1562,6 +1586,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/sessions/{id}:
     get:
       operationId: getSession
@@ -1585,6 +1615,12 @@ paths:
                 $ref: '#/components/schemas/Session'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1618,6 +1654,12 @@ paths:
                 $ref: '#/components/schemas/SessionNarrativeResponse'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1669,6 +1711,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -1674,7 +1674,7 @@ components:
     SelectedProjectId:
       name: project_id
       in: query
-      description: Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+      description: Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
       schema:
         type: string
         format: uuid

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -1374,6 +1374,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /api/traces/{id}:
     get:
@@ -1397,6 +1403,12 @@ paths:
                 $ref: '#/components/schemas/TraceDetail'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1430,6 +1442,12 @@ paths:
                 $ref: '#/components/schemas/SpanList'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1482,6 +1500,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1545,6 +1569,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /api/sessions/{id}:
     get:
@@ -1568,6 +1598,12 @@ paths:
                 $ref: '#/components/schemas/Session'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1601,6 +1637,12 @@ paths:
                 $ref: '#/components/schemas/SessionNarrativeResponse'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1652,6 +1694,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -1690,7 +1690,7 @@ components:
     SelectedProjectId:
       name: project_id
       in: query
-      description: Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+      description: Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
       schema:
         type: string
         format: uuid

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -1387,6 +1387,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/traces/{id}:
     get:
       operationId: getTrace
@@ -1410,6 +1416,12 @@ paths:
                 $ref: '#/components/schemas/TraceDetail'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1443,6 +1455,12 @@ paths:
                 $ref: '#/components/schemas/SpanList'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1495,6 +1513,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1562,6 +1586,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/sessions/{id}:
     get:
       operationId: getSession
@@ -1585,6 +1615,12 @@ paths:
                 $ref: '#/components/schemas/Session'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1618,6 +1654,12 @@ paths:
                 $ref: '#/components/schemas/SessionNarrativeResponse'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:
@@ -1669,6 +1711,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized - missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Project selection does not match the authenticated API key
           content:
             application/json:
               schema:

--- a/internal/api/project_scope_selection_test.go
+++ b/internal/api/project_scope_selection_test.go
@@ -1,0 +1,205 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/api/middleware"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+type projectScopeFixture struct {
+	server   *Server
+	router   http.Handler
+	apiKeyA  string
+	projectA platform.Project
+	projectB platform.Project
+	traceA   platform.Trace
+	traceB   platform.Trace
+	sessionA platform.Session
+	sessionB platform.Session
+}
+
+func TestListTracesWithMismatchedProjectIDIsRejected(t *testing.T) {
+	fixture := newProjectScopeFixture(t)
+
+	rec := fixture.getWithAPIKey(
+		t,
+		"/api/traces?project_id="+fixture.projectB.ID.String(),
+		fixture.apiKeyA,
+	)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	resp := decodeJSONBody[Error](t, rec)
+	assert.Equal(t, "project_scope_mismatch", resp.Code)
+	assert.NotContains(t, rec.Body.String(), fixture.traceA.ID.String())
+}
+
+func TestListTracesWithMatchingProjectIDReturnsThatProject(t *testing.T) {
+	fixture := newProjectScopeFixture(t)
+
+	rec := fixture.getWithAPIKey(
+		t,
+		"/api/traces?project_id="+fixture.projectA.ID.String(),
+		fixture.apiKeyA,
+	)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeJSONBody[TraceList](t, rec)
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Traces, 1)
+	assert.Equal(t, fixture.traceA.ID, resp.Traces[0].Id)
+	assert.Equal(t, "Project A trace", resp.Traces[0].Name)
+	assert.NotContains(t, rec.Body.String(), fixture.traceB.ID.String())
+}
+
+func TestListTracesWithoutProjectIDUsesAPIKeyProject(t *testing.T) {
+	fixture := newProjectScopeFixture(t)
+
+	rec := fixture.getWithAPIKey(t, "/api/traces", fixture.apiKeyA)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeJSONBody[TraceList](t, rec)
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Traces, 1)
+	assert.Equal(t, fixture.traceA.ID, resp.Traces[0].Id)
+	assert.Equal(t, "Project A trace", resp.Traces[0].Name)
+	assert.NotContains(t, rec.Body.String(), fixture.traceB.ID.String())
+}
+
+func TestListTracesWithMalformedProjectIDIsRejected(t *testing.T) {
+	fixture := newProjectScopeFixture(t)
+
+	rec := fixture.getWithAPIKey(
+		t,
+		"/api/traces?project_id=not-a-uuid",
+		fixture.apiKeyA,
+	)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	// The OpenAPI-generated router owns UUID parameter binding and rejects this
+	// request before the handler's shared scope resolver is reached.
+	assert.NotContains(t, rec.Body.String(), fixture.traceA.ID.String())
+}
+
+func TestListSessionsWithMismatchedProjectIDIsRejected(t *testing.T) {
+	fixture := newProjectScopeFixture(t)
+
+	rec := fixture.getWithAPIKey(
+		t,
+		"/api/sessions?project_id="+fixture.projectB.ID.String(),
+		fixture.apiKeyA,
+	)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	resp := decodeJSONBody[Error](t, rec)
+	assert.Equal(t, "project_scope_mismatch", resp.Code)
+	assert.NotContains(t, rec.Body.String(), fixture.sessionA.ID.String())
+}
+
+func TestOperatorProjectIDSelectionStillHonored(t *testing.T) {
+	fixture := newProjectScopeFixture(t)
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/traces?project_id="+fixture.projectB.ID.String(),
+		nil,
+	)
+	reqCtx := context.WithValue(req.Context(), middleware.AuthModeKey, middleware.AuthModeOperator)
+	reqCtx = context.WithValue(reqCtx, middleware.OperatorEmailKey, "operator@example.com")
+	reqCtx = context.WithValue(reqCtx, middleware.OperatorSubjectKey, "google-oauth2|operator")
+	rec := httptest.NewRecorder()
+
+	fixture.server.ListTraces(rec, req.WithContext(reqCtx), ListTracesParams{})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeJSONBody[TraceList](t, rec)
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Traces, 1)
+	assert.Equal(t, fixture.traceB.ID, resp.Traces[0].Id)
+	assert.Equal(t, "Project B trace", resp.Traces[0].Name)
+	assert.NotContains(t, rec.Body.String(), fixture.traceA.ID.String())
+}
+
+func newProjectScopeFixture(t *testing.T) projectScopeFixture {
+	t.Helper()
+
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	platformStore := store.New(pool)
+	q := platformStore.Queries()
+	apiKeyA := "project-scope-a-" + uuid.NewString()
+	apiKeyB := "project-scope-b-" + uuid.NewString()
+
+	projectA, err := q.CreateProject(ctx, platform.CreateProjectParams{
+		Name:       "Project A " + uuid.NewString(),
+		ApiKeyHash: middleware.HashAPIKey(apiKeyA),
+	})
+	require.NoError(t, err)
+	projectB, err := q.CreateProject(ctx, platform.CreateProjectParams{
+		Name:       "Project B " + uuid.NewString(),
+		ApiKeyHash: middleware.HashAPIKey(apiKeyB),
+	})
+	require.NoError(t, err)
+
+	sessionA, err := q.CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectA.ID,
+		ExternalID: "project-a-session-" + uuid.NewString(),
+		Name:       testutil.StrPtr("Project A session"),
+	})
+	require.NoError(t, err)
+	sessionB, err := q.CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectB.ID,
+		ExternalID: "project-b-session-" + uuid.NewString(),
+		Name:       testutil.StrPtr("Project B session"),
+	})
+	require.NoError(t, err)
+
+	traceA := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectA.ID,
+		SessionID: testutil.PgtypeUUID(sessionA.ID),
+		TraceID:   "project-a-trace-" + uuid.NewString(),
+		Name:      testutil.StrPtr("Project A trace"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC)),
+	})
+	traceB := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectB.ID,
+		SessionID: testutil.PgtypeUUID(sessionB.ID),
+		TraceID:   "project-b-trace-" + uuid.NewString(),
+		Name:      testutil.StrPtr("Project B trace"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 8, 15, 11, 0, 0, 0, time.UTC)),
+	})
+
+	server := NewServer(platformStore, nil)
+	return projectScopeFixture{
+		server:   server,
+		router:   newAuthenticatedRouter(t, server, platformStore),
+		apiKeyA:  apiKeyA,
+		projectA: projectA,
+		projectB: projectB,
+		traceA:   traceA,
+		traceB:   traceB,
+		sessionA: sessionA,
+		sessionB: sessionB,
+	}
+}
+
+func (f projectScopeFixture) getWithAPIKey(t *testing.T, path, apiKey string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+	f.router.ServeHTTP(rec, req)
+	return rec
+}

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -1354,7 +1354,7 @@ type SelectedProjectId = openapi_types.UUID
 
 // ListSessionsParams defines parameters for ListSessions.
 type ListSessionsParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 	Limit     *int               `form:"limit,omitempty" json:"limit,omitempty"`
 	Offset    *int               `form:"offset,omitempty" json:"offset,omitempty"`
@@ -1380,13 +1380,13 @@ type ListSessionsParamsSortDir string
 
 // GetSessionParams defines parameters for GetSession.
 type GetSessionParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 }
 
 // GetSessionCompareParams defines parameters for GetSessionCompare.
 type GetSessionCompareParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId        *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 	BaselineTraceId  openapi_types.UUID `form:"baseline_trace_id" json:"baseline_trace_id"`
 	CandidateTraceId openapi_types.UUID `form:"candidate_trace_id" json:"candidate_trace_id"`
@@ -1394,13 +1394,13 @@ type GetSessionCompareParams struct {
 
 // GetSessionNarrativeParams defines parameters for GetSessionNarrative.
 type GetSessionNarrativeParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 }
 
 // ListTracesParams defines parameters for ListTraces.
 type ListTracesParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId  `form:"project_id,omitempty" json:"project_id,omitempty"`
 	Limit     *int                `form:"limit,omitempty" json:"limit,omitempty"`
 	Offset    *int                `form:"offset,omitempty" json:"offset,omitempty"`
@@ -1481,13 +1481,13 @@ type ListTracesParamsEngineRunStatus string
 
 // GetTraceParams defines parameters for GetTrace.
 type GetTraceParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 }
 
 // GetTraceEventsParams defines parameters for GetTraceEvents.
 type GetTraceEventsParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 
 	// After Opaque cursor returned by a previous timeline response
@@ -1499,7 +1499,7 @@ type GetTraceEventsParams struct {
 
 // ListSpansByTraceParams defines parameters for ListSpansByTrace.
 type ListSpansByTraceParams struct {
-	// ProjectId Required when authenticating with an Auth0 bearer token. Ignored when the request is already project-scoped by API key.
+	// ProjectId Required as a selection filter when authenticating with an Auth0 bearer token. For API-key requests, it must match the key's project; a mismatch is rejected with 403 project_scope_mismatch.
 	ProjectId *SelectedProjectId `form:"project_id,omitempty" json:"project_id,omitempty"`
 }
 

--- a/internal/api/server_helpers.go
+++ b/internal/api/server_helpers.go
@@ -151,6 +151,21 @@ func boundProjectIDFromRequest(w http.ResponseWriter, r *http.Request) (uuid.UUI
 
 func scopeFromRequest(w http.ResponseWriter, r *http.Request, policy requestScopePolicy) (store.Scope, bool) {
 	if projectID, ok := middleware.GetProjectID(r.Context()); ok {
+		if authMode, _ := middleware.GetAuthMode(r.Context()); authMode == middleware.AuthModeAPIKey {
+			selectedProjectID, selected, valid := projectIDSelectionFromRequest(w, r, false)
+			if !valid {
+				return store.Scope{}, false
+			}
+			if selected && selectedProjectID != projectID {
+				writeError(
+					w,
+					http.StatusForbidden,
+					"project_scope_mismatch",
+					"The API key is scoped to a different project",
+				)
+				return store.Scope{}, false
+			}
+		}
 		return store.BoundScope(projectID), true
 	}
 

--- a/web/e2e/ui-smoke.spec.ts
+++ b/web/e2e/ui-smoke.spec.ts
@@ -16,6 +16,8 @@ import {
 const E2E_OPERATOR_TOKEN = 'e2e-operator-token';
 const PRIMARY_PROJECT_ID = '11111111-1111-1111-1111-111111111111';
 const SECONDARY_PROJECT_ID = '22222222-2222-2222-2222-222222222222';
+const PRIMARY_PROJECT_API_KEY = 'pk_primary';
+const SECONDARY_PROJECT_API_KEY = 'pk_secondary';
 const RUN_LOCALLY_DOCS_URL = 'https://www.continua.in/docs/guides/installation';
 const ENGINE_RUN_ID = '123e4567-e89b-12d3-a456-426614174100';
 const ENGINE_TRACE_ID = 'engine-trace-1';
@@ -237,6 +239,28 @@ async function bootstrapOperatorSession(page: Page) {
   }, E2E_OPERATOR_TOKEN);
 }
 
+async function bootstrapLocalApiKeySession(page: Page) {
+  await page.addInitScript(
+    ({ primaryProjectId, primaryKey, secondaryProjectId, secondaryKey }) => {
+      window.localStorage.setItem('continua_api_key', primaryKey);
+      window.localStorage.setItem(
+        'continua_project_api_keys',
+        JSON.stringify({
+          [primaryProjectId]: primaryKey,
+          [secondaryProjectId]: secondaryKey,
+        })
+      );
+      window.localStorage.setItem('continua_theme_mode', 'light');
+    },
+    {
+      primaryProjectId: PRIMARY_PROJECT_ID,
+      primaryKey: PRIMARY_PROJECT_API_KEY,
+      secondaryProjectId: SECONDARY_PROJECT_ID,
+      secondaryKey: SECONDARY_PROJECT_API_KEY,
+    }
+  );
+}
+
 async function fulfillJson(route: Route, data: unknown, status = 200) {
   await route.fulfill({
     status,
@@ -452,6 +476,53 @@ async function mockApiRoutes(page: Page, mode: 'operator' | 'public-demo' = 'ope
   });
 }
 
+async function mockLocalProjectRoutes(page: Page) {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname === '/api/auth/config') {
+      return fulfillJson(route, { enabled: false });
+    }
+
+    if (url.pathname === '/api/projects') {
+      expect(route.request().headers().authorization).toBe(
+        `Bearer ${PRIMARY_PROJECT_API_KEY}`
+      );
+      return fulfillJson(route, {
+        authenticated_project_id: PRIMARY_PROJECT_ID,
+        projects: [
+          {
+            id: PRIMARY_PROJECT_ID,
+            name: 'Primary Project',
+            created_at: '2026-03-14T10:00:00.000Z',
+            updated_at: '2026-03-14T10:00:00.000Z',
+          },
+          {
+            id: SECONDARY_PROJECT_ID,
+            name: 'Secondary Project',
+            created_at: '2026-03-15T10:00:00.000Z',
+            updated_at: '2026-03-15T10:00:00.000Z',
+          },
+        ],
+      });
+    }
+
+    if (url.pathname === '/api/traces') {
+      const projectId = url.searchParams.get('project_id');
+      const isSecondary = projectId === SECONDARY_PROJECT_ID;
+      expect(route.request().headers().authorization).toBe(
+        `Bearer ${isSecondary ? SECONDARY_PROJECT_API_KEY : PRIMARY_PROJECT_API_KEY}`
+      );
+      const trace = isSecondary
+        ? { ...TRACE_TWO, name: 'Secondary project trace' }
+        : { ...TRACE_ONE, name: 'Primary project trace' };
+      return fulfillJson(route, { traces: [trace], total: 1 });
+    }
+
+    return fulfillJson(route, { code: 'not_found', message: 'Resource not found' }, 404);
+  });
+}
+
 async function mockEngineRoutes(page: Page) {
   await page.route('**/v1/engine/**', async (route) => {
     const request = route.request();
@@ -647,6 +718,40 @@ test('opens a protected route and switches the selected project', async ({ page 
   await projectSwitcher.selectOption(SECONDARY_PROJECT_ID);
   await expect(page).toHaveURL(new RegExp(`project_id=${SECONDARY_PROJECT_ID}`));
   await expect(projectSwitcher).toHaveValue(SECONDARY_PROJECT_ID);
+});
+
+test('switches displayed traces with the selected project API key in local mode', async ({
+  page,
+}, testInfo) => {
+  await bootstrapLocalApiKeySession(page);
+  await mockLocalProjectRoutes(page);
+  await page.goto('/traces');
+
+  await expect(
+    page.getByRole('row').filter({ hasText: 'Primary project trace' })
+  ).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`project_id=${PRIMARY_PROJECT_ID}`));
+
+  if (testInfo.project.name === 'mobile-chromium') {
+    await page.getByRole('button', { name: 'Open navigation' }).click();
+    await page.getByRole('combobox', { name: 'Project' }).selectOption(
+      SECONDARY_PROJECT_ID
+    );
+  } else {
+    await page.getByLabel('Active project').selectOption(SECONDARY_PROJECT_ID);
+  }
+
+  await expect(page).toHaveURL(new RegExp(`project_id=${SECONDARY_PROJECT_ID}`));
+  await expect(
+    page.getByRole('row').filter({ hasText: 'Secondary project trace' })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('row').filter({ hasText: 'Primary project trace' })
+  ).toHaveCount(0);
+  await testInfo.attach(`${testInfo.project.name}-local-project-switch`, {
+    body: await page.screenshot({ fullPage: true, animations: 'disabled' }),
+    contentType: 'image/png',
+  });
 });
 
 test('captures overview, traces, sessions, and settings shells', async ({ page }, testInfo) => {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -10,6 +10,7 @@ import {
   getKnownProjectApiKey,
   rememberProjectApiKey,
   setAccessTokenProvider,
+  setLocalApiKeyMode,
   setPublicDemoMode,
   setSelectedProjectIdProvider,
 } from './client';
@@ -226,6 +227,7 @@ describe('client', () => {
     window.localStorage.setItem('continua_api_key', 'pk_A');
     rememberProjectApiKey(selectedProjectId, 'pk_B');
     setSelectedProjectIdProvider(() => selectedProjectId);
+    setLocalApiKeyMode(true);
 
     await fetchAPI('/api/traces');
 
@@ -249,6 +251,7 @@ describe('client', () => {
     );
     window.localStorage.setItem('continua_api_key', 'pk_A');
     setSelectedProjectIdProvider(() => selectedProjectId);
+    setLocalApiKeyMode(true);
 
     await fetchAPI('/api/traces');
 
@@ -274,6 +277,7 @@ describe('client', () => {
     rememberProjectApiKey(selectedProjectId, 'pk_B');
     setSelectedProjectIdProvider(() => selectedProjectId);
     setAccessTokenProvider(async () => 'auth0-operator-token');
+    setLocalApiKeyMode(false);
 
     await fetchAPI('/api/traces');
 

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -213,6 +213,78 @@ describe('client', () => {
     });
   });
 
+  it("sends the selected project's remembered API key in local API-key mode", async () => {
+    const selectedProjectId = '22222222-2222-2222-2222-222222222222';
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ traces: [], total: 0 }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+    window.localStorage.setItem('continua_api_key', 'pk_A');
+    rememberProjectApiKey(selectedProjectId, 'pk_B');
+    setSelectedProjectIdProvider(() => selectedProjectId);
+
+    await fetchAPI('/api/traces');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers
+    ).toMatchObject({
+      Authorization: 'Bearer pk_B',
+    });
+  });
+
+  it('falls back to the stored API key when the selected project has no remembered key', async () => {
+    const selectedProjectId = '33333333-3333-3333-3333-333333333333';
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ traces: [], total: 0 }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+    window.localStorage.setItem('continua_api_key', 'pk_A');
+    setSelectedProjectIdProvider(() => selectedProjectId);
+
+    await fetchAPI('/api/traces');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers
+    ).toMatchObject({
+      Authorization: 'Bearer pk_A',
+    });
+  });
+
+  it('does not substitute a project API key in Auth0 operator mode', async () => {
+    const selectedProjectId = '44444444-4444-4444-4444-444444444444';
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ traces: [], total: 0 }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+    window.localStorage.setItem('continua_api_key', 'pk_A');
+    rememberProjectApiKey(selectedProjectId, 'pk_B');
+    setSelectedProjectIdProvider(() => selectedProjectId);
+    setAccessTokenProvider(async () => 'auth0-operator-token');
+
+    await fetchAPI('/api/traces');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers
+    ).toMatchObject({
+      Authorization: 'Bearer auth0-operator-token',
+    });
+  });
+
   it('allows unauthenticated demo reads when public demo mode is enabled', async () => {
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ traces: [], total: 0 }), {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -29,6 +29,7 @@ let accessTokenProvider: AccessTokenProvider | null = null;
 let selectedProjectIdProvider: SelectedProjectIdProvider | null = null;
 let legacyTestToken: string | null = null;
 let publicDemoModeEnabled = false;
+let localApiKeyModeEnabled = true;
 
 export type { FetchTracesParams } from '../utils/tracesSearchParams';
 export type {
@@ -42,6 +43,9 @@ export type {
  */
 export function setAccessTokenProvider(provider: AccessTokenProvider | null): void {
   accessTokenProvider = provider;
+  if (provider) {
+    localApiKeyModeEnabled = false;
+  }
 }
 
 export function setSelectedProjectIdProvider(
@@ -52,6 +56,10 @@ export function setSelectedProjectIdProvider(
 
 export function setPublicDemoMode(enabled: boolean): void {
   publicDemoModeEnabled = enabled;
+}
+
+export function setLocalApiKeyMode(enabled: boolean): void {
+  localApiKeyModeEnabled = enabled;
 }
 
 export function getApiKey(): string | null {
@@ -72,6 +80,7 @@ export function setApiKey(key: string): void {
     window.dispatchEvent(new Event(LOCAL_API_KEY_CHANGED_EVENT));
   }
   setAccessTokenProvider(async () => trimmedKey);
+  setLocalApiKeyMode(true);
 }
 
 export function clearApiKey(): void {
@@ -81,6 +90,7 @@ export function clearApiKey(): void {
     window.dispatchEvent(new Event(LOCAL_API_KEY_CHANGED_EVENT));
   }
   setAccessTokenProvider(null);
+  setLocalApiKeyMode(true);
 }
 
 export function rememberProjectApiKey(projectId: string, apiKey: string): void {
@@ -242,6 +252,7 @@ export async function fetchAPI<T>(
   options: FetchAPIOptions = {}
 ): Promise<T> {
   const { allowUnauthenticated = false, ...requestOptions } = options;
+  const requestUrl = buildRequestUrl(path);
   const localApiKey = publicDemoModeEnabled ? null : getApiKey();
 
   if (
@@ -266,11 +277,15 @@ export async function fetchAPI<T>(
     }
   }
 
+  const selectedProjectId = requestUrl.searchParams.get('project_id');
+  if (localApiKeyModeEnabled && selectedProjectId) {
+    accessToken = getKnownProjectApiKey(selectedProjectId) ?? accessToken;
+  }
+
   if (!accessToken && !publicDemoModeEnabled && !allowUnauthenticated) {
     throw new ApiError(401, 'unauthorized', 'Sign in required');
   }
 
-  const requestUrl = buildRequestUrl(path);
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     ...(requestOptions.headers as Record<string, string> | undefined),

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -29,7 +29,7 @@ let accessTokenProvider: AccessTokenProvider | null = null;
 let selectedProjectIdProvider: SelectedProjectIdProvider | null = null;
 let legacyTestToken: string | null = null;
 let publicDemoModeEnabled = false;
-let localApiKeyModeEnabled = true;
+let localApiKeyModeEnabled = false;
 
 export type { FetchTracesParams } from '../utils/tracesSearchParams';
 export type {
@@ -43,9 +43,6 @@ export type {
  */
 export function setAccessTokenProvider(provider: AccessTokenProvider | null): void {
   accessTokenProvider = provider;
-  if (provider) {
-    localApiKeyModeEnabled = false;
-  }
 }
 
 export function setSelectedProjectIdProvider(
@@ -90,7 +87,7 @@ export function clearApiKey(): void {
     window.dispatchEvent(new Event(LOCAL_API_KEY_CHANGED_EVENT));
   }
   setAccessTokenProvider(null);
-  setLocalApiKeyMode(true);
+  setLocalApiKeyMode(false);
 }
 
 export function rememberProjectApiKey(projectId: string, apiKey: string): void {

--- a/web/src/auth/runtime.tsx
+++ b/web/src/auth/runtime.tsx
@@ -18,6 +18,7 @@ import {
   LOCAL_API_KEY_CHANGED_EVENT,
   setAccessTokenProvider,
   setApiKey,
+  setLocalApiKeyMode,
   setPublicDemoMode,
   type RuntimeAuthConfig,
 } from '../api/client';
@@ -196,6 +197,7 @@ function AuthSessionBridge() {
   const { getAccessTokenSilently, isAuthenticated } = useOperatorAuth();
 
   useLayoutEffect(() => {
+    setLocalApiKeyMode(false);
     setPublicDemoMode(false);
     setAccessTokenProvider(async () => {
       if (!isAuthenticated) {
@@ -214,10 +216,12 @@ function AuthSessionBridge() {
 }
 
 function E2EAuthSessionBridge({ children }: { children: ReactNode }) {
+  setLocalApiKeyMode(false);
   setAccessTokenProvider(async () => getE2EAuthToken());
   setPublicDemoMode(false);
 
   useLayoutEffect(() => {
+    setLocalApiKeyMode(false);
     setPublicDemoMode(false);
     setAccessTokenProvider(async () => getE2EAuthToken());
 
@@ -237,6 +241,7 @@ function UnauthenticatedSessionBridge({
   publicDemoEnabled: boolean;
 }) {
   useLayoutEffect(() => {
+    setLocalApiKeyMode(false);
     setAccessTokenProvider(null);
     setPublicDemoMode(publicDemoEnabled);
 
@@ -322,7 +327,9 @@ function LocalApiKeyProtectedOutlet() {
     }
 
     setAccessTokenProvider(async () => storedKey);
+    setLocalApiKeyMode(true);
     return () => {
+      setLocalApiKeyMode(false);
       setAccessTokenProvider(null);
     };
   }, [storedKey]);

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -124,6 +124,9 @@ export function AppShell() {
     if (!isAuthError(projectsQuery.error)) {
       return;
     }
+    if (projectsQuery.error.code === 'project_scope_mismatch') {
+      return;
+    }
     if (staleKeyClearedFor.current === localAuthVersion) {
       return;
     }

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -124,9 +124,6 @@ export function AppShell() {
     if (!isAuthError(projectsQuery.error)) {
       return;
     }
-    if (projectsQuery.error.code === 'project_scope_mismatch') {
-      return;
-    }
     if (staleKeyClearedFor.current === localAuthVersion) {
       return;
     }

--- a/web/src/pages/SessionsPage.test.tsx
+++ b/web/src/pages/SessionsPage.test.tsx
@@ -1,3 +1,4 @@
+import { act } from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -53,6 +54,46 @@ afterEach(() => {
 });
 
 describe('SessionsPage', () => {
+  it('sessions query cache is scoped per project', async () => {
+    const projectA = '55555555-5555-4555-8555-555555555555';
+    const projectB = '66666666-6666-4666-8666-666666666666';
+    const sessionA = {
+      ...SESSION_ONE,
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      external_id: 'project-a-session',
+      name: 'Project A session',
+    };
+    const sessionB = {
+      ...SESSION_TWO,
+      id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      external_id: 'project-b-session',
+      name: 'Project B session',
+    };
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        sessionsList: (url) => {
+          const session =
+            url.searchParams.get('project_id') === projectB ? sessionB : sessionA;
+          return jsonResponse({ sessions: [session], total: 1 });
+        },
+      })
+    );
+
+    const { router } = renderTraceRoutes([
+      `/sessions?project_id=${projectA}&q=checkout`,
+    ]);
+    expect(await screen.findByText('project-a-session')).toBeInTheDocument();
+
+    await act(async () => {
+      await router.navigate(`/sessions?project_id=${projectB}&q=checkout`);
+    });
+
+    expect(await screen.findByText('project-b-session')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('project-a-session')).not.toBeInTheDocument();
+    });
+  });
+
   it('does not introduce engine aggregate badges on the sessions index', async () => {
     fetchMock.mockImplementation(buildFetchHandler());
 

--- a/web/src/pages/TracesPage.test.tsx
+++ b/web/src/pages/TracesPage.test.tsx
@@ -87,6 +87,79 @@ afterEach(() => {
 });
 
 describe('TracesPage', () => {
+  it('traces query cache is scoped per project', async () => {
+    const projectA = '11111111-1111-4111-8111-111111111111';
+    const projectB = '22222222-2222-4222-8222-222222222222';
+    const traceA = {
+      ...TRACE_ONE,
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      name: 'Project A trace',
+    };
+    const traceB = {
+      ...TRACE_TWO,
+      id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      name: 'Project B trace',
+    };
+    fetchMock.mockImplementation(
+      buildFetchHandler({
+        list: (url) => {
+          const trace = url.searchParams.get('project_id') === projectB ? traceB : traceA;
+          return jsonResponse({ traces: [trace], total: 1 });
+        },
+      })
+    );
+
+    const { router } = renderTraceRoutes([
+      `/traces?project_id=${projectA}&q=checkout`,
+    ]);
+    expect(await screen.findByText('Project A trace')).toBeInTheDocument();
+
+    await act(async () => {
+      await router.navigate(`/traces?project_id=${projectB}&q=checkout`);
+    });
+
+    expect(await screen.findByText('Project B trace')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('Project A trace')).not.toBeInTheDocument();
+    });
+  });
+
+  it('builds deterministic trace query cache keys from project and filters', async () => {
+    const projectA = '33333333-3333-4333-8333-333333333333';
+    const projectB = '44444444-4444-4444-8444-444444444444';
+    fetchMock.mockImplementation(buildFetchHandler());
+
+    const firstProjectAView = renderTraceRoutes([
+      `/traces?project_id=${projectA}&q=checkout`,
+    ]);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    const keyForProjectA = firstProjectAView.queryClient.getQueryCache().findAll({
+      queryKey: ['traces'],
+    })[0]?.queryKey;
+    expect(keyForProjectA).toBeDefined();
+    firstProjectAView.unmount();
+
+    const secondProjectAView = renderTraceRoutes([
+      `/traces?project_id=${projectA}&q=checkout`,
+    ]);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    const equalKeyForProjectA = secondProjectAView.queryClient.getQueryCache().findAll({
+      queryKey: ['traces'],
+    })[0]?.queryKey;
+    secondProjectAView.unmount();
+
+    const projectBView = renderTraceRoutes([
+      `/traces?project_id=${projectB}&q=checkout`,
+    ]);
+    expect(await screen.findByText('Checkout Trace')).toBeInTheDocument();
+    const keyForProjectB = projectBView.queryClient.getQueryCache().findAll({
+      queryKey: ['traces'],
+    })[0]?.queryKey;
+
+    expect(equalKeyForProjectA).toEqual(keyForProjectA);
+    expect(keyForProjectB).not.toEqual(keyForProjectA);
+  });
+
   it('loads the default trace list from /traces', async () => {
     fetchMock.mockImplementation(buildFetchHandler());
 


### PR DESCRIPTION
## What and why

Switching the project selector changed `?project_id=` in the URL but the Traces page kept
showing the previous project's rows — the same `10 of 10 traces`, same trace IDs, across three
different project selections.

The cause is entirely in the backend scope resolver. `scopeFromRequest()` in
`internal/api/server_helpers.go` returned `store.BoundScope(projectID)` the moment
`middleware.GetProjectID(ctx)` resolved an API key, and only ever read the `project_id` query
parameter on the operator/Auth0 path. So an API-key request asking for project B silently
received project A's data. The OpenAPI parameter description documented this as intended
("Ignored when the request is already project-scoped by API key").

The React Query cache key was investigated and found **not** to be at fault —
`web/src/utils/tracesSearchParams.ts` already threads `project_id` into the canonical query
string, so cache entries are already per-project. Tests were added to lock that in.

## What changed

**Backend — reject rather than obey.** An API key is bound to exactly one project, so honoring
a foreign `project_id` would be a cross-project read escalation. `scopeFromRequest()` now
compares the selection against the authenticated scope for `AuthModeAPIKey` requests:

| `project_id` | Behavior |
| --- | --- |
| absent | unchanged — bound to the API key's project |
| matches the key's project | 200, that project's data |
| differs from the key's project | **403 `project_scope_mismatch`** |
| malformed | 400 from the generated parameter binding |

Because this lives in the shared scope resolver, it covers traces, sessions, and the engine
console at once. Operator (Auth0) and public-demo modes are unchanged — `project_id` remains a
selection filter for operators. Malformed UUIDs are left to the OpenAPI-generated binding rather
than duplicating that rejection by hand.

**Contract.** The `project_id` description in `contracts/openapi/openapi.yaml` now states the
real rule instead of documenting the bug; generated output regenerated via `make generate`.

**Frontend — send the selected project's own key.** `fetchAPI` resolved its token from
`getApiKey()`/`accessTokenProvider` only, never consulting the `getKnownProjectApiKey()` store
that `AppShell` already populates. It now substitutes the selected project's remembered key, so
the selector genuinely switches data instead of turning into an honest-but-useless 403.

That substitution is gated on an explicit `setLocalApiKeyMode()` flag that defaults to **off**
and is declared by the session bridges in `web/src/auth/runtime.tsx`. This is deliberate: local
mode also sets an access-token provider, exactly like Auth0 mode, so inferring the mode from
provider state would make the behavior depend on call ordering and would pass unit tests while
staying broken in the browser. Auth0 tokens are never replaced by a project key.

## Review and test evidence

Acceptance tests were written first, committed red, and verified failing for the right reason
before any implementation existed:

- `TestListTracesWithMismatchedProjectIDIsRejected` — expected 403, **actual 200**
- `TestListSessionsWithMismatchedProjectIDIsRejected` — expected 403, **actual 200**
- `sends the selected project's remembered API key in local API-key mode` — expected `Bearer pk_B`, **received `Bearer pk_A`**

The Go tests seed two projects with deliberately distinguishable rows and assert both the status
code and the absence of the other project's ID from the body, so a silent fallback to the key's
project fails the test rather than passing on a count check.

Verification:
- `go test ./internal/api/...` against a real Postgres — pass
- `pnpm --filter web test` — 554 tests across 67 files, pass
- `pnpm --filter web test:e2e` — 14/14 desktop + mobile, including a new local-mode project-switch
  test whose route mock asserts the per-project `Authorization` header on every `/api/traces` call
- Real server booted and exercised with curl: mismatch → 403 `project_scope_mismatch`, match → A's
  traces, no parameter → A's traces
- `make generate` clean; no regressions in traces, trace detail, sessions, compare, settings,
  engine runs, or public demo

Review removed an unreachable `project_scope_mismatch` guard in `AppShell` (`ListProjects` never
calls the scope resolver, so that endpoint cannot emit the code) and eliminated a hidden
mode-flipping side effect in `setAccessTokenProvider` that made the fix order-dependent.

Closes #237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-aware API key selection in local mode, including project-specific key fallback behavior.
  * Added project switching support across desktop and mobile interfaces, with updated URLs and project-specific trace results.

* **Bug Fixes**
  * API-key requests now reject mismatched project selections with `403 project_scope_mismatch`.
  * Sessions and traces are correctly isolated by project.

* **Tests**
  * Expanded coverage for project authorization, project switching, API-key selection, and project-specific caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->