### PR TITLE
fix(web): word missing-credential 401s for local mode

### DIFF
--- a/web/e2e/ui-smoke.spec.ts
+++ b/web/e2e/ui-smoke.spec.ts
@@ -853,6 +853,112 @@ test('opens the console with no API key and switches projects in local single-us
   });
 });
 
+// Auth0 disabled and no project API key in the browser: the rotate failure has
+// to name the missing project API key instead of pointing at a sign-in flow this
+// deployment does not have.
+test('explains a failed rotate as a missing project API key in local mode', async ({
+  page,
+}, testInfo) => {
+  const mutationRequests: string[] = [];
+  await bootstrapLocalSingleUserSession(page);
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const method = route.request().method();
+    if (method !== 'GET') {
+      mutationRequests.push(`${method} ${url.pathname}`);
+    }
+
+    if (url.pathname === '/api/auth/config') {
+      return fulfillJson(route, { enabled: false });
+    }
+
+    if (method === 'GET' && url.pathname === '/api/projects') {
+      return fulfillJson(route, {
+        projects: [
+          {
+            id: PRIMARY_PROJECT_ID,
+            name: 'Primary Project',
+            created_at: '2026-03-14T10:00:00.000Z',
+            updated_at: '2026-03-14T10:00:00.000Z',
+          },
+        ],
+      });
+    }
+
+    return fulfillJson(route, { code: 'not_found', message: 'Resource not found' }, 404);
+  });
+
+  await page.goto('/projects');
+
+  await page
+    .getByTestId(`project-row-${PRIMARY_PROJECT_ID}`)
+    .getByRole('button', { name: 'Rotate key' })
+    .click();
+  const rotateDialog = page.getByRole('dialog', { name: /Rotate key for/ });
+  await rotateDialog.getByRole('button', { name: 'Rotate key', exact: true }).click();
+
+  await expect(rotateDialog.getByRole('alert')).toContainText(
+    /project api key required/i
+  );
+  await expect(page.getByText(/sign in required/i)).toHaveCount(0);
+  // The wording change must not loosen the guard: no rotate ever left the browser.
+  expect(mutationRequests).toEqual([]);
+
+  await testInfo.attach(`${testInfo.project.name}-local-rotate-missing-key`, {
+    body: await page.screenshot({ fullPage: true, animations: 'disabled' }),
+    contentType: 'image/png',
+  });
+});
+
+// Regression guard for the wording change: with a project API key present the
+// rotate still reaches the server and reveals the new key.
+test('rotates a project key in local mode when an API key is present', async ({
+  page,
+}) => {
+  await bootstrapLocalApiKeySession(page);
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname === '/api/auth/config') {
+      return fulfillJson(route, { enabled: false });
+    }
+
+    const project = {
+      id: PRIMARY_PROJECT_ID,
+      name: 'Primary Project',
+      created_at: '2026-03-14T10:00:00.000Z',
+      updated_at: '2026-03-14T10:00:00.000Z',
+    };
+
+    if (url.pathname === `/api/projects/${PRIMARY_PROJECT_ID}/rotate`) {
+      expect(route.request().headers().authorization).toBe(
+        `Bearer ${PRIMARY_PROJECT_API_KEY}`
+      );
+      return fulfillJson(route, { ...project, api_key: 'pk_rotated' });
+    }
+
+    if (url.pathname === '/api/projects') {
+      return fulfillJson(route, {
+        authenticated_project_id: PRIMARY_PROJECT_ID,
+        projects: [project],
+      });
+    }
+
+    return fulfillJson(route, { code: 'not_found', message: 'Resource not found' }, 404);
+  });
+
+  await page.goto('/projects');
+
+  await page
+    .getByTestId(`project-row-${PRIMARY_PROJECT_ID}`)
+    .getByRole('button', { name: 'Rotate key' })
+    .click();
+  const rotateDialog = page.getByRole('dialog', { name: /Rotate key for/ });
+  await rotateDialog.getByRole('button', { name: 'Rotate key', exact: true }).click();
+
+  await expect(page.getByTestId('revealed-api-key')).toHaveText('pk_rotated');
+});
+
 test('captures overview, traces, sessions, and settings shells', async ({ page }, testInfo) => {
   const prefix = testInfo.project.name;
   await bootstrapOperatorSession(page);

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -3,6 +3,7 @@ import {
   ApiError,
   backfillEngineProjections,
   clearApiKey,
+  deleteProject,
   fetchAPI,
   fetchRuntimeAuthConfig,
   forgetProjectApiKey,
@@ -10,6 +11,7 @@ import {
   getKnownProjectApiKey,
   rememberProjectApiKey,
   setAccessTokenProvider,
+  setAuthProviderEnabled,
   setLocalApiKeyMode,
   setLocalSingleUserMode,
   setPublicDemoMode,
@@ -28,6 +30,7 @@ beforeEach(() => {
   setAccessTokenProvider(null);
   setPublicDemoMode(false);
   setLocalSingleUserMode(false);
+  setAuthProviderEnabled(false);
   setSelectedProjectIdProvider(null);
 });
 
@@ -36,6 +39,7 @@ afterEach(() => {
   setAccessTokenProvider(null);
   setPublicDemoMode(false);
   setLocalSingleUserMode(false);
+  setAuthProviderEnabled(false);
   setSelectedProjectIdProvider(null);
   vi.unstubAllGlobals();
 });
@@ -214,11 +218,120 @@ describe('client', () => {
   });
 
   it('fails fast when no operator token provider is installed', async () => {
+    setAuthProviderEnabled(true);
+
     await expect(fetchAPI('/api/traces')).rejects.toMatchObject({
       status: 401,
       code: 'unauthorized',
       message: 'Sign in required',
     } satisfies Partial<ApiError>);
+  });
+
+  it('reports missing credentials as a project API-key issue when no sign-in provider is configured', async () => {
+    setAuthProviderEnabled(false);
+
+    const rejection = await fetchAPI('/api/traces').then(
+      () => {
+        throw new Error('expected fetchAPI to reject');
+      },
+      (error: unknown) => error
+    );
+
+    expect(rejection).toBeInstanceOf(ApiError);
+    expect(rejection).toMatchObject({
+      status: 401,
+      code: 'api_key_required',
+      message: 'Project API key required',
+    } satisfies Partial<ApiError>);
+    expect((rejection as ApiError).message).not.toContain('Sign in');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps sign-in wording for missing credentials when a sign-in provider is configured', async () => {
+    setAuthProviderEnabled(true);
+
+    await expect(fetchAPI('/api/traces')).rejects.toMatchObject({
+      status: 401,
+      code: 'unauthorized',
+      message: 'Sign in required',
+    } satisfies Partial<ApiError>);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports an unresolved token as a project API-key issue when no sign-in provider is configured', async () => {
+    setAuthProviderEnabled(false);
+    setAccessTokenProvider(async () => null);
+
+    const rejection = await fetchAPI('/api/traces').then(
+      () => {
+        throw new Error('expected fetchAPI to reject');
+      },
+      (error: unknown) => error
+    );
+
+    expect(rejection).toMatchObject({
+      status: 401,
+      code: 'api_key_required',
+      message: 'Project API key required',
+    } satisfies Partial<ApiError>);
+    expect((rejection as ApiError).message).not.toContain('Sign in');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps sign-in wording for an unresolved token when a sign-in provider is configured', async () => {
+    setAuthProviderEnabled(true);
+    setAccessTokenProvider(async () => null);
+
+    await expect(fetchAPI('/api/traces')).rejects.toMatchObject({
+      status: 401,
+      code: 'unauthorized',
+      message: 'Sign in required',
+    } satisfies Partial<ApiError>);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a credential-free project delete as a project API-key issue in local mode', async () => {
+    setAuthProviderEnabled(false);
+
+    const rejection = await deleteProject('project-to-delete').then(
+      () => {
+        throw new Error('expected deleteProject to reject');
+      },
+      (error: unknown) => error
+    );
+
+    expect(rejection).toMatchObject({
+      status: 401,
+      code: 'api_key_required',
+      message: 'Project API key required',
+    } satisfies Partial<ApiError>);
+    expect((rejection as ApiError).message).not.toContain('Sign in');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps sign-in wording for a credential-free project delete when a sign-in provider is configured', async () => {
+    setAuthProviderEnabled(true);
+
+    await expect(deleteProject('project-to-delete')).rejects.toMatchObject({
+      status: 401,
+      code: 'unauthorized',
+      message: 'Sign in required',
+    } satisfies Partial<ApiError>);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('defaults to project API-key wording before any sign-in provider is announced', async () => {
+    // Import a pristine module instance so the assertion covers the module
+    // default, without the setter ever being called for it.
+    vi.resetModules();
+    const pristineClient = await import('./client');
+
+    await expect(pristineClient.fetchAPI('/api/traces')).rejects.toMatchObject({
+      status: 401,
+      code: 'api_key_required',
+      message: 'Project API key required',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('uses a stored local API key when no operator token provider is installed', async () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -74,6 +74,17 @@ export function isAuthProviderEnabled(): boolean {
 }
 
 /**
+ * Missing credentials mean different things per deployment: with a sign-in
+ * provider configured the operator has to sign in, otherwise the local console
+ * is simply missing its project API key and no login exists to offer.
+ */
+function missingCredentialsError(): ApiError {
+  return authProviderEnabled
+    ? new ApiError(401, 'unauthorized', 'Sign in required')
+    : new ApiError(401, 'api_key_required', 'Project API key required');
+}
+
+/**
  * Toggle API-key-free single-user local mode. When active the client must issue
  * requests with no Authorization header and must not demand a stored API key.
  */
@@ -287,7 +298,7 @@ export async function fetchAPI<T>(
     !publicDemoModeEnabled &&
     !localSingleUserModeEnabled
   ) {
-    throw new ApiError(401, 'unauthorized', 'Sign in required');
+    throw missingCredentialsError();
   }
 
   let accessToken: string | null = localApiKey;
@@ -320,7 +331,7 @@ export async function fetchAPI<T>(
     !localSingleUserModeEnabled &&
     !allowUnauthenticated
   ) {
-    throw new ApiError(401, 'unauthorized', 'Sign in required');
+    throw missingCredentialsError();
   }
 
   const headers: Record<string, string> = {
@@ -966,7 +977,7 @@ async function fetchAPIEmpty(
     accessToken = null;
   }
   if (!accessToken && !publicDemoModeEnabled && !localSingleUserModeEnabled) {
-    throw new ApiError(401, 'unauthorized', 'Sign in required');
+    throw missingCredentialsError();
   }
 
   const requestUrl = buildRequestUrl(path);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -31,6 +31,7 @@ let legacyTestToken: string | null = null;
 let publicDemoModeEnabled = false;
 let localApiKeyModeEnabled = false;
 let localSingleUserModeEnabled = false;
+let authProviderEnabled = false;
 
 export type { FetchTracesParams } from '../utils/tracesSearchParams';
 export type {
@@ -58,6 +59,18 @@ export function setPublicDemoMode(enabled: boolean): void {
 
 export function setLocalApiKeyMode(enabled: boolean): void {
   localApiKeyModeEnabled = enabled;
+}
+
+/**
+ * Record whether an interactive sign-in provider (Auth0) is configured for this
+ * deployment. Self-hosted local mode is the default, so this starts false.
+ */
+export function setAuthProviderEnabled(enabled: boolean): void {
+  authProviderEnabled = enabled;
+}
+
+export function isAuthProviderEnabled(): boolean {
+  return authProviderEnabled;
 }
 
 /**

--- a/web/src/auth/runtime.test.tsx
+++ b/web/src/auth/runtime.test.tsx
@@ -6,7 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearApiKey,
   fetchAPI,
+  isAuthProviderEnabled,
   setAccessTokenProvider,
+  setAuthProviderEnabled,
   setLocalSingleUserMode,
   setPublicDemoMode,
 } from '../api/client';
@@ -80,6 +82,7 @@ beforeEach(() => {
   setAccessTokenProvider(null);
   setPublicDemoMode(false);
   setLocalSingleUserMode(false);
+  setAuthProviderEnabled(false);
   auth0State.error = undefined;
   auth0State.isAuthenticated = true;
   auth0State.isLoading = false;
@@ -91,6 +94,7 @@ afterEach(() => {
   setAccessTokenProvider(null);
   setPublicDemoMode(false);
   setLocalSingleUserMode(false);
+  setAuthProviderEnabled(false);
   vi.unstubAllGlobals();
 });
 
@@ -451,5 +455,84 @@ describe('runtime auth', () => {
       'href',
       '/'
     );
+  });
+
+  it('tells the API client whether an interactive sign-in provider is configured', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ traces: [], total: 0 }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+
+    // Authenticated bridge: Auth0 is configured, so sign-in wording applies.
+    const auth0Deployment = render(
+      <MemoryRouter>
+        <Auth0RuntimeProvider
+          auth={{
+            status: 'ready',
+            enabled: true,
+            domain: 'continua.us.auth0.com',
+            client_id: 'client-id',
+            audience: 'https://continua/api',
+          }}
+        >
+          <div>Operator console</div>
+        </Auth0RuntimeProvider>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Operator console')).toBeInTheDocument();
+    expect(isAuthProviderEnabled()).toBe(true);
+    auth0Deployment.unmount();
+
+    // Unauthenticated bridge: no Auth0, so the client must fall back to
+    // project-API-key wording. Seed the opposite value first so the assertion
+    // cannot pass on the module default alone.
+    setAuthProviderEnabled(true);
+    const localDeployment = render(
+      <MemoryRouter>
+        <Auth0RuntimeProvider
+          auth={{
+            status: 'ready',
+            enabled: false,
+            local_mode_enabled: true,
+          }}
+        >
+          <div>Local console</div>
+        </Auth0RuntimeProvider>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Local console')).toBeInTheDocument();
+    expect(isAuthProviderEnabled()).toBe(false);
+    localDeployment.unmount();
+
+    // Public-demo bridge with Auth0 still configured: the demo reads are
+    // unauthenticated, but a sign-in provider exists, so the wording stays
+    // sign-in oriented.
+    setAuthProviderEnabled(false);
+    render(
+      <MemoryRouter>
+        <Auth0RuntimeProvider
+          auth={{
+            status: 'ready',
+            enabled: true,
+            domain: 'continua.us.auth0.com',
+            client_id: 'client-id',
+            audience: 'https://continua/api',
+            public_demo_enabled: true,
+            public_demo_label: 'Sample data',
+          }}
+        >
+          <div>Demo console</div>
+        </Auth0RuntimeProvider>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Demo console')).toBeInTheDocument();
+    expect(isAuthProviderEnabled()).toBe(true);
   });
 });

--- a/web/src/auth/runtime.tsx
+++ b/web/src/auth/runtime.tsx
@@ -18,6 +18,7 @@ import {
   LOCAL_API_KEY_CHANGED_EVENT,
   setAccessTokenProvider,
   setApiKey,
+  setAuthProviderEnabled,
   setLocalApiKeyMode,
   setLocalSingleUserMode,
   setPublicDemoMode,
@@ -146,6 +147,14 @@ export function Auth0RuntimeProvider({
   children: ReactNode;
 }) {
   const navigate = useNavigate();
+
+  // Whether a sign-in provider exists is a deployment fact, not a property of
+  // the bridge that ends up mounting: the public demo runs unauthenticated but
+  // may still sit in front of a configured Auth0 tenant. The API client uses it
+  // to word missing-credential failures.
+  useLayoutEffect(() => {
+    setAuthProviderEnabled(auth.enabled);
+  }, [auth.enabled]);
 
   let content = (
     <UnauthenticatedSessionBridge

--- a/web/src/pages/ProjectsPage.test.tsx
+++ b/web/src/pages/ProjectsPage.test.tsx
@@ -8,6 +8,7 @@ import {
   clearApiKey,
   rememberProjectApiKey,
   setApiKey,
+  setAuthProviderEnabled,
 } from '../api/client';
 import { ProjectsPage } from './ProjectsPage';
 import { jsonResponse, mockClipboard, type RequestInput } from './testUtils';
@@ -44,11 +45,13 @@ function renderProjectsPage() {
 
 beforeEach(() => {
   window.localStorage.clear();
+  setAuthProviderEnabled(false);
   setApiKey('test-key');
 });
 
 afterEach(() => {
   clearApiKey();
+  setAuthProviderEnabled(false);
   vi.restoreAllMocks();
 });
 
@@ -549,4 +552,108 @@ describe('ProjectsPage', () => {
 
     expect(window.localStorage.getItem('continua_api_key')).toBe('pk_newkey789');
   });
+
+  it('explains a failed rotate as a missing project API key in local mode', async () => {
+    const user = userEvent.setup();
+    clearApiKey();
+    setAuthProviderEnabled(false);
+
+    const fetchMock = mockProjectListOnly();
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderProjectsPage();
+
+    await openRotateDialogAndSubmit(user);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/project api key/i);
+    expect(screen.queryByText(/sign in required/i)).toBeNull();
+    expect(mutationRequests(fetchMock)).toEqual([]);
+  });
+
+  it('keeps sign-in wording for a failed rotate when Auth0 is enabled', async () => {
+    const user = userEvent.setup();
+    clearApiKey();
+    setAuthProviderEnabled(true);
+
+    const fetchMock = mockProjectListOnly();
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderProjectsPage();
+
+    await openRotateDialogAndSubmit(user);
+
+    expect(await screen.findByText(/sign in required/i)).toBeInTheDocument();
+    expect(mutationRequests(fetchMock)).toEqual([]);
+  });
+
+  it('keeps rotate, rename, and delete protected when no project API key is available', async () => {
+    const user = userEvent.setup();
+    clearApiKey();
+    setAuthProviderEnabled(false);
+
+    const fetchMock = mockProjectListOnly();
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderProjectsPage();
+
+    await openRotateDialogAndSubmit(user);
+    const rotateDialog = screen.getByRole('dialog', { name: /rotate key for/i });
+    expect(await within(rotateDialog).findByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByTestId('revealed-api-key')).toBeNull();
+    await user.click(within(rotateDialog).getByRole('button', { name: /cancel/i }));
+
+    const row = screen.getByTestId(`project-row-${EXISTING_PROJECT.id}`);
+    await user.click(within(row).getByRole('button', { name: /^rename$/i }));
+    const renameDialog = await screen.findByRole('dialog', { name: /rename/i });
+    await user.clear(within(renameDialog).getByLabelText(/new name/i));
+    await user.type(within(renameDialog).getByLabelText(/new name/i), 'Renamed');
+    await user.click(within(renameDialog).getByRole('button', { name: /^save$/i }));
+    expect(await within(renameDialog).findByRole('alert')).toBeInTheDocument();
+    await user.click(within(renameDialog).getByRole('button', { name: /cancel/i }));
+
+    await user.click(within(row).getByRole('button', { name: /^delete$/i }));
+    const deleteDialog = await screen.findByRole('dialog', { name: /delete "/i });
+    await user.type(
+      within(deleteDialog).getByLabelText(/type the project name to confirm/i),
+      EXISTING_PROJECT.name
+    );
+    await user.click(
+      within(deleteDialog).getByRole('button', { name: /delete project/i })
+    );
+    expect(await within(deleteDialog).findByRole('alert')).toBeInTheDocument();
+
+    expect(mutationRequests(fetchMock)).toEqual([]);
+  });
 });
+
+function mockProjectListOnly() {
+  return vi.fn(async (input: RequestInput, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    if (method === 'GET' && url.includes('/api/projects')) {
+      return jsonResponse({ projects: [EXISTING_PROJECT] });
+    }
+    throw new Error(`unexpected ${method} ${url}`);
+  });
+}
+
+function mutationRequests(fetchMock: ReturnType<typeof vi.fn>): string[] {
+  return fetchMock.mock.calls
+    .map(([input, init]) => {
+      const url = typeof input === 'string' ? input : String(input);
+      const method = ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase();
+      return `${method} ${url}`;
+    })
+    .filter((call) => !call.startsWith('GET '));
+}
+
+async function openRotateDialogAndSubmit(
+  user: ReturnType<typeof userEvent.setup>
+): Promise<void> {
+  await screen.findByText(EXISTING_PROJECT.name);
+  const row = screen.getByTestId(`project-row-${EXISTING_PROJECT.id}`);
+  await user.click(within(row).getByRole('button', { name: /rotate key/i }));
+  const rotateDialog = await screen.findByRole('dialog', { name: /rotate key for/i });
+  await user.click(within(rotateDialog).getByRole('button', { name: /^rotate key$/i }));
+}


### PR DESCRIPTION
## What

When Auth0 is disabled, the debugger reported missing or unresolved credentials as **"Sign in required"** — even though no interactive sign-in exists in local mode. Operators hitting **Settings → Projects → Rotate key** without a project API key were told to sign in to something that isn't configured.

Missing credentials now map by deployment shape:

| Sign-in provider | HTTP | Code | Message |
|---|---|---|---|
| Configured (Auth0) | 401 | `unauthorized` | Sign in required |
| Not configured (local) | 401 | `api_key_required` | Project API key required |

## How

- `web/src/api/client.ts` — one `missingCredentialsError()` helper branching on a module-level "is a sign-in provider configured" flag, used at all three 401 throw sites (`fetchAPI` x2, `fetchAPIEmpty`). The credential guards themselves are unchanged; only the thrown error differs.
- `web/src/auth/runtime.tsx` — `Auth0RuntimeProvider` reports `auth.enabled` to the client. Whether a sign-in provider exists is a deployment fact, not a property of which session bridge mounts: a public demo may still sit in front of a configured Auth0 tenant, so the flag is set at the provider rather than threaded through each bridge.
- No UI copy was special-cased — `MutationError` and `ErrorPanel` already render `ApiError.message` verbatim.

Note: #241's `setLocalSingleUserMode` / `local_mode_enabled` could not be reused. Those describe credential-free loopback mode; a deployment with Auth0 off and API keys on matches neither, which is exactly the case this bug reports.

## Verification

Tests were written first, against a spec derived from the issue's acceptance criteria, and committed red before any implementation — by a separate author from the implementer. 10 tests, 6 red before the fix:

- `client.test.ts` — the local-mode/Auth0 split at all three throw sites, plus a pristine-module import proving the default is local-mode wording. Each case asserts the guard fires *before* any network call.
- `ProjectsPage.test.tsx` — a failed rotate renders API-key wording in local mode and sign-in wording under Auth0; a third test drives rotate, rename and delete through real interaction and asserts **zero non-GET requests escape**, so the fix is wording-only and does not relax protection.
- `runtime.test.tsx` — the flag is actually wired from runtime config across all three mount bridges, asserted through observable client state and seeded to the opposite value first so it cannot pass vacuously.

Full suite green, `type-check` and `lint --max-warnings 0` clean.

**Browser E2E** (`web/e2e/ui-smoke.spec.ts`, 20/20 passing): a real local-mode rotate failure renders "Project API key required" with no "Sign in required" anywhere on the page and no non-GET request leaving the browser; a companion spec confirms rotate still genuinely works when a key *is* present, reaching `POST /api/projects/{id}/rotate` with the bearer token and revealing the rotated key.

Closes #242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error messages to distinguish between required sign-in and missing project API keys.
  * Prevented project rotation, renaming, and deletion requests when required credentials are unavailable.
  * Ensured project key rotation works correctly when a valid project API key is configured.
* **Tests**
  * Added coverage for local, Auth0-enabled, and public-demo authentication scenarios.
  * Added end-to-end coverage for project key rotation and credential-related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->