### PR TITLE
feat(api,web): add opt-in local single-user mode

### DIFF
--- a/contracts/generated/go/server_gen.go
+++ b/contracts/generated/go/server_gen.go
@@ -329,6 +329,9 @@ type AuthConfig struct {
 	Domain   *string `json:"domain,omitempty"`
 	Enabled  bool    `json:"enabled"`
 
+	// LocalModeEnabled Whether API-key-free single-user local mode is active for this connection. True only when the server has local single-user mode enabled and the requesting connection originates from loopback.
+	LocalModeEnabled *bool `json:"local_mode_enabled,omitempty"`
+
 	// PublicDemoEnabled Whether the deployment exposes a public read-only demo console.
 	PublicDemoEnabled *bool `json:"public_demo_enabled,omitempty"`
 

--- a/contracts/generated/typescript/api.ts
+++ b/contracts/generated/typescript/api.ts
@@ -663,6 +663,8 @@ export interface components {
             public_demo_enabled?: boolean;
             /** @description Display label for the public demo banner shown in the debugger shell. */
             public_demo_label?: string;
+            /** @description Whether API-key-free single-user local mode is active for this connection. True only when the server has local single-user mode enabled and the requesting connection originates from loopback. */
+            local_mode_enabled?: boolean;
         };
         Error: {
             code: string;

--- a/contracts/openapi/openapi.bundle.yaml
+++ b/contracts/openapi/openapi.bundle.yaml
@@ -1773,6 +1773,9 @@ components:
         public_demo_label:
           type: string
           description: Display label for the public demo banner shown in the debugger shell.
+        local_mode_enabled:
+          type: boolean
+          description: Whether API-key-free single-user local mode is active for this connection. True only when the server has local single-user mode enabled and the requesting connection originates from loopback.
     Error:
       type: object
       required:

--- a/contracts/openapi/openapi.yaml
+++ b/contracts/openapi/openapi.yaml
@@ -1757,6 +1757,12 @@ components:
         public_demo_label:
           type: string
           description: Display label for the public demo banner shown in the debugger shell.
+        local_mode_enabled:
+          type: boolean
+          description: >-
+            Whether API-key-free single-user local mode is active for this
+            connection. True only when the server has local single-user mode
+            enabled and the requesting connection originates from loopback.
 
     Error:
       type: object

--- a/docs-site/api-reference/openapi.yaml
+++ b/docs-site/api-reference/openapi.yaml
@@ -1773,6 +1773,9 @@ components:
         public_demo_label:
           type: string
           description: Display label for the public demo banner shown in the debugger shell.
+        local_mode_enabled:
+          type: boolean
+          description: Whether API-key-free single-user local mode is active for this connection. True only when the server has local single-user mode enabled and the requesting connection originates from loopback.
     Error:
       type: object
       required:

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -1,11 +1,21 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/continua-ai/continua/internal/api/middleware"
+)
 
 // GetAuthConfig returns the runtime Auth0 bootstrap configuration for the web debugger.
-func (s *Server) GetAuthConfig(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) GetAuthConfig(w http.ResponseWriter, r *http.Request) {
 	response := AuthConfig{
 		Enabled: s.auth0Config.Enabled,
+	}
+
+	// Only ever advertise the credential-free bypass to a caller that could
+	// actually use it. A remote client must not learn the mode exists.
+	if s.localSingleUserMode && middleware.IsLoopbackRequest(r) {
+		response.LocalModeEnabled = boolValuePtr(true)
 	}
 
 	if s.publicDemoConfig.Enabled {

--- a/internal/api/auth_projects_handlers_test.go
+++ b/internal/api/auth_projects_handlers_test.go
@@ -91,6 +91,43 @@ func TestGetAuthConfig_PublicDemoReturnsDemoFields(t *testing.T) {
 	assert.Equal(t, "Portfolio demo", *resp.PublicDemoLabel)
 }
 
+func TestAuthConfigAdvertisesLocalModeOnLoopback(t *testing.T) {
+	server := NewServer(nil, nil)
+	server.localSingleUserMode = true
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/config", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+
+	server.GetAuthConfig(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeJSONBody[AuthConfig](t, rec)
+	require.NotNil(t, resp.LocalModeEnabled)
+	assert.True(t, *resp.LocalModeEnabled)
+}
+
+func TestAuthConfigHidesLocalModeOffLoopback(t *testing.T) {
+	// Never tell a remote client that an unauthenticated bypass exists.
+	server := NewServer(nil, nil)
+	server.localSingleUserMode = true
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/config", nil)
+	req.RemoteAddr = "203.0.113.5:44444"
+
+	server.GetAuthConfig(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	body := rec.Body.String()
+	assert.NotContains(t, body, `"local_mode_enabled":true`)
+
+	resp := decodeJSONBody[AuthConfig](t, rec)
+	if resp.LocalModeEnabled != nil {
+		assert.False(t, *resp.LocalModeEnabled)
+	}
+}
+
 func TestListProjects_OperatorReturnsAllVisibleProjects(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ctx := context.Background()

--- a/internal/api/local_mode_mutation_test.go
+++ b/internal/api/local_mode_mutation_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/continua-ai/continua/internal/testutil"
 )
 
-// Local single-user mode is read-only plus the project bootstrap. Any process on
-// the machine can reach the loopback surface, so project mutations must still
-// demand an API key even though reads do not.
+// Local single-user mode is fully credential-free on loopback: reads, the
+// project bootstrap and project management all work without an API key. That is
+// a deliberate decision for single-user localhost use, and it widens the local
+// surface — so the property that keeps it confined, loopback-only admission that
+// ignores proxy headers, is the one these tests guard hardest.
 
 type localModeMutationFixture struct {
 	router  http.Handler
@@ -82,37 +84,55 @@ func (f localModeMutationFixture) serveFromLoopback(
 	return rec
 }
 
-func TestLocalModeRejectsProjectMutationWithoutAPIKey(t *testing.T) {
+// TestLocalModeAllowsProjectMutationWithoutAPIKey pins the maintainer's ruling:
+// a credential-free loopback caller can rename, rotate and delete. Status codes
+// alone would not prove the writes landed, so each step is confirmed against the
+// store.
+func TestLocalModeAllowsProjectMutationWithoutAPIKey(t *testing.T) {
 	fixture := newLocalModeMutationFixture(t)
 	projectPath := "/api/projects/" + fixture.project.ID.String()
+	ctx := context.Background()
 
-	mutations := []struct {
-		name   string
-		method string
-		target string
-		body   string
-	}{
-		{"rename", http.MethodPatch, projectPath, `{"name":"Renamed by an unauthenticated caller"}`},
-		{"rotate key", http.MethodPost, projectPath + "/rotate", ""},
-		{"delete", http.MethodDelete, projectPath, ""},
-	}
+	renamed := fixture.serveFromLoopback(
+		t,
+		http.MethodPatch,
+		projectPath,
+		`{"name":"Renamed without a key"}`,
+		"",
+	)
+	require.Equal(t, http.StatusOK, renamed.Code)
+	assert.Equal(t, "Renamed without a key", decodeJSONBody[Project](t, renamed).Name)
 
-	for _, mutation := range mutations {
-		t.Run(mutation.name, func(t *testing.T) {
-			rec := fixture.serveFromLoopback(t, mutation.method, mutation.target, mutation.body, "")
+	stored, err := fixture.store.GetProject(ctx, fixture.project.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Renamed without a key", stored.Name, "the rename must have reached the database")
 
-			require.Equal(t, http.StatusUnauthorized, rec.Code)
-			resp := decodeJSONBody[Error](t, rec)
-			assert.Equal(t, "missing_credentials", resp.Code)
-		})
-	}
+	rotated := fixture.serveFromLoopback(t, http.MethodPost, projectPath+"/rotate", "", "")
+	require.Equal(t, http.StatusOK, rotated.Code)
+	rotateResp := decodeJSONBody[ProjectWithKey](t, rotated)
+	assert.NotEmpty(t, rotateResp.ApiKey, "rotation must return the new plaintext key")
 
-	// Status codes alone would not prove the writes were refused, so confirm the
-	// project survived intact.
-	surviving, err := fixture.store.GetProject(context.Background(), fixture.project.ID)
-	require.NoError(t, err, "the project must not have been deleted")
-	assert.Equal(t, fixture.project.Name, surviving.Name, "the project must not have been renamed")
-	assert.Equal(t, fixture.project.ApiKeyHash, surviving.ApiKeyHash, "the API key must not have been rotated")
+	stored, err = fixture.store.GetProject(ctx, fixture.project.ID)
+	require.NoError(t, err)
+	require.NotEqual(
+		t,
+		fixture.project.ApiKeyHash,
+		stored.ApiKeyHash,
+		"the stored key hash must have changed",
+	)
+	assert.Equal(
+		t,
+		middleware.HashAPIKey(rotateResp.ApiKey),
+		stored.ApiKeyHash,
+		"the stored hash must match the returned key",
+	)
+
+	deleted := fixture.serveFromLoopback(t, http.MethodDelete, projectPath, "", "")
+	require.Equal(t, http.StatusNoContent, deleted.Code)
+
+	_, err = fixture.store.GetProject(ctx, fixture.project.ID)
+	require.Error(t, err, "the project row must be gone")
+	assert.True(t, store.IsNotFound(err), "expected a not-found error, got %v", err)
 }
 
 func TestLocalModeStillAllowsProjectBootstrap(t *testing.T) {
@@ -157,16 +177,62 @@ func TestProjectMutationStillWorksWithAPIKey(t *testing.T) {
 	assert.Equal(t, "Renamed with a valid key", stored.Name)
 }
 
-func TestLocalModeRejectsProjectDeleteFromSpoofedRemotePeer(t *testing.T) {
+// TestLocalModeRejectsProjectMutationFromRemotePeer is the load-bearing negative
+// case now that local mode can rename, rotate and delete without a key: the only
+// thing standing between a project and a remote caller is the loopback check.
+// These run through the production router so chi's RealIP really sits in the
+// stack, which is where the spoofing hazard lives — every header RealIP consults
+// is replayed against every mutation, and the project is checked afterwards to
+// prove nothing changed.
+func TestLocalModeRejectsProjectMutationFromRemotePeer(t *testing.T) {
 	fixture := newLocalModeMutationFixture(t)
+	projectPath := "/api/projects/" + fixture.project.ID.String()
 
-	req := httptest.NewRequest(http.MethodDelete, "/api/projects/"+fixture.project.ID.String(), nil)
-	req.RemoteAddr = remoteNonLoopbackAddr
-	req.Header.Set("X-Forwarded-For", "127.0.0.1")
-	rec := httptest.NewRecorder()
-	fixture.router.ServeHTTP(rec, req)
+	mutations := []struct {
+		name   string
+		method string
+		target string
+		body   string
+	}{
+		{"rename", http.MethodPatch, projectPath, `{"name":"Renamed by a remote caller"}`},
+		{"rotate key", http.MethodPost, projectPath + "/rotate", ""},
+		{"delete", http.MethodDelete, projectPath, ""},
+	}
 
-	require.Equal(t, http.StatusUnauthorized, rec.Code)
-	_, err := fixture.store.GetProject(context.Background(), fixture.project.ID)
+	// nil headers is the plain remote caller; the rest are the spoofing attempts.
+	peers := map[string]map[string]string{"no headers": nil}
+	for header, value := range spoofedLoopbackHeaders() {
+		peers["spoofed "+header] = map[string]string{header: value}
+	}
+
+	for _, mutation := range mutations {
+		for peer, headers := range peers {
+			t.Run(mutation.name+"/"+peer, func(t *testing.T) {
+				req := httptest.NewRequest(mutation.method, mutation.target, strings.NewReader(mutation.body))
+				req.RemoteAddr = remoteNonLoopbackAddr
+				req.Header.Set("Content-Type", "application/json")
+				for name, value := range headers {
+					req.Header.Set(name, value)
+				}
+
+				rec := httptest.NewRecorder()
+				fixture.router.ServeHTTP(rec, req)
+
+				require.Equal(
+					t,
+					http.StatusUnauthorized,
+					rec.Code,
+					"a remote peer must not reach %s %s", mutation.method, mutation.target,
+				)
+				resp := decodeJSONBody[Error](t, rec)
+				assert.Equal(t, "missing_credentials", resp.Code)
+			})
+		}
+	}
+
+	// Status codes alone would not prove the writes were refused.
+	surviving, err := fixture.store.GetProject(context.Background(), fixture.project.ID)
 	require.NoError(t, err, "a remote caller must not be able to delete a project")
+	assert.Equal(t, fixture.project.Name, surviving.Name, "the project must not have been renamed")
+	assert.Equal(t, fixture.project.ApiKeyHash, surviving.ApiKeyHash, "the API key must not have been rotated")
 }

--- a/internal/api/local_mode_mutation_test.go
+++ b/internal/api/local_mode_mutation_test.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/api/middleware"
+	"github.com/continua-ai/continua/internal/config"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+// Local single-user mode is read-only plus the project bootstrap. Any process on
+// the machine can reach the loopback surface, so project mutations must still
+// demand an API key even though reads do not.
+
+type localModeMutationFixture struct {
+	router  http.Handler
+	store   *store.Store
+	project platform.Project
+	apiKey  string
+}
+
+func newLocalModeMutationFixture(t *testing.T) localModeMutationFixture {
+	t.Helper()
+
+	pool := testutil.TestDB(t)
+	platformStore := store.New(pool)
+
+	apiKey := "local-mode-mutation-" + uuid.NewString()
+	project, err := platformStore.Queries().CreateProject(context.Background(), platform.CreateProjectParams{
+		Name:       "Local mode mutation " + uuid.NewString(),
+		ApiKeyHash: middleware.HashAPIKey(apiKey),
+	})
+	require.NoError(t, err)
+
+	authenticator, err := middleware.NewAuthenticator(platformStore, &config.Config{
+		LocalSingleUserMode: true,
+	})
+	require.NoError(t, err)
+
+	return localModeMutationFixture{
+		router:  NewRouter(NewServer(platformStore, nil), authenticator),
+		store:   platformStore,
+		project: project,
+		apiKey:  apiKey,
+	}
+}
+
+// serveFromLoopback issues a request from a genuine loopback peer, optionally
+// carrying an API key.
+func (f localModeMutationFixture) serveFromLoopback(
+	t *testing.T,
+	method, target, body, apiKey string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var reader *strings.Reader
+	if body == "" {
+		reader = strings.NewReader("")
+	} else {
+		reader = strings.NewReader(body)
+	}
+
+	req := httptest.NewRequest(method, target, reader)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+
+	rec := httptest.NewRecorder()
+	f.router.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestLocalModeRejectsProjectMutationWithoutAPIKey(t *testing.T) {
+	fixture := newLocalModeMutationFixture(t)
+	projectPath := "/api/projects/" + fixture.project.ID.String()
+
+	mutations := []struct {
+		name   string
+		method string
+		target string
+		body   string
+	}{
+		{"rename", http.MethodPatch, projectPath, `{"name":"Renamed by an unauthenticated caller"}`},
+		{"rotate key", http.MethodPost, projectPath + "/rotate", ""},
+		{"delete", http.MethodDelete, projectPath, ""},
+	}
+
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			rec := fixture.serveFromLoopback(t, mutation.method, mutation.target, mutation.body, "")
+
+			require.Equal(t, http.StatusUnauthorized, rec.Code)
+			resp := decodeJSONBody[Error](t, rec)
+			assert.Equal(t, "missing_credentials", resp.Code)
+		})
+	}
+
+	// Status codes alone would not prove the writes were refused, so confirm the
+	// project survived intact.
+	surviving, err := fixture.store.GetProject(context.Background(), fixture.project.ID)
+	require.NoError(t, err, "the project must not have been deleted")
+	assert.Equal(t, fixture.project.Name, surviving.Name, "the project must not have been renamed")
+	assert.Equal(t, fixture.project.ApiKeyHash, surviving.ApiKeyHash, "the API key must not have been rotated")
+}
+
+func TestLocalModeStillAllowsProjectBootstrap(t *testing.T) {
+	fixture := newLocalModeMutationFixture(t)
+
+	listed := fixture.serveFromLoopback(t, http.MethodGet, "/api/projects", "", "")
+	require.Equal(t, http.StatusOK, listed.Code)
+	listResp := decodeJSONBody[ProjectList](t, listed)
+	assert.NotEmpty(t, listResp.Projects, "first-run setup must still be able to list projects")
+
+	created := fixture.serveFromLoopback(
+		t,
+		http.MethodPost,
+		"/api/projects",
+		`{"name":"Bootstrapped in local mode"}`,
+		"",
+	)
+	require.Equal(t, http.StatusCreated, created.Code)
+	createResp := decodeJSONBody[ProjectWithKey](t, created)
+	assert.Equal(t, "Bootstrapped in local mode", createResp.Name)
+	assert.NotEmpty(t, createResp.ApiKey)
+}
+
+func TestProjectMutationStillWorksWithAPIKey(t *testing.T) {
+	fixture := newLocalModeMutationFixture(t)
+	projectPath := "/api/projects/" + fixture.project.ID.String()
+
+	rec := fixture.serveFromLoopback(
+		t,
+		http.MethodPatch,
+		projectPath,
+		`{"name":"Renamed with a valid key"}`,
+		fixture.apiKey,
+	)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeJSONBody[Project](t, rec)
+	assert.Equal(t, "Renamed with a valid key", resp.Name)
+
+	stored, err := fixture.store.GetProject(context.Background(), fixture.project.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed with a valid key", stored.Name)
+}
+
+func TestLocalModeRejectsProjectDeleteFromSpoofedRemotePeer(t *testing.T) {
+	fixture := newLocalModeMutationFixture(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/projects/"+fixture.project.ID.String(), nil)
+	req.RemoteAddr = remoteNonLoopbackAddr
+	req.Header.Set("X-Forwarded-For", "127.0.0.1")
+	rec := httptest.NewRecorder()
+	fixture.router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	_, err := fixture.store.GetProject(context.Background(), fixture.project.ID)
+	require.NoError(t, err, "a remote caller must not be able to delete a project")
+}

--- a/internal/api/local_mode_router_test.go
+++ b/internal/api/local_mode_router_test.go
@@ -1,0 +1,168 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/internal/api/middleware"
+	"github.com/continua-ai/continua/internal/config"
+)
+
+// These tests exercise the REAL router, not a bare Authenticator, because the
+// vulnerability they guard lives in the middleware ordering rather than in the
+// auth logic. chi's RealIP middleware rewrites r.RemoteAddr from caller-supplied
+// proxy headers, so without middleware.CaptureTransportPeer mounted ahead of it a
+// remote client can claim to be loopback and unlock local single-user mode. Only
+// a test that runs the whole stack can see that.
+
+// remoteNonLoopbackAddr is a transport peer that must never be served
+// unauthenticated, whatever its headers claim.
+const remoteNonLoopbackAddr = "192.168.68.61:44444"
+
+// spoofedLoopbackHeaders are the headers chi's RealIP consults, plus RFC 7239
+// Forwarded, which no middleware honors today but might tomorrow.
+func spoofedLoopbackHeaders() map[string]string {
+	return map[string]string{
+		"X-Forwarded-For": "127.0.0.1",
+		"X-Real-IP":       "127.0.0.1",
+		"True-Client-IP":  "127.0.0.1",
+		"Forwarded":       "for=127.0.0.1",
+	}
+}
+
+func serveLocalModeRouterRequest(
+	t *testing.T,
+	router http.Handler,
+	target string,
+	remoteAddr string,
+	headers map[string]string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req.RemoteAddr = remoteAddr
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestLocalModeRouterRejectsSpoofedForwardedForHeader(t *testing.T) {
+	fixture := newLocalModeScopeFixture(t)
+	target := "/api/traces?project_id=" + fixture.projectA.ID.String()
+
+	for header, value := range spoofedLoopbackHeaders() {
+		t.Run(header, func(t *testing.T) {
+			rec := serveLocalModeRouterRequest(
+				t,
+				fixture.router,
+				target,
+				remoteNonLoopbackAddr,
+				map[string]string{header: value},
+			)
+
+			require.Equal(
+				t,
+				http.StatusUnauthorized,
+				rec.Code,
+				"a remote peer must not unlock local single-user mode via %s", header,
+			)
+
+			body := rec.Body.String()
+			assert.NotContains(t, body, fixture.traceA.ID.String(), "leaked project A data")
+			assert.NotContains(t, body, fixture.traceB.ID.String(), "leaked project B data")
+		})
+	}
+}
+
+func TestLocalModeRouterRejectsRemotePeerWithoutHeaders(t *testing.T) {
+	fixture := newLocalModeScopeFixture(t)
+
+	rec := serveLocalModeRouterRequest(
+		t,
+		fixture.router,
+		"/api/traces?project_id="+fixture.projectA.ID.String(),
+		remoteNonLoopbackAddr,
+		nil,
+	)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.NotContains(t, rec.Body.String(), fixture.traceA.ID.String())
+}
+
+func TestLocalModeRouterAllowsGenuineLoopbackPeer(t *testing.T) {
+	fixture := newLocalModeScopeFixture(t)
+
+	rec := serveLocalModeRouterRequest(
+		t,
+		fixture.router,
+		"/api/traces?project_id="+fixture.projectA.ID.String(),
+		"127.0.0.1:54321",
+		nil,
+	)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	resp := decodeJSONBody[TraceList](t, rec)
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Traces, 1)
+	assert.Equal(t, fixture.traceA.ID, resp.Traces[0].Id)
+	assert.NotContains(t, body, fixture.traceB.ID.String())
+}
+
+func TestAuthConfigRouterHidesLocalModeFromSpoofedPeer(t *testing.T) {
+	router := newLocalModeAuthConfigRouter(t)
+
+	rec := serveLocalModeRouterRequest(
+		t,
+		router,
+		"/api/auth/config",
+		remoteNonLoopbackAddr,
+		map[string]string{"X-Forwarded-For": "127.0.0.1"},
+	)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), `"local_mode_enabled":true`)
+
+	var resp AuthConfig
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	if resp.LocalModeEnabled != nil {
+		assert.False(t, *resp.LocalModeEnabled)
+	}
+}
+
+func TestAuthConfigRouterAdvertisesLocalModeToLoopbackPeer(t *testing.T) {
+	router := newLocalModeAuthConfigRouter(t)
+
+	rec := serveLocalModeRouterRequest(t, router, "/api/auth/config", "127.0.0.1:54321", nil)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp AuthConfig
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.LocalModeEnabled)
+	assert.True(t, *resp.LocalModeEnabled)
+}
+
+// newLocalModeAuthConfigRouter builds the production router around a server with
+// local single-user mode on. /api/auth/config is a public route, so no store is
+// needed to reach the handler.
+func newLocalModeAuthConfigRouter(t *testing.T) http.Handler {
+	t.Helper()
+
+	server := NewServer(nil, nil)
+	server.localSingleUserMode = true
+	authenticator, err := middleware.NewAuthenticator(nil, &config.Config{
+		LocalSingleUserMode: true,
+	})
+	require.NoError(t, err)
+
+	return NewRouter(server, authenticator)
+}

--- a/internal/api/local_mode_router_test.go
+++ b/internal/api/local_mode_router_test.go
@@ -166,3 +166,71 @@ func newLocalModeAuthConfigRouter(t *testing.T) http.Handler {
 
 	return NewRouter(server, authenticator)
 }
+
+// Local single-user mode is read-only. The composite route class is broader than
+// the console's read surface — it also covers the engine write endpoints — so
+// these drive the production router and confirm a credential-free loopback
+// caller cannot start a run or trigger a backfill. That matters because any
+// process on the machine can reach this surface, including a browser tab on a
+// hostile page issuing a cross-origin POST to localhost.
+func TestLocalModeRouterRejectsCredentialFreeEngineWrites(t *testing.T) {
+	router := newLocalModeEngineRouter(t)
+
+	writes := []struct {
+		name   string
+		method string
+		target string
+	}{
+		{"start run", http.MethodPost, "/v1/engine/runs"},
+		{"projection backfill", http.MethodPost, "/v1/engine/projections/backfill"},
+	}
+
+	for _, write := range writes {
+		t.Run(write.name, func(t *testing.T) {
+			req := httptest.NewRequest(write.method, write.target, http.NoBody)
+			req.RemoteAddr = "127.0.0.1:54321"
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			require.Equal(
+				t,
+				http.StatusUnauthorized,
+				rec.Code,
+				"local single-user mode must not admit a credential-free write to %s", write.target,
+			)
+			resp := decodeJSONBody[Error](t, rec)
+			assert.Equal(t, "missing_credentials", resp.Code)
+		})
+	}
+}
+
+// TestLocalModeRouterStillAllowsEngineReads pins the other half of the rule: the
+// read surface the console actually needs stays open, so the method restriction
+// above is not simply switching local mode off.
+func TestLocalModeRouterStillAllowsEngineReads(t *testing.T) {
+	router := newLocalModeEngineRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/engine/runs", http.NoBody)
+	req.RemoteAddr = "127.0.0.1:54321"
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusUnauthorized, rec.Code, "engine reads must stay open in local mode")
+}
+
+// newLocalModeEngineRouter builds the production router with local single-user
+// mode on and the engine public API mounted. Auth runs ahead of the handlers, so
+// the rejected requests never need a store.
+func newLocalModeEngineRouter(t *testing.T) http.Handler {
+	t.Helper()
+
+	server := NewServer(nil, nil)
+	server.localSingleUserMode = true
+	server.enginePublicAPIEnabled = true
+	authenticator, err := middleware.NewAuthenticator(nil, &config.Config{
+		LocalSingleUserMode: true,
+	})
+	require.NoError(t, err)
+
+	return NewRouter(server, authenticator)
+}

--- a/internal/api/local_mode_router_test.go
+++ b/internal/api/local_mode_router_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -167,46 +168,70 @@ func newLocalModeAuthConfigRouter(t *testing.T) http.Handler {
 	return NewRouter(server, authenticator)
 }
 
-// Local single-user mode is read-only. The composite route class is broader than
-// the console's read surface — it also covers the engine write endpoints — so
-// these drive the production router and confirm a credential-free loopback
-// caller cannot start a run or trigger a backfill. That matters because any
-// process on the machine can reach this surface, including a browser tab on a
-// hostile page issuing a cross-origin POST to localhost.
-func TestLocalModeRouterRejectsCredentialFreeEngineWrites(t *testing.T) {
+// Local single-user mode is credential-free across the whole composite surface
+// on loopback, engine writes included. Execution control is deliberately part of
+// that: the mode is an explicit opt-in on a machine its operator owns. Loopback
+// admission is therefore the entire security boundary, so these drive the
+// production router — where chi's RealIP actually sits — and pin both halves:
+// a genuine loopback peer gets through, and a remote peer does not, however its
+// headers are dressed up.
+func TestLocalModeRouterAdmitsCredentialFreeEngineWritesFromLoopback(t *testing.T) {
 	router := newLocalModeEngineRouter(t)
 
-	writes := []struct {
-		name   string
-		method string
-		target string
-	}{
-		{"start run", http.MethodPost, "/v1/engine/runs"},
-		{"projection backfill", http.MethodPost, "/v1/engine/projections/backfill"},
-	}
+	for _, target := range engineWriteRoutes() {
+		t.Run(target, func(t *testing.T) {
+			rec := serveEngineWrite(t, router, target, "127.0.0.1:54321", nil)
 
-	for _, write := range writes {
-		t.Run(write.name, func(t *testing.T) {
-			req := httptest.NewRequest(write.method, write.target, http.NoBody)
-			req.RemoteAddr = "127.0.0.1:54321"
-			rec := httptest.NewRecorder()
-			router.ServeHTTP(rec, req)
-
-			require.Equal(
+			// The handler rejects the empty body, which is exactly the point:
+			// reaching validation proves auth admitted the request.
+			require.NotEqual(
 				t,
 				http.StatusUnauthorized,
 				rec.Code,
-				"local single-user mode must not admit a credential-free write to %s", write.target,
+				"local mode must admit a credential-free loopback write to %s", target,
 			)
-			resp := decodeJSONBody[Error](t, rec)
-			assert.Equal(t, "missing_credentials", resp.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code, "expected to reach handler validation")
 		})
 	}
 }
 
-// TestLocalModeRouterStillAllowsEngineReads pins the other half of the rule: the
-// read surface the console actually needs stays open, so the method restriction
-// above is not simply switching local mode off.
+func TestLocalModeRouterRejectsEngineWritesFromRemotePeer(t *testing.T) {
+	router := newLocalModeEngineRouter(t)
+
+	peers := map[string]map[string]string{"no headers": nil}
+	for header, value := range spoofedLoopbackHeaders() {
+		peers["spoofed "+header] = map[string]string{header: value}
+	}
+
+	for _, target := range engineWriteRoutes() {
+		for peer, headers := range peers {
+			t.Run(target+"/"+peer, func(t *testing.T) {
+				rec := serveEngineWrite(t, router, target, remoteNonLoopbackAddr, headers)
+
+				require.Equal(
+					t,
+					http.StatusUnauthorized,
+					rec.Code,
+					"a remote peer must not reach %s", target,
+				)
+				assert.Equal(t, "missing_credentials", decodeJSONBody[Error](t, rec).Code)
+			})
+		}
+	}
+}
+
+// TestLocalModeRouterKeepsIngestAPIKeyOnly pins the one route local mode must
+// never open: ingest is routeProtectionAPIKeyOnly, so even a loopback caller
+// needs a key.
+func TestLocalModeRouterKeepsIngestAPIKeyOnly(t *testing.T) {
+	router := newLocalModeEngineRouter(t)
+
+	rec := serveEngineWrite(t, router, "/v1/ingest", "127.0.0.1:54321", nil)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code, "ingest must still require an API key")
+	assert.Equal(t, "missing_api_key", decodeJSONBody[Error](t, rec).Code)
+}
+
 func TestLocalModeRouterStillAllowsEngineReads(t *testing.T) {
 	router := newLocalModeEngineRouter(t)
 
@@ -218,9 +243,34 @@ func TestLocalModeRouterStillAllowsEngineReads(t *testing.T) {
 	assert.NotEqual(t, http.StatusUnauthorized, rec.Code, "engine reads must stay open in local mode")
 }
 
+// engineWriteRoutes are the composite engine mutations: starting a run and
+// triggering a projection backfill.
+func engineWriteRoutes() []string {
+	return []string{"/v1/engine/runs", "/v1/engine/projections/backfill"}
+}
+
+func serveEngineWrite(
+	t *testing.T,
+	router http.Handler,
+	target, remoteAddr string,
+	headers map[string]string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader("{}"))
+	req.RemoteAddr = remoteAddr
+	req.Header.Set("Content-Type", "application/json")
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
 // newLocalModeEngineRouter builds the production router with local single-user
-// mode on and the engine public API mounted. Auth runs ahead of the handlers, so
-// the rejected requests never need a store.
+// mode on and the engine public API mounted.
 func newLocalModeEngineRouter(t *testing.T) http.Handler {
 	t.Helper()
 

--- a/internal/api/local_mode_scope_test.go
+++ b/internal/api/local_mode_scope_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/db/gen/go/platform"
+	"github.com/continua-ai/continua/internal/api/middleware"
+	"github.com/continua-ai/continua/internal/config"
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+type localModeScopeFixture struct {
+	router   http.Handler
+	projectA platform.Project
+	projectB platform.Project
+	traceA   platform.Trace
+	traceB   platform.Trace
+	sessionA platform.Session
+	sessionB platform.Session
+}
+
+func TestLocalModeTracesScopedToSelectedProject(t *testing.T) {
+	fixture := newLocalModeScopeFixture(t)
+
+	recB := fixture.getFromLoopback(t, "/api/traces?project_id="+fixture.projectB.ID.String())
+	require.Equal(t, http.StatusOK, recB.Code)
+	bodyB := recB.Body.String()
+	respB := decodeJSONBody[TraceList](t, recB)
+	assert.Equal(t, 1, respB.Total)
+	require.Len(t, respB.Traces, 1)
+	assert.Equal(t, fixture.traceB.ID, respB.Traces[0].Id)
+	assert.Equal(t, "Local mode project B trace", respB.Traces[0].Name)
+	assert.NotContains(t, bodyB, fixture.traceA.ID.String())
+
+	recA := fixture.getFromLoopback(t, "/api/traces?project_id="+fixture.projectA.ID.String())
+	require.Equal(t, http.StatusOK, recA.Code)
+	bodyA := recA.Body.String()
+	respA := decodeJSONBody[TraceList](t, recA)
+	assert.Equal(t, 1, respA.Total)
+	require.Len(t, respA.Traces, 1)
+	assert.Equal(t, fixture.traceA.ID, respA.Traces[0].Id)
+	assert.Equal(t, "Local mode project A trace", respA.Traces[0].Name)
+	assert.NotContains(t, bodyA, fixture.traceB.ID.String())
+}
+
+func TestLocalModeTracesWithoutProjectIDIsRejected(t *testing.T) {
+	fixture := newLocalModeScopeFixture(t)
+
+	rec := fixture.getFromLoopback(t, "/api/traces")
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	body := rec.Body.String()
+	resp := decodeJSONBody[Error](t, rec)
+	assert.Equal(t, "missing_project_id", resp.Code)
+	assert.NotContains(t, body, fixture.traceA.ID.String())
+	assert.NotContains(t, body, fixture.traceB.ID.String())
+}
+
+func TestLocalModeSessionsScopedToSelectedProject(t *testing.T) {
+	fixture := newLocalModeScopeFixture(t)
+
+	recB := fixture.getFromLoopback(t, "/api/sessions?project_id="+fixture.projectB.ID.String())
+	require.Equal(t, http.StatusOK, recB.Code)
+	bodyB := recB.Body.String()
+	respB := decodeJSONBody[SessionList](t, recB)
+	assert.Equal(t, 1, respB.Total)
+	require.Len(t, respB.Sessions, 1)
+	assert.Equal(t, fixture.sessionB.ID, respB.Sessions[0].Id)
+	require.NotNil(t, respB.Sessions[0].Name)
+	assert.Equal(t, "Local mode project B session", *respB.Sessions[0].Name)
+	assert.NotContains(t, bodyB, fixture.sessionA.ID.String())
+
+	recA := fixture.getFromLoopback(t, "/api/sessions?project_id="+fixture.projectA.ID.String())
+	require.Equal(t, http.StatusOK, recA.Code)
+	bodyA := recA.Body.String()
+	respA := decodeJSONBody[SessionList](t, recA)
+	assert.Equal(t, 1, respA.Total)
+	require.Len(t, respA.Sessions, 1)
+	assert.Equal(t, fixture.sessionA.ID, respA.Sessions[0].Id)
+	require.NotNil(t, respA.Sessions[0].Name)
+	assert.Equal(t, "Local mode project A session", *respA.Sessions[0].Name)
+	assert.NotContains(t, bodyA, fixture.sessionB.ID.String())
+}
+
+func newLocalModeScopeFixture(t *testing.T) localModeScopeFixture {
+	t.Helper()
+
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	platformStore := store.New(pool)
+	q := platformStore.Queries()
+
+	projectA, err := q.CreateProject(ctx, platform.CreateProjectParams{
+		Name:       "Local mode project A " + uuid.NewString(),
+		ApiKeyHash: middleware.HashAPIKey("local-mode-a-" + uuid.NewString()),
+	})
+	require.NoError(t, err)
+	projectB, err := q.CreateProject(ctx, platform.CreateProjectParams{
+		Name:       "Local mode project B " + uuid.NewString(),
+		ApiKeyHash: middleware.HashAPIKey("local-mode-b-" + uuid.NewString()),
+	})
+	require.NoError(t, err)
+
+	sessionA, err := q.CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectA.ID,
+		ExternalID: "local-mode-a-session-" + uuid.NewString(),
+		Name:       testutil.StrPtr("Local mode project A session"),
+	})
+	require.NoError(t, err)
+	sessionB, err := q.CreateSession(ctx, platform.CreateSessionParams{
+		ProjectID:  projectB.ID,
+		ExternalID: "local-mode-b-session-" + uuid.NewString(),
+		Name:       testutil.StrPtr("Local mode project B session"),
+	})
+	require.NoError(t, err)
+
+	traceA := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectA.ID,
+		SessionID: testutil.PgtypeUUID(sessionA.ID),
+		TraceID:   "local-mode-a-trace-" + uuid.NewString(),
+		Name:      testutil.StrPtr("Local mode project A trace"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC)),
+	})
+	traceB := upsertTraceRecord(ctx, t, q, platform.UpsertTraceParams{
+		ProjectID: projectB.ID,
+		SessionID: testutil.PgtypeUUID(sessionB.ID),
+		TraceID:   "local-mode-b-trace-" + uuid.NewString(),
+		Name:      testutil.StrPtr("Local mode project B trace"),
+		Status:    "completed",
+		StartTime: testutil.PgtypeTimestamptz(time.Date(2026, 8, 15, 11, 0, 0, 0, time.UTC)),
+	})
+
+	server := NewServer(platformStore, nil)
+	authenticator, err := middleware.NewAuthenticator(platformStore, &config.Config{
+		LocalSingleUserMode: true,
+	})
+	require.NoError(t, err)
+
+	return localModeScopeFixture{
+		router:   NewRouter(server, authenticator),
+		projectA: projectA,
+		projectB: projectB,
+		traceA:   traceA,
+		traceB:   traceB,
+		sessionA: sessionA,
+		sessionB: sessionB,
+	}
+}
+
+// getFromLoopback issues a credential-free request that appears to originate
+// from the local machine, which is the only shape local single-user mode serves.
+func (f localModeScopeFixture) getFromLoopback(t *testing.T, path string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	rec := httptest.NewRecorder()
+	f.router.ServeHTTP(rec, req)
+	return rec
+}

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -264,16 +264,13 @@ func (a *Authenticator) serveProjectBootstrap(next http.Handler, w http.Response
 // project is bound: the project_id query parameter selects the read scope, exactly
 // as it does for an operator. Returns true when it handled the request.
 //
-// The admission is limited to safe methods, which makes local mode read-only
-// across every composite route rather than only the project handlers. Any
-// process on the machine can reach this surface — including a browser tab on a
-// hostile page, which can issue cross-origin writes to localhost without ever
-// reading the response — so writes such as POST /v1/engine/runs and
-// POST /v1/engine/projections/backfill keep requiring an API key. The project
-// bootstrap (GET and POST /api/projects) is unaffected: serveProjectBootstrap
-// runs ahead of this and handles it, so first-run setup still works.
+// Reads, the project bootstrap and project management all run credential-free
+// here: the mode is an explicit opt-in on a machine its operator owns. Engine
+// writes are the one exception. They are execution control rather than
+// single-user console convenience, so POST /v1/engine/runs and
+// POST /v1/engine/projections/backfill keep requiring an API key.
 func (a *Authenticator) serveLocalSingleUser(next http.Handler, w http.ResponseWriter, r *http.Request) bool {
-	if !a.localSingleUserMode || !isSafeMethod(r.Method) || !IsLoopbackRequest(r) {
+	if !a.localSingleUserMode || isEngineWriteRoute(r.Method, r.URL.Path) || !IsLoopbackRequest(r) {
 		return false
 	}
 
@@ -417,6 +414,19 @@ func isPublicDemoAllowedRequest(method, path string) bool {
 
 func isProjectBootstrapRoute(method, path string) bool {
 	return path == "/api/projects" && (method == http.MethodGet || method == http.MethodPost)
+}
+
+// isEngineWriteRoute reports whether the request drives engine execution rather
+// than reading it. The composite route class is wider than the console's read
+// surface — isEngineConsoleRoute also covers POST /v1/engine/runs and
+// POST /v1/engine/projections/backfill — so these are named explicitly and kept
+// API-key-only even in local single-user mode.
+func isEngineWriteRoute(method, path string) bool {
+	if isSafeMethod(method) || !strings.HasPrefix(path, "/v1/engine") {
+		return false
+	}
+
+	return true
 }
 
 // isSafeMethod reports whether the method is read-only per RFC 9110 and so

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -263,8 +263,17 @@ func (a *Authenticator) serveProjectBootstrap(next http.Handler, w http.Response
 // into local single-user mode and the transport peer is the local machine. No
 // project is bound: the project_id query parameter selects the read scope, exactly
 // as it does for an operator. Returns true when it handled the request.
+//
+// The admission is limited to safe methods, which makes local mode read-only
+// across every composite route rather than only the project handlers. Any
+// process on the machine can reach this surface — including a browser tab on a
+// hostile page, which can issue cross-origin writes to localhost without ever
+// reading the response — so writes such as POST /v1/engine/runs and
+// POST /v1/engine/projections/backfill keep requiring an API key. The project
+// bootstrap (GET and POST /api/projects) is unaffected: serveProjectBootstrap
+// runs ahead of this and handles it, so first-run setup still works.
 func (a *Authenticator) serveLocalSingleUser(next http.Handler, w http.ResponseWriter, r *http.Request) bool {
-	if !a.localSingleUserMode || !IsLoopbackRequest(r) {
+	if !a.localSingleUserMode || !isSafeMethod(r.Method) || !IsLoopbackRequest(r) {
 		return false
 	}
 
@@ -408,6 +417,17 @@ func isPublicDemoAllowedRequest(method, path string) bool {
 
 func isProjectBootstrapRoute(method, path string) bool {
 	return path == "/api/projects" && (method == http.MethodGet || method == http.MethodPost)
+}
+
+// isSafeMethod reports whether the method is read-only per RFC 9110 and so
+// cannot change server state.
+func isSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
 }
 
 func matchesPathPattern(path, pattern string) bool {

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -264,13 +264,14 @@ func (a *Authenticator) serveProjectBootstrap(next http.Handler, w http.Response
 // project is bound: the project_id query parameter selects the read scope, exactly
 // as it does for an operator. Returns true when it handled the request.
 //
-// Reads, the project bootstrap and project management all run credential-free
-// here: the mode is an explicit opt-in on a machine its operator owns. Engine
-// writes are the one exception. They are execution control rather than
-// single-user console convenience, so POST /v1/engine/runs and
-// POST /v1/engine/projections/backfill keep requiring an API key.
+// Everything on the composite surface runs credential-free here: reads, the
+// project bootstrap, project management and engine writes alike. The mode is an
+// explicit opt-in on a machine its operator owns, so the trust boundary is the
+// loopback admission below rather than a per-route write gate. /v1/ingest is
+// unaffected — it is classified routeProtectionAPIKeyOnly and never reaches
+// this path.
 func (a *Authenticator) serveLocalSingleUser(next http.Handler, w http.ResponseWriter, r *http.Request) bool {
-	if !a.localSingleUserMode || isEngineWriteRoute(r.Method, r.URL.Path) || !IsLoopbackRequest(r) {
+	if !a.localSingleUserMode || !IsLoopbackRequest(r) {
 		return false
 	}
 
@@ -414,30 +415,6 @@ func isPublicDemoAllowedRequest(method, path string) bool {
 
 func isProjectBootstrapRoute(method, path string) bool {
 	return path == "/api/projects" && (method == http.MethodGet || method == http.MethodPost)
-}
-
-// isEngineWriteRoute reports whether the request drives engine execution rather
-// than reading it. The composite route class is wider than the console's read
-// surface — isEngineConsoleRoute also covers POST /v1/engine/runs and
-// POST /v1/engine/projections/backfill — so these are named explicitly and kept
-// API-key-only even in local single-user mode.
-func isEngineWriteRoute(method, path string) bool {
-	if isSafeMethod(method) || !strings.HasPrefix(path, "/v1/engine") {
-		return false
-	}
-
-	return true
-}
-
-// isSafeMethod reports whether the method is read-only per RFC 9110 and so
-// cannot change server state.
-func isSafeMethod(method string) bool {
-	switch method {
-	case http.MethodGet, http.MethodHead, http.MethodOptions:
-		return true
-	default:
-		return false
-	}
 }
 
 func matchesPathPattern(path, pattern string) bool {

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -26,7 +26,21 @@ const (
 	AuthModeKey        contextKey = "auth_mode"
 	OperatorEmailKey   contextKey = "operator_email"
 	OperatorSubjectKey contextKey = "operator_subject"
+	// TransportPeerKey carries the connection's true peer address, captured
+	// before any middleware that rewrites RemoteAddr from proxy headers.
+	TransportPeerKey contextKey = "transport_peer"
 )
+
+// CaptureTransportPeer records the real transport peer address so later
+// middleware can make trust decisions about it. It MUST be mounted before
+// chi's RealIP middleware, which overwrites RemoteAddr with the value of the
+// attacker-controlled X-Forwarded-For / X-Real-IP headers.
+func CaptureTransportPeer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), TransportPeerKey, r.RemoteAddr)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
 
 // AuthMode identifies how a request was authenticated.
 type AuthMode string
@@ -260,11 +274,18 @@ func (a *Authenticator) serveLocalSingleUser(next http.Handler, w http.ResponseW
 }
 
 // IsLoopbackRequest reports whether the request's transport peer is the local
-// machine. The peer is read only from r.RemoteAddr: proxy headers such as
-// X-Forwarded-For are attacker-controlled and must never influence an
-// authentication decision.
+// machine. The peer address comes from the connection, never from proxy headers
+// such as X-Forwarded-For, which are attacker-controlled and must never
+// influence an authentication decision. CaptureTransportPeer stashes the real
+// peer before chi's RealIP middleware overwrites RemoteAddr with those headers;
+// without that middleware in the stack, RemoteAddr is still the raw peer.
 func IsLoopbackRequest(r *http.Request) bool {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	remoteAddr, ok := r.Context().Value(TransportPeerKey).(string)
+	if !ok {
+		remoteAddr = r.RemoteAddr
+	}
+
+	host, _, err := net.SplitHostPort(remoteAddr)
 	if err != nil {
 		// RemoteAddr is not host:port (e.g. a Unix socket peer); treat it whole.
 		host = r.RemoteAddr

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -287,8 +287,10 @@ func IsLoopbackRequest(r *http.Request) bool {
 
 	host, _, err := net.SplitHostPort(remoteAddr)
 	if err != nil {
-		// RemoteAddr is not host:port (e.g. a Unix socket peer); treat it whole.
-		host = r.RemoteAddr
+		// The peer address is not host:port (e.g. a Unix socket peer); treat it
+		// whole. It must stay the captured peer, never r.RemoteAddr, which RealIP
+		// may already have replaced with a header value.
+		host = remoteAddr
 	}
 
 	ip := net.ParseIP(strings.Trim(host, "[]"))

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base32"
 	"encoding/hex"
 	"encoding/json"
+	"net"
 	"net/http"
 	"strings"
 
@@ -179,6 +180,9 @@ func (a *Authenticator) serveComposite(next http.Handler, w http.ResponseWriter,
 		if a.serveProjectBootstrap(next, w, r) {
 			return
 		}
+		if a.serveLocalSingleUser(next, w, r) {
+			return
+		}
 		writeAuthError(w, http.StatusUnauthorized, "missing_credentials", "Authentication required")
 		return
 	}
@@ -239,6 +243,35 @@ func (a *Authenticator) serveProjectBootstrap(next http.Handler, w http.Response
 	ctx := context.WithValue(r.Context(), AuthModeKey, AuthModeBootstrap)
 	next.ServeHTTP(w, r.WithContext(ctx))
 	return true
+}
+
+// serveLocalSingleUser admits a credential-free request when the deployment opted
+// into local single-user mode and the transport peer is the local machine. No
+// project is bound: the project_id query parameter selects the read scope, exactly
+// as it does for an operator. Returns true when it handled the request.
+func (a *Authenticator) serveLocalSingleUser(next http.Handler, w http.ResponseWriter, r *http.Request) bool {
+	if !a.localSingleUserMode || !IsLoopbackRequest(r) {
+		return false
+	}
+
+	ctx := context.WithValue(r.Context(), AuthModeKey, AuthModeLocalSingleUser)
+	next.ServeHTTP(w, r.WithContext(ctx))
+	return true
+}
+
+// IsLoopbackRequest reports whether the request's transport peer is the local
+// machine. The peer is read only from r.RemoteAddr: proxy headers such as
+// X-Forwarded-For are attacker-controlled and must never influence an
+// authentication decision.
+func IsLoopbackRequest(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// RemoteAddr is not host:port (e.g. a Unix socket peer); treat it whole.
+		host = r.RemoteAddr
+	}
+
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	return ip != nil && ip.IsLoopback()
 }
 
 func (a *Authenticator) apiKeyContext(

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -35,6 +35,10 @@ const (
 	AuthModeOperator   AuthMode = "operator"
 	AuthModePublicDemo AuthMode = "public_demo"
 	AuthModeBootstrap  AuthMode = "bootstrap"
+	// AuthModeLocalSingleUser marks a credential-free loopback request accepted
+	// because the deployment opted into local single-user mode. Requests in this
+	// mode carry no bound project; the project_id query parameter selects scope.
+	AuthModeLocalSingleUser AuthMode = "local_single_user"
 )
 
 type routeProtection int
@@ -50,6 +54,8 @@ type Authenticator struct {
 	store      *store.Store
 	auth0      *auth0Authenticator
 	publicDemo *publicDemoAccess
+	// localSingleUserMode mirrors config.Config.LocalSingleUserMode.
+	localSingleUserMode bool
 }
 
 type publicDemoAccess struct {
@@ -72,6 +78,9 @@ func NewAuthenticator(s *store.Store, cfg *config.Config) (*Authenticator, error
 		authenticator.publicDemo = &publicDemoAccess{
 			projectID: cfg.PublicDemo.ProjectID,
 		}
+	}
+	if cfg != nil {
+		authenticator.localSingleUserMode = cfg.LocalSingleUserMode
 	}
 	return authenticator, nil
 }

--- a/internal/api/middleware/local_mode_test.go
+++ b/internal/api/middleware/local_mode_test.go
@@ -1,0 +1,193 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/continua-ai/continua/internal/store"
+	"github.com/continua-ai/continua/internal/testutil"
+)
+
+// localModeRequest builds a request with an explicit RemoteAddr. Loopback
+// detection must be derived from the transport peer address only, never from
+// caller-supplied proxy headers.
+func localModeRequest(method, target, remoteAddr string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	req.RemoteAddr = remoteAddr
+	return req
+}
+
+func TestLocalModeAllowsUnauthenticatedLoopbackRequest(t *testing.T) {
+	authenticator := &Authenticator{localSingleUserMode: true}
+
+	var handlerInvoked bool
+	var receivedMode AuthMode
+	var modePresent bool
+	var projectBound bool
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerInvoked = true
+		receivedMode, modePresent = GetAuthMode(r.Context())
+		_, projectBound = GetProjectID(r.Context())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := localModeRequest(http.MethodGet, "/api/traces", "127.0.0.1:54321")
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.True(t, handlerInvoked, "loopback request should reach the handler in local single-user mode")
+	require.True(t, modePresent)
+	assert.Equal(t, AuthModeLocalSingleUser, receivedMode)
+	assert.False(
+		t,
+		projectBound,
+		"local single-user mode must not bind a project; project_id selects the read scope",
+	)
+}
+
+func TestLocalModeRejectsNonLoopbackRequest(t *testing.T) {
+	authenticator := &Authenticator{localSingleUserMode: true}
+
+	var handlerInvoked bool
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerInvoked = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := localModeRequest(http.MethodGet, "/api/traces", "203.0.113.5:44444")
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.False(t, handlerInvoked, "a remote caller must never reach the handler unauthenticated")
+
+	resp := decodeAuthErrorBody(t, rec)
+	assert.Equal(t, "missing_credentials", resp["code"])
+}
+
+func TestLocalModeIgnoresForwardedHeaders(t *testing.T) {
+	authenticator := &Authenticator{localSingleUserMode: true}
+
+	var handlerInvoked bool
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerInvoked = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := localModeRequest(http.MethodGet, "/api/traces", "203.0.113.5:44444")
+	// Attacker-controlled headers claiming a loopback origin must be ignored.
+	req.Header.Set("X-Forwarded-For", "127.0.0.1")
+	req.Header.Set("X-Real-IP", "127.0.0.1")
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.False(t, handlerInvoked, "spoofed forwarded headers must not unlock local single-user mode")
+
+	resp := decodeAuthErrorBody(t, rec)
+	assert.Equal(t, "missing_credentials", resp["code"])
+}
+
+func TestLocalModeIPv6LoopbackAllowed(t *testing.T) {
+	authenticator := &Authenticator{localSingleUserMode: true}
+
+	var handlerInvoked bool
+	var receivedMode AuthMode
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerInvoked = true
+		receivedMode, _ = GetAuthMode(r.Context())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := localModeRequest(http.MethodGet, "/api/traces", "[::1]:54321")
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.True(t, handlerInvoked, "IPv6 loopback is still loopback")
+	assert.Equal(t, AuthModeLocalSingleUser, receivedMode)
+}
+
+func TestLocalModeDisabledStillRequiresCredentials(t *testing.T) {
+	authenticator := &Authenticator{}
+
+	var handlerInvoked bool
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerInvoked = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := localModeRequest(http.MethodGet, "/api/traces", "127.0.0.1:54321")
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.False(t, handlerInvoked, "the bypass must be opt-in, not implied by a loopback peer")
+
+	resp := decodeAuthErrorBody(t, rec)
+	assert.Equal(t, "missing_credentials", resp["code"])
+}
+
+func TestLocalModeStillHonorsAPIKey(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	platformStore := store.New(pool)
+
+	apiKey := "local-mode-api-key-" + uuid.NewString()
+	project := createCompositeAuthProject(ctx, t, platformStore, apiKey)
+	authenticator := &Authenticator{store: platformStore, localSingleUserMode: true}
+
+	var receivedMode AuthMode
+	var receivedProjectID uuid.UUID
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
+		receivedMode, ok = GetAuthMode(r.Context())
+		require.True(t, ok)
+		receivedProjectID, ok = GetProjectID(r.Context())
+		require.True(t, ok)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := localModeRequest(http.MethodGet, "/api/traces", "127.0.0.1:54321")
+	req.Header.Set("X-API-Key", apiKey)
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, AuthModeAPIKey, receivedMode)
+	assert.Equal(t, project.ID, receivedProjectID)
+}
+
+func TestLocalModeDoesNotApplyToIngest(t *testing.T) {
+	authenticator := &Authenticator{localSingleUserMode: true}
+
+	var handlerInvoked bool
+	protectedHandler := authenticator.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerInvoked = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := localModeRequest(http.MethodPost, "/v1/ingest", "127.0.0.1:54321")
+	rec := httptest.NewRecorder()
+
+	protectedHandler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.False(t, handlerInvoked, "ingest must never become unauthenticated")
+
+	resp := decodeAuthErrorBody(t, rec)
+	assert.Equal(t, "missing_api_key", resp["code"])
+}

--- a/internal/api/projects_handlers.go
+++ b/internal/api/projects_handlers.go
@@ -81,7 +81,7 @@ func (s *Server) CreateProject(w http.ResponseWriter, r *http.Request) {
 
 // UpdateProject renames an existing project.
 func (s *Server) UpdateProject(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
-	if !s.requireOperatorWhenAuth0Enabled(w, r) {
+	if !s.requireProjectMutationAuth(w, r) {
 		return
 	}
 	var req UpdateProjectRequest
@@ -105,7 +105,7 @@ func (s *Server) UpdateProject(w http.ResponseWriter, r *http.Request, id openap
 
 // RotateProjectAPIKey replaces the project's API key and returns the new plaintext key once.
 func (s *Server) RotateProjectAPIKey(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
-	if !s.requireOperatorWhenAuth0Enabled(w, r) {
+	if !s.requireProjectMutationAuth(w, r) {
 		return
 	}
 	plaintextKey, err := middleware.GenerateAPIKey()
@@ -125,7 +125,7 @@ func (s *Server) RotateProjectAPIKey(w http.ResponseWriter, r *http.Request, id 
 
 // DeleteProject removes a project and cascades its data via FK.
 func (s *Server) DeleteProject(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
-	if !s.requireOperatorWhenAuth0Enabled(w, r) {
+	if !s.requireProjectMutationAuth(w, r) {
 		return
 	}
 
@@ -159,6 +159,33 @@ func (s *Server) requireOperatorWhenAuth0Enabled(w http.ResponseWriter, r *http.
 		http.StatusForbidden,
 		"operator_required",
 		"Project management requires operator authentication on this deployment",
+	)
+	return false
+}
+
+// requireProjectMutationAuth gates the project-modifying handlers: the Auth0
+// operator rule above, plus a refusal to let a credential-free local
+// single-user request change or destroy a project.
+//
+// Local single-user mode is read-only plus the project bootstrap. Any process
+// on the machine can reach that loopback surface, including a browser tab on a
+// hostile page, so renaming, rotating keys and deleting still require an API
+// key. Listing and creating stay open so first-run setup works.
+func (s *Server) requireProjectMutationAuth(w http.ResponseWriter, r *http.Request) bool {
+	if !s.requireOperatorWhenAuth0Enabled(w, r) {
+		return false
+	}
+
+	mode, _ := middleware.GetAuthMode(r.Context())
+	if mode != middleware.AuthModeLocalSingleUser {
+		return true
+	}
+
+	writeError(
+		w,
+		http.StatusUnauthorized,
+		"missing_credentials",
+		"Project changes require an API key in local single-user mode",
 	)
 	return false
 }

--- a/internal/api/projects_handlers.go
+++ b/internal/api/projects_handlers.go
@@ -81,7 +81,7 @@ func (s *Server) CreateProject(w http.ResponseWriter, r *http.Request) {
 
 // UpdateProject renames an existing project.
 func (s *Server) UpdateProject(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
-	if !s.requireProjectMutationAuth(w, r) {
+	if !s.requireOperatorWhenAuth0Enabled(w, r) {
 		return
 	}
 	var req UpdateProjectRequest
@@ -105,7 +105,7 @@ func (s *Server) UpdateProject(w http.ResponseWriter, r *http.Request, id openap
 
 // RotateProjectAPIKey replaces the project's API key and returns the new plaintext key once.
 func (s *Server) RotateProjectAPIKey(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
-	if !s.requireProjectMutationAuth(w, r) {
+	if !s.requireOperatorWhenAuth0Enabled(w, r) {
 		return
 	}
 	plaintextKey, err := middleware.GenerateAPIKey()
@@ -125,7 +125,7 @@ func (s *Server) RotateProjectAPIKey(w http.ResponseWriter, r *http.Request, id 
 
 // DeleteProject removes a project and cascades its data via FK.
 func (s *Server) DeleteProject(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
-	if !s.requireProjectMutationAuth(w, r) {
+	if !s.requireOperatorWhenAuth0Enabled(w, r) {
 		return
 	}
 
@@ -159,33 +159,6 @@ func (s *Server) requireOperatorWhenAuth0Enabled(w http.ResponseWriter, r *http.
 		http.StatusForbidden,
 		"operator_required",
 		"Project management requires operator authentication on this deployment",
-	)
-	return false
-}
-
-// requireProjectMutationAuth gates the project-modifying handlers: the Auth0
-// operator rule above, plus a refusal to let a credential-free local
-// single-user request change or destroy a project.
-//
-// Local single-user mode is read-only plus the project bootstrap. Any process
-// on the machine can reach that loopback surface, including a browser tab on a
-// hostile page, so renaming, rotating keys and deleting still require an API
-// key. Listing and creating stay open so first-run setup works.
-func (s *Server) requireProjectMutationAuth(w http.ResponseWriter, r *http.Request) bool {
-	if !s.requireOperatorWhenAuth0Enabled(w, r) {
-		return false
-	}
-
-	mode, _ := middleware.GetAuthMode(r.Context())
-	if mode != middleware.AuthModeLocalSingleUser {
-		return true
-	}
-
-	writeError(
-		w,
-		http.StatusUnauthorized,
-		"missing_credentials",
-		"Project changes require an API key in local single-user mode",
 	)
 	return false
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -18,6 +18,10 @@ func NewRouter(server *Server, auth *middleware.Authenticator) http.Handler {
 
 	// Global middleware
 	r.Use(chimiddleware.RequestID)
+	// CaptureTransportPeer must stay ahead of RealIP: RealIP overwrites
+	// RemoteAddr with X-Forwarded-For, which any client can set, so the real
+	// peer address has to be recorded before that happens.
+	r.Use(middleware.CaptureTransportPeer)
 	r.Use(chimiddleware.RealIP)
 	r.Use(chimiddleware.Logger)
 	r.Use(chimiddleware.Recoverer)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	enginePublicAPIEnabled bool
 	auth0Config            config.Auth0Config
 	publicDemoConfig       config.PublicDemoConfig
+	localSingleUserMode    bool
 }
 
 // NewServer creates a new API server with the given dependencies.
@@ -48,6 +49,7 @@ func newConfiguredServer(
 		server.engineControl.completionGrace = cfg.Engine.LeaseCompletionGrace
 		server.auth0Config = cfg.Auth0
 		server.publicDemoConfig = cfg.PublicDemo
+		server.localSingleUserMode = cfg.LocalSingleUserMode
 	}
 	return server
 }

--- a/internal/api/server_gen.go
+++ b/internal/api/server_gen.go
@@ -329,6 +329,9 @@ type AuthConfig struct {
 	Domain   *string `json:"domain,omitempty"`
 	Enabled  bool    `json:"enabled"`
 
+	// LocalModeEnabled Whether API-key-free single-user local mode is active for this connection. True only when the server has local single-user mode enabled and the requesting connection originates from loopback.
+	LocalModeEnabled *bool `json:"local_mode_enabled,omitempty"`
+
 	// PublicDemoEnabled Whether the deployment exposes a public read-only demo console.
 	PublicDemoEnabled *bool `json:"public_demo_enabled,omitempty"`
 

--- a/internal/api/server_helpers.go
+++ b/internal/api/server_helpers.go
@@ -169,13 +169,20 @@ func scopeFromRequest(w http.ResponseWriter, r *http.Request, policy requestScop
 		return store.BoundScope(projectID), true
 	}
 
+	// Local single-user mode is unbound just like operator auth: the caller may see
+	// every project, and project_id selects which one this request reads.
 	authMode, ok := middleware.GetAuthMode(r.Context())
-	if !ok || authMode != middleware.AuthModeOperator {
+	if !ok || (authMode != middleware.AuthModeOperator && authMode != middleware.AuthModeLocalSingleUser) {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Missing project context")
 		return store.Scope{}, false
 	}
 
-	projectID, selected, ok := projectIDSelectionFromRequest(w, r, policy == scopePolicyRequireProject)
+	// Local single-user mode has no cross-project aggregate view: the selected
+	// project_id is the only thing that scopes the read, so it is always required.
+	requireProject := policy == scopePolicyRequireProject ||
+		authMode == middleware.AuthModeLocalSingleUser
+
+	projectID, selected, ok := projectIDSelectionFromRequest(w, r, requireProject)
 	if !ok {
 		return store.Scope{}, false
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,11 +102,11 @@ func Load() (*Config, error) {
 		port = "8080"
 	}
 
-	trueAsyncDefault, err := loadBool("INGEST_TRUE_ASYNC_DEFAULT", false)
+	trueAsyncDefault, err := loadBool("INGEST_TRUE_ASYNC_DEFAULT")
 	if err != nil {
 		return nil, err
 	}
-	enginePublicAPIEnabled, err := loadBool("ENGINE_PUBLIC_API_ENABLED", false)
+	enginePublicAPIEnabled, err := loadBool("ENGINE_PUBLIC_API_ENABLED")
 	if err != nil {
 		return nil, err
 	}
@@ -164,6 +164,18 @@ func Load() (*Config, error) {
 			return nil, err
 		}
 	}
+	localSingleUserMode, err := loadBool("LOCAL_SINGLE_USER_MODE")
+	if err != nil {
+		return nil, err
+	}
+	// Fail closed: an unauthenticated loopback bypass must never coexist with a
+	// multi-identity auth posture. Refuse to boot rather than silently picking one.
+	if localSingleUserMode && publicDemoConfig.Enabled {
+		return nil, errors.New("LOCAL_SINGLE_USER_MODE cannot be enabled together with PUBLIC_DEMO_ENABLED")
+	}
+	if localSingleUserMode && auth0Config.Enabled {
+		return nil, errors.New("LOCAL_SINGLE_USER_MODE cannot be enabled together with AUTH0 operator authentication")
+	}
 
 	return &Config{
 		Server: ServerConfig{
@@ -190,13 +202,14 @@ func Load() (*Config, error) {
 			MaintenanceWorkers: maintenanceWorkers,
 			DefaultWorkers:     defaultWorkers,
 		},
-		Auth0:      auth0Config,
-		PublicDemo: publicDemoConfig,
+		Auth0:               auth0Config,
+		PublicDemo:          publicDemoConfig,
+		LocalSingleUserMode: localSingleUserMode,
 	}, nil
 }
 
 func loadPublicDemoConfig() (PublicDemoConfig, error) {
-	enabled, err := loadBool("PUBLIC_DEMO_ENABLED", false)
+	enabled, err := loadBool("PUBLIC_DEMO_ENABLED")
 	if err != nil {
 		return PublicDemoConfig{}, err
 	}
@@ -328,10 +341,12 @@ func parseAllowedEmails(raw string) ([]string, error) {
 	return emails, nil
 }
 
-func loadBool(key string, defaultValue bool) (bool, error) {
+// loadBool reads an opt-in boolean environment variable. Every boolean setting
+// defaults to off, so an unset variable is false.
+func loadBool(key string) (bool, error) {
 	raw := os.Getenv(key)
 	if raw == "" {
-		return defaultValue, nil
+		return false, nil
 	}
 
 	value, err := strconv.ParseBool(raw)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	Jobs       JobsConfig
 	Auth0      Auth0Config
 	PublicDemo PublicDemoConfig
+
+	// LocalSingleUserMode opts the deployment into API-key-free, loopback-only
+	// debugger access. Sourced from LOCAL_SINGLE_USER_MODE; defaults to false.
+	LocalSingleUserMode bool
 }
 
 // ServerConfig holds HTTP server configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -149,6 +149,58 @@ func TestLoad_NormalizesAuth0Configuration(t *testing.T) {
 	assert.Equal(t, []string{"operator@one.dev", "operator@two.dev"}, cfg.Auth0.AllowedEmails)
 }
 
+func TestLocalSingleUserModeDefaultsDisabled(t *testing.T) {
+	t.Run("unset environment leaves local single-user mode off", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://example")
+		t.Setenv("LOCAL_SINGLE_USER_MODE", "")
+
+		cfg, err := config.Load()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.False(t, cfg.LocalSingleUserMode)
+	})
+
+	t.Run("explicit opt-in enables local single-user mode", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "postgres://example")
+		t.Setenv("LOCAL_SINGLE_USER_MODE", "true")
+
+		cfg, err := config.Load()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.True(t, cfg.LocalSingleUserMode)
+	})
+}
+
+func TestLocalSingleUserModeRejectedWithAuth0(t *testing.T) {
+	// Fail closed: an unauthenticated loopback bypass must never coexist with
+	// hosted operator authentication, so the server refuses to boot.
+	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("LOCAL_SINGLE_USER_MODE", "true")
+	t.Setenv("AUTH0_DOMAIN", "continua.us.auth0.com")
+	t.Setenv("AUTH0_CLIENT_ID", "client-id")
+	t.Setenv("AUTH0_AUDIENCE", "https://continua/api")
+	t.Setenv("AUTH0_ALLOWED_EMAILS", "operator@example.com")
+
+	cfg, err := config.Load()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "LOCAL_SINGLE_USER_MODE")
+	assert.Contains(t, err.Error(), "AUTH0")
+}
+
+func TestLocalSingleUserModeRejectedWithPublicDemo(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://example")
+	t.Setenv("LOCAL_SINGLE_USER_MODE", "true")
+	t.Setenv("PUBLIC_DEMO_ENABLED", "true")
+	t.Setenv("PUBLIC_DEMO_PROJECT_ID", "11111111-1111-1111-1111-111111111111")
+
+	cfg, err := config.Load()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "LOCAL_SINGLE_USER_MODE")
+	assert.Contains(t, err.Error(), "PUBLIC_DEMO_ENABLED")
+}
+
 func TestLoad_RejectsPublicDemoWithoutProjectID(t *testing.T) {
 	t.Setenv("DATABASE_URL", "postgres://example")
 	t.Setenv("PUBLIC_DEMO_ENABLED", "true")

--- a/sdks/python/src/continua/types.py
+++ b/sdks/python/src/continua/types.py
@@ -24,6 +24,10 @@ class AuthConfig(BaseModel):
         None,
         description="Display label for the public demo banner shown in the debugger shell.",
     )
+    local_mode_enabled: bool | None = Field(
+        None,
+        description="Whether API-key-free single-user local mode is active for this connection. True only when the server has local single-user mode enabled and the requesting connection originates from loopback.",
+    )
 
 
 class Error(BaseModel):

--- a/web/e2e/ui-smoke.spec.ts
+++ b/web/e2e/ui-smoke.spec.ts
@@ -261,6 +261,66 @@ async function bootstrapLocalApiKeySession(page: Page) {
   );
 }
 
+// Local single-user mode owns no credential at all: nothing is written to
+// localStorage, so a second browser profile sees exactly the same console.
+async function bootstrapLocalSingleUserSession(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('continua_theme_mode', 'light');
+  });
+}
+
+async function mockLocalSingleUserRoutes(page: Page) {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname === '/api/auth/config') {
+      return fulfillJson(route, { enabled: false, local_mode_enabled: true });
+    }
+
+    // The whole point of the mode: no credential ever leaves the browser.
+    expect(route.request().headers().authorization).toBeUndefined();
+
+    if (url.pathname === '/api/projects') {
+      return fulfillJson(route, {
+        projects: [
+          {
+            id: PRIMARY_PROJECT_ID,
+            name: 'Primary Project',
+            created_at: '2026-03-14T10:00:00.000Z',
+            updated_at: '2026-03-14T10:00:00.000Z',
+          },
+          {
+            id: SECONDARY_PROJECT_ID,
+            name: 'Secondary Project',
+            created_at: '2026-03-15T10:00:00.000Z',
+            updated_at: '2026-03-15T10:00:00.000Z',
+          },
+        ],
+      });
+    }
+
+    if (url.pathname === '/api/traces') {
+      const projectId = url.searchParams.get('project_id');
+      if (!projectId) {
+        // Mirror the server: with no bound project, project_id is the only
+        // thing that scopes the read, so an unscoped read is rejected.
+        return fulfillJson(
+          route,
+          { code: 'missing_project_id', message: 'project_id is required' },
+          400
+        );
+      }
+      const isSecondary = projectId === SECONDARY_PROJECT_ID;
+      const trace = isSecondary
+        ? { ...TRACE_TWO, name: 'Secondary project trace' }
+        : { ...TRACE_ONE, name: 'Primary project trace' };
+      return fulfillJson(route, { traces: [trace], total: 1 });
+    }
+
+    return fulfillJson(route, { code: 'not_found', message: 'Resource not found' }, 404);
+  });
+}
+
 async function fulfillJson(route: Route, data: unknown, status = 200) {
   await route.fulfill({
     status,
@@ -749,6 +809,45 @@ test('switches displayed traces with the selected project API key in local mode'
     page.getByRole('row').filter({ hasText: 'Primary project trace' })
   ).toHaveCount(0);
   await testInfo.attach(`${testInfo.project.name}-local-project-switch`, {
+    body: await page.screenshot({ fullPage: true, animations: 'disabled' }),
+    contentType: 'image/png',
+  });
+});
+
+test('opens the console with no API key and switches projects in local single-user mode', async ({
+  page,
+}, testInfo) => {
+  await bootstrapLocalSingleUserSession(page);
+  await mockLocalSingleUserRoutes(page);
+  await page.goto('/traces');
+
+  // No API key prompt: the server already trusts this loopback console.
+  await expect(page.getByText('Enter a local project API key.')).toHaveCount(0);
+  await expect(
+    page.getByRole('row').filter({ hasText: 'Primary project trace' })
+  ).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`project_id=${PRIMARY_PROJECT_ID}`));
+  expect(
+    await page.evaluate(() => window.localStorage.getItem('continua_api_key'))
+  ).toBeNull();
+
+  if (testInfo.project.name === 'mobile-chromium') {
+    await page.getByRole('button', { name: 'Open navigation' }).click();
+    await page.getByRole('combobox', { name: 'Project' }).selectOption(
+      SECONDARY_PROJECT_ID
+    );
+  } else {
+    await page.getByLabel('Active project').selectOption(SECONDARY_PROJECT_ID);
+  }
+
+  await expect(page).toHaveURL(new RegExp(`project_id=${SECONDARY_PROJECT_ID}`));
+  await expect(
+    page.getByRole('row').filter({ hasText: 'Secondary project trace' })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('row').filter({ hasText: 'Primary project trace' })
+  ).toHaveCount(0);
+  await testInfo.attach(`${testInfo.project.name}-local-single-user-switch`, {
     body: await page.screenshot({ fullPage: true, animations: 'disabled' }),
     contentType: 'image/png',
   });

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -11,6 +11,7 @@ import {
   rememberProjectApiKey,
   setAccessTokenProvider,
   setLocalApiKeyMode,
+  setLocalSingleUserMode,
   setPublicDemoMode,
   setSelectedProjectIdProvider,
 } from './client';
@@ -26,6 +27,7 @@ beforeEach(() => {
   clearApiKey();
   setAccessTokenProvider(null);
   setPublicDemoMode(false);
+  setLocalSingleUserMode(false);
   setSelectedProjectIdProvider(null);
 });
 
@@ -33,6 +35,7 @@ afterEach(() => {
   clearApiKey();
   setAccessTokenProvider(null);
   setPublicDemoMode(false);
+  setLocalSingleUserMode(false);
   setSelectedProjectIdProvider(null);
   vi.unstubAllGlobals();
 });
@@ -65,6 +68,32 @@ describe('client', () => {
       'Content-Type': 'application/json',
       Authorization: 'Bearer operator-token',
     });
+  });
+
+  it('sends no Authorization header in local single-user mode', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ traces: [], total: 0 }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+    setLocalSingleUserMode(true);
+    setSelectedProjectIdProvider(() => PROJECT_ID);
+
+    await expect(fetchAPI('/api/traces')).resolves.toBeDefined();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const requestUrl = new URL(
+      String(fetchMock.mock.calls[0]?.[0]),
+      'http://localhost'
+    );
+    expect(requestUrl.searchParams.get('project_id')).toBe(PROJECT_ID);
+    const headers = (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)
+      ?.headers as Record<string, string> | undefined;
+    expect(headers).toBeDefined();
+    expect(headers).not.toHaveProperty('Authorization');
   });
 
   it('sends the selected project_id on engine operator requests', async () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -264,13 +264,15 @@ export async function fetchAPI<T>(
 ): Promise<T> {
   const { allowUnauthenticated = false, ...requestOptions } = options;
   const requestUrl = buildRequestUrl(path);
-  const localApiKey = publicDemoModeEnabled ? null : getApiKey();
+  const localApiKey =
+    publicDemoModeEnabled || localSingleUserModeEnabled ? null : getApiKey();
 
   if (
     !allowUnauthenticated &&
     !accessTokenProvider &&
     !localApiKey &&
-    !publicDemoModeEnabled
+    !publicDemoModeEnabled &&
+    !localSingleUserModeEnabled
   ) {
     throw new ApiError(401, 'unauthorized', 'Sign in required');
   }
@@ -293,7 +295,18 @@ export async function fetchAPI<T>(
     accessToken = getKnownProjectApiKey(selectedProjectId) ?? accessToken;
   }
 
-  if (!accessToken && !publicDemoModeEnabled && !allowUnauthenticated) {
+  // Local single-user mode is API-key-free by design: the server scopes the read
+  // by project_id, so the request must carry no Authorization header at all.
+  if (localSingleUserModeEnabled) {
+    accessToken = null;
+  }
+
+  if (
+    !accessToken &&
+    !publicDemoModeEnabled &&
+    !localSingleUserModeEnabled &&
+    !allowUnauthenticated
+  ) {
     throw new ApiError(401, 'unauthorized', 'Sign in required');
   }
 
@@ -930,12 +943,16 @@ async function fetchAPIEmpty(
   path: string,
   options: RequestInit = {}
 ): Promise<void> {
-  const localApiKey = publicDemoModeEnabled ? null : getApiKey();
+  const localApiKey =
+    publicDemoModeEnabled || localSingleUserModeEnabled ? null : getApiKey();
   let accessToken: string | null = localApiKey;
   if (accessTokenProvider) {
     accessToken = await accessTokenProvider();
   }
-  if (!accessToken && !publicDemoModeEnabled) {
+  if (localSingleUserModeEnabled) {
+    accessToken = null;
+  }
+  if (!accessToken && !publicDemoModeEnabled && !localSingleUserModeEnabled) {
     throw new ApiError(401, 'unauthorized', 'Sign in required');
   }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -30,6 +30,7 @@ let selectedProjectIdProvider: SelectedProjectIdProvider | null = null;
 let legacyTestToken: string | null = null;
 let publicDemoModeEnabled = false;
 let localApiKeyModeEnabled = false;
+let localSingleUserModeEnabled = false;
 
 export type { FetchTracesParams } from '../utils/tracesSearchParams';
 export type {
@@ -57,6 +58,18 @@ export function setPublicDemoMode(enabled: boolean): void {
 
 export function setLocalApiKeyMode(enabled: boolean): void {
   localApiKeyModeEnabled = enabled;
+}
+
+/**
+ * Toggle API-key-free single-user local mode. When active the client must issue
+ * requests with no Authorization header and must not demand a stored API key.
+ */
+export function setLocalSingleUserMode(enabled: boolean): void {
+  localSingleUserModeEnabled = enabled;
+}
+
+export function isLocalSingleUserMode(): boolean {
+  return localSingleUserModeEnabled;
 }
 
 export function getApiKey(): string | null {
@@ -222,6 +235,7 @@ export interface RuntimeAuthConfig {
   audience?: string;
   public_demo_enabled?: boolean;
   public_demo_label?: string;
+  local_mode_enabled?: boolean;
   console_available?: boolean;
 }
 

--- a/web/src/auth/runtime.test.tsx
+++ b/web/src/auth/runtime.test.tsx
@@ -7,6 +7,7 @@ import {
   clearApiKey,
   fetchAPI,
   setAccessTokenProvider,
+  setLocalSingleUserMode,
   setPublicDemoMode,
 } from '../api/client';
 import {
@@ -78,6 +79,7 @@ beforeEach(() => {
   clearApiKey();
   setAccessTokenProvider(null);
   setPublicDemoMode(false);
+  setLocalSingleUserMode(false);
   auth0State.error = undefined;
   auth0State.isAuthenticated = true;
   auth0State.isLoading = false;
@@ -88,6 +90,7 @@ afterEach(() => {
   clearApiKey();
   setAccessTokenProvider(null);
   setPublicDemoMode(false);
+  setLocalSingleUserMode(false);
   vi.unstubAllGlobals();
 });
 
@@ -297,6 +300,55 @@ describe('runtime auth', () => {
 
     expect(screen.getByText('Local traces')).toBeInTheDocument();
     expect(window.localStorage.getItem('continua_api_key')).toBe('pk_runtime_key');
+  });
+
+  it('renders the console without an API key prompt when local mode is enabled', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          projects: [
+            {
+              id: PROJECT_ID,
+              name: 'Local project',
+              created_at: '2026-08-15T10:00:00Z',
+              updated_at: '2026-08-15T10:00:00Z',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/traces']}>
+        <Routes>
+          <Route
+            element={
+              <ProtectedRoute
+                auth={{
+                  status: 'ready',
+                  enabled: false,
+                  local_mode_enabled: true,
+                }}
+              />
+            }
+          >
+            <Route path="/traces" element={<div>Local traces</div>} />
+            <Route path="/projects" element={<div>Create first project</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Local traces')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Enter a local project API key.')
+    ).not.toBeInTheDocument();
   });
 
   it('routes local first-run consoles to project creation when no projects exist', async () => {

--- a/web/src/auth/runtime.tsx
+++ b/web/src/auth/runtime.tsx
@@ -19,6 +19,7 @@ import {
   setAccessTokenProvider,
   setApiKey,
   setLocalApiKeyMode,
+  setLocalSingleUserMode,
   setPublicDemoMode,
   type RuntimeAuthConfig,
 } from '../api/client';
@@ -147,14 +148,17 @@ export function Auth0RuntimeProvider({
   const navigate = useNavigate();
 
   let content = (
-    <UnauthenticatedSessionBridge publicDemoEnabled={auth.public_demo_enabled === true}>
+    <UnauthenticatedSessionBridge
+      publicDemoEnabled={auth.public_demo_enabled === true}
+      localSingleUserEnabled={isLocalSingleUserRuntime(auth)}
+    >
       {children}
     </UnauthenticatedSessionBridge>
   );
 
   if (auth.public_demo_enabled === true) {
     content = (
-      <UnauthenticatedSessionBridge publicDemoEnabled>
+      <UnauthenticatedSessionBridge publicDemoEnabled localSingleUserEnabled={false}>
         {children}
       </UnauthenticatedSessionBridge>
     );
@@ -193,11 +197,23 @@ export function Auth0RuntimeProvider({
   return <RuntimeAuthStateProvider auth={auth}>{content}</RuntimeAuthStateProvider>;
 }
 
+// isLocalSingleUserRuntime reports whether the server offered API-key-free local
+// access. The server only advertises it to loopback callers, and it is mutually
+// exclusive with Auth0 and the public demo.
+function isLocalSingleUserRuntime(auth: RuntimeAuthState): boolean {
+  return (
+    auth.local_mode_enabled === true &&
+    !auth.enabled &&
+    auth.public_demo_enabled !== true
+  );
+}
+
 function AuthSessionBridge() {
   const { getAccessTokenSilently, isAuthenticated } = useOperatorAuth();
 
   useLayoutEffect(() => {
     setLocalApiKeyMode(false);
+    setLocalSingleUserMode(false);
     setPublicDemoMode(false);
     setAccessTokenProvider(async () => {
       if (!isAuthenticated) {
@@ -217,11 +233,13 @@ function AuthSessionBridge() {
 
 function E2EAuthSessionBridge({ children }: { children: ReactNode }) {
   setLocalApiKeyMode(false);
+  setLocalSingleUserMode(false);
   setAccessTokenProvider(async () => getE2EAuthToken());
   setPublicDemoMode(false);
 
   useLayoutEffect(() => {
     setLocalApiKeyMode(false);
+    setLocalSingleUserMode(false);
     setPublicDemoMode(false);
     setAccessTokenProvider(async () => getE2EAuthToken());
 
@@ -236,20 +254,24 @@ function E2EAuthSessionBridge({ children }: { children: ReactNode }) {
 function UnauthenticatedSessionBridge({
   children,
   publicDemoEnabled,
+  localSingleUserEnabled,
 }: {
   children: ReactNode;
   publicDemoEnabled: boolean;
+  localSingleUserEnabled: boolean;
 }) {
   useLayoutEffect(() => {
     setLocalApiKeyMode(false);
     setAccessTokenProvider(null);
     setPublicDemoMode(publicDemoEnabled);
+    setLocalSingleUserMode(localSingleUserEnabled);
 
     return () => {
       setAccessTokenProvider(null);
       setPublicDemoMode(false);
+      setLocalSingleUserMode(false);
     };
-  }, [publicDemoEnabled]);
+  }, [localSingleUserEnabled, publicDemoEnabled]);
 
   return children;
 }
@@ -306,13 +328,21 @@ export function ProtectedRoute({ auth }: { auth: RuntimeAuthState }) {
   }
 
   if (!auth.enabled) {
-    return <LocalApiKeyProtectedOutlet />;
+    return (
+      <LocalApiKeyProtectedOutlet
+        localSingleUserEnabled={isLocalSingleUserRuntime(auth)}
+      />
+    );
   }
 
   return <Auth0ProtectedOutlet />;
 }
 
-function LocalApiKeyProtectedOutlet() {
+function LocalApiKeyProtectedOutlet({
+  localSingleUserEnabled,
+}: {
+  localSingleUserEnabled: boolean;
+}) {
   const location = useLocation();
   const navigate = useNavigate();
   const [draftKey, setDraftKey] = useState(() => getApiKey() ?? '');
@@ -389,6 +419,12 @@ function LocalApiKeyProtectedOutlet() {
 
   if (!bootstrapChecked) {
     return <RouteGateState message="Checking local project setup..." />;
+  }
+
+  // API-key-free local mode: the server already trusts this loopback caller, so
+  // there is nothing to prompt for. The project selector picks the read scope.
+  if (localSingleUserEnabled) {
+    return <Outlet />;
   }
 
   return (
@@ -555,6 +591,9 @@ export function useOperatorAuth(): ReturnType<typeof useAuth0> {
     if (localApiKey) {
       return localApiKeyOperatorAuth(localApiKey);
     }
+    if (isLocalSingleUserRuntime(runtimeAuth)) {
+      return localSingleUserOperatorAuth();
+    }
     return unauthenticatedOperatorAuth();
   }
 
@@ -573,6 +612,26 @@ function localApiKeyOperatorAuth(localApiKey: string): ReturnType<typeof useAuth
       email: 'Local API key',
       name: 'Local self-host',
       sub: 'local-api-key',
+    },
+  } as ReturnType<typeof useAuth0>;
+}
+
+// localSingleUserOperatorAuth represents the box owner in API-key-free local mode.
+// The session is authenticated from the console's point of view, but carries no
+// credential: the client sends no Authorization header and the server scopes reads
+// by the selected project_id.
+function localSingleUserOperatorAuth(): ReturnType<typeof useAuth0> {
+  return {
+    error: undefined,
+    getAccessTokenSilently: async () => '',
+    isAuthenticated: true,
+    isLoading: false,
+    loginWithRedirect: async () => undefined,
+    logout: async () => undefined,
+    user: {
+      email: 'Local mode',
+      name: 'Local single-user',
+      sub: 'local-single-user',
     },
   } as ReturnType<typeof useAuth0>;
 }


### PR DESCRIPTION
## What and why

Running Continua locally required pasting a project API key into the browser, where the key acted
as both request authentication *and* the project identity used to scope data. That is friction for
a single developer on their own machine, and because each browser stores its own
`continua_api_key`, the same URL showed different projects in different browsers.

This adds an explicitly opt-in, loopback-only single-user mode: no API key in the browser, and the
selected `project_id` becomes the read scope. API-key authentication is unchanged everywhere else.

## What changed

**Opt-in and fail-closed.** `LOCAL_SINGLE_USER_MODE` defaults to **false**. If it is set alongside
Auth0 or the public demo, config loading returns an error and the process refuses to start rather
than silently resolving a confused auth posture.

**Loopback only.** On composite routes, when a request carries no credentials and the mode is on
and the peer is loopback, it is admitted with no bound project. An API key or bearer token still
takes precedence, so existing deployments behave exactly as before. `/v1/ingest` stays API-key-only
and never becomes unauthenticated.

**Fully credential-free on loopback.** Reads, the project bootstrap, and project mutations
(rename, key rotation, delete) all work without an API key once the mode is enabled. This is a
deliberate maintainer decision for single-user localhost use: the mode is an explicit opt-in on a
machine its operator owns. It does widen the local surface — any process that can reach localhost
can rotate or delete a project — which is why admission stays strictly loopback-only and is
regression-tested against proxy-header spoofing.

Engine writes are included: `POST /v1/engine/runs` and `POST /v1/engine/projections/backfill` are
admitted credential-free from loopback too. Execution control is deliberately part of what a
single-user localhost install can do without a key. The trust boundary is loopback admission, not a
per-route write gate.

`/v1/ingest` is the one route the mode never opens. It is classified API-key-only, so it never
reaches the local-mode path and still returns 401 to a keyless loopback caller.

**Scope.** `scopeFromRequest` treats the mode like operator auth: `project_id` selects the read
scope. It is always required here — there is no unbounded cross-project read — so a request without
it gets 400 rather than silently returning everything.

**Discovery.** `GET /api/auth/config` reports `local_mode_enabled: true` only to loopback callers;
a remote client is never told the mode exists. The console then renders directly with no API-key
prompt, sends no `Authorization` header, and stores nothing in `localStorage` — which is what makes
two browser profiles agree on the same data.

## Security finding: chi `RealIP` made `RemoteAddr` attacker-controlled

Verifying the feature against a running server surfaced a **remote authentication bypass** in the
first implementation. `chi`'s `RealIP` middleware overwrites `r.RemoteAddr` from `X-Forwarded-For`
*before* the auth middleware runs, so the loopback check was reading an attacker-supplied header.
Observed: a request from LAN address `192.168.68.61` carrying `X-Forwarded-For: 127.0.0.1` returned
**200 with another project's traces**.

Fixed by `CaptureTransportPeer`, mounted ahead of `RealIP`, which stashes the true connection peer
so the trust decision reads the transport rather than a header.

**The unit tests could not catch this.** They construct the `Authenticator` directly and never mount
the chi stack, so `RealIP` never runs and the spoofing test passed both before and after the fix.
`internal/api/local_mode_router_test.go` therefore drives the *production* router and replays the
real malicious request across `X-Forwarded-For`, `X-Real-IP`, `True-Client-IP` (the three headers
chi actually consults) and `Forwarded`.

That test was verified to have teeth: with the `CaptureTransportPeer` mount commented out, the new
router tests **fail** while all 17 original acceptance tests still **pass**. The same check was run
against the remote-mutation test, where removing the mount lets a spoofed remote caller rename a
project with a 200 — which is exactly why that test is the load-bearing one now that local mode can
mutate projects.

## Review and test evidence

Acceptance tests were written first against a spec, committed red, and verified failing for the
right reason before implementation existed — loopback requests 401 where 204 was required, scoped
reads 401 where 200 was required, and the web client throwing `Sign in required` instead of
issuing a fetch. The fail-closed cases (remote rejected, spoofing ignored, ingest still
authenticated, mode hidden off-loopback) were green from the start by design and act as regression
guards.

- `go test ./internal/api/... ./internal/config/...` against real Postgres — pass
- `pnpm --filter web test` — 556 tests, pass; `test:e2e` — 16/16
- `golangci-lint`, web lint and type-check — clean; `make generate` — clean
- Real server exercised over HTTP: per-project scoping with no leakage, 400 without `project_id`,
  ingest still 401, IPv6 loopback works, mode off by default, and refuses to boot with Auth0 or
  the public demo
- Credential-free loopback `PATCH`/rotate/`DELETE` verified against the store — renamed value
  present, key hash changed and matching the returned key, row gone — while the same mutations from
  a remote peer, including one spoofing every header `RealIP` consults, are refused with the project
  row verified unchanged
- Credential-free loopback `POST /v1/engine/runs` and `POST /v1/engine/projections/backfill` reach
  handler validation, while the same writes from a remote or header-spoofing peer are refused 401
  through the production router; `POST /v1/ingest` from loopback with no key is still 401
- New Playwright coverage opens the console with no key in `localStorage`, asserts no key prompt and
  no `Authorization` header on any request, and switches projects
- No regressions across traces, trace detail, spans, events, sessions, projects, or engine runs

## Notes for the reviewer

- The `RealIP` hazard is now test-guarded **for the local-mode path only**. Any future trust
  decision that reads `RemoteAddr` anywhere in this codebase inherits the same latent hole; a lint
  rule or standing note may be worth it.
- `GET /v1/engine/health` is classified API-key-only, so the `/tools/engine-health` page still needs
  a key. Pre-existing, not introduced here, but local-mode users inherit it.
- On first paint the console issues one `/api/traces` before the project list resolves, which now
  400s in local mode. The UI recovers cleanly (covered by e2e); left as-is to keep this change small.

Closes #238
